### PR TITLE
GVT-2892: Ratko-puskun virhekäsittely ei huomioi hauissa aiheutuvia virheitä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
@@ -16,6 +16,7 @@ enum class RatkoOperation {
     CREATE,
     UPDATE,
     DELETE,
+    FETCH_EXISTING,
 }
 
 enum class RatkoAssetType {

--- a/infra/src/main/resources/db/migration/prod/V98__add_fetch_ratko_push_error_operation.sql
+++ b/infra/src/main/resources/db/migration/prod/V98__add_fetch_ratko_push_error_operation.sql
@@ -1,0 +1,1 @@
+alter type integrations.ratko_push_error_operation add value 'FETCH_EXISTING';

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -271,7 +271,8 @@
         "ratko-push-error-operation": {
             "CREATE": "luonti",
             "UPDATE": "päivitys",
-            "DELETE": "poisto"
+            "DELETE": "poisto",
+            "FETCH_EXISTING": "pohjatietojen hakeminen Ratkosta"
         },
         "trap-point": {
             "Yes": "Kyllä",
@@ -1672,7 +1673,8 @@
             "switch": "Vaihteen",
             "connection-issue": "Yhteysvirhe Ratko-viennissä",
             "internal-error": "SISÄINEN VIRHE: {{assetType}} ({{name}}) {{operation}} epäonnistui. Ota yhteyttä {{geoviiteSupportEmail}}",
-            "ratko-error": "{{assetType}} ({{name}}) {{errorType}} {{operation}} epäonnistui"
+            "ratko-error": "{{assetType}} ({{name}}) {{errorType}} {{operation}} epäonnistui",
+            "ratko-fetch-error": "{{assetType}} ({{name}}) {{operation}} epäonnistui"
         }
     },
     "split-details-dialog": {

--- a/ui/src/ratko/ratko-model.ts
+++ b/ui/src/ratko/ratko-model.ts
@@ -28,7 +28,7 @@ export const ratkoPushSucceeded = (status: RatkoPushStatus | undefined) =>
 
 export type RatkoPushErrorType = 'PROPERTIES' | 'GEOMETRY' | 'LOCATION' | 'STATE' | 'INTERNAL';
 
-export type RatkoPushErrorOperation = 'CREATE' | 'DELETE' | 'UPDATE';
+export type RatkoPushErrorOperation = 'CREATE' | 'DELETE' | 'UPDATE' | 'FETCH_EXISTING';
 
 export enum RatkoAssetType {
     TRACK_NUMBER = 'TRACK_NUMBER',

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -55,6 +55,13 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
     }
 
     const isInternalError = error.errorType === 'INTERNAL';
+    const isFetchError = error.operation === 'FETCH_EXISTING';
+
+    const ratkoFetchErrorString = t('publication-card.push-error.ratko-fetch-error', {
+        assetType: t(assetTranslationKeyByType(error)),
+        name: assetNameByType(error),
+        operation: t(`enum.ratko-push-error-operation.${error.operation}`),
+    });
 
     const ratkoErrorString = t('publication-card.push-error.ratko-error', {
         assetType: t(assetTranslationKeyByType(error)),
@@ -78,7 +85,9 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
                 ? t('publication-card.push-error.connection-issue')
                 : isInternalError
                   ? internalErrorString
-                  : ratkoErrorString}
+                  : isFetchError
+                    ? ratkoFetchErrorString
+                    : ratkoErrorString}
         </div>
     );
 };

--- a/ui/src/utils/enum-localization-utils.ts
+++ b/ui/src/utils/enum-localization-utils.ts
@@ -75,7 +75,7 @@ export const ratkoPushErrorTypes: LocalizedEnum<RatkoPushErrorType>[] = values(
 
 export const ratkoPushErrorOperations: LocalizedEnum<RatkoPushErrorOperation>[] = values(
     'ratko-push-error-operation',
-    ['CREATE', 'UPDATE', 'DELETE'],
+    ['CREATE', 'UPDATE', 'DELETE', 'FETCH_EXISTING'],
 );
 
 export const topologicalConnectivityTypes: LocalizedEnum<TopologicalConnectivityType>[] = values(


### PR DESCRIPTION
Täällä käytännössä lisätty virheidenkäsittely Ratko-puskussa tehtäville Ratkon assettien hauille. Testasin tämän käsin (sikäli kun pystyin, en koittanut saada mitään oikeaa Ratko-ympäristöä palauttamaan virhettä.) Automaattitestit tämä kuitenkin kaipaisi, ja `FakeRatko`:lla ne pitäisi kyllä pystyä tekemään - nyt vaan loppui vähän aika. Jäävät työlistalle loman jälkeiseen maailmaan