### PR TITLE
GVT-2910 Fix version confusion in fetchLinkedLocationTracks

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -117,7 +117,7 @@ sealed class LayoutContextData<T> : LayoutContextAware<T> {
             when (branch) {
                 is MainBranch ->
                     MainDraftContextData(
-                        layoutAssetId = TemporaryAssetId(),
+                        layoutAssetId = id?.let(::IdentifiedAssetId) ?: TemporaryAssetId(),
                         hasOfficial = false,
                         originBranch = LayoutBranch.main,
                     )


### PR DESCRIPTION
Perinteinen versiohämmennys. Näiltä pitäisi onneksi alkaa olla nyt tästä asti aika helppoa välttyä, kun in_layout_context-funktioiden kutsumisesta on tullut riittävän kevyttä, eikä tarvitse enää tehdä niinkään paljoa hämäriä joineja kuin ennen, mutta kyllä näitä ID-remontin kokoisesta myrskystä tulee.

"not materialized" haun CTE:ssä tarkoittaa, että postgressin hakumoottori vaan inlinettää "lt":n määritelmän jokaiseen paikkaan, missä sitä haussa käytetään, ja sitten tekee hakuoptimoinnit ilmaan mitään tietoa että näillä eri käyttöpaikoilla oli mitään yhteistä. Se sattuu tässä tapauksessa olemaan oikein, koska koko sijaintiraidetaulussa on tuhansia rivejä, mutta niissä kolmessa paikassa, joissa lt:tä käytetään, on kaikissa aika tiukka suodatusehto, ts. käytännössä haussa päädytään tekemään kolmesti hyvin vähän työtä sen sijaan että tehtäisiin kerran aika paljon työtä.