### PR TITLE
GVT-2912 (Part 2): Varmista että kaikissa frontin kontekstisiirtymissä vaihdetaan myös `layoutContextMode`

### DIFF
--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -29,7 +29,7 @@ import {
 import { GeometryKmPostId } from 'geometry/geometry-model';
 import { angleDiffRads, directionBetweenPoints } from 'utils/math-utils';
 import { exhaustiveMatchingGuard, expectDefined } from 'utils/type-utils';
-import { draftLayoutContext } from 'common/common-model';
+import { draftLayoutContext, LayoutContext, LayoutContextMode } from 'common/common-model';
 import { brand } from 'common/brand';
 
 export const linkingReducers = {
@@ -37,7 +37,10 @@ export const linkingReducers = {
         state: TrackLayoutState,
         { payload }: PayloadAction<GeometryPreliminaryLinkingParameters>,
     ): void => {
-        state.layoutContext = draftLayoutContext(state.layoutContext);
+        const newLayoutContext = draftLayoutContext(state.layoutContext);
+        state.layoutContext = newLayoutContext;
+        state.layoutContextMode = inferLayoutContextMode(newLayoutContext);
+
         state.selection.selectedItems.clusterPoints = [];
         state.linkingState = {
             type: LinkingType.UnknownAlignment,
@@ -181,7 +184,10 @@ export const linkingReducers = {
         const alignmentType = interval.start?.alignmentType || interval.end?.alignmentType;
 
         if (alignmentId && alignmentType) {
-            state.layoutContext = draftLayoutContext(state.layoutContext);
+            const newLayoutContext = draftLayoutContext(state.layoutContext);
+            state.layoutContext = newLayoutContext;
+            state.layoutContextMode = inferLayoutContextMode(newLayoutContext);
+
             state.linkingState = validateLinkingState({
                 layoutAlignment: {
                     id: brand<LocationTrackId & ReferenceLineId>(alignmentId),
@@ -212,7 +218,10 @@ export const linkingReducers = {
             payload: { suggestedSwitch, source },
         }: PayloadAction<{ suggestedSwitch: SuggestedSwitch; source: LinkingAssetSource }>,
     ): void => {
-        state.layoutContext = draftLayoutContext(state.layoutContext);
+        const newLayoutContext = draftLayoutContext(state.layoutContext);
+        state.layoutContext = newLayoutContext;
+        state.layoutContextMode = inferLayoutContextMode(newLayoutContext);
+
         state.linkingState = {
             type: LinkingType.LinkingSwitch,
             suggestedSwitch: suggestedSwitch,
@@ -240,7 +249,10 @@ export const linkingReducers = {
         state: TrackLayoutState,
         { payload: geometryKmPostId }: PayloadAction<GeometryKmPostId>,
     ) => {
-        state.layoutContext = draftLayoutContext(state.layoutContext);
+        const newLayoutContext = draftLayoutContext(state.layoutContext);
+        state.layoutContext = newLayoutContext;
+        state.layoutContextMode = inferLayoutContextMode(newLayoutContext);
+
         state.linkingState = {
             type: LinkingType.LinkingKmPost,
             geometryKmPostId: geometryKmPostId,
@@ -249,6 +261,9 @@ export const linkingReducers = {
         };
     },
 };
+
+export const inferLayoutContextMode = (layoutContext: LayoutContext): LayoutContextMode =>
+    layoutContext.branch === 'MAIN' ? 'MAIN_DRAFT' : 'MAIN_DRAFT';
 
 export function createUpdatedIntervalRemovePoint(
     interval: LinkInterval,

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -19,6 +19,7 @@ import { getOperation } from './splitting/split-utils';
 import { mapReducers } from 'map/map-store';
 import { expectDefined } from 'utils/type-utils';
 import { filterNotEmpty } from 'utils/array-utils';
+import { inferLayoutContextMode } from 'linking/linking-store';
 
 export const PARTIAL_DUPLICATE_EXPECTED_MINIMUM_NON_OVERLAPPING_PART_LENGTH_METERS = 10;
 
@@ -234,7 +235,10 @@ export const splitReducers = {
                 payload.trackSwitches,
             );
 
-            state.layoutContext = draftLayoutContext(state.layoutContext);
+            const newLayoutContext = draftLayoutContext(state.layoutContext);
+            state.layoutContext = newLayoutContext;
+            state.layoutContextMode = inferLayoutContextMode(newLayoutContext);
+
             state.splittingState = {
                 state: 'SETUP',
                 originLocationTrack: payload.locationTrack,

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -16,7 +16,7 @@ import {
     ToggleKmPostPayload,
     ToggleSwitchPayload,
 } from 'selection/selection-store';
-import { linkingReducers } from 'linking/linking-store';
+import { inferLayoutContextMode, linkingReducers } from 'linking/linking-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import {
     draftDesignLayoutContext,
@@ -474,10 +474,13 @@ const trackLayoutSlice = createSlice({
             state: TrackLayoutState,
             { payload: publicationState }: PayloadAction<PublicationState>,
         ): void => {
-            state.layoutContext = {
+            const newLayoutContext = {
                 publicationState: publicationState,
                 branch: state.layoutContext.branch,
             };
+            state.layoutContext = newLayoutContext;
+            state.layoutContextMode = inferLayoutContextMode(newLayoutContext);
+
             if (publicationState === 'OFFICIAL') linkingReducers.stopLinking(state);
         },
         onLayoutContextModeChange: function (
@@ -496,6 +499,12 @@ const trackLayoutSlice = createSlice({
         ) {
             state.designId = designId;
             state.layoutContext = getLayoutContext(state.layoutContextMode, state.designId);
+            state.layoutContextMode =
+                designId !== undefined
+                    ? 'DESIGN'
+                    : state.layoutContext.publicationState === 'OFFICIAL'
+                      ? 'MAIN_OFFICIAL'
+                      : 'MAIN_DRAFT';
         },
         onLayoutModeChange: (
             state: TrackLayoutState,


### PR DESCRIPTION
Päädyin nyt vaan lisäämään nuo asettamiset käsin kaikkialle missä niitä tehdään, mutta en ole tuohon ratkaisuun mitenkään tyytyväinen. Problematiikka on siis ollut siinä, että frontilla on erikseen tallessa `layoutContext` sekä tieto siitä mikä tabi on valittuna (`layoutContextMode`, joka kertoo käytännössä mikä karttanäkymän vasemman yläkulman tabi on valittuna.) Näiden tarvii olla jotenkin eroteltuna käytännössä pakosta, sillä vaikka `LayoutContext` pystyy kuvaamaan kaikki validit branch-publicationState-combot joissa voidaan tehdä muutoksia, sillä on käytännössä mahdotonta kuvata tilannetta jossa ollaan suunnitelmatilassa mutta suunnitelmaa ei ole vielä valittu. Ideaalitilanteessa näitä haluttaisiin varmaankin käyttää siten, että aina kun reduxiin tallennettu `layoutContext` muuttuu, niin muutetaan `layoutContextMode` sen mukaiseksi (joka täällä on tehtykin, mutta käsin.) Sikäli kun Reduxia ymmärrän ja olen googletellut, niin siellä ei oikeastaan taida mitään fiksua tapaa muuttaa polun X arvoa aina kun polku A muuttuu. Yksi vaihtoehto olisi tehdä `layoutContext`:in asettamiselle oma reducer joka muuttaa molemmat polut, mutta se kuulostaa jotenkin räjähdysherkältä, koska sitä pitää tajuta käyttää ja `layoutContext` kuitenkin on vaan oma polkunsa jota voi helposti muuttaa sellaisenaan.