### PR TITLE
GVT-2820 Implement cancellation from designs

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -324,6 +324,7 @@ interface PublicationCandidate<T> {
     val issues: List<LayoutValidationIssue>
     val operation: Operation?
     val publicationGroup: PublicationGroup?
+    val cancelled: Boolean
 
     val id: IntId<T>
         get() = rowVersion.id
@@ -339,6 +340,7 @@ data class TrackNumberPublicationCandidate(
     override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
+    override val cancelled: Boolean,
     val boundingBox: BoundingBox?,
 ) : PublicationCandidate<TrackLayoutTrackNumber> {
     override val type = DraftChangeType.TRACK_NUMBER
@@ -353,6 +355,7 @@ data class ReferenceLinePublicationCandidate(
     override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation?,
     override val publicationGroup: PublicationGroup? = null,
+    override val cancelled: Boolean,
     val boundingBox: BoundingBox?,
 ) : PublicationCandidate<ReferenceLine> {
     override val type = DraftChangeType.REFERENCE_LINE
@@ -368,6 +371,7 @@ data class LocationTrackPublicationCandidate(
     override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
+    override val cancelled: Boolean,
     val boundingBox: BoundingBox?,
 ) : PublicationCandidate<LocationTrack> {
     override val type = DraftChangeType.LOCATION_TRACK
@@ -382,6 +386,7 @@ data class SwitchPublicationCandidate(
     override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
+    override val cancelled: Boolean,
     val location: Point?,
 ) : PublicationCandidate<TrackLayoutSwitch> {
     override val type = DraftChangeType.SWITCH
@@ -396,6 +401,7 @@ data class KmPostPublicationCandidate(
     override val issues: List<LayoutValidationIssue> = listOf(),
     override val operation: Operation,
     override val publicationGroup: PublicationGroup? = null,
+    override val cancelled: Boolean,
     val location: Point?,
 ) : PublicationCandidate<TrackLayoutKmPost> {
     override val type = DraftChangeType.KM_POST

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -53,7 +53,9 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
 
     @Transactional
     fun cancel(branch: DesignBranch, id: IntId<ObjectType>): LayoutRowVersion<ObjectType>? =
-        dao.fetchVersion(branch.official, id)?.let { version -> saveDraft(branch, cancelled(dao.fetch(version))) }
+        dao.fetchVersion(branch.official, id)?.let { version -> saveDraft(branch, cancelInternal(dao.fetch(version))) }
+
+    protected fun cancelInternal(asset: ObjectType) = cancelled(asset)
 
     protected open fun idMatches(term: String, item: ObjectType): Boolean = false
 
@@ -103,10 +105,6 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
             if (originBranch is DesignBranch) {
                 dao.deleteRow(LayoutRowId(draftVersion.id, originBranch.official))
             }
-        }
-
-        if (published.isCancelled) {
-            dao.deleteRow(publicationVersion.rowId)
         }
 
         return publicationVersion

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -107,10 +107,10 @@ sealed class LayoutContextData<T> : LayoutContextAware<T> {
         }
 
     companion object {
-        fun <T : LayoutAsset<T>> new(context: LayoutContext): LayoutContextData<T> =
+        fun <T : LayoutAsset<T>> new(context: LayoutContext, id: IntId<T>?): LayoutContextData<T> =
             when (context.state) {
-                DRAFT -> newDraft(context.branch, id = null)
-                OFFICIAL -> newOfficial(context.branch)
+                DRAFT -> newDraft(context.branch, id = id)
+                OFFICIAL -> newOfficial(context.branch, id = id)
             }
 
         fun <T : LayoutAsset<T>> newDraft(branch: LayoutBranch, id: IntId<T>?): LayoutContextData<T> =
@@ -130,12 +130,13 @@ sealed class LayoutContextData<T> : LayoutContextAware<T> {
                     )
             }
 
-        fun <T : LayoutAsset<T>> newOfficial(branch: LayoutBranch): LayoutContextData<T> =
+        fun <T : LayoutAsset<T>> newOfficial(branch: LayoutBranch, id: IntId<T>? = null): LayoutContextData<T> =
             when (branch) {
-                is MainBranch -> MainOfficialContextData(layoutAssetId = TemporaryAssetId())
+                is MainBranch ->
+                    MainOfficialContextData(layoutAssetId = id?.let { IdentifiedAssetId(id) } ?: TemporaryAssetId())
                 is DesignBranch ->
                     DesignOfficialContextData(
-                        layoutAssetId = TemporaryAssetId(),
+                        layoutAssetId = id?.let { IdentifiedAssetId(id) } ?: TemporaryAssetId(),
                         designId = branch.designId,
                         cancelled = false,
                     )
@@ -324,5 +325,5 @@ fun <T : LayoutAsset<T>> asDesignDraft(item: T, designId: IntId<LayoutDesign>): 
 fun <T : LayoutAsset<T>> cancelled(item: T): T =
     item.withContext(
         (item.contextData as? DesignOfficialContextData)?.cancelled()
-            ?: error("Only design-official items can be cancelled")
+            ?: error("The cancellation operation is only allowed for design-official items")
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -74,9 +74,11 @@ constructor(
 
     @Transactional
     override fun deleteDraft(branch: LayoutBranch, id: IntId<TrackLayoutSwitch>): LayoutRowVersion<TrackLayoutSwitch> {
-        val draft = dao.getOrThrow(branch.draft, id)
+        // cancellations are hidden, so if we're deleting a cancellation, this will return
+        // main-official or null
+        val draft = dao.get(branch.draft, id)
         // If removal also breaks references, clear them out first
-        if (!draft.contextData.hasOfficial) {
+        if (draft?.contextData?.hasOfficial != true) {
             clearSwitchInformationFromSegments(branch, id)
         }
         return super.deleteDraft(branch, id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -210,7 +210,7 @@ class LocationTrackController(
     }
 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
-    @PostMapping("/{$LAYOUT_BRANCH}/{id}/cancel")
+    @PostMapping("/location-tracks/{$LAYOUT_BRANCH}/{id}/cancel")
     fun cancelLocationTrack(
         @PathVariable(LAYOUT_BRANCH) branch: DesignBranch,
         @PathVariable("id") id: IntId<LocationTrack>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -118,9 +118,8 @@ class ReferenceLineService(
 
     @Transactional
     override fun deleteDraft(branch: LayoutBranch, id: IntId<ReferenceLine>): LayoutRowVersion<ReferenceLine> {
-        val draft = dao.getOrThrow(branch.draft, id)
         val deletedVersion = super.deleteDraft(branch, id)
-        draft.alignmentVersion?.id?.let(alignmentDao::delete)
+        dao.fetch(deletedVersion).alignmentVersion?.id?.let(alignmentDao::delete)
         return deletedVersion
     }
 
@@ -245,6 +244,9 @@ class ReferenceLineService(
             asMainDraft(line.copy(alignmentVersion = alignmentService.duplicate(line.getAlignmentVersionOrThrow())))
         )
     }
+
+    override fun cancelInternal(asset: ReferenceLine) =
+        cancelled(asset.copy(alignmentVersion = alignmentService.duplicate(asset.getAlignmentVersionOrThrow())))
 }
 
 fun referenceLineWithAlignment(

--- a/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.06_track_number_in_layout_context.sql
@@ -30,6 +30,7 @@ select
                                from layout.track_number overriding_design_official
                                where overriding_design_official.design_id = design_id_in
                                  and not overriding_design_official.draft
+                                 and not overriding_design_official.cancelled
                                  and overriding_design_official.id = track_number.id
                                  and (publication_state_in = 'OFFICIAL' or not exists (
                                    select *

--- a/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.07_reference_line_in_layout_context.sql
@@ -30,6 +30,7 @@ select
                                from layout.reference_line overriding_design_official
                                where overriding_design_official.design_id = design_id_in
                                  and not overriding_design_official.draft
+                                 and not overriding_design_official.cancelled
                                  and overriding_design_official.id = reference_line.id
                                    and (publication_state_in = 'OFFICIAL' or not exists (
                                      select *

--- a/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.08_location_track_in_layout_context.sql
@@ -30,6 +30,7 @@ select
                                from layout.location_track overriding_design_official
                                where overriding_design_official.design_id = design_id_in
                                  and not overriding_design_official.draft
+                                 and not overriding_design_official.cancelled
                                  and overriding_design_official.id = location_track.id
                                    and (publication_state_in = 'OFFICIAL' or not exists (
                                      select *

--- a/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.09_switch_in_layout_context.sql
@@ -29,6 +29,7 @@ select
                                from layout.switch overriding_design_official
                                where overriding_design_official.design_id = design_id_in
                                  and not overriding_design_official.draft
+                                 and not overriding_design_official.cancelled
                                  and overriding_design_official.id = switch.id
                                  and (publication_state_in = 'OFFICIAL' or not exists (
                                    select *

--- a/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__04.10.km_post_in_layout_context.sql
@@ -30,6 +30,7 @@ select
                                from layout.km_post overriding_design_official
                                where overriding_design_official.design_id = design_id_in
                                  and not overriding_design_official.draft
+                                 and not overriding_design_official.cancelled
                                  and overriding_design_official.id = km_post.id
                                    and (publication_state_in = 'OFFICIAL' or not exists (
                                      select *

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1327,6 +1327,7 @@
         "warnings-status-text": "varoituksia ({{warnings}} kpl)",
         "errors-group-title": "Virheitä",
         "warnings-group-title": "Varoituksia",
+        "cancellation": "Suunnitellun muutoksen ({{operation}}) peruminen",
         "api-error-icon-hover-text": "Validointipyynnössä tapahtui virhe"
     },
     "preview-footer": {
@@ -1389,6 +1390,7 @@
         "revert-change": "Hylkää muutos",
         "show-on-map": "Kohdista kartalla",
         "publish-success": "Muutokset julkaistu paikannuspohjaan",
+        "cancellation-success": "Muutoksen peruminen on kirjattu julkaistavaksi suunnitelman muutokseksi",
         "revert-success": "Luonnosmuutokset peruttu",
         "track-numbers": "Ratanumeroita",
         "km-posts": "Tasakilometripisteitä",
@@ -1398,7 +1400,8 @@
         "move-publication-group": "Siirrä kokonaisuus ({{amount}} kpl)",
         "revert-publication-group": "Hylkää kokonaisuus  ({{amount}} kpl)",
         "move-all-shown-changes": "Siirrä kaikki listan muutokset ({{amount}} kpl)",
-        "revert-all-shown-changes": "Hylkää kaikki listan muutokset ({{amount}} kpl)"
+        "revert-all-shown-changes": "Hylkää kaikki listan muutokset ({{amount}} kpl)",
+        "cancel-change": "Peru muutos suunnitelmasta"
     },
     "validation": {
         "layout": {
@@ -1406,7 +1409,8 @@
                 "no-context": "Ratanumerolta ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava ratanumero ei ole luonnos",
                 "reference-line": {
-                    "not-published": "Ratanumeron pituusmittauslinja ei ole mukana julkaisussa"
+                    "not-published": "Ratanumeron pituusmittauslinja ei ole mukana julkaisussa",
+                    "cancelled": "Ratanumeron pituusmittauslinja on peruttu suunnitelmasta"
                 },
                 "location-track": {
                     "reference-deleted": "Poistettavaan ratanumeroon viittaa edelleen raiteita: {{locationTracks}}"
@@ -1426,6 +1430,7 @@
                     "null": "Tasakilometripisteeltä puuttuu ratanumero tai se ei ole mukana julkaisussa",
                     "not-official": "Tasakilometripiste viittaa ratanumeron {{trackNumber}} luonnosriviin",
                     "not-published": "Tasakilometripiste viittaa julkaisemattomaan ratanumeroon {{trackNumber}}",
+                    "cancelled": "Tasakilometripiste viittaa suunnitelmasta peruttuun ratanumeroon {{trackNumber}}",
                     "state": {
                         "DELETED": "Tasakilometripiste viittaa ratanumeroon {{trackNumber}} joka on tilassa \"Poistettu\""
                     }
@@ -1440,7 +1445,8 @@
                 "not-draft": "Virhe julkaisun sisällössä: julkaistava pituusmittauslinja ei ole luonnos",
                 "track-number": {
                     "not-official": "Pituusmittauslinja viittaa ratanumeron {{trackNumber}} luonnosriviin",
-                    "not-published": "Pituusmittauslinja viittaa julkaisemattomaan ratanumeroon {{trackNumber}}"
+                    "not-published": "Pituusmittauslinja viittaa julkaisemattomaan ratanumeroon {{trackNumber}}",
+                    "cancelled": "Pituusmittauslinja viittaa suunnitelmasta peruttuun ratanumeroon {{trackNumber}}"
                 },
                 "empty-segments": "Pituusmittauslinjalla ei ole geometriaa",
                 "points": {
@@ -1455,6 +1461,7 @@
                     },
                     "not-official": "Raide viittaa duplikaattiraiteen {{duplicateTrack}} luonnosriviin",
                     "not-published": "Raide viittaa julkaisemattomaan duplikaattiraiteeseen {{duplicateTrack}}",
+                    "cancelled": "Raide viittaa suunnitelmasta peruttuun duplikaattiraiteeseen {{duplicateTrack}}",
                     "publishing-duplicate-of-duplicated": "Raide on merkitty duplikaatiksi raiteelle {{duplicateTrack}}, joka itse on myös duplikaatti",
                     "publishing-duplicate-while-duplicated": "Raide on merkitty duplikaatiksi, mutta raide {{otherDuplicates}} on tämän raiteen duplikaatti",
                     "publishing-duplicate-while-duplicated-multiple": "Raide on merkitty duplikaatiksi, mutta raiteet {{otherDuplicates}} ovat tämän raiteen duplikaatteja"
@@ -1468,6 +1475,7 @@
                 "track-number": {
                     "not-official": "Sijaintiraide viittaa ratanumeron {{trackNumber}} luonnosriviin",
                     "not-published": "Sijaintiraide viittaa ratanumeroon {{trackNumber}}, joka ei ole mukana julkaisussa",
+                    "cancelled": "Sijaintiraide viittaa suunnitelmasta peruttuun ratanumeroon {{trackNumber}}",
                     "state": {
                         "DELETED": "Sijaintiraide viittaa ratanumeroon {{trackNumber}} joka on tilassa \"Poistettu\""
                     }
@@ -1475,6 +1483,7 @@
                 "switch": {
                     "not-official": "Sijaintiraide viittaa vaihteen {{switch}} luonnosriviin",
                     "not-published": "Sijaintiraide viittaa julkaisemattomaan luonnosvaihteeseen {{switch}}",
+                    "cancelled": "Sijaintiraide viittaa suunnitelmasta peruttuun vaihteeseen {{switch}}",
                     "state-category": {
                         "NOT_EXISTING": "Sijaintiraide viittaa vaihteeseen {{switch}}, joka on tilakategoriassa \"Poistunut kohde\""
                     },
@@ -1557,7 +1566,8 @@
                 "no-geometry": "Raiteella ei ole geometriaa",
                 "affected-split-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteella {{sourceName}}, jonka jakamista ei ole vielä viety Ratkoon",
                 "track-split-in-progress": "Raiteen {{sourceName}} jakamista ei ole vielä viety Ratkoon, joten muita muutoksia ei voi vielä tehdä",
-                "track-links-missing-after-relinking": "Vaihteen {{switchName}} kaikki linjat eivät enää kulje vaihteen kautta uudelleenlinkityksen jälkeen"
+                "track-links-missing-after-relinking": "Vaihteen {{switchName}} kaikki linjat eivät enää kulje vaihteen kautta uudelleenlinkityksen jälkeen",
+                "track-is-cancelled": "Jakamisessa mukanaa olevaa raidetta {{name}} ei voi perua julkaisusta"
             }
         }
     },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -295,9 +295,8 @@ class TestDBService(
         TestLayoutContext(LayoutContext.of(branch, state), this)
 
     fun <T : LayoutAsset<T>> updateContext(original: T, context: LayoutContext): T =
-        original.takeIf { o ->
-            o.contextData.designId == context.branch.designId && o.isDraft == (context.state == DRAFT)
-        } ?: original.withContext(LayoutContextData.new(context))
+        original.takeIf { o -> o.layoutContext == context }
+            ?: original.withContext(LayoutContextData.new(context, original.id as? IntId))
 
     fun insertProject(): RowVersion<Project> = geometryDao.insertProject(project(getUnusedProjectName().toString()))
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
@@ -119,6 +119,14 @@ constructor(
     fun getCalculatedChangesInRequest(versions: ValidationVersions): CalculatedChanges =
         calculatedChangesService.getCalculatedChanges(versions)
 
+    fun publish(layoutBranch: LayoutBranch, request: PublicationRequestIds): PublicationResult {
+        val versions = publicationService.getValidationVersions(layoutBranch, request)
+        verifyVersions(request, versions)
+        verifyVersionsAreDrafts(layoutBranch, versions)
+        val draftCalculatedChanges = getCalculatedChangesInRequest(versions)
+        return testPublish(layoutBranch, versions, draftCalculatedChanges)
+    }
+
     fun publishAndVerify(layoutBranch: LayoutBranch, request: PublicationRequestIds): PublicationResult {
         val versions = publicationService.getValidationVersions(layoutBranch, request)
         verifyVersions(request, versions)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -462,7 +462,7 @@ class PublicationValidationTest {
         val lt = locationTrack(IntId(0), duplicateOf = IntId(0), draft = true)
         assertContainsError(
             true,
-            validateDuplicateOfState(lt, lt, AlignmentName("duplicateof"), listOf()),
+            validateDuplicateOfState(lt, lt, AlignmentName("duplicateof"), false, listOf()),
             "$VALIDATION_LOCATION_TRACK.duplicate-of.publishing-duplicate-of-duplicated",
         )
     }

--- a/ui/src/preview/preview-table-item.tsx
+++ b/ui/src/preview/preview-table-item.tsx
@@ -41,6 +41,7 @@ export type PreviewTableItemProps = {
     onShowOnMap: (bbox: BoundingBox) => void;
     validationState: PublicationValidationState;
     canRevertChanges: boolean;
+    canCancelChanges: boolean;
 };
 
 export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
@@ -53,6 +54,7 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
     onShowOnMap,
     validationState,
     canRevertChanges,
+    canCancelChanges,
 }) => {
     const { t } = useTranslation();
     const [isErrorRowExpanded, setIsErrorRowExpanded] = React.useState(false);
@@ -150,6 +152,12 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
         'preview-revert-publication-group',
     );
 
+    const menuOptionCancelSingleChange: MenuSelectOption = menuOption(
+        () => previewOperations.cancel(tableEntry.publishCandidate),
+        t('publish.cancel-change'),
+        'preview-cancel-change',
+    );
+
     const menuOptionShowOnMap: MenuSelectOption = menuOption(
         () => {
             tableEntry.boundingBox && onShowOnMap(tableEntry.boundingBox);
@@ -178,14 +186,23 @@ export const PreviewTableItem: React.FC<PreviewTableItemProps> = ({
                   menuOptionRevertAllShownChanges,
               ]
             : []),
+        ...conditionalMenuOption(canCancelChanges, menuOptionCancelSingleChange),
     ];
+
+    const operation = tableEntry.operation
+        ? tableEntry.publishCandidate.cancelled
+            ? t('preview-table.cancellation', {
+                  operation: t(`enum.Operation.${tableEntry.operation}`),
+              })
+            : t(`enum.Operation.${tableEntry.operation}`)
+        : '';
 
     return (
         <React.Fragment>
             <tr className={'preview-table-item'}>
                 <td>{tableEntry.uiName}</td>
                 <td>{tableEntry.trackNumber ? tableEntry.trackNumber : ''}</td>
-                <td>{tableEntry.operation ? t(`enum.Operation.${tableEntry.operation}`) : ''}</td>
+                <td>{operation}</td>
                 <td>{formatDateFull(tableEntry.changeTime)}</td>
                 <td>{tableEntry.userName}</td>
                 <ValidationStateCell

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -71,6 +71,7 @@ type PreviewTableProps = {
     tableValidationState: PublicationValidationState;
     tableEntryValidationState: (tableEntry: PreviewTableEntry) => PublicationValidationState;
     canRevertChanges: boolean;
+    canCancelChanges: boolean;
 };
 
 const PreviewTable: React.FC<PreviewTableProps> = ({
@@ -86,6 +87,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     tableValidationState,
     tableEntryValidationState,
     canRevertChanges,
+    canCancelChanges,
 }) => {
     const { t } = useTranslation();
     const trackNumbers =
@@ -217,6 +219,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
                                     }
                                     validationState={tableEntryValidationState(entry)}
                                     canRevertChanges={canRevertChanges}
+                                    canCancelChanges={canCancelChanges}
                                 />
                             }
                         </React.Fragment>

--- a/ui/src/preview/publication-request-dependency-list.tsx
+++ b/ui/src/preview/publication-request-dependency-list.tsx
@@ -23,30 +23,59 @@ import { ChangesBeingReverted } from 'preview/preview-view';
 
 const TrackNumberItem: React.FC<{
     layoutContext: LayoutContext;
-    trackNumberId: LayoutTrackNumberId;
+    trackNumber: PublicationCandidateReference & { type: DraftChangeType.TRACK_NUMBER };
     changeTime: TimeStamp;
 }> = (props) => {
     const { t } = useTranslation();
-    const trackNumbers = useTrackNumbersIncludingDeleted(
-        draftLayoutContext(props.layoutContext),
-        props.changeTime,
-    );
-    const trackNumber = trackNumbers && trackNumbers.find((tn) => tn.id === props.trackNumberId);
-    return trackNumber === undefined ? (
-        <li />
-    ) : (
+    return (
         <li>
-            {t('publish.revert-confirm.dependency-list.track-number')} {trackNumber.number}
+            {t('publish.revert-confirm.dependency-list.track-number')}{' '}
+            {props.trackNumber.number ?? (
+                <LookupTrackNumberItem
+                    layoutContext={props.layoutContext}
+                    trackNumberId={props.trackNumber.id}
+                    changeTime={props.changeTime}
+                />
+            )}
         </li>
     );
 };
 
+const LookupTrackNumberItem: React.FC<{
+    layoutContext: LayoutContext;
+    trackNumberId: LayoutTrackNumberId;
+    changeTime: TimeStamp;
+}> = (props) =>
+    useTrackNumbersIncludingDeleted(
+        draftLayoutContext(props.layoutContext),
+        props.changeTime,
+    )?.find((tn) => tn.id === props.trackNumberId)?.number ?? '';
+
 const ReferenceLineItem: React.FC<{
+    layoutContext: LayoutContext;
+    referenceLine: PublicationCandidateReference & { type: DraftChangeType.REFERENCE_LINE };
+    changeTimes: ChangeTimes;
+}> = (props) => {
+    const { t } = useTranslation();
+    return (
+        <li>
+            {t('publish.revert-confirm.dependency-list.reference-line')}{' '}
+            {props.referenceLine.name ?? (
+                <LookupReferenceLineItem
+                    layoutContext={props.layoutContext}
+                    referenceLineId={props.referenceLine.id}
+                    changeTimes={props.changeTimes}
+                />
+            )}
+        </li>
+    );
+};
+
+const LookupReferenceLineItem: React.FC<{
     layoutContext: LayoutContext;
     referenceLineId: ReferenceLineId;
     changeTimes: ChangeTimes;
 }> = (props) => {
-    const { t } = useTranslation();
     const trackNumbers = useTrackNumbersIncludingDeleted(
         draftLayoutContext(props.layoutContext),
         props.changeTimes.layoutTrackNumber,
@@ -60,64 +89,78 @@ const ReferenceLineItem: React.FC<{
         return <li />;
     }
     const trackNumber = trackNumbers.find((tn) => tn.id === referenceLine.trackNumberId);
-    return trackNumber === undefined ? (
-        <li />
-    ) : (
-        <li>
-            {t('publish.revert-confirm.dependency-list.reference-line')} {trackNumber.number}
-        </li>
-    );
+    return trackNumber?.number ?? '';
 };
 
 const LocationTrackItem: React.FC<{
     layoutContext: LayoutContext;
-    locationTrackId: LocationTrackId;
+    locationTrack: PublicationCandidateReference & { type: DraftChangeType.LOCATION_TRACK };
     changeTime: TimeStamp;
 }> = (props) => {
     const { t } = useTranslation();
-    const locationTrack = useLocationTrack(
+    return (
+        <li>
+            {t('publish.revert-confirm.dependency-list.location-track')}{' '}
+            {props.locationTrack.name ?? (
+                <LookupLocationTrackItem
+                    layoutContext={props.layoutContext}
+                    locationTrackId={props.locationTrack.id}
+                    changeTime={props.changeTime}
+                />
+            )}
+        </li>
+    );
+};
+const LookupLocationTrackItem: React.FC<{
+    layoutContext: LayoutContext;
+    locationTrackId: LocationTrackId;
+    changeTime: TimeStamp;
+}> = (props) =>
+    useLocationTrack(
         props.locationTrackId,
         draftLayoutContext(props.layoutContext),
         props.changeTime,
-    );
-    return locationTrack === undefined ? (
-        <li />
-    ) : (
+    )?.name;
+
+const SwitchItem: React.FC<{
+    layoutContext: LayoutContext;
+    switchCandidate: PublicationCandidateReference & { type: DraftChangeType.SWITCH };
+}> = ({ layoutContext, switchCandidate }) => {
+    const { t } = useTranslation();
+    return (
         <li>
-            {t('publish.revert-confirm.dependency-list.location-track')} {locationTrack.name}
+            {t('publish.revert-confirm.dependency-list.switch')}{' '}
+            {switchCandidate.name ?? (
+                <LookupSwitchItem layoutContext={layoutContext} switchId={switchCandidate.id} />
+            )}
         </li>
     );
 };
 
-const SwitchItem: React.FC<{ layoutContext: LayoutContext; switchId: LayoutSwitchId }> = ({
+const LookupSwitchItem: React.FC<{ layoutContext: LayoutContext; switchId: LayoutSwitchId }> = ({
     layoutContext,
     switchId,
-}) => {
+}) => useSwitch(switchId, draftLayoutContext(layoutContext))?.name;
+
+const KmPostItem: React.FC<{
+    layoutContext: LayoutContext;
+    kmPost: PublicationCandidateReference & { type: DraftChangeType.KM_POST };
+}> = ({ layoutContext, kmPost }) => {
     const { t } = useTranslation();
-    const switchObj = useSwitch(switchId, draftLayoutContext(layoutContext));
-    return switchObj === undefined ? (
-        <li />
-    ) : (
+    return (
         <li>
-            {t('publish.revert-confirm.dependency-list.switch')} {switchObj.name}
+            {t('publish.revert-confirm.dependency-list.km-post')}{' '}
+            {kmPost.kmNumber ?? (
+                <LookupKmPostItem layoutContext={layoutContext} kmPostId={kmPost.id} />
+            )}
         </li>
     );
 };
 
-const KmPostItem: React.FC<{ layoutContext: LayoutContext; kmPostId: LayoutKmPostId }> = ({
+const LookupKmPostItem: React.FC<{ layoutContext: LayoutContext; kmPostId: LayoutKmPostId }> = ({
     layoutContext,
     kmPostId,
-}) => {
-    const { t } = useTranslation();
-    const kmPost = useKmPost(kmPostId, draftLayoutContext(layoutContext));
-    return kmPost === undefined ? (
-        <li />
-    ) : (
-        <li>
-            {t('publish.revert-confirm.dependency-list.km-post')} {kmPost.kmNumber}
-        </li>
-    );
-};
+}) => useKmPost(kmPostId, draftLayoutContext(layoutContext))?.kmNumber;
 
 export const publicationRequestTypeTranslationKey = (type: DraftChangeType) => {
     switch (type) {
@@ -179,7 +222,7 @@ const getPublicationCandidateComponent = (
                 <TrackNumberItem
                     layoutContext={layoutContext}
                     key={candidateComponentKey}
-                    trackNumberId={candidate.id}
+                    trackNumber={candidate}
                     changeTime={changeTimes.layoutTrackNumber}
                 />
             );
@@ -189,7 +232,7 @@ const getPublicationCandidateComponent = (
                 <LocationTrackItem
                     layoutContext={layoutContext}
                     key={candidateComponentKey}
-                    locationTrackId={candidate.id}
+                    locationTrack={candidate}
                     changeTime={changeTimes.layoutLocationTrack}
                 />
             );
@@ -199,7 +242,7 @@ const getPublicationCandidateComponent = (
                 <ReferenceLineItem
                     layoutContext={layoutContext}
                     key={candidateComponentKey}
-                    referenceLineId={candidate.id}
+                    referenceLine={candidate}
                     changeTimes={changeTimes}
                 />
             );
@@ -208,7 +251,7 @@ const getPublicationCandidateComponent = (
             return (
                 <SwitchItem
                     layoutContext={layoutContext}
-                    switchId={candidate.id}
+                    switchCandidate={candidate}
                     key={candidateComponentKey}
                 />
             );
@@ -217,7 +260,7 @@ const getPublicationCandidateComponent = (
             return (
                 <KmPostItem
                     layoutContext={layoutContext}
-                    kmPostId={candidate.id}
+                    kmPost={candidate}
                     key={candidateComponentKey}
                 />
             );

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -82,7 +82,7 @@ export type BasePublicationCandidate = {
     issues: LayoutValidationIssue[];
     validationState: PublicationValidationState;
     stage: PublicationStage;
-    designRowReferrer: DesignRowReferrer;
+    cancelled: boolean;
 };
 
 export type PublicationCandidate =
@@ -93,11 +93,15 @@ export type PublicationCandidate =
     | KmPostPublicationCandidate;
 
 export type PublicationCandidateReference =
-    | { id: LayoutTrackNumberId; type: DraftChangeType.TRACK_NUMBER }
-    | { id: ReferenceLineId; type: DraftChangeType.REFERENCE_LINE }
-    | { id: LocationTrackId; type: DraftChangeType.LOCATION_TRACK }
-    | { id: LayoutSwitchId; type: DraftChangeType.SWITCH }
-    | { id: LayoutKmPostId; type: DraftChangeType.KM_POST };
+    | {
+          id: LayoutTrackNumberId;
+          type: DraftChangeType.TRACK_NUMBER;
+          number?: TrackNumber;
+      }
+    | { id: ReferenceLineId; type: DraftChangeType.REFERENCE_LINE; name?: TrackNumber }
+    | { id: LocationTrackId; type: DraftChangeType.LOCATION_TRACK; name?: string }
+    | { id: LayoutSwitchId; type: DraftChangeType.SWITCH; name?: string }
+    | { id: LayoutKmPostId; type: DraftChangeType.KM_POST; kmNumber?: KmNumber };
 
 export type WithBoundingBox = {
     boundingBox?: BoundingBox;

--- a/ui/src/track-layout/layout-km-post-api.ts
+++ b/ui/src/track-layout/layout-km-post-api.ts
@@ -7,6 +7,7 @@ import {
     LayoutTrackNumberId,
 } from 'track-layout/track-layout-model';
 import {
+    DesignBranch,
     draftLayoutContext,
     KmNumber,
     LayoutAssetChangeInfo,
@@ -21,7 +22,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri, layoutUriByBranch } from 'track-layout/track-layout-api';
 import { getChangeTimes, updateKmPostChangeTime } from 'common/change-time-api';
 import { BoundingBox, Point } from 'model/geometry';
 import { bboxString, pointString } from 'common/common-api';
@@ -218,3 +219,7 @@ export const getKmPostChangeInfo = (id: LayoutKmPostId, layoutContext: LayoutCon
 
 export const getEntireRailNetworkKmLengthsCsvUrl = (layoutContext: LayoutContext) =>
     `${layoutUri('track-numbers', layoutContext)}/rail-network/km-lengths/file`;
+
+export async function cancelKmPost(design: DesignBranch, id: LayoutKmPostId): Promise<void> {
+    return postNonNull(`${layoutUriByBranch('km-posts', design)}/${id}/cancel`, '');
+}

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -9,6 +9,7 @@ import {
     LocationTrackInfoboxExtras,
 } from 'track-layout/track-layout-model';
 import {
+    DesignBranch,
     draftLayoutContext,
     LayoutAssetChangeInfo,
     LayoutContext,
@@ -23,7 +24,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri, layoutUriByBranch } from 'track-layout/track-layout-api';
 import { asyncCache } from 'cache/cache';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
@@ -312,4 +313,11 @@ export async function getLocationTrackValidation(
     return getNullable<ValidatedLocationTrack>(
         `${layoutUri('location-tracks', layoutContext, id)}/validation`,
     );
+}
+
+export async function cancelLocationTrack(
+    design: DesignBranch,
+    id: LocationTrackId,
+): Promise<void> {
+    return postNonNull(`${layoutUriByBranch('location-tracks', design)}/${id}/cancel`, '');
 }

--- a/ui/src/track-layout/layout-reference-line-api.ts
+++ b/ui/src/track-layout/layout-reference-line-api.ts
@@ -5,13 +5,14 @@ import {
     ReferenceLineId,
 } from 'track-layout/track-layout-model';
 import {
-    LayoutAssetChangeInfo,
+    DesignBranch,
     draftLayoutContext,
+    LayoutAssetChangeInfo,
     LayoutContext,
     TimeStamp,
 } from 'common/common-model';
-import { getNonNull, getNullable, queryParams } from 'api/api-fetch';
-import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
+import { getNonNull, getNullable, postNonNull, queryParams } from 'api/api-fetch';
+import { changeInfoUri, layoutUri, layoutUriByBranch } from 'track-layout/track-layout-api';
 import { BoundingBox } from 'model/geometry';
 import { bboxString } from 'common/common-api';
 import { asyncCache } from 'cache/cache';
@@ -101,3 +102,10 @@ export const getReferenceLineChangeTimes = (
 ): Promise<LayoutAssetChangeInfo | undefined> => {
     return getNullable<LayoutAssetChangeInfo>(changeInfoUri('reference-lines', id, layoutContext));
 };
+
+export async function cancelReferenceLine(
+    design: DesignBranch,
+    id: ReferenceLineId,
+): Promise<void> {
+    return postNonNull(`${layoutUriByBranch('reference-lines', design)}/${id}/cancel`, '');
+}

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -1,5 +1,6 @@
 import { BoundingBox, Point } from 'model/geometry';
 import {
+    DesignBranch,
     draftLayoutContext,
     LayoutAssetChangeInfo,
     LayoutContext,
@@ -18,7 +19,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri, layoutUriByBranch } from 'track-layout/track-layout-api';
 import { bboxString, pointString } from 'common/common-api';
 import { getChangeTimes, updateSwitchChangeTime } from 'common/change-time-api';
 import { asyncCache } from 'cache/cache';
@@ -197,3 +198,7 @@ export const getSwitchChangeTimes = (
 ): Promise<LayoutAssetChangeInfo | undefined> => {
     return getNonNull<LayoutAssetChangeInfo>(changeInfoUri('switches', id, layoutContext));
 };
+
+export async function cancelSwitch(design: DesignBranch, id: LayoutSwitchId): Promise<void> {
+    return postNonNull(`${layoutUriByBranch('switches', design)}/${id}/cancel`, '');
+}

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -1,6 +1,7 @@
 import { asyncCache } from 'cache/cache';
 import { LayoutTrackNumber, LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import {
+    DesignBranch,
     draftLayoutContext,
     LayoutAssetChangeInfo,
     LayoutContext,
@@ -14,7 +15,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { changeInfoUri, layoutUri } from 'track-layout/track-layout-api';
+import { changeInfoUri, layoutUri, layoutUriByBranch } from 'track-layout/track-layout-api';
 import { TrackNumberSaveRequest } from 'tool-panel/track-number/dialog/track-number-edit-store';
 import {
     getChangeTimes,
@@ -111,3 +112,10 @@ export const getTrackNumberChangeTimes = (
 ): Promise<LayoutAssetChangeInfo | undefined> => {
     return getNullable<LayoutAssetChangeInfo>(changeInfoUri('track-numbers', id, layoutContext));
 };
+
+export async function cancelTrackNumber(
+    design: DesignBranch,
+    id: LayoutTrackNumberId,
+): Promise<void> {
+    return postNonNull(`${layoutUriByBranch('track-numbers', design)}/${id}/cancel`, '');
+}

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -1,4 +1,4 @@
-import { LayoutContext } from 'common/common-model';
+import { LayoutBranch, LayoutContext } from 'common/common-model';
 import { API_URI } from 'api/api-fetch';
 
 type LayoutDataType =
@@ -24,6 +24,15 @@ export function layoutUri(
     id?: string,
 ): string {
     const baseUri = `${TRACK_LAYOUT_URI}/${dataType}/${contextInUri(layoutContext)}`;
+    return id ? `${baseUri}/${id}` : baseUri;
+}
+
+export function layoutUriByBranch(
+    dataType: LayoutDataType,
+    layoutBranch: LayoutBranch,
+    id?: string,
+): string {
+    const baseUri = `${TRACK_LAYOUT_URI}/${dataType}/${layoutBranch.toLowerCase()}`;
     return id ? `${baseUri}/${id}` : baseUri;
 }
 


### PR DESCRIPTION
Iloksenne taas kookas pullari. Perusperiaatteet:

- cancelled-lippu (tieto että rivi on peruttu) tarkoittaa "ei me haluttukaan tätä muutosta tässä suunnitelmassa". in_layout_context-funktiot eivät koskaan palauta peruttuja rivejä, ja siten ei myöskään fetchVersion(), ja siten ei myöskään mikään LayoutAssetDao-metodi, paitsi ne, jotka ottavat paramatriksi varsinaisen version
- Eri paikoissa, joissa peruttuja rivejä käsitellään, ratkaistaan niiden tietojen saaminen tarvittavassa kohdassa saataville aina tapauskohtaisilla tavoilla. Tämä siksi, että näitä paikkoja on lopulta aika vähän, ja tällä tavalla saadaan vältettyä se, että tulevaisuudessa pitäisi ihmetellä LayoutAssetDaosta, miksi siinä on omat metodinsa mahdollisesti peruttujen rivien hakuun: Asiayhteyksiä, joissa tarvitsee lainkaan miettiä peruttuja rivejä, on vaan hyvin vähän, ja niistä jokaisessa on aika helppo saada käsille tarvittavat tiedot.
- Design-draftin julkaisussa ei varsinaisessa julkaisussa itsessään huomioida perumista millään tavalla; design-officialiksi riviksi vaan tulee ihan normaalisti draftin tila, ja sen mukana sen canceled-lipun tila