### PR TITLE
GVT-2726 Ratko push for designs, part 1

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -92,6 +92,14 @@ data class IndirectChanges(
 )
 
 data class CalculatedChanges(val directChanges: DirectChanges, val indirectChanges: IndirectChanges) {
+    companion object {
+        fun empty() =
+            CalculatedChanges(
+                DirectChanges(listOf(), listOf(), listOf(), listOf(), listOf()),
+                IndirectChanges(listOf(), listOf(), listOf()),
+            )
+    }
+
     init {
         checkDuplicates(
             directChanges.kmPostChanges,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -127,7 +127,13 @@ constructor(
             val versions = publicationService.getValidationVersions(branch, request.content)
             publicationValidationService.validatePublicationRequest(versions)
             val calculatedChanges = publicationService.getCalculatedChanges(versions)
-            publicationService.publishChanges(branch, versions, calculatedChanges, request.message)
+            publicationService.publishChanges(
+                branch,
+                versions,
+                calculatedChanges,
+                request.message,
+                PublicationCause.MANUAL,
+            )
         }
             ?: throw PublicationFailureException(
                 message = "Could not reserve publication lock",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -170,3 +170,11 @@ enum class RatkoAccuracyType(@get:JsonValue val value: String) {
     @Suppress("unused") DIGITALIZED_AERIAL_IMAGE("DIGITIZED AERIAL IMAGE"),
     @Suppress("unused") ESTIMATED_TRACK_ADDRESS("ESTIMATED TRACKADDRESS"),
 }
+
+data class RatkoPlanId(val id: Int)
+
+enum class RatkoPlanState {
+    OPEN,
+    COMPLETED,
+    CANCELLED,
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -180,6 +180,9 @@ data class MainOfficialContextData<T>(override val layoutAssetId: LayoutAssetId<
             hasOfficial = true,
         )
     }
+
+    fun asCancelledDraft(designId: IntId<LayoutDesign>): DesignDraftContextData<T> =
+        asDesignDraft(designId).copy(cancelled = true)
 }
 
 data class MainDraftContextData<T>(
@@ -326,8 +329,11 @@ fun <T : LayoutAsset<T>> asDesignDraft(item: T, designId: IntId<LayoutDesign>): 
         }
     }
 
-fun <T : LayoutAsset<T>> cancelled(item: T): T =
-    item.withContext(
-        (item.contextData as? DesignOfficialContextData)?.cancelled()
-            ?: error("The cancellation operation is only allowed for design-official items")
-    )
+fun <T : LayoutAsset<T>> cancelled(item: T, designId: IntId<LayoutDesign>): T =
+    item.contextData.let { ctx ->
+        when (ctx) {
+            is DesignOfficialContextData -> item.withContext(ctx.cancelled())
+            is MainOfficialContextData -> item.withContext(ctx.asCancelledDraft(designId))
+            else -> error("The cancellation operation is only allowed for official items")
+        }
+    }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.ratko.model.RatkoPlanId
 import fi.fta.geoviite.infra.util.StringSanitizer
 import java.time.LocalDate
 
@@ -33,6 +34,7 @@ data class LayoutDesignName @JsonCreator(mode = DELEGATING) constructor(private 
 
 data class LayoutDesign(
     val id: DomainId<LayoutDesign>,
+    val ratkoId: RatkoPlanId?,
     val name: LayoutDesignName,
     val estimatedCompletion: LocalDate,
     val designState: DesignState,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -1,12 +1,34 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.integration.CalculatedChanges
+import fi.fta.geoviite.infra.publication.PublicationCause
+import fi.fta.geoviite.infra.publication.PublicationInDesign
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.ValidateContext
+import fi.fta.geoviite.infra.publication.ValidateTransition
+import fi.fta.geoviite.infra.publication.ValidationVersions
+import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 
 @GeoviiteService
-class LayoutDesignService(private val dao: LayoutDesignDao) {
+class LayoutDesignService(
+    private val dao: LayoutDesignDao,
+    private val publicationService: PublicationService,
+    private val trackNumberService: LayoutTrackNumberService,
+    private val referenceLineService: ReferenceLineService,
+    private val locationTrackService: LocationTrackService,
+    private val switchService: LayoutSwitchService,
+    private val kmPostService: LayoutKmPostService,
+    private val trackNumberDao: LayoutTrackNumberDao,
+    private val referenceLineDao: ReferenceLineDao,
+    private val locationTrackDao: LocationTrackDao,
+    private val switchDao: LayoutSwitchDao,
+    private val kmPostDao: LayoutKmPostDao,
+) {
     fun list(): List<LayoutDesign> {
         return dao.list()
     }
@@ -18,6 +40,16 @@ class LayoutDesignService(private val dao: LayoutDesignDao) {
     @Transactional
     fun update(id: IntId<LayoutDesign>, request: LayoutDesignSaveRequest): IntId<LayoutDesign> =
         try {
+            val designBranch = DesignBranch.of(id)
+            if (request.designState == DesignState.DELETED) {
+                deleteDraftsInDesign(designBranch)
+            }
+            if (dao.designHasPublications(id)) {
+                makeEmptyPublicationForDesign(designBranch)
+                if (request.designState == DesignState.DELETED) {
+                    cancelUnpublishedObjectsInDesign(designBranch)
+                }
+            }
             dao.update(id, request)
         } catch (e: DataIntegrityViolationException) {
             throw asDuplicateNameException(e) ?: e
@@ -30,4 +62,76 @@ class LayoutDesignService(private val dao: LayoutDesignDao) {
         } catch (e: DataIntegrityViolationException) {
             throw asDuplicateNameException(e) ?: e
         }
+
+    private fun deleteDraftsInDesign(branch: DesignBranch) {
+        kmPostDao.deleteDrafts(branch)
+        switchDao.deleteDrafts(branch)
+        locationTrackDao.deleteDrafts(branch)
+        referenceLineDao.deleteDrafts(branch)
+        trackNumberDao.deleteDrafts(branch)
+    }
+
+    private fun cancelUnpublishedObjectsInDesign(branch: DesignBranch) {
+        val trackNumberExtIds = trackNumberDao.fetchExternalIds(branch)
+        val trackNumbers =
+            trackNumberService.list(branch.official, true).mapNotNull { trackNumber ->
+                if (trackNumber.layoutContext.branch == branch || trackNumberExtIds.containsKey(trackNumber.id)) {
+                    trackNumberService.cancel(branch, trackNumber.id as IntId)
+                } else null
+            }
+        val referenceLines =
+            referenceLineService.list(branch.official, true).mapNotNull { referenceLine ->
+                if (referenceLine.layoutContext.branch == branch) {
+                    referenceLineService.cancel(branch, referenceLine.id as IntId)
+                } else null
+            }
+        val locationTrackExtIds = locationTrackDao.fetchExternalIds(branch)
+        val locationTracks =
+            locationTrackService.list(branch.official, true).mapNotNull { locationTrack ->
+                if (locationTrack.layoutContext.branch == branch || locationTrackExtIds.containsKey(locationTrack.id)) {
+                    locationTrackService.cancel(branch, locationTrack.id as IntId)
+                } else null
+            }
+        val switchExtIds = switchDao.fetchExternalIds(branch)
+        val switches =
+            switchService.list(branch.official, true).mapNotNull { switch ->
+                if (switch.layoutContext.branch == branch || switchExtIds.containsKey(switch.id)) {
+                    switchService.cancel(branch, switch.id as IntId)
+                } else null
+            }
+        val kmPosts =
+            kmPostService.list(branch.official, true).mapNotNull { kmPost ->
+                if (kmPost.layoutContext.branch == branch) {
+                    kmPostService.cancel(branch, kmPost.id as IntId)
+                } else null
+            }
+
+        val cancellationVersions =
+            ValidationVersions(
+                ValidateTransition(PublicationInDesign(branch)),
+                trackNumbers,
+                locationTracks,
+                referenceLines,
+                switches,
+                kmPosts,
+                listOf(),
+            )
+
+        publicationService.publishChanges(
+            branch,
+            cancellationVersions,
+            publicationService.getCalculatedChanges(cancellationVersions),
+            FreeTextWithNewLines.of(""),
+            PublicationCause.LAYOUT_DESIGN_CANCELLATION,
+        )
+    }
+
+    private fun makeEmptyPublicationForDesign(designBranch: DesignBranch) =
+        publicationService.publishChanges(
+            designBranch,
+            ValidationVersions.emptyWithTarget(ValidateContext(designBranch.official)),
+            CalculatedChanges.empty(),
+            FreeTextWithNewLines.of(""),
+            PublicationCause.LAYOUT_DESIGN_CHANGE,
+        )
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -748,8 +748,11 @@ class LocationTrackService(
         )
     }
 
-    override fun cancelInternal(asset: LocationTrack) =
-        cancelled(asset.copy(alignmentVersion = alignmentService.duplicate(asset.getAlignmentVersionOrThrow())))
+    override fun cancelInternal(asset: LocationTrack, designBranch: DesignBranch) =
+        cancelled(
+            asset.copy(alignmentVersion = alignmentService.duplicate(asset.getAlignmentVersionOrThrow())),
+            designBranch.designId,
+        )
 
     fun getExternalIdChangeTime(): Instant = dao.getExternalIdChangeTime()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -245,8 +245,11 @@ class ReferenceLineService(
         )
     }
 
-    override fun cancelInternal(asset: ReferenceLine) =
-        cancelled(asset.copy(alignmentVersion = alignmentService.duplicate(asset.getAlignmentVersionOrThrow())))
+    override fun cancelInternal(asset: ReferenceLine, designBranch: DesignBranch) =
+        cancelled(
+            asset.copy(alignmentVersion = alignmentService.duplicate(asset.getAlignmentVersionOrThrow())),
+            designBranch.designId,
+        )
 }
 
 fun referenceLineWithAlignment(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -28,6 +28,9 @@ import fi.fta.geoviite.infra.projektivelho.PVDictionaryName
 import fi.fta.geoviite.infra.projektivelho.PVId
 import fi.fta.geoviite.infra.projektivelho.PVProjectName
 import fi.fta.geoviite.infra.publication.Change
+import fi.fta.geoviite.infra.publication.PublishedInBranch
+import fi.fta.geoviite.infra.publication.PublishedInDesign
+import fi.fta.geoviite.infra.publication.PublishedInMain
 import fi.fta.geoviite.infra.tracklayout.DesignDraftContextData
 import fi.fta.geoviite.infra.tracklayout.DesignOfficialContextData
 import fi.fta.geoviite.infra.tracklayout.LayoutContextData
@@ -349,6 +352,11 @@ fun ResultSet.getPublicationStateOrNull(draftFlagName: String): PublicationState
 
 fun ResultSet.getLayoutBranch(designIdName: String): LayoutBranch =
     getIntIdOrNull<LayoutDesign>(designIdName).let { id -> if (id == null) LayoutBranch.main else DesignBranch.of(id) }
+
+fun ResultSet.getPublicationPublishedIn(designIdName: String, designVersionName: String): PublishedInBranch =
+    getIntIdOrNull<LayoutDesign>(designIdName).let { id ->
+        if (id == null) PublishedInMain else PublishedInDesign(DesignBranch.of(id), getInt(designVersionName))
+    }
 
 // no getLayoutBranchOrNull, as we couldn't distinguish between when to return the main branch and
 // when null

--- a/infra/src/main/resources/db/migration/prod/V101__add_design_ratko_push_support.sql
+++ b/infra/src/main/resources/db/migration/prod/V101__add_design_ratko_push_support.sql
@@ -1,0 +1,17 @@
+alter table layout.design
+  add column ratko_id int;
+alter table layout.design_version
+  add column ratko_id int;
+
+create type publication.publication_cause as enum ('MANUAL', 'LAYOUT_DESIGN_CHANGE', 'LAYOUT_DESIGN_CANCELLATION', 'MERGE_FINALIZATION', 'CALCULATED_CHANGE');
+
+alter table publication.publication
+  add column design_version integer,
+  add column cause          publication.publication_cause,
+  add constraint publication_design_version_consistency_check check ((design_id is null) = (design_version is null)),
+  add constraint publication_design_version_fk foreign key (design_id, design_version) references layout.design_version (id, version);
+
+update publication.publication set cause = 'MANUAL';
+
+alter table publication.publication
+  alter column cause set not null;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.ratko.RatkoPushDao
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
@@ -16,6 +17,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackLayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.TrackLayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndAlignment
+import fi.fta.geoviite.infra.tracklayout.publishedVersions
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getInstantOrNull
@@ -65,7 +67,7 @@ constructor(
         val locationTrackResponse = insertAndPublishLocationTrack()
         locationTrackId = locationTrackResponse.id
         val beforePublish = ratkoPushDao.getLatestPublicationMoment()
-        publicationId = createPublication(locationTracks = listOf(locationTrackResponse.id))
+        publicationId = createPublication(locationTracks = listOf(locationTrackResponse))
         publicationMoment = publicationDao.getPublication(publicationId).publicationTime
         assertTrue(publicationMoment > beforePublish)
         assertEquals(publicationMoment, ratkoPushDao.getLatestPublicationMoment())
@@ -180,7 +182,7 @@ constructor(
     @Test
     fun shouldReturnMultipleUnpublishedLayoutPublishes() {
         val locationTrack2Response = insertAndPublishLocationTrack()
-        val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response.id), message = "Test")
+        val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response), message = "Test")
 
         val latestPushedMoment = ratkoPushDao.getLatestPushedPublicationMoment()
         assertTrue(latestPushedMoment < publicationMoment)
@@ -205,9 +207,9 @@ constructor(
     @Test
     fun `Should return latest publications`() {
         val locationTrack1Response = insertAndPublishLocationTrack()
-        val publicationId1 = createPublication(locationTracks = listOf(locationTrack1Response.id), message = "Test")
+        val publicationId1 = createPublication(locationTracks = listOf(locationTrack1Response), message = "Test")
         val locationTrack2Response = insertAndPublishLocationTrack()
-        val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response.id), message = "Test")
+        val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response), message = "Test")
 
         val publications = publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, 2)
 
@@ -249,26 +251,30 @@ constructor(
 
     fun createPublication(
         layoutBranch: LayoutBranch = LayoutBranch.main,
-        trackNumbers: List<IntId<TrackLayoutTrackNumber>> = listOf(),
-        referenceLines: List<IntId<ReferenceLine>> = listOf(),
-        locationTracks: List<IntId<LocationTrack>> = listOf(),
-        switches: List<IntId<TrackLayoutSwitch>> = listOf(),
-        kmPosts: List<IntId<TrackLayoutKmPost>> = listOf(),
+        trackNumbers: List<LayoutRowVersion<TrackLayoutTrackNumber>> = listOf(),
+        referenceLines: List<LayoutRowVersion<ReferenceLine>> = listOf(),
+        locationTracks: List<LayoutRowVersion<LocationTrack>> = listOf(),
+        switches: List<LayoutRowVersion<TrackLayoutSwitch>> = listOf(),
+        kmPosts: List<LayoutRowVersion<TrackLayoutKmPost>> = listOf(),
         message: String = "",
     ): IntId<Publication> =
         publicationDao
-            .createPublication(layoutBranch = layoutBranch, message = FreeTextWithNewLines.of(message))
+            .createPublication(
+                layoutBranch = layoutBranch,
+                message = FreeTextWithNewLines.of(message),
+                cause = PublicationCause.MANUAL,
+            )
             .also { publicationId ->
                 val calculatedChanges =
                     CalculatedChanges(
                         directChanges =
                             DirectChanges(
-                                kmPostChanges = kmPosts,
-                                referenceLineChanges = referenceLines,
+                                kmPostChanges = kmPosts.map { it.id },
+                                referenceLineChanges = referenceLines.map { it.id },
                                 trackNumberChanges =
                                     trackNumbers.map {
                                         TrackNumberChange(
-                                            trackNumberId = it,
+                                            trackNumberId = it.id,
                                             changedKmNumbers = emptySet(),
                                             isStartChanged = false,
                                             isEndChanged = false,
@@ -277,13 +283,13 @@ constructor(
                                 locationTrackChanges =
                                     locationTracks.map {
                                         LocationTrackChange(
-                                            locationTrackId = it,
+                                            locationTrackId = it.id,
                                             changedKmNumbers = emptySet(),
                                             isStartChanged = false,
                                             isEndChanged = false,
                                         )
                                     },
-                                switchChanges = switches.map { SwitchChange(it, emptyList()) },
+                                switchChanges = switches.map { SwitchChange(it.id, emptyList()) },
                             ),
                         indirectChanges =
                             IndirectChanges(
@@ -292,6 +298,10 @@ constructor(
                                 switchChanges = emptyList(),
                             ),
                     )
-                publicationDao.insertCalculatedChanges(publicationId, calculatedChanges)
+                publicationDao.insertCalculatedChanges(
+                    publicationId,
+                    calculatedChanges,
+                    publishedVersions(trackNumbers, referenceLines, locationTracks, switches, kmPosts),
+                )
             }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -1,6 +1,7 @@
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationRequestIds
 import fi.fta.geoviite.infra.publication.PublicationResult
 import fi.fta.geoviite.infra.publication.PublicationService
@@ -70,5 +71,11 @@ fun publish(
 ): PublicationResult {
     val versions = publicationService.getValidationVersions(branch, request)
     val calculatedChanges = publicationService.getCalculatedChanges(versions)
-    return publicationService.publishChanges(branch, versions, calculatedChanges, FreeTextWithNewLines.of("Test"))
+    return publicationService.publishChanges(
+        branch,
+        versions,
+        calculatedChanges,
+        FreeTextWithNewLines.of("Test"),
+        PublicationCause.MANUAL,
+    )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -702,6 +702,7 @@ constructor(
                             versions,
                             publicationTestSupportService.getCalculatedChangesInRequest(versions),
                             FreeTextWithNewLines.of(""),
+                            PublicationCause.MANUAL,
                         )
                         .publicationId
                 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
@@ -177,6 +177,7 @@ constructor(
             versions,
             calculatedChanges,
             FreeTextWithNewLines.of("${this::class.simpleName}"),
+            PublicationCause.MANUAL,
         )
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -74,6 +74,10 @@ class FakeRatko(port: Int) {
         get("/api/versions/v1.0/version").withId("version-check").respond(HttpResponse.response().withStatusCode(500))
     }
 
+    fun acceptsNewPlansGivingThemIds(ids: List<Int>) {
+        ids.forEach { id -> post("/api/plan/v1.0/plans", times = Times.once()).respond(okJson(mapOf("id" to id))) }
+    }
+
     fun acceptsNewRouteNumbersGivingThemOids(oids: List<String>) {
         patch("/api/infra/v1.0/routenumbers/geom", oids).respond(ok())
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -22,6 +22,7 @@ import fi.fta.geoviite.infra.inframodel.InfraModelFile
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
+import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.publication.PublicationRequestIds
 import fi.fta.geoviite.infra.publication.PublicationService
@@ -1226,6 +1227,7 @@ constructor(
             publicationDao.createPublication(
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("test: bulk transfer to in progress"),
+                PublicationCause.MANUAL,
             )
         splitDao.updateSplit(splitId = splitId, publicationId = publicationId)
 
@@ -1257,6 +1259,7 @@ constructor(
                         publicationDao.createPublication(
                             LayoutBranch.main,
                             FreeTextWithNewLines.of("some in progress bulk transfer"),
+                            PublicationCause.MANUAL,
                         ),
                     bulkTransferState = BulkTransferState.IN_PROGRESS,
                     bulkTransferId = someBulkTransferId,
@@ -1273,6 +1276,7 @@ constructor(
                             publicationDao.createPublication(
                                 LayoutBranch.main,
                                 FreeTextWithNewLines.of("pending bulk transfer"),
+                                PublicationCause.MANUAL,
                             ),
                     )
                     .id
@@ -1299,6 +1303,7 @@ constructor(
                             publicationDao.createPublication(
                                 LayoutBranch.main,
                                 FreeTextWithNewLines.of("pending bulk transfer"),
+                                PublicationCause.MANUAL,
                             ),
                     )
                     .id
@@ -1337,6 +1342,7 @@ constructor(
                                 publicationDao.createPublication(
                                     LayoutBranch.main,
                                     FreeTextWithNewLines.of("pending bulk transfer $index"),
+                                    PublicationCause.MANUAL,
                                 ),
                         )
                         .id
@@ -1371,6 +1377,7 @@ constructor(
                                     publicationDao.createPublication(
                                         LayoutBranch.main,
                                         FreeTextWithNewLines.of("testing $bulkTransferState"),
+                                        PublicationCause.MANUAL,
                                     ),
                                 bulkTransferId = testDBService.getUnusedBulkTransferId(),
                                 bulkTransferState = bulkTransferState,
@@ -1432,7 +1439,13 @@ constructor(
         publicationService.updateExternalId(LayoutBranch.main, ids)
         val versions = publicationService.getValidationVersions(LayoutBranch.main, ids)
         val calculatedChanges = publicationService.getCalculatedChanges(versions)
-        publicationService.publishChanges(LayoutBranch.main, versions, calculatedChanges, FreeTextWithNewLines.of(""))
+        publicationService.publishChanges(
+            LayoutBranch.main,
+            versions,
+            calculatedChanges,
+            FreeTextWithNewLines.of(""),
+            PublicationCause.MANUAL,
+        )
         ratkoService.pushChangesToRatko(LayoutBranch.main)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.locationTrack
@@ -73,7 +74,11 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 .let(splitDao::getOrThrow)
 
         val publicationId =
-            publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("SPLIT PUBLICATION"))
+            publicationDao.createPublication(
+                LayoutBranch.main,
+                FreeTextWithNewLines.of("SPLIT PUBLICATION"),
+                PublicationCause.MANUAL,
+            )
         val updatedSplit =
             splitDao
                 .updateSplit(
@@ -203,6 +208,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
             publicationDao.createPublication(
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("test: bulk transfer state update"),
+                PublicationCause.MANUAL,
             )
 
         BulkTransferState.entries.forEach { newBulkTransferState ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -216,11 +216,11 @@ constructor(
         val switch = designOfficialContext.insert(switch())
         val kmPost = designOfficialContext.insert(kmPost(trackNumber.id, KmNumber(123)))
 
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(trackNumber.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(referenceLine.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(locationTrack.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(switch.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(kmPost.id)!!))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(trackNumber.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(referenceLine.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(locationTrack.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(switch.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(kmPost.id)!!, someDesignBranch.designId))
 
         assertEquals(trackNumber, designOfficialContext.fetchVersion(trackNumber.id))
         assertEquals(referenceLine, designOfficialContext.fetchVersion(referenceLine.id))
@@ -278,11 +278,11 @@ constructor(
                 )
             )
 
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(trackNumber.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(referenceLine.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(locationTrack.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(switch.id)!!))
-        designDraftContext.insert(cancelled(designOfficialContext.fetch(kmPost.id)!!))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(trackNumber.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(referenceLine.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(locationTrack.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(switch.id)!!, someDesignBranch.designId))
+        designDraftContext.insert(cancelled(designOfficialContext.fetch(kmPost.id)!!, someDesignBranch.designId))
 
         assertEquals(designOfficialTrackNumber, designOfficialContext.fetchVersion(trackNumber.id))
         assertEquals(designOfficialReferenceLine, designOfficialContext.fetchVersion(referenceLine.id))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignServiceIT.kt
@@ -1,0 +1,249 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.PublicationState
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.PublicationDao
+import fi.fta.geoviite.infra.publication.PublicationLogService
+import fi.fta.geoviite.infra.publication.PublicationTestSupportService
+import fi.fta.geoviite.infra.publication.publicationRequestIds
+import fi.fta.geoviite.infra.util.LayoutAssetTable
+import fi.fta.geoviite.infra.util.queryOne
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class LayoutDesignServiceIT
+@Autowired
+constructor(
+    private val layoutDesignService: LayoutDesignService,
+    private val layoutDesignDao: LayoutDesignDao,
+    private val publicationDao: PublicationDao,
+    private val publicationLogService: PublicationLogService,
+    private val publicationTestSupportService: PublicationTestSupportService,
+    private val trackNumberService: LayoutTrackNumberService,
+    private val trackNumberDao: LayoutTrackNumberDao,
+    private val referenceLineDao: ReferenceLineDao,
+    private val locationTrackDao: LocationTrackDao,
+    private val switchDao: LayoutSwitchDao,
+    private val kmPostDao: LayoutKmPostDao,
+) : DBTestBase() {
+    @BeforeEach
+    fun setup() {
+        testDBService.clearLayoutTables()
+    }
+
+    @Test
+    fun `updating a design with no publications does not cause a design publication`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designId = designBranch.designId
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(1.0, 0.0)))
+
+        val trackNumber = designDraftContext.insert(trackNumber())
+        designDraftContext.insert(referenceLine(trackNumber.id), alignment)
+        designDraftContext.insert(locationTrack(trackNumber.id), alignment)
+        designDraftContext.insert(switch())
+        designDraftContext.insert(kmPost(trackNumber.id, KmNumber(123)))
+
+        val latestPublication = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        layoutDesignService.update(designId, designForm(designId))
+        val afterUpdate = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        assertEquals(latestPublication.map { it.id }, afterUpdate.map { it.id })
+    }
+
+    @Test
+    fun `updating a design with past design publications creates a new design publication`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designId = designBranch.designId
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+
+        val trackNumber = designDraftContext.insert(trackNumber()).id
+        publicationTestSupportService.publish(designBranch, publicationRequestIds(trackNumbers = listOf(trackNumber)))
+        val latestPublication = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        layoutDesignService.update(designId, designForm(designId))
+        val afterUpdate = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        assertNotEquals(latestPublication.map { it.id }, afterUpdate.map { it.id })
+        val details = publicationLogService.getPublicationDetails(afterUpdate[0].id)
+        assertEquals(listOf(), details.trackNumbers)
+        assertEquals(listOf(), details.referenceLines)
+        assertEquals(listOf(), details.locationTracks)
+        assertEquals(listOf(), details.switches)
+        assertEquals(listOf(), details.kmPosts)
+        assertEquals(designId, details.layoutBranch.branch.designId)
+    }
+
+    @Test
+    fun `updating a previously published design that no longer contains any assets still causes a design publication`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designId = designBranch.designId
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+        val trackNumber = designDraftContext.insert(trackNumber()).id
+
+        publicationTestSupportService.publish(designBranch, publicationRequestIds(trackNumbers = listOf(trackNumber)))
+        trackNumberService.mergeToMainBranch(designBranch, trackNumber)
+        publicationTestSupportService.publish(
+            LayoutBranch.main,
+            publicationRequestIds(trackNumbers = listOf(trackNumber)),
+        )
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_TRACK_NUMBER))
+        val latestPublicationsBeforeEdit = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        layoutDesignService.update(designId, designForm(designId))
+        val latestPublicationsAfterEdit = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        assertNotEquals(latestPublicationsBeforeEdit.map { it.id }, latestPublicationsAfterEdit.map { it.id })
+        val latestDetails = publicationLogService.getPublicationDetails(latestPublicationsAfterEdit[0].id)
+        assertEquals(listOf(), latestDetails.trackNumbers)
+    }
+
+    @Test
+    fun `cancelling a design creates a cancelling publication and leaves no trace behind in the layout asset tables`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designId = designBranch.designId
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(1.0, 0.0)))
+
+        val trackNumber = designDraftContext.insert(trackNumber())
+        val referenceLine = designDraftContext.insert(referenceLine(trackNumber.id), alignment)
+        val locationTrack = designDraftContext.insert(locationTrack(trackNumber.id), alignment)
+        val switch = designDraftContext.insert(switch())
+        val kmPost = designDraftContext.insert(kmPost(trackNumber.id, KmNumber(123)))
+
+        publicationTestSupportService.publish(
+            designBranch,
+            publicationRequestIds(
+                trackNumbers = listOf(trackNumber.id),
+                referenceLines = listOf(referenceLine.id),
+                locationTracks = listOf(locationTrack.id),
+                switches = listOf(switch.id),
+                kmPosts = listOf(kmPost.id),
+            ),
+        )
+
+        deleteDesign(designId)
+
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_TRACK_NUMBER))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_REFERENCE_LINE))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_LOCATION_TRACK))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_SWITCH))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_KM_POST))
+
+        val latestPublication = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        val details = publicationLogService.getPublicationDetails(latestPublication[0].id)
+        assertContainsSingleCancelledOfficialObject(details.trackNumbers.map { it.version }, trackNumberDao)
+        assertContainsSingleCancelledOfficialObject(details.referenceLines.map { it.version }, referenceLineDao)
+        assertContainsSingleCancelledOfficialObject(details.locationTracks.map { it.version }, locationTrackDao)
+        assertContainsSingleCancelledOfficialObject(details.switches.map { it.version }, switchDao)
+        assertContainsSingleCancelledOfficialObject(details.kmPosts.map { it.version }, kmPostDao)
+    }
+
+    @Test
+    fun `deleting a design with no publications deletes all of its drafts`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designId = designBranch.designId
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(1.0, 0.0)))
+
+        val trackNumber = designDraftContext.insert(trackNumber())
+        designDraftContext.insert(referenceLine(trackNumber.id), alignment)
+        designDraftContext.insert(locationTrack(trackNumber.id), alignment)
+        designDraftContext.insert(switch())
+        designDraftContext.insert(kmPost(trackNumber.id, KmNumber(123)))
+
+        deleteDesign(designId)
+
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_TRACK_NUMBER))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_REFERENCE_LINE))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_LOCATION_TRACK))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_SWITCH))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_KM_POST))
+    }
+
+    @Test
+    fun `deleting a design containing calculated changes to objects not directly changed in the design cancels those as well`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designId = designBranch.designId
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
+
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        mainOfficialContext.insert(referenceLine(trackNumber), alignment)
+        val switch =
+            mainOfficialContext
+                .insert(switch(joints = listOf(TrackLayoutSwitchJoint(JointNumber(1), Point(10.0, 0.0), null))))
+                .id
+        val locationTrack =
+            mainOfficialContext
+                .insert(
+                    locationTrack(trackNumber),
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(10.0, 0.0))
+                            .copy(switchId = switch, endJointNumber = JointNumber(1))
+                    ),
+                )
+                .id
+        designDraftContext.insert(mainOfficialContext.fetch(trackNumber)!!)
+        publicationTestSupportService.publish(designBranch, publicationRequestIds(trackNumbers = listOf(trackNumber)))
+
+        // at the time of writing this test, we don't actually have support for updating designs
+        // on inheriting calculated changes from main; but once we do, they will be identified by
+        // those objects having an extId in the design
+        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
+        switchDao.insertExternalId(switch, designBranch, Oid("2.3.4.5.6"))
+
+        val latestPublicationBeforeDelete = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        deleteDesign(designId)
+        val latestPublicationAfterDelete = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
+        assertNotEquals(latestPublicationBeforeDelete.map { it.id }, latestPublicationAfterDelete.map { it.id })
+        val details = publicationLogService.getPublicationDetails(latestPublicationAfterDelete[0].id)
+
+        assertContainsSingleCancelledOfficialObject(details.switches.map { it.version }, switchDao)
+        assertContainsSingleCancelledOfficialObject(details.locationTracks.map { it.version }, locationTrackDao)
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_LOCATION_TRACK))
+        assertEquals(0, countDesignObjectsInLayoutTable(designId, LayoutAssetTable.LAYOUT_ASSET_SWITCH))
+    }
+
+    private fun <T : LayoutAsset<T>> assertContainsSingleCancelledOfficialObject(
+        versions: List<LayoutRowVersion<T>>,
+        dao: LayoutAssetDao<T>,
+    ) {
+        assertEquals(1, versions.size)
+        val asset = dao.fetch(versions[0])
+        assertTrue(asset.isCancelled)
+        assertTrue(asset.isOfficial)
+    }
+
+    private fun countDesignObjectsInLayoutTable(designId: IntId<LayoutDesign>, table: LayoutAssetTable): Int {
+        return jdbc.queryOne(
+            "select count(*) c from ${table.fullName} where design_id = :design_id",
+            mapOf("design_id" to designId.intValue),
+        ) { rs, _ ->
+            rs.getInt("c")
+        }
+    }
+
+    private fun deleteDesign(designId: IntId<LayoutDesign>) {
+        layoutDesignService.update(designId, designForm(designId).copy(designState = DesignState.DELETED))
+    }
+
+    private fun designForm(designId: IntId<LayoutDesign>): LayoutDesignSaveRequest {
+        val design = layoutDesignDao.fetch(designId)
+        return LayoutDesignSaveRequest(
+            name = design.name,
+            designState = design.designState,
+            estimatedCompletion = design.estimatedCompletion,
+        )
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -40,6 +40,7 @@ import fi.fta.geoviite.infra.math.Point3DZ
 import fi.fta.geoviite.infra.math.Point4DZM
 import fi.fta.geoviite.infra.math.boundingBoxCombining
 import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.publication.PublishedVersions
 import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchElementCurve
 import fi.fta.geoviite.infra.switchLibrary.SwitchElementLine
@@ -1152,3 +1153,11 @@ fun geocodingContextCacheKey(
         referenceLineVersion = referenceLineVersion,
         kmPostVersions = kmPostVersions.toList().sortedBy { rv -> rv.id.intValue },
     )
+
+fun publishedVersions(
+    trackNumbers: List<LayoutRowVersion<TrackLayoutTrackNumber>> = listOf(),
+    referenceLines: List<LayoutRowVersion<ReferenceLine>> = listOf(),
+    locationTracks: List<LayoutRowVersion<LocationTrack>> = listOf(),
+    switches: List<LayoutRowVersion<TrackLayoutSwitch>> = listOf(),
+    kmPosts: List<LayoutRowVersion<TrackLayoutKmPost>> = listOf(),
+) = PublishedVersions(trackNumbers, referenceLines, locationTracks, switches, kmPosts)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationRequest
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.publicationRequestIds
@@ -136,6 +137,7 @@ constructor(
                 versions,
                 calculatedChanges,
                 publicationRequest.message,
+                PublicationCause.MANUAL,
             )
 
         return result.publicationId!!


### PR DESCRIPTION
Hieman monen jutun pullari, toteutussuunta kun yhä elää designien Ratko-puskua tehdessä.

Tietomalliin lisätään:

- designeille uusi ratko_id-tieto, jota ei vielä osata varsinaisesti hakea Ratkosta, mutta onpahan olemassa
- julkaisuille julkaisusyy (olemassaolevilla kaikilla että oli käyttäjän käsin tekemä julkaisu), ja suunnitelmajulkaisuille designin versio

Funktionaaliset muutokset lähtee käytännössä siitä, kun tehdään muutos suunnitelmaan (joko johonkin suunnitelman tietoon, tai suunnitelman tilaan, ml. poisto eli deleted-tilaan asettaminen). Tällöin:

- Jos suunnitelmasta on tehty julkaisu: Tehdään tyhjä julkaisu, jossa tietona vaan että suunnitelma (nykyversiollaan) on muuttunut. Tämä siksi, että Ratkoon päätyy tieto suunnitelmaan tehdystä tiedosta, vaikka sen sisältöä ei välttämättä julkaistaisi enää.
- Jos suunnitelmaa ollaan poistamassa: Sen sisältö poistetaan myös. Jo julkaistut asiat perutaaan ja perumiset julkaistaan, luonnokset poistetaan. Mainiin jo mergettyjä asioita ei poisteta suunnitelmasta, kiitos sen, että nehän on poistettu jo mergessä.

... mutta isoimmat ja monimutkaisimmat koodimuutokset tulee siitä, että tämä perumisten julkaisu saadaan oikeasti tallentamaan kantaan oikeat muutokset, mikä on periaatteessa osa perumista, mutta vasta tässä toteutettu oikein. Koska peruttu olio ei ole enää näkyvillä kontekstissaan, pitää erikseen pitää kirjaa siitä, mikäs oliversio varsinaisesti julkaistiin, jotta Ratko-integraatiossa pystytään sitten tietämään, mikä muutos oikeasti lähettää.

Suunnitelman poistaminen voi koskea myös olioihin, joista on lähetetty vain suunnitelmassa vain laskennallisia muutoksia, ja joista siten on olemassa suunnitelman OID, mutta ei varsinaista suunnitelman riviä. Tällöin sellainen tehdään ensimmäistä kertaa suunnitelman poiston yhteydessä, ja tässähän se ei oikeastaan aiheuta mitään närää: Oliorivi käy olemassa live-taulussa ainoastaan julkaisutransaktion sisällä, ihan vaan siksi että saadaan versiotauluun siitä rivi. Tätä varten piti toteuttaa myös mahdollisuus tehdä main-officialista rivistä suoraan peruminen suunnitelmaan.