### PR TITLE
GVT-2874: Virasto- ja konsulttikäyttäjille näytetään yläpalkissa ekstraväli

### DIFF
--- a/ui/src/tool-bar/tool-bar.scss
+++ b/ui/src/tool-bar/tool-bar.scss
@@ -61,14 +61,15 @@
         padding: 12px 8px;
         max-width: none;
 
+        > * {
+            min-height: 24px;
+            display: flex;
+            align-items: center;
+        }
+
         &:not(:last-child) {
             margin-right: 10px;
         }
-    }
-
-    &__design-tab-content {
-        display: flex;
-        align-items: center;
     }
 
     &__design-name {

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -442,7 +442,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         title={layoutContextTransferDisabledReason()}
                         disabled={!!splittingState || !!linkingState}
                         onClick={() => switchToMainOfficial()}>
-                        {t('tool-bar.current-mode')}
+                        <span>{t('tool-bar.current-mode')}</span>
                     </TabHeader>
                     <PrivilegeRequired privilege={VIEW_LAYOUT_DRAFT}>
                         <TabHeader
@@ -452,7 +452,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                             title={layoutContextTransferDisabledReason()}
                             disabled={!!splittingState || !!linkingState}
                             onClick={() => switchToMainDraft()}>
-                            {t('tool-bar.draft-mode')}
+                            <span>{t('tool-bar.draft-mode')}</span>
                         </TabHeader>
                     </PrivilegeRequired>
                     <EnvRestricted restrictTo={'test'}>
@@ -465,7 +465,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                     title={layoutContextTransferDisabledReason()}
                                     disabled={!!splittingState || !!linkingState}
                                     onClick={switchToDesign}>
-                                    <div className={styles['tool-bar__design-tab-content']}>
+                                    <span>
                                         {t('tool-bar.design-mode')}
                                         <span>{currentDesign && `:`}</span>
                                         <div className={styles['tool-bar__design-tab-actions']}>
@@ -519,7 +519,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                                     )}
                                             </PrivilegeRequired>
                                         </div>
-                                    </div>
+                                    </span>
                                 </TabHeader>
 
                                 {showDesignIdSelector && (


### PR DESCRIPTION
Täällä ongelmana oli, että kaikki `<ToolBar>`:in `<TabHeader>`:it flexbox-itemeinä laskivat korkeutensa korkeimman tabheaderin mukaan. Suunnitelmatilan valinta-dropdownin kadotessa näkyvistä `<TabHeader>`:eilla ei ole enää syytä olla yhtä korkeita kuin jos se olisi näkyvissä, mutta itse `<ToolBar>`:in korkeus pysyi (on joko määritetty staattisesti tai lasketaan hakulaatikon perusteella, en tarkastanut.) Tämä näkyi käytännössä tuona tiketin mainitsemana välinä. Jumppasin nyt toolbarin tabheaderien sisällöille minimikorkeuden ja yhdenmukaistin muutenkin tabien sisältöjä -> nyt joka näkymässä tabien pitäisi olla yhtä korkeita, ja suunnitelmatilan valintatabi on nyt tekniseltä rakenteeltaan vähemmän special snowflake.