### PR TITLE
GVT-2901: Fix deprecation warning

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -84,7 +84,7 @@ module.exports = (env) => {
                     target: process.env.PROJEKTIVELHO_REDIRECT_URL,
                     logLevel: 'debug',
                     changeOrigin: true,
-                    pathRewrite: (_path, req) => {
+                    router: function (req) {
                         const documentOid = req.query['document'];
                         const assignmentOid = req.query['assignment'];
                         const projectOid = req.query['project'];


### PR DESCRIPTION
Korjaa nillityksen:
```
DeprecationWarning: Invalid proxy configuration:
{
  "context": "/redirect/projektivelho/files",
  "logLevel": "debug",
  "changeOrigin": true
}
The use of proxy object notation as proxy routes has been removed.
```