### PR TITLE
General: Refactor and optimize collectTrackMeterHeights

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -27,10 +27,8 @@ import fi.fta.geoviite.infra.integration.LockDao
 import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.math.BoundingBox
-import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.ElementListingFile
 import fi.fta.geoviite.infra.tracklayout.ElementListingFileDao
-import fi.fta.geoviite.infra.tracklayout.IAlignment
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
@@ -45,12 +43,10 @@ import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsLastComparator
-import java.math.BigDecimal
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.stream.Collectors
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import withUser
@@ -579,8 +575,8 @@ constructor(
         val alignmentBoundaryAddresses =
             alignmentLinkEndSegmentIndices.flatMap { i ->
                 listOf(
-                    PlanBoundaryPoint(alignment.segments[i].endM, i),
-                    PlanBoundaryPoint(alignment.segments[i + 1].startM, i + 1),
+                    GeometryAlignmentBoundaryPoint(alignment.segments[i].endM, i),
+                    GeometryAlignmentBoundaryPoint(alignment.segments[i + 1].startM, i + 1),
                 )
             }
 
@@ -592,7 +588,7 @@ constructor(
             geocodingContext,
             alignment,
             tickLength,
-            alignmentBoundaryAddresses = alignmentBoundaryAddresses,
+            geometryAlignmentBoundaryPoints = alignmentBoundaryAddresses,
         ) { point, givenSegmentIndex ->
             val segmentIndex = givenSegmentIndex ?: alignment.getSegmentIndexAtM(point.m)
             val segment = alignment.segments[segmentIndex]
@@ -656,120 +652,6 @@ constructor(
         }
     }
 
-    private fun collectTrackMeterHeights(
-        startDistance: Double,
-        endDistance: Double,
-        geocodingContext: GeocodingContext,
-        alignment: IAlignment,
-        tickLength: Int,
-        alignmentBoundaryAddresses: List<PlanBoundaryPoint> = listOf(),
-        getHeightAt: (point: AlignmentPoint, segmentIndex: Int?) -> Double?,
-    ): List<KmHeights>? {
-        val addressOfStartDistance =
-            geocodingContext.getAddress(alignment.getPointAtM(startDistance) ?: return null)?.first ?: return null
-        val addressOfEndDistance =
-            geocodingContext.getAddress(alignment.getPointAtM(endDistance) ?: return null)?.first ?: return null
-        val (alignmentStart, alignmentEnd) = geocodingContext.getStartAndEnd(alignment)
-        if (alignmentStart == null || alignmentEnd == null) return null
-
-        val referencePointIndices =
-            geocodingContext.referencePoints.indexOfFirst { referencePoint ->
-                referencePoint.kmNumber == addressOfStartDistance.kmNumber
-            }..geocodingContext.referencePoints.indexOfFirst { referencePoint ->
-                    referencePoint.kmNumber == addressOfEndDistance.kmNumber
-                }
-
-        val alignmentBoundaryAddressesByKm =
-            alignmentBoundaryAddresses
-                .mapNotNull { boundary ->
-                    alignment.getPointAtM(boundary.distanceOnAlignment)?.let { point ->
-                        geocodingContext.getAddress(point)?.let { address -> address.first to boundary.segmentIndex }
-                    }
-                }
-                .groupBy(
-                    { (trackMeter) -> trackMeter.kmNumber },
-                    { (trackMeter, segmentIndex) -> trackMeter.meters to segmentIndex },
-                )
-
-        return referencePointIndices
-            .toList()
-            .parallelStream()
-            .map { referencePointIndex ->
-                val referencePoint = geocodingContext.referencePoints[referencePointIndex]
-                val kmNumber = referencePoint.kmNumber
-                // The choice of a half-tick-length minimum is totally arbitrary
-                val minTickSpace = BigDecimal(tickLength).setScale(1) / BigDecimal(2)
-                val lastPoint =
-                    (referencePoint.meters.toDouble() +
-                            getKmLengthAtReferencePointIndex(referencePointIndex, geocodingContext) -
-                            minTickSpace.toDouble())
-                        .toInt()
-                        .coerceAtLeast(0)
-
-                // Pairs of (track meter, segment index). Ordinary ticks don't need segment indices
-                // because they clearly
-                // hit a specific segment; but points on different sides of a segment boundary are
-                // often the exact same
-                // point, but potentially have different heights (or more often null/not-null
-                // heights).
-                val allTicks =
-                    ((alignmentBoundaryAddressesByKm[kmNumber] ?: listOf()) +
-                            ((0..lastPoint step tickLength).map { distance -> distance.toBigDecimal() to null }))
-                        .sortedBy { (trackMeterInKm) -> trackMeterInKm }
-
-                val ticksToSend =
-                    (allTicks.filterIndexed { i, (trackMeterInKm, segmentIndex) ->
-                            segmentIndex != null ||
-                                i == 0 ||
-                                ((trackMeterInKm - allTicks[i - 1].first >= minTickSpace) &&
-                                    (i == allTicks.lastIndex || allTicks[i + 1].first - trackMeterInKm >= minTickSpace))
-                        }
-                        // Special-case first and last points so we get as close as possible to the
-                        // track ends
-                        +
-                            (if (kmNumber == alignmentStart.address.kmNumber)
-                                listOf(alignmentStart.address.meters to null)
-                            else listOf()) +
-                            (if (kmNumber == alignmentEnd.address.kmNumber) listOf(alignmentEnd.address.meters to null)
-                            else listOf()))
-                        .sortedBy { (trackMeterInKm) -> trackMeterInKm }
-
-                val endM =
-                    if (kmNumber == alignmentEnd.address.kmNumber) {
-                        alignmentEnd.point.m
-                    } else {
-                        geocodingContext
-                            .getTrackLocation(
-                                alignment,
-                                TrackMeter(geocodingContext.referencePoints[referencePointIndex + 1].kmNumber, 0),
-                            )
-                            ?.point
-                            ?.m!!
-                    }
-
-                KmHeights(
-                    referencePoint.kmNumber,
-                    ticksToSend
-                        .mapNotNull { (trackMeterInKm, segmentIndex) ->
-                            val trackMeter = TrackMeter(kmNumber, trackMeterInKm)
-                            geocodingContext.getTrackLocation(alignment, trackMeter)?.let { address ->
-                                TrackMeterHeight(
-                                    address.point.m,
-                                    address.address.meters.toDouble(),
-                                    getHeightAt(address.point, segmentIndex),
-                                    address.point.toPoint(),
-                                )
-                            }
-                        }
-                        .distinct(), // don't bother sending segment boundary sides with the same
-                    // location and height
-                    endM,
-                )
-            }
-            .collect(Collectors.toList())
-            .filter { km -> km.trackMeterHeights.isNotEmpty() }
-    }
-
     @Transactional
     fun setPlanHidden(planId: IntId<GeometryPlan>, hidden: Boolean): RowVersion<GeometryPlan> {
         if (hidden && !geometryDao.getPlanLinking(planId).isEmpty) {
@@ -791,14 +673,6 @@ constructor(
             ?.let { number -> trackNumberService.find(MainLayoutContext.official, number).firstOrNull()?.id }
             ?.let { trackNumberId -> geocodingService.getGeocodingContext(MainLayoutContext.official, trackNumberId) }
 }
-
-private fun getKmLengthAtReferencePointIndex(referencePointIndex: Int, geocodingContext: GeocodingContext) =
-    if (referencePointIndex == geocodingContext.referencePoints.size - 1) {
-        geocodingContext.referenceLineGeometry.length - geocodingContext.referencePoints[referencePointIndex].distance
-    } else {
-        geocodingContext.referencePoints[referencePointIndex + 1].distance -
-            geocodingContext.referencePoints[referencePointIndex].distance
-    }
 
 private fun trackNumbersMatch(header: GeometryPlanHeader, trackNumbers: List<TrackNumber>) =
     (trackNumbers.isEmpty() || (header.trackNumber?.let(trackNumbers::contains) ?: false))
@@ -833,5 +707,3 @@ private data class SegmentSource(
     val alignment: GeometryAlignment?,
     val plan: GeometryPlan?,
 )
-
-private data class PlanBoundaryPoint(val distanceOnAlignment: Double, val segmentIndex: Int)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
@@ -193,16 +193,17 @@ private fun getAllTicksToSendForKm(
 // segment boundary ticks for clarity.
 private fun tickIsGoodToSend(
     segmentIndex: Int?,
-    i: Int,
+    tickIndex: Int,
     trackMeterInKm: BigDecimal,
     allTicks: List<TrackMeterHeightTick>,
     minTickSpace: BigDecimal,
 ): Boolean {
     val isSegmentBoundaryPoint = segmentIndex != null
-    val isKmStartTick = i == 0
-    val hasSpaceAfterPreviousTick = i > 0 && trackMeterInKm - allTicks[i - 1].trackMeterInKm >= minTickSpace
+    val isKmStartTick = tickIndex == 0
+    val hasSpaceAfterPreviousTick =
+        tickIndex > 0 && trackMeterInKm - allTicks[tickIndex - 1].trackMeterInKm >= minTickSpace
     val hasSpaceBeforeNextTick =
-        (i == allTicks.lastIndex || allTicks[i + 1].trackMeterInKm - trackMeterInKm >= minTickSpace)
+        (tickIndex == allTicks.lastIndex || allTicks[tickIndex + 1].trackMeterInKm - trackMeterInKm >= minTickSpace)
 
     return isSegmentBoundaryPoint || isKmStartTick || (hasSpaceAfterPreviousTick && hasSpaceBeforeNextTick)
 }
@@ -245,8 +246,8 @@ private fun getTickTrackLocationsByKm(
             kmTicks.map { tick -> TrackMeter(km, tick.trackMeterInKm) }
         }
     return processFlattened(trackAddresses) { allTrackAddresses ->
-        // null-safety: fitKmTicksWithinAlignmentBounds drops all ticks outside the alignment
-        // bounds, so everything is geocodable.
+        // null-safety: ticksByKm came from fitKmTicksWithinAlignmentBounds, which
+        // drops all ticks outside the alignment bounds, so everything is geocodable.
         geocodingContext.getTrackLocations(alignment, allTrackAddresses).map(::checkNotNull)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
@@ -1,0 +1,281 @@
+package fi.fta.geoviite.infra.geometry
+
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.geocoding.AddressPoint
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
+import fi.fta.geoviite.infra.geocoding.GeocodingReferencePoint
+import fi.fta.geoviite.infra.geocoding.getIndexRangeForRangeInOrderedList
+import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
+import fi.fta.geoviite.infra.tracklayout.IAlignment
+import fi.fta.geoviite.infra.util.processFlattened
+import java.math.BigDecimal
+
+fun collectTrackMeterHeights(
+    startDistance: Double,
+    endDistance: Double,
+    geocodingContext: GeocodingContext,
+    alignment: IAlignment,
+    tickLength: Int,
+    geometryAlignmentBoundaryPoints: List<GeometryAlignmentBoundaryPoint> = listOf(),
+    getHeightAt: (point: AlignmentPoint, segmentIndex: Int?) -> Double?,
+): List<KmHeights>? {
+    val (alignmentStart, alignmentEnd) = geocodingContext.getStartAndEnd(alignment)
+    if (alignmentStart == null || alignmentEnd == null) return null
+
+    val referencePointIndices =
+        getReferencePointIndexRangeCoveringAlignmentMRange(geocodingContext, alignment, startDistance, endDistance)
+            ?: return null
+
+    val ticksByKm =
+        getTicksToSendByKm(
+            geometryAlignmentBoundaryPoints,
+            alignment,
+            geocodingContext,
+            referencePointIndices,
+            tickLength,
+            alignmentStart,
+            alignmentEnd,
+        )
+    val tickTrackLocationsByKm =
+        getTickTrackLocationsByKm(geocodingContext, alignment, ticksByKm, referencePointIndices)
+
+    return referencePointIndices.toList().mapIndexed { kmIndex, referencePointIndex ->
+        val kmNumber = geocodingContext.referencePoints[referencePointIndex].kmNumber
+        val kmTicks = ticksByKm[kmIndex]
+        val kmTrackLocations = tickTrackLocationsByKm[kmIndex]
+        val endM =
+            (if (referencePointIndex == referencePointIndices.last)
+                getLastEndM(geocodingContext, referencePointIndices, alignmentEnd, alignment)
+            else tickTrackLocationsByKm[kmIndex + 1].first().point.m)
+
+        val trackKmHeights =
+            kmTicks
+                .zip(kmTrackLocations) { tick, address ->
+                    TrackMeterHeight(
+                        address.point.m,
+                        address.address.meters.toDouble(),
+                        getHeightAt(address.point, tick.segmentIndex),
+                        address.point.toPoint(),
+                    )
+                }
+                // if different sides of a segment boundary have exactly the same height, the height
+                // ticks end up equal here: Throw one out as unneeded
+                .distinct()
+        KmHeights(kmNumber, trackKmHeights, endM)
+    }
+}
+
+private fun getReferencePointIndexRangeCoveringAlignmentMRange(
+    geocodingContext: GeocodingContext,
+    alignment: IAlignment,
+    startDistance: Double,
+    endDistance: Double,
+): IntRange? =
+    alignment.getPointAtM(startDistance)?.let(geocodingContext::getAddress)?.let { (startAddress) ->
+        alignment.getPointAtM(endDistance)?.let(geocodingContext::getAddress)?.let { (endAddress) ->
+            getIndexRangeForRangeInOrderedList(geocodingContext.referencePoints, startAddress, endAddress) {
+                referencePoint,
+                address ->
+                referencePoint.kmNumber.compareTo(address.kmNumber)
+            }
+        }
+    }
+
+private fun getTicksToSendByKm(
+    geometryAlignmentBoundaryPoints: List<GeometryAlignmentBoundaryPoint>,
+    alignment: IAlignment,
+    geocodingContext: GeocodingContext,
+    referencePointIndices: IntRange,
+    tickLength: Int,
+    alignmentStart: AddressPoint,
+    alignmentEnd: AddressPoint,
+): List<List<TrackMeterHeightTick>> {
+    val geometryAlignmentBoundariesInKmRange =
+        filterGeometryAlignmentBoundariesWithinKmRange(
+            alignment,
+            geocodingContext,
+            referencePointIndices,
+            geometryAlignmentBoundaryPoints,
+        )
+    val alignmentBoundaryTicksByKm =
+        locateAlignmentBoundaryAddresses(geometryAlignmentBoundariesInKmRange, alignment, geocodingContext)
+
+    return referencePointIndices.map { referencePointIndex ->
+        val referencePoint = geocodingContext.referencePoints[referencePointIndex]
+        val kmNumber = referencePoint.kmNumber
+        getTicksToSendForKm(
+            tickLength,
+            alignmentBoundaryTicksByKm[kmNumber] ?: listOf(),
+            referencePoint,
+            getKmLengthAtReferencePointIndex(referencePointIndex, geocodingContext),
+            kmNumber,
+            alignmentStart,
+            alignmentEnd,
+        )
+    }
+}
+
+// pure optimization: Ignore geometry alignment boundaries not within the km range we're sending
+private fun filterGeometryAlignmentBoundariesWithinKmRange(
+    alignment: IAlignment,
+    geocodingContext: GeocodingContext,
+    referencePointIndices: IntRange,
+    geometryAlignmentBoundaries: List<GeometryAlignmentBoundaryPoint>,
+): List<GeometryAlignmentBoundaryPoint> {
+    val startAddress = TrackMeter(geocodingContext.referencePoints[referencePointIndices.first].kmNumber, 0)
+    val endAddress =
+        if (referencePointIndices.last == geocodingContext.referencePoints.lastIndex) null
+        else TrackMeter(geocodingContext.referencePoints[referencePointIndices.last + 1].kmNumber, 0)
+    val rangePoints = geocodingContext.getTrackLocations(alignment, listOfNotNull(startAddress, endAddress))
+    // either or both addresses could fail to geocode onto the alignment
+    val rangeStart = rangePoints[0]?.point?.m
+    val rangeEnd = rangePoints.getOrNull(1)?.point?.m
+
+    return geometryAlignmentBoundaries.filter { boundary ->
+        (rangeStart == null || boundary.distanceOnAlignment >= rangeStart) &&
+            (rangeEnd == null || boundary.distanceOnAlignment <= rangeEnd)
+    }
+}
+
+private fun locateAlignmentBoundaryAddresses(
+    alignmentBoundaryAddresses: List<GeometryAlignmentBoundaryPoint>,
+    alignment: IAlignment,
+    geocodingContext: GeocodingContext,
+): Map<KmNumber, List<TrackMeterHeightTick>> =
+    alignmentBoundaryAddresses
+        .mapNotNull { boundary ->
+            alignment.getPointAtM(boundary.distanceOnAlignment)?.let { point ->
+                geocodingContext.getAddress(point)?.let { address -> address.first to boundary.segmentIndex }
+            }
+        }
+        .groupBy(
+            { (trackMeter) -> trackMeter.kmNumber },
+            { (trackMeter, segmentIndex) -> TrackMeterHeightTick(trackMeter.meters, segmentIndex) },
+        )
+
+private fun getTicksToSendForKm(
+    tickLength: Int,
+    alignmentBoundaryTicks: List<TrackMeterHeightTick>,
+    referencePoint: GeocodingReferencePoint,
+    kmLength: Double,
+    kmNumber: KmNumber,
+    alignmentStart: AddressPoint,
+    alignmentEnd: AddressPoint,
+): List<TrackMeterHeightTick> {
+    val allTicksForKm = getAllTicksToSendForKm(tickLength, referencePoint, kmLength, alignmentBoundaryTicks)
+    return fitKmTicksWithinAlignmentBounds(kmNumber, alignmentStart, alignmentEnd, allTicksForKm)
+}
+
+private fun getAllTicksToSendForKm(
+    tickLength: Int,
+    referencePoint: GeocodingReferencePoint,
+    kmLength: Double,
+    alignmentBoundaryTicks: List<TrackMeterHeightTick>,
+): List<TrackMeterHeightTick> {
+    // The choice of a half-tick-length minimum is totally arbitrary
+    val minTickSpace = BigDecimal(tickLength).setScale(1) / BigDecimal(2)
+    val lastPoint = (referencePoint.meters.toDouble() + kmLength - minTickSpace.toDouble()).toInt().coerceAtLeast(0)
+
+    // Ordinary track meter height ticks don't need segment indices because they clearly hit a
+    // specific segment; but points on different sides of a segment boundary are often the exact
+    // same point, but potentially have different heights (or more often null/not-null heights).
+    val ordinaryTicks =
+        (0..lastPoint step tickLength).map { distance -> TrackMeterHeightTick(distance.toBigDecimal(), null) }
+    val allTicks = (alignmentBoundaryTicks + ordinaryTicks).sortedBy { it.trackMeterInKm }
+    return allTicks.filterIndexed { i, (trackMeterInKm, segmentIndex) ->
+        tickIsGoodToSend(segmentIndex, i, trackMeterInKm, allTicks, minTickSpace)
+    }
+}
+
+// Logic for visualization: prevent height ticks from getting too close to each other. Ordinary
+// ticks always have room between each other, we just want to prevent them from getting too close to
+// segment boundary ticks for clarity.
+private fun tickIsGoodToSend(
+    segmentIndex: Int?,
+    i: Int,
+    trackMeterInKm: BigDecimal,
+    allTicks: List<TrackMeterHeightTick>,
+    minTickSpace: BigDecimal,
+): Boolean {
+    val isSegmentBoundaryPoint = segmentIndex != null
+    val isKmStartTick = i == 0
+    val hasSpaceAfterPreviousTick = i > 0 && trackMeterInKm - allTicks[i - 1].trackMeterInKm >= minTickSpace
+    val hasSpaceBeforeNextTick =
+        (i == allTicks.lastIndex || allTicks[i + 1].trackMeterInKm - trackMeterInKm >= minTickSpace)
+
+    return isSegmentBoundaryPoint || isKmStartTick || (hasSpaceAfterPreviousTick && hasSpaceBeforeNextTick)
+}
+
+private fun fitKmTicksWithinAlignmentBounds(
+    kmNumber: KmNumber,
+    alignmentStart: AddressPoint,
+    alignmentEnd: AddressPoint,
+    ticks: List<TrackMeterHeightTick>,
+): List<TrackMeterHeightTick> {
+    // Special-case first and last alignment points so we get as close as possible to the track ends
+    val alignmentStartTick =
+        if (kmNumber == alignmentStart.address.kmNumber) TrackMeterHeightTick(alignmentStart.address.meters, null)
+        else null
+    val alignmentEndTick =
+        if (kmNumber == alignmentEnd.address.kmNumber) TrackMeterHeightTick(alignmentEnd.address.meters, null) else null
+
+    val ticksStrictlyAfterStart =
+        if (alignmentStartTick != null)
+            ticks.dropWhile { tick -> tick.trackMeterInKm <= alignmentStartTick.trackMeterInKm }
+        else ticks
+
+    val ticksStrictlyWithinAlignment =
+        if (alignmentEndTick != null)
+            ticksStrictlyAfterStart.takeWhile { tick -> tick.trackMeterInKm < alignmentEndTick.trackMeterInKm }
+        else ticksStrictlyAfterStart
+
+    return listOfNotNull(alignmentStartTick) + ticksStrictlyWithinAlignment + listOfNotNull(alignmentEndTick)
+}
+
+private fun getTickTrackLocationsByKm(
+    geocodingContext: GeocodingContext,
+    alignment: IAlignment,
+    ticksByKm: List<List<TrackMeterHeightTick>>,
+    referencePointIndices: IntRange,
+): List<List<AddressPoint>> {
+    val trackAddresses =
+        ticksByKm.zip(referencePointIndices) { kmTicks, referencePointIndex ->
+            val km = geocodingContext.referencePoints[referencePointIndex].kmNumber
+            kmTicks.map { tick -> TrackMeter(km, tick.trackMeterInKm) }
+        }
+    return processFlattened(trackAddresses) { allTrackAddresses ->
+        // null-safety: fitKmTicksWithinAlignmentBounds drops all ticks outside the alignment
+        // bounds, so everything is geocodable.
+        geocodingContext.getTrackLocations(alignment, allTrackAddresses).map(::checkNotNull)
+    }
+}
+
+private fun getKmLengthAtReferencePointIndex(referencePointIndex: Int, geocodingContext: GeocodingContext) =
+    if (referencePointIndex == geocodingContext.referencePoints.size - 1) {
+        geocodingContext.referenceLineGeometry.length - geocodingContext.referencePoints[referencePointIndex].distance
+    } else {
+        geocodingContext.referencePoints[referencePointIndex + 1].distance -
+            geocodingContext.referencePoints[referencePointIndex].distance
+    }
+
+private fun getLastEndM(
+    geocodingContext: GeocodingContext,
+    referencePointIndices: IntRange,
+    alignmentEnd: AddressPoint,
+    alignment: IAlignment,
+): Double =
+    if (geocodingContext.referencePoints[referencePointIndices.last].kmNumber == alignmentEnd.address.kmNumber)
+        alignmentEnd.point.m
+    else {
+        // indexing and null safety: Here we know we're on a track km before the alignment's end
+        // address, so the next track km's start address must both exist on the reference line and
+        // be geocodable onto the alignment.
+        val nextKmTrackAddress =
+            TrackMeter(geocodingContext.referencePoints[referencePointIndices.last + 1].kmNumber, 0)
+        checkNotNull(geocodingContext.getTrackLocation(alignment, nextKmTrackAddress)).point.m
+    }
+
+data class GeometryAlignmentBoundaryPoint(val distanceOnAlignment: Double, val segmentIndex: Int)
+
+data class TrackMeterHeightTick(val trackMeterInKm: BigDecimal, val segmentIndex: Int?)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
@@ -22,3 +22,11 @@ fun rangesOfConsecutiveIndicesOf(
         .chunked(2)
         .map { c -> c[0] until c[1] + offsetRangeEndsBy }
         .toList()
+
+fun <T> chunkBySizes(list: List<T>, sizes: List<Int>): List<List<T>> {
+    val starts = sizes.scan(0) { acc, size -> acc + size }
+    return sizes.zip(starts) { size, start -> list.subList(start, start + size) }
+}
+
+fun <T, R> processFlattened(lists: List<List<T>>, process: (listIn: List<T>) -> List<R>): List<List<R>> =
+    chunkBySizes(process(lists.flatten()), lists.map { it.size })

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/util/ListTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/util/ListTest.kt
@@ -19,4 +19,12 @@ class ListTest {
         assertEquals(listOf(0..2, 3..4), rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false), 1))
         assertEquals(listOf(0..3, 3..5), rangesOfConsecutiveIndicesOf(false, listOf(false, false, true, false), 2))
     }
+
+    @Test
+    fun `chunkBySizes chunks by sizes`() {
+        assertEquals(
+            listOf(listOf(1), listOf(2, 3), listOf(4, 5, 6), listOf(7, 8, 9, 10)),
+            chunkBySizes((1..10).toList(), listOf(1, 2, 3, 4)),
+        )
+    }
 }


### PR DESCRIPTION
Tämä funktio oli aikoinaan Geoviitteen huonous-aatelia, nyt räjäytetty selkeämmin nimetyiksi ja kommentoiduiksi kokonaisuuksiksi. Ei funktionaalisia muutoksia, mutta optimointimuutoksia kyllä: Laskutoimituksia tehdään nyt huomattavasti tarkemmin niin, että pyydetyn ratakilometrivälin ulkopuoliset asiat ja raiteelle osumattomat asiat suodatetaan aikaisin pois, ja geokoodaukset pyritään tekemään yhdessä isossa getTrackLocations()-pompsissa. Aiemmalle rinnakkaistukselle ei näin ole enää tarvetta.