### PR TITLE
GVT-2951 Only center dialogs initially upon display

### DIFF
--- a/ui/src/geoviite-design-lib/dialog/dialog.tsx
+++ b/ui/src/geoviite-design-lib/dialog/dialog.tsx
@@ -65,7 +65,7 @@ export const Dialog: React.FC<DialogProps> = ({
             setDialogPositionX((window.innerWidth - dialogBounds.width) / 2);
             setDialogPositionY((window.innerHeight - dialogBounds.height) / 2);
         }
-    });
+    }, [dialogHeaderRef.current]);
 
     function close() {
         props.onClose && props.onClose();


### PR DESCRIPTION
GVT-2951 toteutuksessa esiintynyt juttu, jonka ajattelin heittää omana ehdotuksenaan, koska en ole ihan varma, onko tästä odotettavissa outouksia.

Kyseisessä taskissa tuli ongelmia siitä, että:
- Lähtötilassa fokus vaihteiden muokkauslomakkeessa on nimikentässä, joka on tyhjä
- Tyhjästä nimikentästä poistuttaessa (onBlur) se otetaan validoitavaksi, ja tyhjästä nimestähän tulee virheitä
- Virheet kasvattavat dialogin korkeutta
- Tämä layoutEffecti keskittää dialogin uuden koon perusteella, ja siksi siirtää sen yläpäätä siksi vähän ylemmäksi
- ... mutta tässä tapauksessa syy miksi kentästä poistuttiin oli, että käyttäjä painoi OIDin "Aseta nyt"-nappia... mutta nyt tämä nappi siirtyykin klikin aikana ylemmäs pois hiiren kursorin alta, ja siksi sen onClick()ia ei kutsutakaan.

Ajattelin, että tuo jatkuva automaattinen keskittäminen olisi helpoin kohta katkaista tämä ketju.