### PR TITLE
GVT-2883 Treat zero geometry km post locations as null

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -84,7 +84,9 @@ fun toTrackLayoutKmPosts(
     planToGkTransformation: ToGkFinTransformation,
 ): List<TrackLayoutKmPost> {
     return kmPosts.mapIndexedNotNull { _, kmPost ->
-        if (kmPost.location != null && kmPost.kmNumber != null) {
+        if (
+            kmPost.location != null && kmPost.kmNumber != null && (kmPost.location.x != 0.0 || kmPost.location.y != 0.0)
+        ) {
             TrackLayoutKmPost(
                 kmNumber = kmPost.kmNumber,
                 state = getLayoutStateOrDefault(kmPost.state),


### PR DESCRIPTION
Osassa suunnitelmista (useissa, jotka nimen mukaan on "muutettu") tulee ensimmäisenä kilometritolppana outous, jolla onkin tavallisen nullin sijasta sijaintina (0, 0). Tehdään perinteiset ATK-tepposet ja hämmennetään tätä nolla-nulli-soppaa lisää käsittämällä vaan nämäkin sijainnittomiksi, jotta saadaan nämäkin suunnitelmat piirtymään kartalla.