### PR TITLE
General: Kotlin-versiopäivitys ja muita juttuja testiajojen nopeuttamiseksi

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -11,14 +11,14 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_OUT
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val geotoolsVersion = "31.3"
-val kotlinVersion = "1.9.25"
+val kotlinVersion = "2.0.20"
 
 plugins {
     id("org.springframework.boot") version "3.3.3"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.github.jk1.dependency-license-report") version "2.9"
-    kotlin("jvm") version "1.9.25"
-    kotlin("plugin.spring") version "1.9.25"
+    kotlin("jvm") version "2.0.20"
+    kotlin("plugin.spring") version "2.0.20"
     id("com.ncorti.ktfmt.gradle") version "0.20.1"
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/SpringContextUtility.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/SpringContextUtility.kt
@@ -2,6 +2,7 @@ package fi.fta.geoviite.infra
 
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Component
 
 /**
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component
  * used only if normal @Autowire isn't usable.
  */
 @Component
+@Lazy(false) // we use lazy init in tests by default, but this bean can't be lazy-init'd
 class SpringContextUtility : ApplicationContextAware {
     companion object {
         var applicationContext: ApplicationContext? = null

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -114,17 +114,17 @@ constructor(
 ) : DBTestBase() {
     @BeforeEach
     fun cleanup() {
-        val sql =
-            """
-            truncate publication.publication cascade;
-            truncate integrations.lock cascade;
-            truncate layout.track_number_id cascade;
-            truncate layout.switch cascade;
-            truncate layout.operating_point cascade;
-            truncate layout.operating_point_version cascade;
-        """
-                .trimIndent()
-        jdbc.execute(sql) { it.execute() }
+        testDBService.deleteFromTables("publication", "split")
+        testDBService.deleteFromTables(
+            "layout",
+            "location_track",
+            "segment_version",
+            "switch_joint",
+            "switch",
+            "track_number",
+            "operating_point",
+            "operating_point_version",
+        )
     }
 
     lateinit var fakeRatko: FakeRatko

--- a/infra/src/test/resources/application-test.yml
+++ b/infra/src/test/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    lazy-initialization: true
   datasource:
     url: "jdbc:postgresql://${DB_URL:localhost:5436/geoviite}"
     hikari:


### PR DESCRIPTION
Tässä haetaan tietenkin lähinnä RatkoServiceIT:n ajonopeutta, mutta muutokset on laajempia.

Isoin muutos on Kotlin-versiomuutos, tosin en tiedä, tarvitseeko sen takia kenenkään oikeastaan tehdä mitään: Ainakin minulla toimi testit ja Geoviite ihan ongelmitta, tai ainakin sen verran ongelmitta että en lähtenyt kokeilemaan jokaista ominaisuutta läpi. Muutamasta asiasta tulee kääntäjävaroituksia, joita ei aiemmin tullut: En lähtenyt niitä tähän hätään korjaamaan, niissä kun näyttäisi olevan kaikissa kyse ominaisuuksista, joita aiotaan myöhemmin kielessä muokata, mutta ei vielä.

Laiskan initoinnin asettaminen testeissä ei taida vaikuttaa ihan hirveästi ajoaikaan, mutta ei myöskään riko testejä.

RatkoServiceIT:stä poistettu truncate tablen käytöt: Postgressissä pienillä tauluilla deletet on nopeampia kuin truncatet.