### PR TITLE
General: Restore sorting in fetchProfileInfoForSegmentsInBoundingBox

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -556,7 +556,8 @@ class LayoutAlignmentDao(
                         )
                     and location_track.state != 'DELETED'
               ) s
-              where ((:has_profile_info::boolean is null) or :has_profile_info = has_profile_info);
+              where ((:has_profile_info::boolean is null) or :has_profile_info = has_profile_info)
+              order by id, segment_index
         """
                 .trimIndent()
 


### PR DESCRIPTION
Satunnainen testifaili onneksi löysi tämän sorttauksen, joka jäi vahingossa jätettyä pois hakua yksinkertaistaessa.