### PR TITLE
Review-korjauksia sijaintiraiteiden manuaaliseen Ratko-puskuun ja parannuksia Ratkon offline-käsittelyyn

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -29,17 +29,17 @@ class RatkoController(private val ratkoServiceParam: RatkoService?, private val 
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PostMapping("/push")
-    fun pushChangesToRatko(): HttpStatus {
+    fun pushChangesToRatko(): ResponseEntity<Unit> {
         ratkoService.retryLatestFailedPush()
 
-        return HttpStatus.NO_CONTENT
+        return ResponseEntity(HttpStatus.NO_CONTENT)
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PostMapping("/push-designs")
-    fun pushDesignChangesToRatko(): HttpStatus {
+    fun pushDesignChangesToRatko() {
         // TODO implement
-        return HttpStatus.NO_CONTENT
+        throw NotImplementedError("Not implemented")
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -36,7 +36,7 @@ constructor(
 
     @Cacheable(CACHE_RATKO_HEALTH_STATUS, sync = true)
     fun getRatkoOnlineStatus(): RatkoStatus {
-        return ratkoClient?.getRatkoOnlineStatus() ?: RatkoStatus(false)
+        return ratkoClient?.getRatkoOnlineStatus() ?: RatkoStatus(false, null)
     }
 
     fun getRatkoPushError(publicationId: IntId<Publication>): RatkoPushErrorWithAsset? {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -712,7 +712,9 @@
                 "end-km": "Loppukilometri",
                 "push": "Vie Ratkoon",
                 "pushing-started": "Sijaintiraiteen tietojen vienti käynnistetty",
-                "follow-in-ratko": "Seuraa raidetta Ratkosta"
+                "follow-in-ratko": "Seuraa raidetta Ratkosta",
+                "pushing-failed": "Sijaintiraiteen tietojen vienti epäonnistui",
+                "connection-failed": "Geoviite ei saanut yhteyttä Ratkoon, yritä myöhemmin uudelleen. Ongelman jatkuessa ota yhteyttä Geoviite-tiimiin"
             },
             "vertical-geometry": {
                 "heading": "Raiteen pystygeometria",
@@ -1669,6 +1671,7 @@
         "show-split-info": "Näytä raiteen jakamisen tiedot",
         "mark-as-successful": "Merkitse kohteiden siirto onnistuneeksi",
         "transfer-starts-shortly": "Vienti käynnistyy automaattisesti hetken kuluttua",
+        "transfer-starts-after-reconnect": "Vienti käynnistyy automaattisesti Ratko-yhteyden palautumisen jälkeen",
         "bulk-transfer-marked-as-successful": "Kohteiden siirto merkitty onnistuneeksi",
         "push-error": {
             "location-track": "Sijaintiraiteen",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -49,10 +49,10 @@ constructor(
     @Test
     fun checkOnlineStatus() {
         fakeRatko.isOnline()
-        assertEquals(RatkoClient.RatkoStatus(true), ratkoClient.getRatkoOnlineStatus())
+        assertEquals(RatkoClient.RatkoStatus(true, 200), ratkoClient.getRatkoOnlineStatus())
 
         fakeRatko.isOffline()
-        assertEquals(RatkoClient.RatkoStatus(false), ratkoClient.getRatkoOnlineStatus())
+        assertEquals(RatkoClient.RatkoStatus(false, 500), ratkoClient.getRatkoOnlineStatus())
     }
 
     @Test

--- a/ui/src/ratko/ratko-api.ts
+++ b/ui/src/ratko/ratko-api.ts
@@ -12,14 +12,17 @@ export const pushToRatko = (branchType: LayoutBranchType) =>
 export const getRatkoPushError = (publicationId: PublicationId) =>
     getNonNull<RatkoPushError>(`${RATKO_URI}/errors/${publicationId}`);
 
-export type RatkoStatus = { isOnline: true } | { isOnline: false; statusCode: number };
+export type RatkoStatus = { isOnline: boolean; ratkoStatusCode: number | undefined };
 
 export const getRatkoStatus: () => Promise<RatkoStatus> = () =>
     getNonNullAdt<RatkoStatus>(`${RATKO_URI}/is-online`).then((result) => {
         if (result.isOk()) {
-            return { isOnline: true };
+            return result.value;
         } else {
-            return { statusCode: result?.error?.status ?? 400, isOnline: false };
+            return {
+                ratkoStatusCode: undefined,
+                isOnline: false,
+            };
         }
     });
 

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -84,10 +84,10 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
             {failedPublication.ratkoPushStatus === 'CONNECTION_ISSUE'
                 ? t('publication-card.push-error.connection-issue')
                 : isInternalError
-                ? internalErrorString
-                : isFetchError
-                ? ratkoFetchErrorString
-                : ratkoErrorString}
+                  ? internalErrorString
+                  : isFetchError
+                    ? ratkoFetchErrorString
+                    : ratkoErrorString}
         </div>
     );
 };

--- a/ui/src/tool-panel/location-track/dialog/location-track-ratko-push-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-ratko-push-dialog.tsx
@@ -83,6 +83,8 @@ export const LocationTrackRatkoPushDialog: React.FC<LocationTrackRatkoPushDialog
                         );
                         return;
                     } else {
+                        // Manual location track push is synchronous, but we don't want to wait for it to finish,
+                        // so this is intentionally fired-and-forgotten
                         pushLocationTracksToRatko([
                             {
                                 locationTrackId: locationTrack.id,

--- a/ui/src/tool-panel/location-track/dialog/location-track-ratko-push-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-ratko-push-dialog.tsx
@@ -12,7 +12,7 @@ import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import { Dropdown, DropdownSize, Item } from 'vayla-design-lib/dropdown/dropdown';
 import { KmNumber, LayoutContext, officialLayoutContext } from 'common/common-model';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
-import { pushLocationTracksToRatko } from 'ratko/ratko-api';
+import { getRatkoStatus, pushLocationTracksToRatko } from 'ratko/ratko-api';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { ChangeTimes } from 'common/common-slice';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
@@ -65,27 +65,38 @@ export const LocationTrackRatkoPushDialog: React.FC<LocationTrackRatkoPushDialog
     );
     const [startKm, setStartKm] = React.useState<KmNumber>();
     const [endKm, setEndKm] = React.useState<KmNumber>();
+    const [startingPush, setStartingPush] = React.useState(false);
     const kmOptions = startAndEndPoints && getKmOptions(startAndEndPoints);
     const canPush = !!startKm && !!endKm;
 
     async function pushToRatko() {
         if (locationTrack && startKm && endKm) {
-            try {
-                const kms = getKmsInRange(Number.parseInt(startKm), Number.parseInt(endKm));
+            const kms = getKmsInRange(Number.parseInt(startKm), Number.parseInt(endKm));
+            setStartingPush(true);
 
-                pushLocationTracksToRatko([
-                    {
-                        locationTrackId: locationTrack.id,
-                        changedKmNumbers: kms,
-                    },
-                ]);
-                Snackbar.success(
-                    t('tool-panel.location-track.ratko-push-dialog.pushing-started'),
-                    t('tool-panel.location-track.ratko-push-dialog.follow-in-ratko'),
-                );
-            } finally {
-                props.onClose();
-            }
+            await getRatkoStatus()
+                .then((status) => {
+                    if (!status.isOnline) {
+                        Snackbar.error(
+                            t('tool-panel.location-track.ratko-push-dialog.pushing-failed'),
+                            t('tool-panel.location-track.ratko-push-dialog.connection-failed'),
+                        );
+                        return;
+                    } else {
+                        pushLocationTracksToRatko([
+                            {
+                                locationTrackId: locationTrack.id,
+                                changedKmNumbers: kms,
+                            },
+                        ]);
+                        Snackbar.success(
+                            t('tool-panel.location-track.ratko-push-dialog.pushing-started'),
+                            t('tool-panel.location-track.ratko-push-dialog.follow-in-ratko'),
+                        );
+                        props.onClose();
+                    }
+                })
+                .finally(() => setStartingPush(false));
         }
     }
 
@@ -97,10 +108,16 @@ export const LocationTrackRatkoPushDialog: React.FC<LocationTrackRatkoPushDialog
             footerContent={
                 <div className={dialogStyles['dialog__footer-content--centered']}>
                     <>
-                        <Button onClick={props.onClose} variant={ButtonVariant.SECONDARY}>
+                        <Button
+                            onClick={props.onClose}
+                            variant={ButtonVariant.SECONDARY}
+                            disabled={startingPush}>
                             {t('button.cancel')}
                         </Button>
-                        <Button onClick={pushToRatko} disabled={!canPush}>
+                        <Button
+                            onClick={pushToRatko}
+                            disabled={!canPush || startingPush}
+                            isProcessing={startingPush}>
                             {t('tool-panel.location-track.ratko-push-dialog.push')}
                         </Button>
                     </>


### PR DESCRIPTION
Tämä lähti liikkeelle review-korjauksina ja sitten hieman eskaloitui... Alunperin ajattelin vain lisätä sijaintiraiteiden manuaaliseen Ratko-vientiin sanity checkin, että ei yritetä puskea jos Ratko-yhteyttä ei ylipäätään ole (aiempi toteutus olisi vaan syönyt tuosta aiheutuvan virheen.) Huomasin kuitenkin Ratko-yhteyden online-tarkastelussa juttuja, joiden takia päädyin refaktoroimaan sen ihan kokonaan sekä frontin että bäkkärin päässä. Sen lisäksi tein hieman UX-parannuksia etusivulle tilanteisiin joissa Ratko-yhteys on pois päältä