### PR TITLE
GVT-2897: Fix improper usage of error-blocks

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVClient.kt
@@ -64,7 +64,7 @@ constructor(val pvWebClient: PVWebClient, val pvLoginWebClient: PVLoginWebClient
             .body(BodyInserters.fromFormData("grant_type", "client_credentials"))
             .retrieve()
             .bodyToMono<PVAccessToken>()
-            .block(defaultBlockTimeout) ?: error { "ProjektiVelho login failed" }
+            .block(defaultBlockTimeout) ?: error("ProjektiVelho login failed")
     }
 
     fun postXmlFileSearch(fetchStartTime: Instant, startOid: Oid<PVDocument>?): PVApiSearchStatus {
@@ -209,7 +209,7 @@ constructor(val pvWebClient: PVWebClient, val pvLoginWebClient: PVLoginWebClient
                     token
                 }
             }
-            ?.accessToken ?: error { "ProjektiVelho login token can't be null after login" }
+            ?.accessToken ?: error("ProjektiVelho login token can't be null after login")
 }
 
 fun encodingTypeDictionary(type: PVDictionaryType) = "${encodingGroupPath(type.group)}/${encodingTypePath(type)}"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/testing/GeoviiteTestingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/testing/GeoviiteTestingController.kt
@@ -15,6 +15,6 @@ class GeoviiteTestingController {
     @PreAuthorize(AUTH_BASIC)
     @GetMapping("/stack-trace")
     fun testStackTrace() {
-        error { "This is a stack trace logging test" }
+        error("This is a stack trace logging test")
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -113,9 +113,9 @@ sealed class LayoutContextData<T> : LayoutContextAware<T> {
         contextIdHolder.let { current ->
             if (current is StoredContextIdHolder) current.version
             else
-                error {
+                error(
                     "Only $STORED rows can transition to a different context: context=${this::class.simpleName} dataType=$dataType"
-                }
+                )
         }
 
     companion object {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
@@ -90,7 +90,7 @@ class LayoutDesignDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(
                 .trimIndent()
         val response =
             jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getRowVersion<LayoutDesign>("id", "version") }
-                ?: error { "Failed to generate ID for new row version of updated layout design" }
+                ?: error("Failed to generate ID for new row version of updated layout design")
         logger.daoAccess(AccessType.UPDATE, LayoutDesign::class, response)
         return response.id
     }
@@ -115,7 +115,7 @@ class LayoutDesignDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(
                 ),
             ) { rs, _ ->
                 rs.getRowVersion<LayoutDesign>("id", "version")
-            } ?: error { "Failed to generate ID for new layout design" }
+            } ?: error("Failed to generate ID for new layout design")
         logger.daoAccess(AccessType.INSERT, LayoutDesign::class, response)
         return response.id
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -255,7 +255,7 @@ constructor(
     private fun alignmentExists(id: IntId<LayoutAlignment>): Boolean {
         val sql = "select exists(select 1 from layout.alignment where id = :id) as exists"
         val params = mapOf("id" to id.intValue)
-        return jdbc.queryForObject(sql, params) { rs, _ -> rs.getBoolean("exists") } ?: error { "Exists-check failed" }
+        return jdbc.queryForObject(sql, params) { rs, _ -> rs.getBoolean("exists") } ?: error("Exists-check failed")
     }
 
     private fun createAndPublishTrackNumber() =


### PR DESCRIPTION
The Kotlin standard error-function does not support using lazily-evaluated values. These kinds of blocks were logged as "() -> String)" instead of the actual error message.