### PR TITLE
GVT-2909: Muunnetun koordinaatiston näyttäminen olemassaolevalla km-pylväällä

### DIFF
--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section.tsx
@@ -38,7 +38,6 @@ type KmPostEditDialogGkLocationSectionProps = {
     hasErrors: (prop: keyof KmPostEditFields) => boolean;
     getVisibleErrorsByProp: (prop: keyof KmPostEditFields) => string[];
     getVisibleWarningsByProp: (prop: keyof KmPostEditFields) => string[];
-    geometryKmPostGkLocation?: GeometryPoint;
     editType: KmPostEditDialogType;
     geometryPlanSrid?: Srid;
 };
@@ -80,12 +79,9 @@ function transformGkToLayout(point: GeometryPoint): Point | undefined {
 const gkLocationSourceTranslationKey = (
     source: KmPostGkLocationSource | undefined,
     gkLocationEnabled: boolean,
-    dialogRole: KmPostEditDialogType,
 ) => {
     if (!gkLocationEnabled || source === undefined) {
         return 'km-post-dialog.gk-location.source-none';
-    } else if (dialogRole === 'LINKING') {
-        return gkLocationSourceI18nKey('FROM_GEOMETRY');
     } else {
         return gkLocationSourceI18nKey(source);
     }
@@ -151,12 +147,15 @@ export const KmPostEditDialogGkLocationSection: React.FC<
     const layoutLocation = gkLocation ? transformGkToLayout(gkLocation) : undefined;
     const gkLocationEnabled = state.gkLocationEnabled;
     const fieldsEnabled = !isLinking && gkLocationEnabled;
+    const gkSource = isLinking ? 'FROM_GEOMETRY' : gkLocationSource(state);
 
     const coordinateSystems = useCoordinateSystems(GK_FIN_COORDINATE_SYSTEMS.map(([srid]) => srid));
     const isFromNonGkPlan =
+        gkSource === 'FROM_GEOMETRY' &&
         geometryPlanSrid !== undefined &&
         !GK_FIN_COORDINATE_SYSTEMS.find(([srid]) => srid === geometryPlanSrid);
     const isFromDifferentGk =
+        gkSource === 'FROM_GEOMETRY' &&
         geometryPlanSrid !== undefined &&
         geometryPlanSrid !== state.kmPost.gkSrid &&
         !!GK_FIN_COORDINATE_SYSTEMS.find(([srid]) => srid === geometryPlanSrid);
@@ -210,9 +209,9 @@ export const KmPostEditDialogGkLocationSection: React.FC<
                 label={`${t('km-post-dialog.gk-location.location-field')} *`}
                 disabled={!fieldsEnabled}
                 help={
-                    isLinking && isFromNonGkPlan ? (
+                    isFromNonGkPlan ? (
                         <TransformedFromNonGkWarning originalSrid={geometryPlanSrid} />
-                    ) : isLinking && isFromDifferentGk ? (
+                    ) : isFromDifferentGk ? (
                         <TransformedGkWarning originalSrid={geometryPlanSrid} />
                     ) : (
                         <React.Fragment />
@@ -288,13 +287,7 @@ export const KmPostEditDialogGkLocationSection: React.FC<
             <FieldLayout
                 label={t('km-post-dialog.gk-location.source')}
                 disabled={!fieldsEnabled}
-                value={t(
-                    gkLocationSourceTranslationKey(
-                        gkLocationSource(state),
-                        gkLocationEnabled,
-                        editType,
-                    ),
-                )}
+                value={t(gkLocationSourceTranslationKey(gkSource, gkLocationEnabled))}
             />
             <FieldLayout
                 label={t('km-post-dialog.gk-location.location-in-layout')}

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -367,7 +367,6 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                             state={state}
                             stateActions={stateActions}
                             updateProp={updateProp}
-                            geometryKmPostGkLocation={props.geometryKmPostGkLocation}
                             editType={props.editType}
                             geometryPlanSrid={props.geometryPlanSrid}
                         />

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -338,6 +338,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                     onSave={handleKmPostSave}
                     geometryKmPostGkLocation={kmPost.gkLocation?.location}
                     editType={'MODIFY'}
+                    geometryPlanSrid={geometryPlan?.units?.coordinateSystemSrid}
                 />
             )}
         </React.Fragment>


### PR DESCRIPTION
Koordinaatistomuunnosinformaatio näytettiin edit-dialogissa aiemmin siis pelkästään linkityksen yhteydessä. Nyt se näytetään myös kun ollaan muokkaamassa olemassaolevaa kilometripylvästä jonka GK-sijainti on muunnettu