### PR TITLE
GVT-2788 Log response body on failing RatkoClient deletePoints

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -146,6 +146,10 @@ class FakeRatko(port: Int) {
         put("/api/infra/v1.0/locationtracks", mapOf("id" to locationTrackAsset.id)).respond(ok())
         get("/api/locations/v1.1/locationtracks/${locationTrackAsset.id}").respond(okJson(listOf(locationTrackAsset)))
         patch("/api/infra/v1.0/points/${locationTrackAsset.id}").respond(ok())
+        locationTrackAsset.nodecollection.nodes
+            .map { node -> node.point.km }
+            .distinct()
+            .forEach { km -> delete("/api/infra/v1.0/points/${locationTrackAsset.id}/${km}").respond(ok()) }
     }
 
     fun hasSwitch(switchAsset: InterfaceRatkoSwitch) {
@@ -324,6 +328,13 @@ class FakeRatko(port: Int) {
         bodyMatchType: MatchType? = null,
         times: Times? = null,
     ): ForwardChainExpectation = expectation(url, "PATCH", body, bodyMatchType, times)
+
+    private fun delete(
+        url: String,
+        body: Any? = null,
+        bodyMatchType: MatchType? = null,
+        times: Times? = null,
+    ): ForwardChainExpectation = expectation(url, "DELETE", body, bodyMatchType, times)
 
     private fun expectation(
         url: String,


### PR DESCRIPTION
FakeRatko-muutos ei liity ihan totaalisen suoraan tähän, mutta onpahan selvennystä sitä varten, että noihin deletointeihinkin vastataan loogisesti (ja oli hyvin hyödyksi testatessa, kun korvasi ok():n 500-statuksella). Aiemminhan tuo toimi vähän implisiittisesti niin, että siitä ei ollut mitään odotuksia, joten oletuksena FakeRatko vastasi 404-statusta, josta RatkoClient sitten katsoi erikseen että jaa sehän on juuri tässä tapauksessa ok.