### PR TITLE
GVT-2577 (part 5): Add root path redirect & automatic index.html serving

### DIFF
--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -41,6 +41,8 @@ spring:
 
 geoviite:
   api-root: "/api"
+  app-root: "/app"
+
   cookies:
     secure: true
 


### PR DESCRIPTION
Aiemmin sama toiminnallisuus on ollut ympäristökonffissa (cloudfront), ja nyt kun ympäristö yksinkertaistuu, niin tällaista pikkutoiminnallisuutta päätyy monoliitin puolelle 