### PR TITLE
General: Korjauksia etusivun julkaisulistaukseen ja failaaviin E2E-testeihin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -166,11 +166,7 @@ constructor(
     fun getLatestPublications(
         @PathVariable("branchType") branchType: LayoutBranchType,
         @RequestParam("count") count: Int,
-    ): Page<PublicationDetails> {
-        val publications = publicationLogService.fetchLatestPublicationDetails(branchType, count)
-
-        return Page(totalCount = publications.size, start = 0, items = publications)
-    }
+    ): Page<PublicationDetails> = publicationLogService.fetchLatestPublicationDetails(branchType, count)
 
     @PreAuthorize(AUTH_DOWNLOAD_PUBLICATION)
     @GetMapping("csv")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -33,6 +33,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.TrackNumberAndChangeTime
 import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FreeText
+import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsFirstComparator
 import fi.fta.geoviite.infra.util.printCsv
@@ -132,9 +133,10 @@ constructor(
     }
 
     @Transactional(readOnly = true)
-    fun fetchLatestPublicationDetails(branchType: LayoutBranchType, count: Int): List<PublicationDetails> {
-        return publicationDao.fetchLatestPublications(branchType, count).map { getPublicationDetails(it.id) }
-    }
+    fun fetchLatestPublicationDetails(branchType: LayoutBranchType, count: Int): Page<PublicationDetails> =
+        publicationDao.list(branchType).let {
+            Page(it.size, it.take(count), 0).map { item -> getPublicationDetails(item.id) }
+        }
 
     @Transactional(readOnly = true)
     fun fetchPublicationDetails(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -36,7 +36,7 @@ constructor(
 
     @Cacheable(CACHE_RATKO_HEALTH_STATUS, sync = true)
     fun getRatkoOnlineStatus(): RatkoStatus {
-        return ratkoClient?.getRatkoOnlineStatus() ?: RatkoStatus(false, null)
+        return ratkoClient?.getRatkoOnlineStatus() ?: RatkoStatus(RatkoConnectionStatus.NOT_CONFIGURED, null)
     }
 
     fun getRatkoPushError(publicationId: IntId<Publication>): RatkoPushErrorWithAsset? {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -89,7 +89,7 @@ constructor(
 
             if (previousPushStateIn(RatkoPushStatus.FAILED)) {
                 logger.info("Ratko push cancelled because previous push is failed")
-            } else if (!ratkoClient.getRatkoOnlineStatus().isOnline) {
+            } else if (ratkoClient.getRatkoOnlineStatus().connectionStatus != RatkoConnectionStatus.ONLINE) {
                 logger.info("Ratko push cancelled because ratko connection is offline")
             } else {
                 val lastPublicationMoment = ratkoPushDao.getLatestPushedPublicationMoment()
@@ -182,7 +182,9 @@ constructor(
                 "Push all publications before pushing location track point manually"
             }
 
-            check(ratkoClient.getRatkoOnlineStatus().isOnline) { "Ratko is offline" }
+            check(ratkoClient.getRatkoOnlineStatus().connectionStatus == RatkoConnectionStatus.ONLINE) {
+                "Ratko is offline"
+            }
 
             // Here, we only care about current moment, but fix it to the latest publication DB
             // time, pushed or not
@@ -335,7 +337,8 @@ constructor(
 
             // dummy check if Ratko is online
             val pushStatus =
-                if (ratkoClient.getRatkoOnlineStatus().isOnline) RatkoPushStatus.FAILED
+                if (ratkoClient.getRatkoOnlineStatus().connectionStatus == RatkoConnectionStatus.ONLINE)
+                    RatkoPushStatus.FAILED
                 else RatkoPushStatus.CONNECTION_ISSUE
 
             ratkoPushDao.updatePushStatus(ratkoPushId, pushStatus)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1710,6 +1710,7 @@
         "integration-error-status-code": "Vika Ratko-integraatiossa ({{code}}) ",
         "temporary-error-status-code": "Tilapäinen vika Ratko-integraatiossa ({{code}}). Yritä myöhemmin uudelleen.",
         "contact-geoviite-support": "Ota yhteyttä {{geoviiteSupportEmail}}",
+        "contact-geoviite-support-if-needed": "Tilanteen jatkuessa ota yhteyttä {{geoviiteSupportEmail}}",
         "contact-ratko-support": "Ota yhteyttä {{ratkoSupportEmail}}",
         "contact-ratko-support-if-needed": "Tilanteen jatkuessa ota yhteyttä {{ratkoSupportEmail}}"
     },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -207,7 +207,8 @@ constructor(
             LayoutBranch.main,
             publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)),
         )
-        val thisAndPreviousPublication = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val thisAndPreviousPublication =
+            publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val changes =
             publicationDao.fetchPublicationTrackNumberChanges(
                 LayoutBranch.main,
@@ -265,7 +266,8 @@ constructor(
             LayoutBranch.main,
             publicationRequest(trackNumbers = listOf(trackNumber.id as IntId)),
         )
-        val thisAndPreviousPublication = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val thisAndPreviousPublication =
+            publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val changes =
             publicationDao.fetchPublicationTrackNumberChanges(
                 LayoutBranch.main,
@@ -375,7 +377,7 @@ constructor(
                 )
             )
         publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -429,7 +431,7 @@ constructor(
                 )
             )
         publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId<LocationTrack>))
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -506,7 +508,7 @@ constructor(
             )
         publish(publicationService, kmPosts = listOf(updatedKmPost.id as IntId))
 
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
@@ -546,7 +548,7 @@ constructor(
     private fun getLatestPublicationDiffForKmPost(
         id: IntId<TrackLayoutKmPost>
     ): List<PublicationChange<out Comparable<Nothing>?>> {
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
         return publicationLogService.diffKmPost(
@@ -580,7 +582,7 @@ constructor(
                 kmPostService.updateKmPost(LayoutBranch.main, kmPost.id as IntId, saveReq.copy(kmNumber = KmNumber(1))),
             )
         publish(publicationService, kmPosts = listOf(updatedKmPost.id as IntId))
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val changes = publicationDao.fetchPublicationKmPostChanges(latestPub.id)
 
@@ -650,7 +652,7 @@ constructor(
             )
         publish(publicationService, switches = listOf(updatedSwitch.id as IntId))
 
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -693,7 +695,7 @@ constructor(
             )
         publish(publicationService, switches = listOf(updatedSwitch.id as IntId))
 
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -946,7 +948,7 @@ constructor(
                     newSwitchReplacingOldWithSameName.id,
                 ),
         )
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs[0]
         val previousPub = latestPubs[1]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -1082,7 +1084,7 @@ constructor(
                     newSwitchReplacingOldWithSameName.id,
                 ),
         )
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs[0]
         val previousPub = latestPubs[1]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
@@ -1142,7 +1144,7 @@ constructor(
             newAlignment,
         )
         publish(publicationService, locationTracks = listOf(originalLocationTrack.id))
-        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)[0]
+        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items[0]
         val changes = publicationDao.fetchPublicationLocationTrackChanges(latestPub.id)
 
         val diff =
@@ -1258,19 +1260,19 @@ constructor(
 
         assertEquals(2, publicationLogService.fetchPublications(LayoutBranch.main).size)
 
-        assertEquals(1, publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).size)
+        assertEquals(1, publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items.size)
         assertEquals(
             publish2.publicationId,
-            publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)[0].id,
+            publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items[0].id,
         )
 
-        assertEquals(2, publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).size)
+        assertEquals(2, publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items.size)
         assertEquals(
             publish1.publicationId,
-            publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 10)[1].id,
+            publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 10).items[1].id,
         )
 
-        assertTrue { publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 0).isEmpty() }
+        assertTrue { publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 0).items.isEmpty() }
     }
 
     @Test
@@ -1362,7 +1364,7 @@ constructor(
 
         publish(publicationService, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
 
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -1432,7 +1434,7 @@ constructor(
         switchService.mergeToMainBranch(testBranch, switch.id)
         publish(publicationService, switches = listOf(switch.id), locationTracks = listOf(locationTrack.id))
 
-        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2)
+        val latestPubs = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val latestPub = latestPubs.first()
         val previousPub = latestPubs.last()
         val changes = publicationDao.fetchPublicationSwitchChanges(latestPub.id)
@@ -1596,8 +1598,8 @@ constructor(
         publish(publicationService, testBranch, trackNumbers = listOf(trackNumber))
         trackNumberService.mergeToMainBranch(testBranch, trackNumber)
         publish(publicationService, trackNumbers = listOf(trackNumber))
-        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)
-        assertEquals(Operation.CREATE, latestPub[0].trackNumbers[0].operation)
+        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items[0]
+        assertEquals(Operation.CREATE, latestPub.trackNumbers[0].operation)
     }
 
     @Test
@@ -1609,8 +1611,8 @@ constructor(
         publish(publicationService, testBranch, locationTracks = listOf(locationTrack))
         locationTrackService.mergeToMainBranch(testBranch, locationTrack)
         publish(publicationService, locationTracks = listOf(locationTrack))
-        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)
-        assertEquals(Operation.CREATE, latestPub[0].locationTracks[0].operation)
+        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items[0]
+        assertEquals(Operation.CREATE, latestPub.locationTracks[0].operation)
     }
 
     @Test
@@ -1620,8 +1622,8 @@ constructor(
         publish(publicationService, testBranch, switches = listOf(switch))
         switchService.mergeToMainBranch(testBranch, switch)
         publish(publicationService, switches = listOf(switch))
-        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)
-        assertEquals(Operation.CREATE, latestPub[0].switches[0].operation)
+        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items[0]
+        assertEquals(Operation.CREATE, latestPub.switches[0].operation)
     }
 
     @Test
@@ -1632,8 +1634,8 @@ constructor(
         publish(publicationService, testBranch, kmPosts = listOf(kmPost))
         kmPostService.mergeToMainBranch(testBranch, kmPost)
         publish(publicationService, kmPosts = listOf(kmPost))
-        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1)
-        assertEquals(Operation.CREATE, latestPub[0].kmPosts[0].operation)
+        val latestPub = publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 1).items[0]
+        assertEquals(Operation.CREATE, latestPub.kmPosts[0].operation)
     }
 
     private fun setPublicationTime(publicationId: IntId<Publication>, time: Instant) =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -49,10 +49,13 @@ constructor(
     @Test
     fun checkOnlineStatus() {
         fakeRatko.isOnline()
-        assertEquals(RatkoClient.RatkoStatus(true, 200), ratkoClient.getRatkoOnlineStatus())
+        assertEquals(RatkoClient.RatkoStatus(RatkoConnectionStatus.ONLINE, 200), ratkoClient.getRatkoOnlineStatus())
 
         fakeRatko.isOffline()
-        assertEquals(RatkoClient.RatkoStatus(false, 500), ratkoClient.getRatkoOnlineStatus())
+        assertEquals(
+            RatkoClient.RatkoStatus(RatkoConnectionStatus.ONLINE_ERROR, 500),
+            ratkoClient.getRatkoOnlineStatus(),
+        )
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -74,6 +74,9 @@ constructor(
         val failedRatkoPushId = ratkoPushDao.startPushing(listOf(failingPublicationId))
         ratkoPushDao.updatePushStatus(failedRatkoPushId, RatkoPushStatus.FAILED)
 
+        val fakeRatko = fakeRatkoService.start()
+        fakeRatko.isOnline()
+
         startGeoviite()
 
         // two publications; an original one that succeeded (with the original name), then a new one
@@ -92,9 +95,6 @@ constructor(
             }
             .returnToFrontPage()
 
-        val fakeRatko = fakeRatkoService.start()
-
-        fakeRatko.isOnline()
         fakeRatko.hasRouteNumber(ratkoRouteNumber("1.2.3.4.5"))
 
         E2EFrontPage().pushToRatko()

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -140,10 +140,10 @@ const PublicationCard: React.FC<PublishListProps> = ({
         [publicationChangeTime, ratkoPushChangeTime, splitChangeTime, pageCount],
     );
     const reachedLastPublication =
-        (publications?.length ?? 0) < MAX_LISTED_PUBLICATIONS * pageCount;
+        !publications || publications?.items?.length === publications?.totalCount;
 
     const allPublications =
-        publications
+        publications?.items
             ?.sort((i1, i2) => compareTimestamps(i1.publicationTime, i2.publicationTime))
             ?.reverse() ?? [];
 
@@ -158,8 +158,8 @@ const PublicationCard: React.FC<PublishListProps> = ({
     const latestFailures = latestFailureByLayoutBranch(allPublications);
     const ratkoConnectionError =
         ratkoStatus &&
-        !ratkoStatus.isOnline &&
-        (!ratkoStatus.ratkoStatusCode || ratkoStatus.ratkoStatusCode >= 300);
+        (ratkoStatus.connectionStatus === 'ONLINE_ERROR' ||
+            ratkoStatus.connectionStatus === 'OFFLINE');
 
     const allWaiting =
         nonSuccesses.length > 0 &&

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -242,10 +242,9 @@ export const getLatestPublications = async (count: number, branchType: LayoutBra
         count,
     });
 
-    const page = await getNonNull<Page<PublicationDetails>>(
+    return await getNonNull<Page<PublicationDetails>>(
         `${PUBLICATION_URL}/latest/${branchType}${params}`,
     );
-    return page.items;
 };
 
 export const getPublication = (id: PublicationId) =>

--- a/ui/src/ratko/ratko-api.ts
+++ b/ui/src/ratko/ratko-api.ts
@@ -12,7 +12,12 @@ export const pushToRatko = (branchType: LayoutBranchType) =>
 export const getRatkoPushError = (publicationId: PublicationId) =>
     getNonNull<RatkoPushError>(`${RATKO_URI}/errors/${publicationId}`);
 
-export type RatkoStatus = { isOnline: boolean; ratkoStatusCode: number | undefined };
+export type RatkoConnectionStatus = 'ONLINE' | 'ONLINE_ERROR' | 'OFFLINE' | 'NOT_CONFIGURED';
+
+export type RatkoStatus = {
+    connectionStatus: RatkoConnectionStatus;
+    ratkoStatusCode: number | undefined;
+};
 
 export const getRatkoStatus: () => Promise<RatkoStatus> = () =>
     getNonNullAdt<RatkoStatus>(`${RATKO_URI}/is-online`).then((result) => {
@@ -21,7 +26,7 @@ export const getRatkoStatus: () => Promise<RatkoStatus> = () =>
         } else {
             return {
                 ratkoStatusCode: undefined,
-                isOnline: false,
+                connectionStatus: 'OFFLINE',
             };
         }
     });

--- a/ui/src/tool-panel/location-track/dialog/location-track-ratko-push-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-ratko-push-dialog.tsx
@@ -76,7 +76,7 @@ export const LocationTrackRatkoPushDialog: React.FC<LocationTrackRatkoPushDialog
 
             await getRatkoStatus()
                 .then((status) => {
-                    if (!status.isOnline) {
+                    if (status.connectionStatus !== 'ONLINE') {
                         Snackbar.error(
                             t('tool-panel.location-track.ratko-push-dialog.pushing-failed'),
                             t('tool-panel.location-track.ratko-push-dialog.connection-failed'),


### PR DESCRIPTION
Tällä pullarilla tehty käytännössä kaksi täysin erillistä asiaa:
* Etusivun julkaisulistaukseen on toteutettu parempi sivutus. Bäkkäriltä palautuu nyt julkaisujen oikea kokonaismäärä
* Korjattu edellisten korjausten jälkeen failaava E2E-testi. Failuret johtuivat Ratkon statuksen huonosta tarkastelusta