### PR TITLE
General: Remember to actually save origin_design_id

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -97,6 +97,10 @@ sealed class LayoutContextData<T> : LayoutContextAware<T> {
     open val designId: IntId<LayoutDesign>?
         get() = null
 
+    @get:JsonIgnore
+    open val originBranch: LayoutBranch?
+        get() = null
+
     protected fun requireStoredRowVersion() =
         layoutAssetId.let { current ->
             if (current is StoredAssetId) current.version
@@ -181,7 +185,7 @@ data class MainOfficialContextData<T>(override val layoutAssetId: LayoutAssetId<
 data class MainDraftContextData<T>(
     override val layoutAssetId: LayoutAssetId<T>,
     override val hasOfficial: Boolean,
-    val originBranch: LayoutBranch,
+    override val originBranch: LayoutBranch,
 ) : MainContextData<T>() {
     override val isDraft: Boolean
         get() = true

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -281,7 +281,8 @@ class LayoutKmPostDao(
               state,
               draft,
               cancelled,
-              design_id
+              design_id,
+              origin_design_id
             )
             values (
               :layout_context_id,
@@ -296,7 +297,8 @@ class LayoutKmPostDao(
               :state::layout.state,
               :draft,
               :cancelled,
-              :design_id
+              :design_id,
+              :origin_design_id
             )
             on conflict (id, layout_context_id) do update
               set track_number_id = excluded.track_number_id,
@@ -307,7 +309,8 @@ class LayoutKmPostDao(
                   gk_location_confirmed = excluded.gk_location_confirmed,
                   gk_location_source = excluded.gk_location_source,
                   state = excluded.state,
-                  cancelled = excluded.cancelled
+                  cancelled = excluded.cancelled,
+                  origin_design_id = excluded.origin_design_id
             returning version 
         """
                 .trimIndent()
@@ -330,6 +333,7 @@ class LayoutKmPostDao(
                 "draft" to item.contextData.isDraft,
                 "cancelled" to item.isCancelled,
                 "design_id" to item.contextData.designId?.intValue,
+                "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
             )
 
         jdbcTemplate.setUser()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -163,7 +163,8 @@ class LayoutSwitchDao(
                 draft,
                 cancelled,
                 design_id,
-                source
+                source,
+                origin_design_id
             )
             values (
               :layout_context_id,
@@ -178,7 +179,8 @@ class LayoutSwitchDao(
               :draft,
               :cancelled,
               :design_id,
-              :source::layout.geometry_source
+              :source::layout.geometry_source,
+              :origin_design_id
             )
             on conflict (id, layout_context_id) do update set
               external_id = excluded.external_id,
@@ -189,7 +191,8 @@ class LayoutSwitchDao(
               trap_point = excluded.trap_point,
               owner_id = excluded.owner_id,
               cancelled = excluded.cancelled,
-              source = excluded.source
+              source = excluded.source,
+              origin_design_id = excluded.origin_design_id
             returning id, design_id, draft, version
         """
                 .trimIndent()
@@ -211,6 +214,7 @@ class LayoutSwitchDao(
                     "cancelled" to item.isCancelled,
                     "design_id" to item.contextData.designId?.intValue,
                     "source" to item.source.name,
+                    "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
                 ),
             ) { rs, _ ->
                 rs.getLayoutRowVersion("id", "design_id", "draft", "version")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -175,7 +175,8 @@ class LayoutTrackNumberDao(
                                             state,
                                             draft,
                                             cancelled,
-                                            design_id)
+                                            design_id,
+                                            origin_design_id)
               values
                 (:layout_context_id,
                  :id,
@@ -185,13 +186,15 @@ class LayoutTrackNumberDao(
                  :state::layout.state,
                  :draft,
                  :cancelled,
-                 :design_id)
+                 :design_id,
+                 :origin_design_id)
               on conflict (id, layout_context_id) do update
                 set external_id = excluded.external_id,
                     number = excluded.number,
                     description = excluded.description,
                     state = excluded.state,
-                    cancelled = excluded.cancelled
+                    cancelled = excluded.cancelled,
+                    origin_design_id = excluded.origin_design_id
               returning id, design_id, draft, version;
         """
                 .trimIndent()
@@ -206,6 +209,7 @@ class LayoutTrackNumberDao(
                 "draft" to item.isDraft,
                 "cancelled" to item.isCancelled,
                 "design_id" to item.contextData.designId?.intValue,
+                "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
             )
         jdbcTemplate.setUser()
         val response: LayoutRowVersion<TrackLayoutTrackNumber> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -283,7 +283,8 @@ class LocationTrackDao(
               topology_start_switch_joint_number,
               topology_end_switch_id,
               topology_end_switch_joint_number,
-              owner_id
+              owner_id,
+              origin_design_id
             ) 
             values (
               :layout_context_id,
@@ -306,7 +307,8 @@ class LocationTrackDao(
               :topology_start_switch_joint_number,
               :topology_end_switch_id,
               :topology_end_switch_joint_number,
-              :owner_id
+              :owner_id,
+              :origin_design_id
             ) on conflict (id, layout_context_id) do update set
               track_number_id = excluded.track_number_id,
               external_id = excluded.external_id ,
@@ -324,7 +326,8 @@ class LocationTrackDao(
               topology_start_switch_joint_number = excluded.topology_start_switch_joint_number,
               topology_end_switch_id = excluded.topology_end_switch_id,
               topology_end_switch_joint_number = excluded.topology_end_switch_joint_number,
-              owner_id = excluded.owner_id
+              owner_id = excluded.owner_id,
+              origin_design_id = excluded.origin_design_id
             returning id, design_id, draft, version
         """
                 .trimIndent()
@@ -351,6 +354,7 @@ class LocationTrackDao(
                 "topology_end_switch_id" to item.topologyEndSwitch?.switchId?.intValue,
                 "topology_end_switch_joint_number" to item.topologyEndSwitch?.jointNumber?.intValue,
                 "owner_id" to item.ownerId.intValue,
+                "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
             )
 
         jdbcTemplate.setUser()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -144,7 +144,8 @@ class ReferenceLineDao(
               start_address,
               draft, 
               cancelled,
-              design_id
+              design_id,
+              origin_design_id
             ) 
             values (
               :layout_context_id,
@@ -155,13 +156,15 @@ class ReferenceLineDao(
               :start_address, 
               :draft, 
               :cancelled,
-              :design_id
+              :design_id,
+              :origin_design_id
             ) on conflict (id, layout_context_id) do update set
               track_number_id = excluded.track_number_id,
               alignment_id = excluded.alignment_id,
               alignment_version = excluded.alignment_version,
               start_address = excluded.start_address,
-              cancelled = excluded.cancelled
+              cancelled = excluded.cancelled,
+              origin_design_id = excluded.origin_design_id
             returning id, design_id, draft, version
         """
                 .trimIndent()
@@ -177,6 +180,7 @@ class ReferenceLineDao(
                 "draft" to item.isDraft,
                 "cancelled" to item.isCancelled,
                 "design_id" to item.contextData.designId?.intValue,
+                "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
             )
 
         jdbcTemplate.setUser()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -292,13 +292,7 @@ constructor(
         )
 
         val mainOfficial = trackNumberService.publish(LayoutBranch.main, mainDraft)
-        assertVersionReferences(
-            designBranch,
-            tnId,
-            mainOfficial = mainOfficial,
-            designOfficial = designOfficial,
-            designDraft = designDraft2,
-        )
+        assertVersionReferences(designBranch, tnId, mainOfficial = mainOfficial, designDraft = designDraft2)
     }
 
     @Test
@@ -345,13 +339,7 @@ constructor(
         )
 
         val mainOfficial2 = trackNumberService.publish(LayoutBranch.main, mainDraft2)
-        assertVersionReferences(
-            designBranch,
-            tnId,
-            mainOfficial = mainOfficial2,
-            designOfficial = designOfficial,
-            designDraft = designDraft2,
-        )
+        assertVersionReferences(designBranch, tnId, mainOfficial = mainOfficial2, designDraft = designDraft2)
     }
 
     @Test


### PR DESCRIPTION
ID-remontista sivuun jäänyt detalji.

Tämän myötä myös suunnitelmamuokkauksen mainissa-julkaisun yhteydessä tapahtuva design-officialin poisto alkaa oikeasti toimia, ja pari testiä, jotka olettivat, että sitä ei tapahdu, menivät siitä rikki. Jätin tähän hätään niistä pois eksplisiittisen kannanoton siitä, mitä pitää oikeasti tapahtua: Olen tällä hetkellä sillä kannalla, että se poistaminen on oikein ja kannattaa tehdä, mutta näkyvyys siihen kokonaisuuteen on vielä hieman heikko.