### PR TITLE
General: Edit fetchProfileInfoForSegmentsInBoundingBox back into simple form

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -524,54 +524,39 @@ class LayoutAlignmentDao(
         // language=SQL
         val sql =
             """
-            with applicable_alignment_segments as (
-              select segment_version.alignment_id,
-                     segment_version.alignment_version,
-                     segment_version.segment_index,
-                     segment_version.start,
-                     postgis.st_m(postgis.st_endpoint(segment_geometry.geometry)) as max_m,
-                     (plan.vertical_coordinate_system is not null)
-                       and exists(select *
-                                  from geometry.vertical_intersection vi
-                                  where vi.alignment_id = alignment.id) as has_profile_info
-                from layout.alignment layout_alignment
-                  inner join layout.segment_version on
-                      layout_alignment.id = segment_version.alignment_id and
-                      layout_alignment.version = segment_version.alignment_version
-                  inner join layout.segment_geometry on segment_version.geometry_id = segment_geometry.id
-                  left join geometry.alignment on alignment.id = segment_version.geometry_alignment_id
-                  left join geometry.plan on alignment.plan_id = plan.id
-                where postgis.st_intersects(
-                    postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),
-                    layout_alignment.bounding_box
-                  )
-                  and postgis.st_intersects(
-                    postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),
-                    segment_geometry.bounding_box
-                  )
-            )
-            select id,
-                   alignment_id,
-                   unnest(segment_indices) as segment_index,
-                   unnest(starts) as start,
-                   unnest(max_ms) as max_m,
-                   unnest(has_profile_infos) as has_profile_info
+            select *
               from (
-                select id,
-                       alignment_id,
-                       array_agg(segment_index) as segment_indices,
-                       array_agg(start) as starts,
-                       array_agg(max_m) as max_ms,
-                       array_agg(has_profile_info) as has_profile_infos
-                  from applicable_alignment_segments
-                    join layout.location_track_in_layout_context(
-                          :publication_state::layout.publication_state,
-                          :design_id) location_track using (alignment_id, alignment_version)
-                  where ((:has_profile_info::boolean is null) or :has_profile_info = has_profile_info)
+                select
+                  location_track.id,
+                  alignment_id,
+                  segment_index,
+                  start,
+                  postgis.st_m(postgis.st_endpoint(segment_geometry.geometry)) as max_m,
+                  (plan.vertical_coordinate_system is not null)
+                    and exists(
+                    select *
+                      from geometry.vertical_intersection vi
+                      where vi.alignment_id = alignment.id
+                  ) as has_profile_info
+                  from layout.location_track_in_layout_context(
+                      :publication_state::layout.publication_state,
+                      :design_id) location_track
+                    join layout.segment_version using (alignment_id, alignment_version)
+                    join layout.alignment layout_alignment on alignment_id = layout_alignment.id
+                    join layout.segment_geometry on segment_version.geometry_id = segment_geometry.id
+                    left join geometry.alignment on alignment.id = segment_version.geometry_alignment_id
+                    left join geometry.plan on alignment.plan_id = plan.id
+                  where postgis.st_intersects(
+                      postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),
+                      layout_alignment.bounding_box
+                        )
+                    and postgis.st_intersects(
+                      postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),
+                      segment_geometry.bounding_box
+                        )
                     and location_track.state != 'DELETED'
-                  group by id, alignment_id, alignment_version
-              ) grouped
-              order by id, segment_index;
+              ) s
+              where ((:has_profile_info::boolean is null) or :has_profile_info = has_profile_info);
         """
                 .trimIndent()
 


### PR DESCRIPTION
Putsailen pikkuhiljaa näitä hakuja, joita piti aiemmin tehdä aivan yltiömonimutkaisessa muodossa, mutta jotka ID-remontin jälkeen (tai itse asiassa varmaan lähinnä in_layout_context-funktioiden remontin jälkeen) postgressi osaa ymmärtää oikein hyvin ilman hämäriä pyörittelyjä. Tämä muoto näyttäisi olevan ainakin kokeilemassani tapauksessa (boksi Ilmalan ratapihan ympärillä) myös nyt hieman nopeampi kuin monimutkaisempi muoto.