### PR TITLE
GVT-2940 Fix reporting multiple results per request in forward VKM

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -202,8 +202,8 @@ constructor(
                     params,
                 )
             }
+            .map { it.flatten() }
             .toList()
-            .flatten()
 
     private fun processForwardGeocodingRequestsForTrackNumber(
         geocodingContext: GeocodingContext?,


### PR DESCRIPTION
Tässä olisi reilusti tilaa tyyppien selvennykselle: Tässä kun pyöritellään kolmea tasoa sisäkkäisiä listoja, niin onko ihmekään että tuli litistettyä pois väärä sisäkkäisyyden taso. Mutta tuleepahan toisaalta minikokoisesta pullarista myös selväksi, että mitään muuta ei ole muutettu kuin että mikä taso litistetään.

Ylempänä siis tuo processRights, josta tätä funktiota kutsutaan, toimii niin, että se olettaa käytettävän prosessointifunktion palauttavan yhden tuloksen per pyyntö, ja sen avulla sitten sorttaa vastaukset pyyntöihin niiden alkuperäiseen järjestykseen. Siksi siis tästäkin funktiosta pitäisi tulla ulos lista, jossa on yksi elementti per pyyntö (mutta nämä elementit ovat itse listoja, joissa voi olla useampi tulos, jos raideosumia oli useampi). Tämä ei ole sinällään tässä tapauksessa oleellinen ominaisuus, mutta se, että olisi selvää, minkä pitää olla yksi yhteen minkä kanssa, olisi kyllä koodin rakenteen suhteen hyväksi.