### PR TITLE
GVT-2912: Loppujenkin linkitysten disablointi nykytilassa

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -479,6 +479,8 @@
             "description": "Ratanumeron kuvaus",
             "location-title": "Ratanumeron sijaintitiedot",
             "start-address": "Alkusijainti (km + m)",
+            "cannot-shorten-deleted-track-number": "Poistettua ratanumeroa ei voi lyhentää",
+            "no-geometry": "Ratanumerolla ei ole geometriaa",
             "revert-dialog": {
                 "revert-draft-confirm": "Hylätäänkö luonnos?",
                 "can-be-reverted": "Luonnoksen hylkääminen palauttaa ratanumeron ja pituusmittauslinjan takaisin uusimpaan viralliseen tilaan. Ratanumero ja pituusmittauslinja poistetaan jos niitä ei ole vielä julkaistu Ratkoon.",

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -409,6 +409,13 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                             <InfoboxButtons>
                                 <Button
                                     disabled={layoutContext.publicationState !== 'DRAFT'}
+                                    title={
+                                        layoutContext.publicationState === 'OFFICIAL'
+                                            ? t(
+                                                  'tool-panel.disabled.activity-disabled-in-official-mode',
+                                              )
+                                            : ''
+                                    }
                                     size={ButtonSize.SMALL}
                                     onClick={startLinking}
                                     qa-id="start-alignment-linking">

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -168,6 +168,13 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                             <InfoboxButtons>
                                 <Button
                                     disabled={layoutContext.publicationState !== 'DRAFT'}
+                                    title={
+                                        layoutContext.publicationState !== 'DRAFT'
+                                            ? t(
+                                                  'tool-panel.disabled.activity-disabled-in-official-mode',
+                                              )
+                                            : ''
+                                    }
                                     size={ButtonSize.SMALL}
                                     qa-id="start-geometry-km-post-linking"
                                     onClick={() =>

--- a/ui/src/tool-panel/switch/geometry-switch-linking-initiation.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-initiation.tsx
@@ -25,30 +25,35 @@ export const GeometrySwitchLinkingInitiation: React.FC<GeometrySwitchLinkingInit
     layoutContext,
 }) => {
     const { t } = useTranslation();
+    const warningVisible =
+        linkingState === undefined && geometrySwitchInvalidityReason !== undefined;
+
+    const disabledReason =
+        layoutContext.publicationState === 'OFFICIAL' && !warningVisible
+            ? t('tool-panel.disabled.activity-disabled-in-official-mode')
+            : '';
+
     return (
         <PrivilegeRequired privilege={EDIT_LAYOUT}>
-            {linkingState === undefined &&
-                (geometrySwitchInvalidityReason !== undefined ? (
-                    <InfoboxContentSpread>
-                        <MessageBox>
-                            {t(
-                                `enum.GeometrySwitchSuggestionFailureReason.${geometrySwitchInvalidityReason}`,
-                            )}
-                        </MessageBox>
-                    </InfoboxContentSpread>
-                ) : (
-                    hasSuggestedSwitch && (
-                        <InfoboxButtons>
-                            <Button
-                                disabled={layoutContext.publicationState !== 'DRAFT'}
-                                size={ButtonSize.SMALL}
-                                qa-id="start-geometry-switch-linking"
-                                onClick={onStartLinking}>
-                                {t('tool-panel.switch.geometry.start-setup')}
-                            </Button>
-                        </InfoboxButtons>
-                    )
-                ))}
+            {warningVisible && (
+                <InfoboxContentSpread>
+                    <MessageBox>
+                        {t(
+                            `enum.GeometrySwitchSuggestionFailureReason.${geometrySwitchInvalidityReason}`,
+                        )}
+                    </MessageBox>
+                </InfoboxContentSpread>
+            )}
+            <InfoboxButtons>
+                <Button
+                    disabled={layoutContext.publicationState !== 'DRAFT' || !hasSuggestedSwitch}
+                    size={ButtonSize.SMALL}
+                    qa-id="start-geometry-switch-linking"
+                    title={disabledReason}
+                    onClick={onStartLinking}>
+                    {t('tool-panel.switch.geometry.start-setup')}
+                </Button>
+            </InfoboxButtons>
         </PrivilegeRequired>
     );
 };

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -327,7 +327,16 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             <Button
                                 size={ButtonSize.SMALL}
                                 variant={ButtonVariant.SECONDARY}
-                                disabled={!canStartPlacing}
+                                title={
+                                    layoutContext.publicationState !== 'DRAFT'
+                                        ? t(
+                                              'tool-panel.disabled.activity-disabled-in-official-mode',
+                                          )
+                                        : ''
+                                }
+                                disabled={
+                                    !canStartPlacing || layoutContext.publicationState !== 'DRAFT'
+                                }
                                 onClick={tryToStartSwitchPlacing}>
                                 {t('tool-panel.switch.layout.start-switch-placing')}
                             </Button>

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -135,6 +135,24 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
         onUnselect,
     );
 
+    const canModifyStartOrEnd =
+        layoutContext.publicationState === 'DRAFT' &&
+        trackNumber.state !== 'DELETED' &&
+        !!startAndEndPoints?.start?.point &&
+        !!startAndEndPoints?.end?.point;
+
+    const getModifyStartOrEndDisabledReasonTranslated = () => {
+        if (layoutContext.publicationState !== 'DRAFT') {
+            return t('tool-panel.disabled.activity-disabled-in-official-mode');
+        } else if (trackNumber.state === 'DELETED') {
+            return t('tool-panel.track-number.cannot-shorten-deleted-track-number');
+        } else if (!startAndEndPoints?.start?.point || !startAndEndPoints?.end?.point) {
+            return t('tool-panel.location-track.no-geometry');
+        } else {
+            return undefined;
+        }
+    };
+
     return (
         <React.Fragment>
             <Infobox
@@ -202,6 +220,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                                     <Button
                                         variant={ButtonVariant.SECONDARY}
                                         size={ButtonSize.SMALL}
+                                        title={getModifyStartOrEndDisabledReasonTranslated()}
+                                        disabled={!canModifyStartOrEnd}
                                         onClick={() => {
                                             getEndLinkPoints(
                                                 referenceLine.id,


### PR DESCRIPTION
Tällä pullarilla käyty läpi kaikki paikat missä toolpanelissa on linkitysnappuloita tai geometrian muokkauksia ja pakotettu ne disabloiduiksi nykytilassa. Tiketin yhteydessä on myös ollut puhe siitä, että layoutcontext-tabeihin voisi tehdä jonkinlaisen takalaudan sille, että jos jotenkin ulkoisesti onnistutaan vaihtamaan eri kontekstien välillä. Katson tätä myöhemmällä tiketillä