### PR TITLE
General: Bump Kotlin version to 2.0.20

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -11,14 +11,14 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.STANDARD_OUT
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val geotoolsVersion = "31.3"
-val kotlinVersion = "1.9.25"
+val kotlinVersion = "2.0.20"
 
 plugins {
     id("org.springframework.boot") version "3.3.3"
     id("io.spring.dependency-management") version "1.1.6"
     id("com.github.jk1.dependency-license-report") version "2.9"
-    kotlin("jvm") version "1.9.25"
-    kotlin("plugin.spring") version "1.9.25"
+    kotlin("jvm") version "2.0.20"
+    kotlin("plugin.spring") version "2.0.20"
     id("com.ncorti.ktfmt.gradle") version "0.20.1"
 }
 
@@ -120,7 +120,7 @@ licenseReport {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict")
+        freeCompilerArgs = listOf("-Xjsr305=strict", "-Xconsistent-data-class-copy-visibility")
         jvmTarget = "17"
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -592,11 +592,12 @@ private fun validateSpiral(alignmentName: AlignmentName, spiral: GeometrySpiral)
 
 private fun validateClothoid(alignmentName: AlignmentName, clothoid: GeometryClothoid): List<ElementIssue> {
     val calculatedConstant =
-        if (clothoid.radiusStart != null) {
-            sqrt(clothoid.radiusStart.toDouble() * clothoid.segmentToClothoidDistance(0.0))
-        } else if (clothoid.radiusEnd != null) {
-            sqrt(clothoid.radiusEnd.toDouble() * clothoid.segmentToClothoidDistance(clothoid.length.toDouble()))
-        } else null
+        clothoid.radiusStart?.toDouble()?.let { radiusStart ->
+            sqrt(radiusStart * clothoid.segmentToClothoidDistance(0.0))
+        }
+            ?: clothoid.radiusEnd?.toDouble()?.let { radiusEnd ->
+                sqrt(radiusEnd * clothoid.segmentToClothoidDistance(clothoid.length.toDouble()))
+            }
 
     return listOfNotNull(
         calculatedConstant?.let { calculated ->


### PR DESCRIPTION
Mukavan yllättävän vähän mitään rikkova tai oikeastaan juuri mihinkään vaikuttava juttu. Päämuutos on, että K2-kääntäjä on ainakin mainoslauseiden perusteella selvästi aiempaa nopeampi.

Versiopäivityksestä ei tullut käännösvirheitä, mutta varoituksia tuli, ne korjattu myös. Koodimuutoksen aiheuttava uusi varoitus oli https://youtrack.jetbrains.com/issue/KT-57417 , ts. kääntäjä ei enää suostu varoituksetta olettamaan, etteikö tuolla radiusStartin tai radiusEndin delegoinnin takana olisi jotain pahantahtoista hähmää joka päättääkin palauttaa ensiksi ei-nullia ja sitten nullia: Korjataan tavalliseen tapaan kysymällä niitä vain kerran.