### PR TITLE
GVT-2925 Fix migrating draft switches

### DIFF
--- a/infra/src/main/resources/db/migration/prod/V99_10__redo_id_structure_for_switch_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_10__redo_id_structure_for_switch_version.sql
@@ -41,6 +41,7 @@ create temporary table switch_joint_version_change on commit drop as
         join layout.switch_joint_version sjv
              on svc.id = sjv.switch_id
                and svc.old_version = sjv.switch_version
+               and svc.layout_context_id = sjv.switch_layout_context_id
   );
 
 update publication.switch


### PR DESCRIPTION
Fiksi ID-remonttiin, vaihdepisteiden versiotaulun migraatioon. Pullaroin tämän kylläkin nyt, mutta taidan vielä katella läpi kaikki paikannuspohjan oliotyypit että jokaisesta saa migroitua luonnokset oikein, ennen kuin rikon tällä devin.