### PR TITLE
General: Stricter typing for layout asset id/rowversion

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -137,7 +137,7 @@ class WebConfig(
 
         logger.info("Registering version converters")
         registry.addStringConstructorConverter { RowVersion<Any>(it) }
-        registry.addStringConstructorConverter { LayoutRowVersion<Any>(it) }
+        registry.addStringConstructorConverter(::LayoutRowVersion)
 
         logger.info("Registering geography converters")
         registry.addStringConstructorConverter(::BoundingBox)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -316,7 +316,7 @@ data class LayoutValidationIssue(
     ) : this(type, LocalizationKey(key), localizationParams(params))
 }
 
-interface PublicationCandidate<T> {
+interface PublicationCandidate<T : LayoutAsset<T>> {
     val type: DraftChangeType
     val rowVersion: LayoutRowVersion<T>
     val draftChangeTime: Instant

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -13,12 +13,12 @@ import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.tracklayout.*
 import fi.fta.geoviite.infra.util.*
-import java.sql.Timestamp
-import java.time.Instant
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -1953,7 +1953,7 @@ private fun <T> partitionDirectIndirectChanges(rows: List<Pair<Boolean, T>>) =
             )
         }
 
-private inline fun <reified T> requireUniqueIds(candidates: List<PublicationCandidate<T>>) {
+private inline fun <reified T : LayoutAsset<T>> requireUniqueIds(candidates: List<PublicationCandidate<T>>) {
     filterNonUniqueIds(candidates).let { nonUniqueIds ->
         require(nonUniqueIds.isEmpty()) {
             "${T::class.simpleName} publication candidates contained non-unique ids: $nonUniqueIds"
@@ -1961,7 +1961,7 @@ private inline fun <reified T> requireUniqueIds(candidates: List<PublicationCand
     }
 }
 
-private fun <T> filterNonUniqueIds(candidates: List<PublicationCandidate<T>>): Map<IntId<T>, Int> {
+private fun <T : LayoutAsset<T>> filterNonUniqueIds(candidates: List<PublicationCandidate<T>>): Map<IntId<T>, Int> {
     return candidates
         .groupingBy { candidate -> candidate.id }
         .eachCount()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.split.SplitLayoutValidationIssues
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
@@ -299,7 +300,10 @@ constructor(
         }
     }
 
-    private inline fun <reified T> assertNoErrors(version: LayoutRowVersion<T>, issues: List<LayoutValidationIssue>) {
+    private inline fun <reified T : LayoutAsset<T>> assertNoErrors(
+        version: LayoutRowVersion<T>,
+        issues: List<LayoutValidationIssue>,
+    ) {
         val errors = issues.filter { issue -> issue.type == ERROR }
         if (errors.isNotEmpty()) {
             logger.warn("Validation errors in published ${T::class.simpleName}: item=$version errors=$errors")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -414,5 +414,5 @@ fun <T : LayoutAsset<T>> verifyObjectIsExisting(contextData: LayoutContextData<T
     require(contextData.version != null) { "DB row should have DB ID: context=$contextData" }
 }
 
-inline fun <reified T, reified S> getOne(rowVersion: LayoutRowVersion<T>, result: List<S>) =
+inline fun <reified T : LayoutAsset<T>, reified S> getOne(rowVersion: LayoutRowVersion<T>, result: List<S>) =
     requireOne(T::class, rowVersion, result)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutRowVersion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutRowVersion.kt
@@ -11,9 +11,13 @@ import fi.fta.geoviite.infra.common.parseLayoutContextSqlString
 private const val ID_SEPARATOR = "__"
 private const val VERSION_SEPARATOR = "_v"
 
-data class LayoutRowId<T> @JsonCreator(mode = DISABLED) constructor(val id: IntId<T>, val context: LayoutContext)
+data class LayoutRowId<T : LayoutAsset<T>>
+@JsonCreator(mode = DISABLED)
+constructor(val id: IntId<T>, val context: LayoutContext)
 
-data class LayoutRowVersion<T> @JsonCreator(mode = DISABLED) constructor(val rowId: LayoutRowId<T>, val version: Int) {
+data class LayoutRowVersion<T : LayoutAsset<T>>
+@JsonCreator(mode = DISABLED)
+constructor(val rowId: LayoutRowId<T>, val version: Int) {
     constructor(
         id: IntId<T>,
         layoutContext: LayoutContext,
@@ -44,7 +48,7 @@ data class LayoutRowVersion<T> @JsonCreator(mode = DISABLED) constructor(val row
     fun previous() = if (version > 1) LayoutRowVersion(rowId, version - 1) else null
 }
 
-fun <T> parseLayoutRowVersionValues(text: String): Triple<IntId<T>, LayoutContext, Int> {
+fun <T : LayoutAsset<T>> parseLayoutRowVersionValues(text: String): Triple<IntId<T>, LayoutContext, Int> {
     val idSplit = text.split(ID_SEPARATOR)
     require(idSplit.size == 2) {
         "LayoutRowVersion text must consist of two parts split by $ID_SEPARATOR, but was $text"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -24,8 +24,7 @@ import fi.fta.geoviite.infra.geometry.PlanState.ABANDONED
 import fi.fta.geoviite.infra.geometry.PlanState.DESTROYED
 import fi.fta.geoviite.infra.geometry.PlanState.EXISTING
 import fi.fta.geoviite.infra.geometry.PlanState.PROPOSED
-import fi.fta.geoviite.infra.map.AlignmentHeader
-import fi.fta.geoviite.infra.map.MapAlignmentSource
+import fi.fta.geoviite.infra.map.GeometryAlignmentHeader
 import fi.fta.geoviite.infra.map.MapAlignmentType
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
@@ -173,19 +172,15 @@ fun toAlignmentHeader(
     alignment: GeometryAlignment,
     boundingBoxInLayoutSpace: BoundingBox? = null,
 ) =
-    AlignmentHeader(
+    GeometryAlignmentHeader(
         id = alignment.id,
         name = alignment.name,
-        alignmentSource = MapAlignmentSource.GEOMETRY,
         alignmentType = getAlignmentType(alignment.featureTypeCode),
         state = getLayoutStateOrDefault(alignment.state),
         trackNumberId = trackNumberId,
         boundingBox = boundingBoxInLayoutSpace,
         length = alignment.elements.sumOf(GeometryElement::calculatedLength),
         segmentCount = alignment.elements.size,
-        version = null,
-        duplicateOf = null,
-        trackType = null,
     )
 
 private fun toMapSegments(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -30,6 +30,7 @@ import fi.fta.geoviite.infra.projektivelho.PVProjectName
 import fi.fta.geoviite.infra.publication.Change
 import fi.fta.geoviite.infra.tracklayout.DesignDraftContextData
 import fi.fta.geoviite.infra.tracklayout.DesignOfficialContextData
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutContextData
 import fi.fta.geoviite.infra.tracklayout.LayoutDesign
 import fi.fta.geoviite.infra.tracklayout.LayoutRowId
@@ -74,10 +75,10 @@ fun <T> ResultSet.getIndexedIdOrNull(parent: String, index: String): IndexedId<T
     }
 }
 
-fun <T> ResultSet.getLayoutRowId(idName: String, designIdName: String, draftFlagName: String) =
+fun <T : LayoutAsset<T>> ResultSet.getLayoutRowId(idName: String, designIdName: String, draftFlagName: String) =
     LayoutRowId(getIntId<T>(idName), getLayoutContext(designIdName, draftFlagName))
 
-fun <T> ResultSet.getLayoutRowIdOrNull(idName: String, designIdName: String, draftFlagName: String) =
+fun <T : LayoutAsset<T>> ResultSet.getLayoutRowIdOrNull(idName: String, designIdName: String, draftFlagName: String) =
     getIntIdOrNull<T>(idName)?.let { id ->
         getLayoutContextOrNull(designIdName, draftFlagName)?.let { layoutContext -> LayoutRowId(id, layoutContext) }
     }
@@ -217,7 +218,7 @@ fun <T> ResultSet.getRowVersionOrNull(idName: String, versionName: String): RowV
     return if (rowId != null && version != null) RowVersion(rowId, version) else null
 }
 
-fun <T> ResultSet.getLayoutRowVersion(
+fun <T : LayoutAsset<T>> ResultSet.getLayoutRowVersion(
     idName: String,
     layoutBranchName: String,
     publicationStateName: String,
@@ -225,7 +226,7 @@ fun <T> ResultSet.getLayoutRowVersion(
 ): LayoutRowVersion<T> =
     LayoutRowVersion(getLayoutRowId(idName, layoutBranchName, publicationStateName), getIntNonNull(versionName))
 
-fun <T> ResultSet.getLayoutRowVersionOrNull(
+fun <T : LayoutAsset<T>> ResultSet.getLayoutRowVersionOrNull(
     idName: String,
     layoutBranchName: String,
     publicationStateName: String,
@@ -236,7 +237,7 @@ fun <T> ResultSet.getLayoutRowVersionOrNull(
     return if (rowId != null && version != null) LayoutRowVersion(rowId, version) else null
 }
 
-fun <T> ResultSet.getLayoutRowVersionArray(
+fun <T : LayoutAsset<T>> ResultSet.getLayoutRowVersionArray(
     idsName: String,
     designIdsName: String,
     publicationStatesName: String,
@@ -370,7 +371,7 @@ inline fun <reified T> verifyType(value: Any?): T =
         v
     }
 
-fun <T> ResultSet.getLayoutContextData(
+fun <T : LayoutAsset<T>> ResultSet.getLayoutContextData(
     idName: String,
     designIdName: String,
     draftFlagName: String,

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -24,11 +24,7 @@ import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
-import java.math.BigDecimal
-import java.util.*
-import junit.framework.TestCase.assertNotNull
-import kotlin.math.hypot
-import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,6 +32,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import java.math.BigDecimal
+import java.util.*
+import kotlin.math.hypot
+import kotlin.test.assertEquals
 
 private const val API_TRACK_ADDRESSES: FrameConverterUrl = "/rata-vkm/v1/rataosoitteet"
 
@@ -468,7 +468,7 @@ constructor(
         assertEquals(geocodableTrack.trackNumber.number.toString(), properties["ratanumero"])
         assertEquals(geocodableTrack.locationTrack.name.toString(), properties["sijaintiraide"])
         assertEquals(trackDescription, properties["sijaintiraide_kuvaus"])
-        assertEquals("kujaraide", properties.get("sijaintiraide_tyyppi"))
+        assertEquals("kujaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
         assertEquals(10, properties["ratametri"] as Int)
         assertEquals(0, properties["ratametri_desimaalit"] as Int)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -184,7 +184,7 @@ constructor(
         assertCandidatesContainCorrectVersions(candidates.kmPosts, kmPost)
     }
 
-    private fun <T> assertCandidatesContainCorrectVersions(
+    private fun <T : LayoutAsset<T>> assertCandidatesContainCorrectVersions(
         candidates: List<PublicationCandidate<T>>,
         vararg responses: LayoutRowVersion<T>,
     ) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -438,7 +438,11 @@ constructor(
         }
     }
 
-    fun <T> assertVersionMatch(description: String, expected: LayoutRowVersion<T>?, actual: LayoutRowVersion<T>?) {
+    fun <T : LayoutAsset<T>> assertVersionMatch(
+        description: String,
+        expected: LayoutRowVersion<T>?,
+        actual: LayoutRowVersion<T>?,
+    ) {
         assertEquals(expected = expected, actual = actual, message = "$description expected=$expected actual=$actual")
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -28,8 +28,7 @@ import fi.fta.geoviite.infra.linking.FittedSwitchJointMatch
 import fi.fta.geoviite.infra.linking.SuggestedSwitchJointMatchType
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.linking.fixSegmentStarts
-import fi.fta.geoviite.infra.map.AlignmentHeader
-import fi.fta.geoviite.infra.map.MapAlignmentSource
+import fi.fta.geoviite.infra.map.GeometryAlignmentHeader
 import fi.fta.geoviite.infra.map.MapAlignmentType
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IPoint3DM
@@ -511,17 +510,13 @@ fun mapAlignment(vararg segments: PlanLayoutSegment) = mapAlignment(segments.toL
 fun mapAlignment(segments: List<PlanLayoutSegment>) =
     PlanLayoutAlignment(
         header =
-            AlignmentHeader(
+            GeometryAlignmentHeader(
                 id = StringId(),
                 name = AlignmentName("test-alignment"),
-                alignmentSource = MapAlignmentSource.GEOMETRY,
                 alignmentType = MapAlignmentType.LOCATION_TRACK,
-                trackType = LocationTrackType.MAIN,
                 state = LayoutState.IN_USE,
                 segmentCount = segments.size,
                 trackNumberId = IntId(1),
-                version = null,
-                duplicateOf = null,
                 length = segments.map(PlanLayoutSegment::length).sum(),
                 boundingBox = boundingBoxCombining(segments.mapNotNull(PlanLayoutSegment::boundingBox)),
             ),
@@ -963,7 +958,7 @@ fun switch(
         contextData = contextData,
     )
 
-fun <T> createMainContext(id: IntId<T>?, draft: Boolean): LayoutContextData<T> =
+fun <T : LayoutAsset<T>> createMainContext(id: IntId<T>?, draft: Boolean): LayoutContextData<T> =
     if (draft) {
         MainDraftContextData(
             if (id != null) IdentifiedAssetId(id) else TemporaryAssetId(),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
@@ -86,7 +86,7 @@ class TrackLayoutTest {
         )
     }
 
-    private fun <T> assertRoundTrip(version: LayoutRowVersion<T>) {
+    private fun <T : LayoutAsset<T>> assertRoundTrip(version: LayoutRowVersion<T>) {
         val text = version.toString()
         val versionAgain = LayoutRowVersion<T>(text)
         val textAgain = versionAgain.toString()


### PR DESCRIPTION
Törmäsin näihin tyyppeihin vaihdevälijuttuja miettiessä, mutta ei suoranaisesti liity niihin mitenkään, joten tein erillisen pullarin. Tämä on vähän ehdotus-henkinen, en ole ihan varma maksaako tuo ekstra kompleksisuuden vaivaa, mutta sekoilin remppaa tehdessä noihin tyyppeihin pari kertaa niin tuntui luonnolliselta että ne olisi rajattu niin että layoutrowversion ja -id voidaan tehdä vain layout-asseteille