### PR TITLE
GVT-2813: Kynäikonien karsinta

### DIFF
--- a/ui/src/tool-panel/infobox/infobox-field.tsx
+++ b/ui/src/tool-panel/infobox/infobox-field.tsx
@@ -1,21 +1,13 @@
 import React from 'react';
 import styles from './infobox.module.scss';
-import { Icons } from 'vayla-design-lib/icon/Icon';
 import { createClassName } from 'vayla-design-lib/utils';
-import { useTranslation } from 'react-i18next';
-import { PrivilegeRequired } from 'user/privilege-required';
-import { EDIT_LAYOUT } from 'user/user-model';
-import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 
 type InfoboxFieldProps = {
     label: React.ReactNode;
     qaId?: string;
     value?: React.ReactNode;
     children?: React.ReactNode;
-    onEdit?: () => void;
     className?: string;
-    iconDisabled?: boolean;
-    iconHidden?: boolean;
     hasErrors?: boolean;
 };
 
@@ -25,16 +17,9 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
     children,
     className,
     qaId,
-    iconDisabled = false,
-    iconHidden = false,
     hasErrors = false,
-    ...props
 }: InfoboxFieldProps) => {
     const classes = createClassName(styles['infobox__field'], className);
-    const { t } = useTranslation();
-    const iconTitle = iconDisabled
-        ? t('tool-panel.disabled.activity-disabled-in-official-mode')
-        : '';
 
     return (
         <div className={classes} qa-id={qaId}>
@@ -52,21 +37,6 @@ const InfoboxField: React.FC<InfoboxFieldProps> = ({
                 )}>
                 {children || value}
             </div>
-            {props.onEdit && !iconHidden && (
-                <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                    <span qa-id={`${qaId}-edit`}>
-                        <Button
-                            title={iconTitle}
-                            disabled={iconDisabled || !props.onEdit}
-                            icon={Icons.Edit}
-                            variant={ButtonVariant.GHOST}
-                            size={ButtonSize.SMALL}
-                            onClick={() => !iconDisabled && props.onEdit && props.onEdit()}
-                            qa-id={`infobox-edit-button`}
-                        />
-                    </span>
-                </PrivilegeRequired>
-            )}
         </div>
     );
 };

--- a/ui/src/tool-panel/infobox/infobox.module.scss
+++ b/ui/src/tool-panel/infobox/infobox.module.scss
@@ -13,16 +13,29 @@
         background-color: vayla-design.$color-white-dark;
         box-shadow: 0 1px 1px rgba(vayla-design.$color-black-default, 0.12);
         margin-bottom: 8px;
-        padding: 12px 0 8px 20px;
         user-select: none;
         cursor: pointer;
 
-        .icon {
+        &-accordion {
+            padding: 12px 0 8px 20px;
+            display: flex;
+            flex-grow: 1;
+        }
+
+        &-edit-icon {
+            margin-right: 2px;
+        }
+
+        &-content {
+            flex-grow: 1;
+        }
+
+        &-chevron .icon {
             margin-right: 12px;
             transition: transform 254ms;
         }
 
-        &--visible .icon {
+        &-chevron--visible .icon {
             transform: rotate(90deg);
         }
     }

--- a/ui/src/tool-panel/infobox/infobox.tsx
+++ b/ui/src/tool-panel/infobox/infobox.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import styles from './infobox.module.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
+import { PrivilegeRequired } from 'user/privilege-required';
+import { EDIT_LAYOUT } from 'user/user-model';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { useTranslation } from 'react-i18next';
 
 export enum InfoBoxVariant {
     BLUE = 'infobox--blue',
@@ -14,6 +18,10 @@ export type InfoboxProps = {
     className?: string;
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
+    iconDisabled?: boolean;
+    iconHidden?: boolean;
+    onEdit?: () => void;
+    qaId?: string;
 };
 
 const Infobox: React.FC<InfoboxProps> = ({
@@ -22,19 +30,53 @@ const Infobox: React.FC<InfoboxProps> = ({
     className,
     contentVisible,
     onContentVisibilityChange,
+    qaId,
+    iconDisabled = false,
+    iconHidden = false,
+    onEdit,
     ...props
 }: InfoboxProps) => {
+    const { t } = useTranslation();
+    const iconTitle = iconDisabled
+        ? t('tool-panel.disabled.activity-disabled-in-official-mode')
+        : '';
+
     const classes = createClassName(styles.infobox, variant && styles[variant], className);
     const titleClasses = createClassName(
         'infobox__title',
         contentVisible && 'infobox__title--visible',
     );
 
+    const chevronClasses = createClassName(
+        'infobox__title-chevron',
+        contentVisible && 'infobox__title-chevron--visible',
+    );
+
     return (
         <div className={classes} {...props}>
-            <div className={titleClasses} onClick={onContentVisibilityChange}>
-                <Icons.Chevron size={IconSize.SMALL}></Icons.Chevron>
-                {title}
+            <div className={titleClasses}>
+                <span
+                    className={styles['infobox__title-accordion']}
+                    onClick={onContentVisibilityChange}>
+                    <span className={chevronClasses} onClick={onContentVisibilityChange}>
+                        <Icons.Chevron size={IconSize.SMALL} />
+                    </span>
+                    <span className={styles['infobox__title-content']}>{title}</span>
+                </span>
+                {onEdit && !iconHidden && (
+                    <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                        <span qa-id={`${qaId}-edit`} className={styles['infobox__title-edit-icon']}>
+                            <Button
+                                title={iconTitle}
+                                disabled={iconDisabled || !onEdit}
+                                icon={Icons.Edit}
+                                variant={ButtonVariant.GHOST}
+                                onClick={() => !iconDisabled && onEdit && onEdit()}
+                                qa-id={`infobox-edit-button`}
+                            />
+                        </span>
+                    </PrivilegeRequired>
+                )}
             </div>
             {contentVisible && props.children}
         </div>

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -161,25 +161,17 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
               ? t('tool-panel.km-post.layout.negative-kilometer-length')
               : `${roundToPrecision(infoboxExtras.kmLength, 3)} m`;
 
-    const InfoboxFieldWithEditLink: React.FC<
-        Omit<React.ComponentProps<typeof InfoboxField>, 'onEdit' | 'iconDisabled'>
-    > = (props) => (
-        <InfoboxField
-            {...props}
-            onEdit={openEditDialog}
-            iconDisabled={layoutContext.publicationState === 'OFFICIAL'}
-        />
-    );
-
     return (
         <React.Fragment>
             <Infobox
                 title={t('tool-panel.km-post.layout.general-title')}
                 qa-id="km-post-infobox"
                 contentVisible={visibilities.basic}
-                onContentVisibilityChange={() => visibilityChange('basic')}>
+                onContentVisibilityChange={() => visibilityChange('basic')}
+                onEdit={openEditDialog}
+                iconDisabled={layoutContext.publicationState === 'OFFICIAL'}>
                 <InfoboxContent>
-                    <InfoboxFieldWithEditLink
+                    <InfoboxField
                         qaId="km-post-km-number"
                         label={t('tool-panel.km-post.layout.km-post')}
                         value={updatedKmPost?.kmNumber}
@@ -193,7 +185,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                             />
                         }
                     />
-                    <InfoboxFieldWithEditLink
+                    <InfoboxField
                         label={t('tool-panel.km-post.layout.state')}
                         value={<LayoutState state={kmPost.state} />}
                     />
@@ -228,9 +220,11 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                 title={t('tool-panel.km-post.layout.location-title')}
                 qa-id="layout-km-post-location-infobox"
                 contentVisible={visibilities.location}
-                onContentVisibilityChange={() => visibilityChange('location')}>
+                onContentVisibilityChange={() => visibilityChange('location')}
+                onEdit={openEditDialog}
+                iconDisabled={layoutContext.publicationState === 'OFFICIAL'}>
                 <InfoboxContent>
-                    <InfoboxFieldWithEditLink
+                    <InfoboxField
                         qaId="km-post-gk-coordinate-system"
                         label={t('tool-panel.km-post.layout.gk-coordinates.coordinate-system')}
                         value={
@@ -240,7 +234,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                             />
                         }
                     />
-                    <InfoboxFieldWithEditLink
+                    <InfoboxField
                         qaId="km-post-gk-coordinates"
                         label={
                             gkCoordinateSystem === undefined
@@ -255,7 +249,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                 : '-'
                         }
                     />
-                    <InfoboxFieldWithEditLink
+                    <InfoboxField
                         qaId="km-post-gk-coordinates-confirmed"
                         label={t(`tool-panel.km-post.layout.gk-coordinates.confirmed-title`)}
                         value={t(

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -125,6 +125,8 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
             contentVisible={visibilities.basic && extraInfoLoadingStatus != LoaderStatus.Loading}
             onContentVisibilityChange={() => visibilityChange('basic')}
             title={t('tool-panel.location-track.basic-info-heading')}
+            onEdit={openEditLocationTrackDialog}
+            iconDisabled={editingDisabled}
             qa-id="location-track-infobox">
             <InfoboxContent>
                 <InfoboxField
@@ -136,36 +138,26 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                     qaId="location-track-name"
                     label={t('tool-panel.location-track.track-name')}
                     value={locationTrack.name}
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxField
                     qaId="location-track-state"
                     label={t('tool-panel.location-track.state')}
                     value={<LocationTrackState state={locationTrack.state} />}
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxField
                     qaId="location-track-type"
                     label={t('tool-panel.location-track.type')}
                     value={<LocationTrackTypeLabel type={locationTrack.type} />}
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxField
                     qaId="location-track-description"
                     label={t('tool-panel.location-track.description')}
                     value={description}
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxField
                     qaId="location-track-track-number"
                     label={t('tool-panel.location-track.track-number')}
                     value={<TrackNumberLinkContainer trackNumberId={trackNumber?.id} />}
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxText value={trackNumber?.description} />
                 <InfoboxField
@@ -186,9 +178,6 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                             currentTrackNumberId={trackNumber?.id}
                         />
                     }
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
-                    iconHidden={!locationTrack.duplicateOf}
                 />
                 <InfoboxField
                     label={t('tool-panel.location-track.topological-connectivity')}
@@ -197,14 +186,10 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                             topologicalConnectivity={locationTrack.topologicalConnectivity}
                         />
                     }
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxField
                     label={t('tool-panel.location-track.owner')}
                     value={getLocationTrackOwnerName(locationTrack.ownerId)}
-                    onEdit={openEditLocationTrackDialog}
-                    iconDisabled={editingDisabled}
                 />
                 <InfoboxField
                     label={t('tool-panel.location-track.start-switch')}

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -216,7 +216,9 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                     contentVisible={visibilities.basic}
                     onContentVisibilityChange={() => visibilityChange('basic')}
                     title={t('tool-panel.switch.layout.general-heading')}
-                    qa-id="switch-infobox">
+                    qa-id="switch-infobox"
+                    onEdit={openEditSwitchDialog}
+                    iconDisabled={isOfficial()}>
                     <InfoboxContent>
                         <InfoboxField
                             label={t('tool-panel.switch.layout.km-m')}
@@ -240,8 +242,6 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             qaId="switch-name"
                             label={t('tool-panel.switch.layout.name')}
                             value={layoutSwitch.name}
-                            onEdit={openEditSwitchDialog}
-                            iconDisabled={isOfficial()}
                         />
                         <InfoboxField
                             qaId="switch-state-category"
@@ -249,8 +249,6 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             value={
                                 <LayoutStateCategoryLabel category={layoutSwitch.stateCategory} />
                             }
-                            onEdit={openEditSwitchDialog}
-                            iconDisabled={isOfficial()}
                         />
                         <InfoboxButtons>
                             <Button

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -156,7 +156,9 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                 contentVisible={visibilities.basic}
                 onContentVisibilityChange={() => visibilityChange('basic')}
                 title={t('tool-panel.track-number.general-title')}
-                qa-id="track-number-infobox">
+                qa-id="track-number-infobox"
+                onEdit={() => setShowEditDialog(true)}
+                iconDisabled={isOfficial}>
                 <InfoboxContent>
                     <InfoboxField
                         qaId="track-number-oid"
@@ -167,22 +169,16 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                         qaId="track-number-name"
                         label={t('tool-panel.track-number.track-number')}
                         value={trackNumber.number}
-                        onEdit={() => setShowEditDialog(true)}
-                        iconDisabled={isOfficial}
                     />
                     <InfoboxField
                         qaId="track-number-state"
                         label={t('tool-panel.track-number.state')}
                         value={<LayoutState state={trackNumber.state} />}
-                        onEdit={() => setShowEditDialog(true)}
-                        iconDisabled={isOfficial}
                     />
                     <InfoboxField
                         qaId="track-number-description"
                         label={t('tool-panel.track-number.description')}
                         value={trackNumber.description}
-                        onEdit={() => setShowEditDialog(true)}
-                        iconDisabled={isOfficial}
                     />
                 </InfoboxContent>
             </Infobox>
@@ -191,7 +187,9 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     contentVisible={visibilities.referenceLine}
                     onContentVisibilityChange={() => visibilityChange('referenceLine')}
                     title={t('tool-panel.reference-line.basic-info-heading')}
-                    qa-id="reference-line-location-infobox">
+                    qa-id="reference-line-location-infobox"
+                    onEdit={() => setShowEditDialog(true)}
+                    iconDisabled={isOfficial}>
                     <InfoboxContent>
                         <InfoboxField
                             qaId="track-number-start-track-meter"
@@ -202,8 +200,6 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                                     location={startAndEndPoints?.start?.point}
                                 />
                             }
-                            onEdit={() => setShowEditDialog(true)}
-                            iconDisabled={isOfficial}
                         />
                         <InfoboxField
                             qaId="track-number-end-track-meter"


### PR DESCRIPTION
Täällä siis poistettu kynäikonit infobokseista yksittäisten kenttien yhteydestä ja korvattu ne infoboksin headerissa asuvalla kynäikonilla