### PR TITLE
GVT-2759 (Part 2): Sijaintiraiteen manuaalisen Ratko-puskun käyttökokemusrefakki

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -44,9 +44,9 @@ class RatkoController(private val ratkoServiceParam: RatkoService?, private val 
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)
     @PostMapping("/push-location-tracks")
-    fun pushLocationTracksToRatko(@RequestBody changes: List<LocationTrackChange>): ResponseEntity<String> {
+    fun pushLocationTracksToRatko(@RequestBody changes: List<LocationTrackChange>): ResponseEntity<Unit> {
         ratkoService.pushLocationTracksToRatko(LayoutBranch.main, changes)
-        return ResponseEntity(HttpStatus.OK)
+        return ResponseEntity(HttpStatus.NO_CONTENT)
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -698,7 +698,9 @@
                 "km-range": "Ratakilometriväli",
                 "start-km": "Alkukilometri",
                 "end-km": "Loppukilometri",
-                "push": "Vie Ratkoon"
+                "push": "Vie Ratkoon",
+                "pushing-started": "Sijaintiraiteen tietojen vienti käynnistetty",
+                "follow-in-ratko": "Seuraa raidetta Ratkosta"
             },
             "vertical-geometry": {
                 "heading": "Raiteen pystygeometria",

--- a/ui/src/ratko/ratko-api.ts
+++ b/ui/src/ratko/ratko-api.ts
@@ -29,5 +29,9 @@ type LocationTrackChange = {
 };
 
 export function pushLocationTracksToRatko(locationTrackChanges: LocationTrackChange[]) {
-    return postNullable(`${RATKO_URI}/push-location-tracks`, locationTrackChanges);
+    return postNullable<LocationTrackChange[], undefined>(
+        `${RATKO_URI}/push-location-tracks`,
+        locationTrackChanges,
+        false,
+    );
 }


### PR DESCRIPTION
Juteltiin tästä Karin kanssa Slackissa, ja päädyttiin erilaiseen malliin kuin mitä tiketille oltiin alunperin kirjoitettu. Sen sijasta että oltaisiin lähdetty tekemään tähän monimutkaista virhekäsittelyä, niin käsitelläänkin tämä fire-and-foget-tyylillä. Siinä missä aiemmin sijaintiraiteen manuaalinen Ratko-vienti jätti vientidialogin auki pyörittämään spinneriä, näyttäen geneerisiä virheilmoituksia puskun epäonnistuessa tai viimeistään CloudFrontin timeoutatessa. (Toim.huom. dialogin sai kyllä suljettua Peruuta-napista, joka ei oikeasti bäkkärin näkökulmasta peruuttanut mitään.)

Nyt dialogi suljetaan välittömästi viennin aloituksen jälkeen, ja operaattorille näytetään toasti jossa ohjeistetaan seuraamaan raidetta Ratkosta. Tämä siksi, että vienti on synkroninen operaatio ja sen muuttaminen asynciksi olisi vaatinut monimutkaisempaa logiikkaa bäkkärille ja uusia tauluja kantaan. Kun kyseessä on kuitenkin lähinnä erikoistilanteissa käytettäväksi tarkoitettu niche-feature, niin siihen ei haluta panostaa niin paljoa.