### PR TITLE
General: Simplify in_layout_context functions

### DIFF
--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -42,35 +42,12 @@ select
 $$;
 
 create function layout.track_number_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
-  returns table
-          (
-            layout_context_id text,
-            id integer,
-            design_id   integer,
-            draft   boolean,
-            version integer,
-            external_id varchar(50),
-            number      varchar(30),
-            description varchar(100),
-            state       layout.state,
-            change_user varchar(30),
-            change_time timestamptz
-          )
+  returns setof layout.track_number
   language sql
   stable
 as
 $$
-select
-  row.layout_context_id,
-  row.id,
-  design_id,
-  row.draft,
-  row.version,
-  row.external_id,
-  row.number,
-  row.description,
-  row.state,
-  row.change_user,
-  row.change_time
-  from layout.track_number row, layout.track_number_is_in_layout_context(publication_state_in, design_id_in, row)
+select *
+from layout.track_number,
+  layout.track_number_is_in_layout_context(publication_state_in, design_id_in, track_number)
 $$;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -42,43 +42,12 @@ select
 $$;
 
 create function layout.reference_line_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
-  returns table
-          (
-            layout_context_id text,
-            id                integer,
-            design_id         integer,
-            draft             boolean,
-            version           integer,
-            track_number_id   int,
-            alignment_id      int,
-            alignment_version int,
-            start_address     varchar(20),
-            change_user       varchar(30),
-            change_time       timestamptz,
-            bounding_box      postgis.geometry(Polygon, 3067),
-            length            numeric(13, 6),
-            segment_count     int
-          )
+  returns setof layout.reference_line
   language sql
   stable
 as
 $$
-select
-  row.layout_context_id,
-  row.id,
-  design_id,
-  row.draft,
-  row.version,
-  row.track_number_id,
-  row.alignment_id,
-  row.alignment_version,
-  row.start_address,
-  row.change_user,
-  row.change_time,
-  alignment.bounding_box,
-  alignment.length,
-  alignment.segment_count
-  from layout.reference_line row
-    left join layout.alignment on row.alignment_id = alignment.id,
-    layout.reference_line_is_in_layout_context(publication_state_in, design_id_in, row)
+select *
+from layout.reference_line,
+     layout.reference_line_is_in_layout_context(publication_state_in, design_id_in, reference_line)
 $$

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -42,65 +42,12 @@ select
 $$;
 
 create function layout.location_track_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
-  returns table
-          (
-            layout_context_id                  text,
-            id                                 integer,
-            design_id                          integer,
-            draft                              boolean,
-            version                            integer,
-            alignment_id                       integer,
-            alignment_version                  integer,
-            track_number_id                    integer,
-            external_id                        varchar(50),
-            name                               varchar(50),
-            description_base                   varchar(256),
-            description_suffix                 layout.location_track_description_suffix,
-            type                               layout.track_type,
-            state                              layout.location_track_state,
-            duplicate_of_location_track_id     integer,
-            topological_connectivity           layout.track_topological_connectivity_type,
-            topology_start_switch_id           integer,
-            topology_start_switch_joint_number integer,
-            topology_end_switch_id             integer,
-            topology_end_switch_joint_number   integer,
-            change_user                        varchar(30),
-            change_time                        timestamptz,
-            bounding_box                       postgis.geometry(Polygon, 3067),
-            length                             numeric(13, 6),
-            segment_count                      integer
-          )
+  returns setof layout.location_track
   language sql
   stable
 as
 $$
-select
-  row.layout_context_id,
-  row.id,
-  design_id,
-  row.draft,
-  row.version,
-  row.alignment_id,
-  row.alignment_version,
-  row.track_number_id,
-  row.external_id,
-  row.name,
-  row.description_base,
-  row.description_suffix,
-  row.type,
-  row.state,
-  row.duplicate_of_location_track_id,
-  row.topological_connectivity,
-  row.topology_start_switch_id,
-  row.topology_start_switch_joint_number,
-  row.topology_end_switch_id,
-  row.topology_end_switch_joint_number,
-  row.change_user,
-  row.change_time,
-  alignment.bounding_box,
-  alignment.length,
-  alignment.segment_count
-  from layout.location_track row
-    left join layout.alignment on row.alignment_id = alignment.id,
-    layout.location_track_is_in_layout_context(publication_state_in, design_id_in, row)
+select *
+from layout.location_track,
+  layout.location_track_is_in_layout_context(publication_state_in, design_id_in, location_track)
 $$;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -41,44 +41,12 @@ select
 $$;
 
 create function layout.switch_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
-  returns table
-          (
-            layout_context_id   text,
-            id                  integer,
-            design_id           integer,
-            draft               boolean,
-            version             integer,
-            external_id         varchar(50),
-            geometry_switch_id  integer,
-            name                varchar(50),
-            switch_structure_id integer,
-            state_category      layout.state_category,
-            trap_point          boolean,
-            owner_id            integer,
-            change_user         varchar(30),
-            change_time         timestamptz,
-            source              layout.geometry_source
-          )
+  returns setof layout.switch
   language sql
   stable
 as
 $$
-select
-  layout_context_id,
-  id,
-  design_id,
-  draft,
-  version,
-  row.external_id,
-  row.geometry_switch_id,
-  row.name,
-  row.switch_structure_id,
-  row.state_category,
-  row.trap_point,
-  row.owner_id,
-  row.change_user,
-  row.change_time,
-  row.source
-  from layout.switch row,
-    layout.switch_is_in_layout_context(publication_state_in, design_id_in, row)
+select *
+from layout.switch,
+  layout.switch_is_in_layout_context(publication_state_in, design_id_in, switch)
 $$;

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -42,40 +42,12 @@ select
 $$;
 
 create function layout.km_post_in_layout_context(publication_state_in layout.publication_state, design_id_in int)
-  returns table
-          (
-            layout_context_id   text,
-            id                  integer,
-            design_id           integer,
-            draft               boolean,
-            version             integer,
-            track_number_id     integer,
-            geometry_km_post_id integer,
-            km_number           varchar(6),
-            layout_location     postgis.geometry(Point, 3067),
-            gk_location         postgis.geometry(Point),
-            state               layout.state,
-            change_user         varchar(30),
-            change_time         timestamptz
-          )
+  returns setof layout.km_post
   language sql
   stable
 as
 $$
-select
-  layout_context_id,
-  id,
-  design_id,
-  draft,
-  version,
-  row.track_number_id,
-  row.geometry_km_post_id,
-  row.km_number,
-  row.layout_location,
-  row.gk_location,
-  row.state,
-  row.change_user,
-  row.change_time
-  from layout.km_post row,
-    layout.km_post_is_in_layout_context(publication_state_in, design_id_in, row)
+select *
+from layout.km_post,
+  layout.km_post_is_in_layout_context(publication_state_in, design_id_in, km_post)
 $$;


### PR DESCRIPTION
Noita ylimääräisiä alignment-taulusta joinattuja juttuja ei integraatio- ja kälitestien perusteella käytettykään (enää?) mistään, ja ID-remontin myötä poistui myös official-id-haut ja muut omituisuudet, joten näiden näkymien tarkoitukseksi voisi mielestäni pyhittää nyt sen, että niissä vaan näytetään halutun kontekstin paikannuspohjaa eikä tehdä muuta maailmanparannusta.