### PR TITLE
GVT-2867 Create foreign keys to ID tables from layout asset tables more consistently

### DIFF
--- a/infra/src/main/resources/db/migration/prod/V99_03__redo_id_structure_for_track_number.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_03__redo_id_structure_for_track_number.sql
@@ -53,10 +53,9 @@ alter table integrations.ratko_push_error
   add constraint ratko_push_error_track_number_id_fkey
     foreign key (track_number_id) references layout.track_number_id (id);
 
+-- will be recreated after table rewrite
 alter table layout.track_number
-  drop constraint track_number_official_id_fkey,
-  add constraint track_number_official_id_fkey
-    foreign key (id) references layout.track_number_id (id);
+  drop constraint track_number_official_id_fkey;
 
 alter table publication.track_number
   drop constraint publication_track_number_track_number_fk,
@@ -93,7 +92,8 @@ set id = official_id, version = last_version.version
   );
 
 alter table layout.track_number
-  add constraint layout_track_number_pkey primary key (id, layout_context_id);
+  add constraint layout_track_number_pkey primary key (id, layout_context_id),
+  add constraint track_number_id_fkey foreign key (id) references layout.track_number_id (id);
 
 alter table layout.track_number
   add column origin_design_id int;

--- a/infra/src/main/resources/db/migration/prod/V99_07__redo_id_structure_for_location_track.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_07__redo_id_structure_for_location_track.sql
@@ -128,6 +128,7 @@ set id = official_id, version = last_version.version
 
 alter table layout.location_track
   add constraint layout_location_track_pkey primary key (id, layout_context_id),
+  add constraint location_track_id_fkey foreign key (id) references layout.location_track_id (id),
   -- excess constraint just for publication.split to have something to point to, as before
   add constraint location_track_id_version_unique unique (id, layout_context_id, version);
 
@@ -162,9 +163,6 @@ alter table layout.location_track
   drop column design_row_id;
 alter table layout.location_track
   drop column official_row_id;
-
-alter table layout.location_track
-  add constraint location_track_id_fkey foreign key (id) references layout.location_track_id (id);
 
 alter table layout.location_track
   enable trigger version_update_trigger;


### PR DESCRIPTION
Draftissa olevat ratanumerot rikkoivat migran, koska se loi vahingossa niiden foreign key-tarkistuksen id-tauluun liian aikaisin (ts. ennen iideitten uudelleenkirjoittamista).