### PR TITLE
General: Use public AWS ECR images, bump Selenium image version

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,10 @@
 TAG_GEOVIITE_BUILD_VERSION=latest
 
-IMAGE_BASE_BACKEND_BUILD=eclipse-temurin:17-jdk
-IMAGE_BASE_FRONTEND_BUILD=node:20-alpine
-IMAGE_BASE_DISTRIBUTION=eclipse-temurin:17-jre
-IMAGE_E2E_SELENIUM_CHROME=selenium/standalone-chromium:4.25.0-20241010
+IMAGE_BASE_BACKEND_BUILD=public.ecr.aws/docker/library/eclipse-temurin:17-jdk
+IMAGE_BASE_FRONTEND_BUILD=public.ecr.aws/docker/library/node:20-alpine
+IMAGE_BASE_DISTRIBUTION=public.ecr.aws/docker/library/eclipse-temurin:17-jre
+
+IMAGE_E2E_SELENIUM_CHROME=selenium/standalone-chromium:4.25.0-20241024
 
 IMAGE_DB=geoviite-postgres:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG IMAGE_BASE_BACKEND_BUILD=eclipse-temurin:17-jdk
-ARG IMAGE_BASE_FRONTEND_BUILD=node:20-alpine
-ARG IMAGE_BASE_BACKEND_BUILD=eclipse-temurin:17-jdk
-ARG IMAGE_BASE_DISTRIBUTION=eclipse-temurin:17-jre
+ARG IMAGE_BASE_BACKEND_BUILD=public.ecr.aws/docker/library/eclipse-temurin:17-jdk
+ARG IMAGE_BASE_FRONTEND_BUILD=public.ecr.aws/docker/library/node:20-alpine
+ARG IMAGE_BASE_DISTRIBUTION=public.ecr.aws/docker/library/eclipse-temurin:17-jre
 
 ARG IMAGE_BACKEND_DEPENDENCIES="geoviite-backend-dependencies"
 ARG IMAGE_BACKEND=geoviite-backend-build


### PR DESCRIPTION
These images are synchronized from the public and default Docker repo, but AWS has softer ratelimits.