### PR TITLE
GVT-2914 Useita korjauksia ID-remontin regressioihin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -225,12 +225,12 @@ class LayoutKmPostDao(
               kp.gk_location_source,
               kp.gk_location_confirmed,
               kp.state,
-              kp.origin_design_id,
-              official_kp.id is not null as has_official
+              exists(select * from layout.km_post official_kp
+                     where kp.id = official_kp.id
+                       and (official_kp.design_id is null or official_kp.design_id = kp.design_id)
+                       and not official_kp.draft) as has_official,
+              kp.origin_design_id
             from layout.km_post kp
-              left join layout.km_post official_kp on kp.id = official_kp.id
-                and (official_kp.design_id is null or official_kp.design_id = kp.design_id)
-                and not official_kp.draft
         """
                 .trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -358,12 +358,12 @@ class LayoutSwitchDao(
               joint_x_values,
               joint_y_values,
               joint_location_accuracies,
-              official_s.id is not null as has_official,
+              exists(select * from layout.switch official_sv
+                     where official_sv.id = s.id
+                       and (official_sv.design_id is null or official_sv.design_id = s.design_id)
+                       and not official_sv.draft) as has_official,
               s.origin_design_id
             from layout.switch s
-              left join layout.switch official_s on s.id = official_s.id
-                and (official_s.design_id is null or official_s.design_id = s.design_id)
-                and not official_s.draft
               left join lateral
                 (select coalesce(array_agg(jv.number order by jv.number), '{}') as joint_numbers,
                         coalesce(array_agg(postgis.st_x(jv.location) order by jv.number), '{}') as joint_x_values,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -82,14 +82,14 @@ class LayoutTrackNumberDao(
               tn.number,
               tn.description,
               tn.state,
-              tn.origin_design_id,
               -- Track number reference line identity never changes, so any instance whatsoever is fine
               (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
-              official_tn.id is not null as has_official
+              exists (select * from layout.track_number official_tn
+                      where official_tn.id = tn.id
+                        and (official_tn.design_id is null or official_tn.design_id = tn.design_id)
+                        and not official_tn.draft) has_official,
+              tn.origin_design_id
             from layout.track_number_version tn
-              left join layout.track_number official_tn on official_tn.id = tn.id
-                and (official_tn.design_id is null or official_tn.design_id = tn.design_id)
-                and not official_tn.draft
             where tn.id = :id
               and tn.layout_context_id = :layout_context_id
               and tn.version = :version
@@ -123,12 +123,12 @@ class LayoutTrackNumberDao(
               tn.cancelled,
               -- Track number reference line identity never changes, so any instance whatsoever is fine
               (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
-              official_tn.id is not null as has_official,
+              exists (select * from layout.track_number official_tn
+                      where official_tn.id = tn.id
+                        and (official_tn.design_id is null or official_tn.design_id = tn.design_id)
+                        and not official_tn.draft) has_official,
               tn.origin_design_id
             from layout.track_number tn
-              left join layout.track_number official_tn on official_tn.id = tn.id
-                and (official_tn.design_id is null or official_tn.design_id = tn.design_id)
-                and not official_tn.draft
             order by tn.id
         """
                 .trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -202,13 +202,13 @@ class LocationTrackDao(
                     and sv.alignment_version = lt.alignment_version
                     and sv.switch_id is not null
               ) as segment_switch_ids,
-              official_lt.id is not null as has_official,
+              exists(select * from layout.location_track official_lt
+                     where official_lt.id = lt.id
+                       and (official_lt.design_id is null or official_lt.design_id = lt.design_id)
+                       and not official_lt.draft) as has_official,
               lt.origin_design_id
             from layout.location_track lt
               left join layout.alignment_version av on lt.alignment_id = av.id and lt.alignment_version = av.version
-              left join layout.location_track official_lt on lt.id = official_lt.id
-                 and (official_lt.design_id is null or official_lt.design_id = lt.design_id)
-                 and not official_lt.draft
         """
                 .trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -53,7 +53,7 @@ class ReferenceLineDao(
               rlv.start_address,
               exists(select * from layout.reference_line official_rl
                      where rlv.id = official_rl.id
-                       and (official_rl.design_id is not null or official_rl.design_id = rlv.design_id)
+                       and (official_rl.design_id is null or official_rl.design_id = rlv.design_id)
                        and not official_rl.draft) as has_official,
               origin_design_id
             from layout.reference_line_version rlv

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -91,12 +91,12 @@ class ReferenceLineDao(
               av.length,
               av.segment_count,
               rl.start_address,
-              official_rl.id is not null as has_official,
+              exists(select * from layout.reference_line official_rl
+                     where rl.id = official_rl.id
+                       and (official_rl.design_id is null or official_rl.design_id = rl.design_id)
+                       and not official_rl.draft) as has_official,
               rl.origin_design_id
             from layout.reference_line rl
-              left join layout.reference_line official_rl on rl.id = official_rl.id
-                and (official_rl.design_id is null or official_rl.design_id = rl.design_id)
-                and not official_rl.draft
               left join layout.alignment_version av on rl.alignment_id = av.id and rl.alignment_version = av.version
         """
                 .trimIndent()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -1,7 +1,9 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.TestLayoutContext
 import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.PublicationState
@@ -10,7 +12,9 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -291,5 +295,74 @@ constructor(
         assertEquals(locationTrack, designDraftContext.fetchVersion(locationTrack.id))
         assertEquals(switch, designDraftContext.fetchVersion(switch.id))
         assertEquals(kmPost, designDraftContext.fetchVersion(kmPost.id))
+    }
+
+    @Test
+    fun `hasOfficial indicates having any official row above`() {
+        val someDesignBranch = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
+        val designDraftContext = testDBService.testContext(someDesignBranch, PublicationState.DRAFT)
+
+        val assets = AllAssetTypes.createIn(mainDraftContext)
+
+        assets.fetchAllAndRun(mainDraftContext) { asset -> assertFalse(asset.hasOfficial) }
+        assets.copyFromTo(mainDraftContext, designDraftContext)
+
+        assets.fetchAllAndRun(mainDraftContext) { asset -> assertFalse(asset.hasOfficial) }
+        assets.fetchAllAndRun(designDraftContext) { asset -> assertFalse(asset.hasOfficial) }
+
+        assets.copyFromTo(designDraftContext, designOfficialContext)
+        // normally publication would delete drafts and hence force version increments, we'll just
+        // do it by hand here
+        assets.incrementVersionsInContext(designDraftContext)
+
+        assets.fetchAllAndRun(mainDraftContext) { asset -> assertFalse(asset.hasOfficial) }
+        assets.fetchAllAndRun(designDraftContext) { asset -> assertTrue(asset.hasOfficial) }
+
+        assets.copyFromTo(mainDraftContext, mainOfficialContext)
+        assets.incrementVersionsInContext(designDraftContext)
+        assets.incrementVersionsInContext(mainDraftContext)
+
+        assets.fetchAllAndRun(mainDraftContext) { asset -> assertTrue(asset.hasOfficial) }
+        assets.fetchAllAndRun(designDraftContext) { asset -> assertTrue(asset.hasOfficial) }
+    }
+
+    private data class AllAssetTypes(
+        val trackNumber: IntId<TrackLayoutTrackNumber>,
+        val referenceLine: IntId<ReferenceLine>,
+        val locationTrack: IntId<LocationTrack>,
+        val switch: IntId<TrackLayoutSwitch>,
+        val kmPost: IntId<TrackLayoutKmPost>,
+    ) {
+        companion object {
+            fun createIn(context: TestLayoutContext): AllAssetTypes {
+                val trackNumber = context.insert(trackNumber()).id
+                return AllAssetTypes(
+                    trackNumber = trackNumber,
+                    referenceLine = context.insert(referenceLineAndAlignment(trackNumber)).id,
+                    locationTrack = context.insert(locationTrackAndAlignment(trackNumber)).id,
+                    switch = context.insert(switch()).id,
+                    kmPost = context.insert(kmPost(trackNumber, KmNumber(123))).id,
+                )
+            }
+        }
+
+        fun copyFromTo(fromContext: TestLayoutContext, toContext: TestLayoutContext) {
+            toContext.insert(fromContext.fetch(trackNumber)!!)
+            toContext.insert(fromContext.fetch(referenceLine)!!)
+            toContext.insert(fromContext.fetch(locationTrack)!!)
+            toContext.insert(fromContext.fetch(switch)!!)
+            toContext.insert(fromContext.fetch(kmPost)!!)
+        }
+
+        fun fetchAllAndRun(context: TestLayoutContext, callback: (asset: LayoutAsset<*>) -> Unit) {
+            callback(context.fetch(trackNumber)!!)
+            callback(context.fetch(referenceLine)!!)
+            callback(context.fetch(locationTrack)!!)
+            callback(context.fetch(switch)!!)
+            callback(context.fetch(kmPost)!!)
+        }
+
+        fun incrementVersionsInContext(context: TestLayoutContext) = copyFromTo(context, context)
     }
 }


### PR DESCRIPTION
Suosittelen tarkastelemaan kommiteittain.

- Fix has_official lookup for reference lines: Ilmiömäisen simppeli logiikkabugi, yksi tarkistus vaan vaati että pitää olla jossain designissa, kun olisi pitänyt vaatia että ei ole missään designissa
- Fix track number reference_line_id lookup: Pituusmittauslinjojen reference_line_id-tieto tuli vähän väärällä tavalla. Oikealla tavalla haku on varsin yksinkertainen, ja yksinkertaistaa hakuja vähän rakenteeltaankin, kun mahdollisuus, että pituusmittauslinjarivejä on useita, koskee niissä enää ainoastaan reference_line_id:n hakuun
- Fix has_official fetches causing duplicate rows: Näissä hauissa oli jäljellä mahdollisuus, että jos on sekä design-official että main-official-rivi, joini aiheuttaa hakutulosten duplikaatiota. Korjattu samalla tavalla heivaamalla hakujen rakenne sellaiseksi, että ei enää ole mahdollista.