### PR TITLE
GVT-2947 Refactor switch structures in kotlin for stricter typing + in DB for single (structure) versioning

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/InfraModelMigration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/dataImport/InfraModelMigration.kt
@@ -22,11 +22,9 @@ class V12_01__InfraModelMigration : BaseJavaMigration() {
     private val importEnabled: Boolean by lazy { SpringContextUtility.getProperty("geoviite.data.import") }
 
     override fun migrate(context: Context?) =
-        withImportUser(ImportUser.IM_IMPORT) {
-            if (importEnabled) {
-                throw NotImplementedError("Initial inframodel migration not supported in this version.")
-            } else {
-                logger.info("InfraModel import disabled")
-            }
+        if (importEnabled) {
+            throw NotImplementedError("Initial inframodel migration not supported in this version.")
+        } else {
+            logger.info("InfraModel import disabled")
         }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -8,8 +8,8 @@ import fi.fta.geoviite.infra.geometry.GeometryIssueType.*
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.math.*
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.switchLibrary.calculateSwitchLocationDelta
 import fi.fta.geoviite.infra.switchLibrary.transformSwitchPoint
 import fi.fta.geoviite.infra.tracklayout.REFERENCE_LINE_TYPE_CODE
@@ -754,7 +754,7 @@ fun validateSwitch(
     alignmentSwitches: List<AlignmentSwitch>,
 ): List<GeometryValidationIssue> {
     val jointNumbers = switch.joints.map(GeometrySwitchJoint::number)
-    val structureJointNumbers = structure?.joints?.map(SwitchJoint::number) ?: listOf()
+    val structureJointNumbers = structure?.joints?.map(SwitchStructureJoint::number) ?: listOf()
 
     val fieldErrors =
         listOfNotNull(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
@@ -26,11 +26,11 @@ import fi.fta.geoviite.infra.math.lineIntersection
 import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.math.pointDistanceToLine
 import fi.fta.geoviite.infra.math.radsToDegrees
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchPositionTransformation
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.switchLibrary.calculateSwitchLocationDelta
 import fi.fta.geoviite.infra.switchLibrary.transformSwitchPoint
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
@@ -93,7 +93,7 @@ constructor(
         switchStructure: SwitchStructure,
         tracksLinkedThroughGeometry: List<LayoutRowVersion<LocationTrack>>,
         branch: LayoutBranch,
-        jointsInLayoutSpace: List<SwitchJoint>,
+        jointsInLayoutSpace: List<SwitchStructureJoint>,
         locationAccuracy: LocationAccuracy?,
     ): FittedSwitch {
         val tracks =
@@ -149,15 +149,18 @@ private fun calculateLayoutSwitchJoints(
     geomSwitch: GeometrySwitch,
     switchStructure: SwitchStructure,
     toLayoutCoordinate: Transformation,
-): List<SwitchJoint> {
+): List<SwitchStructureJoint> {
     val layoutJointPoints =
         geomSwitch.joints.map { geomJoint ->
-            SwitchJoint(number = geomJoint.number, location = toLayoutCoordinate.transform(geomJoint.location))
+            SwitchStructureJoint(number = geomJoint.number, location = toLayoutCoordinate.transform(geomJoint.location))
         }
     val switchLocationDelta = calculateSwitchLocationDelta(layoutJointPoints, switchStructure)
     return if (switchLocationDelta != null) {
         switchStructure.alignmentJoints.map { joint ->
-            SwitchJoint(number = joint.number, location = transformSwitchPoint(switchLocationDelta, joint.location))
+            SwitchStructureJoint(
+                number = joint.number,
+                location = transformSwitchPoint(switchLocationDelta, joint.location),
+            )
         }
     } else {
         throw GeometrySwitchFittingException(GeometrySwitchSuggestionFailureReason.INVALID_JOINTS)
@@ -173,7 +176,7 @@ private data class PossibleSegment(
 )
 
 private fun findSuggestedSwitchJointMatches(
-    joint: SwitchJoint,
+    joint: SwitchStructureJoint,
     locationTrack: LocationTrack,
     alignment: CroppedAlignment,
     tolerance: Double,
@@ -305,7 +308,7 @@ fun takeSegmentLineMatches(
         .takeWhile { (_, d) -> d < tolerance }
 
 private fun findSuggestedSwitchJointMatches(
-    joints: List<SwitchJoint>,
+    joints: List<SwitchStructureJoint>,
     locationTrackAlignment: Pair<LocationTrack, CroppedAlignment>,
     tolerance: Double,
 ): List<FittedSwitchJointMatch> {
@@ -320,7 +323,7 @@ private fun findSuggestedSwitchJointMatches(
 }
 
 fun fitSwitch(
-    jointsInLayoutSpace: List<SwitchJoint>,
+    jointsInLayoutSpace: List<SwitchStructureJoint>,
     switchStructure: SwitchStructure,
     alignments: List<Pair<LocationTrack, CroppedAlignment>>,
     locationAccuracy: LocationAccuracy?,
@@ -361,7 +364,7 @@ fun fitSwitch(
 
 private fun getBestMatchByJoint(
     matchesByLocationTrack: Map<LocationTrack, List<FittedSwitchJointMatch>>,
-    endJoints: Map<LocationTrack, Pair<SwitchJoint, SwitchJoint>>,
+    endJoints: Map<LocationTrack, Pair<SwitchStructureJoint, SwitchStructureJoint>>,
 ) =
     matchesByLocationTrack
         .flatMap { (lt, matches) ->
@@ -560,9 +563,9 @@ private fun orderIntersectionsWithDesiredPoint(
 
 private fun findFarthestJoint(
     switchStructure: SwitchStructure,
-    joint: SwitchJoint,
-    switchAlignment: SwitchAlignment,
-): SwitchJoint {
+    joint: SwitchStructureJoint,
+    switchAlignment: SwitchStructureAlignment,
+): SwitchStructureJoint {
     val jointNumber =
         requireNotNull(
             switchAlignment.jointNumbers.maxByOrNull { jointNumber ->
@@ -600,8 +603,8 @@ private fun findPointsOnTrack(from: IPoint, distance: Double, alignment: IAlignm
 private fun findTransformations(
     point: IPoint,
     alignment: IAlignment,
-    switchAlignment: SwitchAlignment,
-    joint: SwitchJoint,
+    switchAlignment: SwitchStructureAlignment,
+    joint: SwitchStructureJoint,
     switchStructure: SwitchStructure,
 ): List<SwitchPositionTransformation> {
     val farthestJoint = findFarthestJoint(switchStructure, joint, switchAlignment)
@@ -621,9 +624,9 @@ private fun findTransformations(
     point: IPoint,
     alignment1: IAlignment,
     alignment2: IAlignment,
-    switchAlignment1: SwitchAlignment,
-    switchAlignment2: SwitchAlignment,
-    joint: SwitchJoint,
+    switchAlignment1: SwitchStructureAlignment,
+    switchAlignment2: SwitchStructureAlignment,
+    joint: SwitchStructureJoint,
     switchStructure: SwitchStructure,
 ): List<SwitchPositionTransformation> {
     return findTransformations(point, alignment1, switchAlignment1, joint, switchStructure) +
@@ -651,7 +654,7 @@ fun fitSwitch(
     )
 }
 
-fun getSharedSwitchJoint(switchStructure: SwitchStructure): Pair<SwitchJoint, List<SwitchAlignment>> {
+fun getSharedSwitchJoint(switchStructure: SwitchStructure): Pair<SwitchStructureJoint, List<SwitchStructureAlignment>> {
     val sortedSwitchJoints =
         switchStructure.joints.sortedWith { jointA, jointB ->
             when {
@@ -687,7 +690,7 @@ data class SuggestedSwitchJointScore(
 fun getSuggestedSwitchScore(
     switchSuggestion: FittedSwitch,
     switchStructure: SwitchStructure,
-    farthestJoint: SwitchJoint,
+    farthestJoint: SwitchStructureJoint,
     maxFarthestJointDistance: Double,
     desiredLocation: IPoint,
     originallyLinkedAlignments: Set<Pair<DomainId<LayoutAlignment>, JointNumber>>,
@@ -725,7 +728,7 @@ fun getSuggestedSwitchScore(
 private fun selectBestSuggestedSwitch(
     switchSuggestions: Set<FittedSwitch>,
     switchStructure: SwitchStructure,
-    farthestJoint: SwitchJoint,
+    farthestJoint: SwitchStructureJoint,
     desiredLocation: IPoint,
     originallyLinkedAlignments: Set<Pair<DomainId<LayoutAlignment>, JointNumber>>,
 ): FittedSwitch {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
@@ -10,9 +10,9 @@ import fi.fta.geoviite.infra.linking.TrackEnd
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.switchLibrary.ISwitchJoint
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
@@ -37,7 +37,7 @@ data class FittedSwitchJointMatch(
     val locationTrackId: IntId<LocationTrack>,
     val segmentIndex: Int,
     val m: Double,
-    val switchJoint: SwitchJoint,
+    val switchJoint: SwitchStructureJoint,
     val matchType: SuggestedSwitchJointMatchType,
     val distance: Double,
     val distanceToAlignment: Double,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -24,9 +24,9 @@ import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.FATAL
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.WARNING
 import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchConnectivity
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_COORDINATE_DELTA
@@ -409,7 +409,7 @@ private fun findValidatingTrackSwitchAlignment(
     validatingTrack: LocationTrack?,
     locationTracks: List<Pair<LocationTrack, LayoutAlignment>>,
     connectivity: SwitchConnectivity,
-): SwitchAlignment? =
+): SwitchStructureAlignment? =
     locationTracks
         .find { (track) -> track.id == validatingTrack?.id }
         ?.let { trackAndAlignment ->
@@ -422,7 +422,9 @@ private fun findValidatingTrackSwitchAlignment(
                 ?.originalAlignment
         }
 
-private fun summarizeSwitchAlignmentLocationTrackLinks(links: List<Pair<LocationTrack, SwitchAlignment>>): String =
+private fun summarizeSwitchAlignmentLocationTrackLinks(
+    links: List<Pair<LocationTrack, SwitchStructureAlignment>>
+): String =
     links
         .groupBy { it.second }
         .entries

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -2,11 +2,11 @@ package fi.fta.geoviite.infra.switchLibrary
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonValue
-import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
-import fi.fta.geoviite.infra.common.StringId
+import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.inframodel.angleBetween
 import fi.fta.geoviite.infra.math.Angle
 import fi.fta.geoviite.infra.math.AngularUnit
@@ -174,130 +174,62 @@ fun switchJointToString(switchJoint: ISwitchJoint): String {
     return "${switchJoint.number} (${switchJoint.location})"
 }
 
-data class SwitchJoint(override val number: JointNumber, override val location: Point) : ISwitchJoint {
+data class SwitchStructureJoint(override val number: JointNumber, override val location: Point) : ISwitchJoint {
     override fun toString(): String {
         return switchJointToString(this)
     }
 }
 
-enum class SwitchElementType {
+enum class SwitchStructureElementType {
     LINE,
     CURVE,
     //    CLOTHOID // this seems to be possible :(
 }
 
-sealed class SwitchElement {
-    abstract val id: DomainId<SwitchElement>
-    abstract val type: SwitchElementType
+sealed class SwitchStructureElement {
+    abstract val type: SwitchStructureElementType
     abstract val start: Point
     abstract val end: Point
 }
 
-data class SwitchElementLine(
-    override val id: DomainId<SwitchElement> = StringId(),
-    override val start: Point,
-    override val end: Point,
-) : SwitchElement() {
-    override val type: SwitchElementType = SwitchElementType.LINE
+data class SwitchStructureLine(override val start: Point, override val end: Point) : SwitchStructureElement() {
+    override val type: SwitchStructureElementType = SwitchStructureElementType.LINE
 }
 
-data class SwitchElementCurve(
-    override val id: DomainId<SwitchElement> = StringId(),
-    override val start: Point,
-    override val end: Point,
-    val radius: Double,
-) : SwitchElement() {
-    override val type: SwitchElementType = SwitchElementType.CURVE
+data class SwitchStructureCurve(override val start: Point, override val end: Point, val radius: Double) :
+    SwitchStructureElement() {
+    override val type: SwitchStructureElementType = SwitchStructureElementType.CURVE
 }
 
-data class SwitchAlignment(
-    val jointNumbers: List<JointNumber>,
-    val elements: List<SwitchElement>,
-    val id: DomainId<SwitchAlignment> = StringId(jointNumbers.joinToString("-") { joint -> joint.intValue.toString() }),
-) {
+data class SwitchStructureAlignment(val jointNumbers: List<JointNumber>, val elements: List<SwitchStructureElement>) {
     init {
-        if (jointNumbers.isEmpty()) {
-            throw IllegalArgumentException("No joint numbers")
-        }
-        if (elements.isEmpty()) {
-            throw IllegalArgumentException("No elements")
-        }
+        require(jointNumbers.isNotEmpty()) { "Switch structure alignment must have some joints" }
+        require(elements.isNotEmpty()) { "Switch structure alignment must have some elements" }
     }
 }
 
-data class SwitchStructure(
-    val id: DomainId<SwitchStructure> = StringId(),
-    val type: SwitchType,
-    val presentationJointNumber: JointNumber,
-    val joints: List<SwitchJoint>,
-    val alignments: List<SwitchAlignment>,
-) {
+interface ISwitchStructure {
+    val type: SwitchType
+    val presentationJointNumber: JointNumber
+    val joints: Set<SwitchStructureJoint>
+    val alignments: List<SwitchStructureAlignment>
+    val data: SwitchStructureData
+
     // These props are published into JSON from API
-    @Suppress("unused") val hand = type.parts.hand
+    @Suppress("unused")
+    val hand
+        get() = type.parts.hand
 
-    @Suppress("unused") val baseType = type.parts.baseType
+    @Suppress("unused")
+    val baseType
+        get() = type.parts.baseType
 
-    val alignmentJoints by lazy {
-        joints.filter { joint -> alignments.any { alignment -> alignment.jointNumbers.contains(joint.number) } }
-    }
+    val alignmentJoints: List<SwitchStructureJoint>
+    val bbox: BoundingBox
 
-    val bbox: BoundingBox by lazy { boundingBoxAroundPoints(joints.map { joint -> joint.location }) }
+    fun isSame(other: ISwitchStructure): Boolean = data == other.data
 
-    init {
-        if (joints.isEmpty()) {
-            throw IllegalArgumentException("No joint points")
-        }
-        if (joints.none { it.number == presentationJointNumber }) {
-            throw IllegalArgumentException(
-                "Presentation joint number $presentationJointNumber does not exists in joints!"
-            )
-        }
-        if (alignments.isEmpty()) {
-            throw IllegalArgumentException("No alignments")
-        }
-        if (
-            alignments.any {
-                it.jointNumbers.any { alignJointNumber -> joints.none { joint -> joint.number == alignJointNumber } }
-            }
-        ) {
-            throw IllegalArgumentException("Alignment contains joint number that does not exists in joints!")
-        }
-        if (
-            alignments.map { alignment -> alignment.id }.let { alignmentIds -> alignmentIds != alignmentIds.distinct() }
-        ) {
-            throw IllegalArgumentException("Two or more alignments has the same id!")
-        }
-    }
-
-    fun getAlignment(id: StringId<SwitchAlignment>): SwitchAlignment {
-        return alignments.find { alignment -> alignment.id == id }
-            ?: throw IllegalArgumentException("Switch structure $type does not contain alignment $id!")
-    }
-
-    fun flipAlongYAxis(): SwitchStructure {
-        val multiplier = Point(1.0, -1.0)
-        return this.copy(
-            joints = joints.map { joint -> joint.copy(location = joint.location * multiplier) },
-            alignments =
-                alignments.map { alignment ->
-                    alignment.copy(
-                        elements =
-                            alignment.elements.map { element ->
-                                when (element) {
-                                    is SwitchElementLine -> {
-                                        element.copy(start = element.start * multiplier, end = element.end * multiplier)
-                                    }
-                                    is SwitchElementCurve -> {
-                                        element.copy(start = element.start * multiplier, end = element.end * multiplier)
-                                    }
-                                }
-                            }
-                    )
-                },
-        )
-    }
-
-    fun getJoint(jointNumber: JointNumber): SwitchJoint {
+    fun getJoint(jointNumber: JointNumber): SwitchStructureJoint {
         return joints.find { joint -> joint.number == jointNumber }
             ?: throw IllegalArgumentException("Joint number $jointNumber does not exist in switch $type!")
     }
@@ -305,29 +237,67 @@ data class SwitchStructure(
     fun getJointLocation(jointNumber: JointNumber): Point {
         return getJoint(jointNumber).location
     }
+}
 
-    fun stripUniqueIdentifiers(): SwitchStructure {
-        var i = 0
-        return copy(
-            id = IntId(i++),
+data class SwitchStructure(
+    val version: RowVersion<SwitchStructure>,
+    @JsonIgnore override val data: SwitchStructureData,
+) : ISwitchStructure by data {
+    val id: IntId<SwitchStructure> = version.id
+}
+
+data class SwitchStructureData(
+    override val type: SwitchType,
+    override val presentationJointNumber: JointNumber,
+    override val joints: Set<SwitchStructureJoint>,
+    override val alignments: List<SwitchStructureAlignment>,
+) : ISwitchStructure {
+    override val data = this
+
+    override val alignmentJoints: List<SwitchStructureJoint> by lazy {
+        joints.filter { joint -> alignments.any { alignment -> alignment.jointNumbers.contains(joint.number) } }
+    }
+
+    override val bbox: BoundingBox by lazy { boundingBoxAroundPoints(joints.map { joint -> joint.location }) }
+
+    init {
+        require(joints.isNotEmpty()) { "Switch structure must have joint points: type=$type" }
+        val allJointNumbers = joints.map { j -> j.number }.toSet()
+        require(allJointNumbers.contains(presentationJointNumber)) {
+            "Switch structure must contain the joint point for presentation joint: type=$type presentationJointNumber=$presentationJointNumber allJoints=$allJointNumbers"
+        }
+
+        require(alignments.isNotEmpty()) { "Switch structure must have at least one alignment: type=$type" }
+        val allAlignmentJointNumbers = alignments.flatMap { a -> a.jointNumbers }.toSet()
+        require(allAlignmentJointNumbers.all(allJointNumbers::contains)) {
+            "Switch structure alignments can only have joints that exist in the structure: type=$type alignmentJoints=$allAlignmentJointNumbers allJoints=$allJointNumbers"
+        }
+        require(allAlignmentJointNumbers.contains(presentationJointNumber)) {
+            "Some switch structure alignment must contain the joint point for presentation joint: type=$type presentationJointNumber=$presentationJointNumber allAlignmentJoints=$allAlignmentJointNumbers"
+        }
+    }
+
+    fun flipAlongYAxis(): SwitchStructureData {
+        val multiplier = Point(1.0, -1.0)
+        return this.copy(
+            joints = joints.map { joint -> joint.copy(location = joint.location * multiplier) }.toSet(),
             alignments =
-                alignments.map { a ->
-                    a.copy(
-                        id = IntId(i++),
+                alignments.map { alignment ->
+                    alignment.copy(
                         elements =
-                            a.elements.map { e ->
-                                when (e) {
-                                    is SwitchElementLine -> e.copy(id = IntId(i++))
-                                    is SwitchElementCurve -> e.copy(id = IntId(i++))
+                            alignment.elements.map { element ->
+                                when (element) {
+                                    is SwitchStructureLine -> {
+                                        element.copy(start = element.start * multiplier, end = element.end * multiplier)
+                                    }
+                                    is SwitchStructureCurve -> {
+                                        element.copy(start = element.start * multiplier, end = element.end * multiplier)
+                                    }
                                 }
-                            },
+                            }
                     )
                 },
         )
-    }
-
-    fun isSame(other: SwitchStructure): Boolean {
-        return stripUniqueIdentifiers() == other.stripUniqueIdentifiers()
     }
 }
 
@@ -371,7 +341,7 @@ fun transformSwitchPoint(transformation: SwitchPositionTransformation, point: Po
         transformation.translation
 }
 
-data class LinkableSwitchAlignment(val joints: List<JointNumber>, val originalAlignment: SwitchAlignment)
+data class LinkableSwitchAlignment(val joints: List<JointNumber>, val originalAlignment: SwitchStructureAlignment)
 
 data class SwitchConnectivity(val alignments: List<LinkableSwitchAlignment>, val frontJoint: JointNumber?)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/EV_SJ43_5_9_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/EV_SJ43_5_9_1_9.kt
@@ -2,39 +2,39 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementCurve
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementLine
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
-import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun EV_SJ43_5_9_1_9_H() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("EV-SJ43-5,9-1:9-H"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.54, 0.0)),
-                SwitchJoint(JointNumber(2), Point(29.02, 0.0)),
-                SwitchJoint(JointNumber(3), Point(28.91, -1.94)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.54, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(29.02, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(28.91, -1.94)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.54, 0.0)),
-                            SwitchElementLine(start = Point(11.54, 0.0), end = Point(29.02, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.54, 0.0)),
+                            SwitchStructureLine(start = Point(11.54, 0.0), end = Point(29.02, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(
+                            SwitchStructureCurve(
                                 start = Point(0.0, 0.0),
                                 end = Point(28.91, -1.94),
                                 radius = 216.2, // Calculated from point locations, is inaccurate/estimation

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_233_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_233_1_9.kt
@@ -5,36 +5,36 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun KRV43_233_1_9() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("KRV43-233-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(16.846, 0.0)),
-                SwitchJoint(JointNumber(2), Point(33.692, 0.0)),
-                SwitchJoint(JointNumber(4), Point(0.103, 1.86)),
-                SwitchJoint(JointNumber(3), Point(33.589, -1.86)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(16.846, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(33.692, 0.0)),
+                SwitchStructureJoint(JointNumber(4), Point(0.103, 1.86)),
+                SwitchStructureJoint(JointNumber(3), Point(33.589, -1.86)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(16.846, 0.0)),
-                            SwitchElementLine(start = Point(16.846, 0.0), end = Point(33.692, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(16.846, 0.0)),
+                            SwitchStructureLine(start = Point(16.846, 0.0), end = Point(33.692, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.103, 1.86), end = Point(16.846, 0.0)),
-                            SwitchElementLine(start = Point(16.846, 0.0), end = Point(33.692, 0.0)),
+                            SwitchStructureLine(start = Point(0.103, 1.86), end = Point(16.846, 0.0)),
+                            SwitchStructureLine(start = Point(16.846, 0.0), end = Point(33.692, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
@@ -45,10 +45,10 @@ fun KRV43_233_1_9() =
                             // is simplified. This does not affect current functionality, joint
                             // point
                             // locations are the most important information.
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(33.589, -1.86), radius = 233.0)
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(33.589, -1.86), radius = 233.0)
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(2)),
                     elements =
                         listOf(
@@ -59,7 +59,7 @@ fun KRV43_233_1_9() =
                             // is simplified. This does not affect current functionality, joint
                             // point
                             // locations are the most important information.
-                            SwitchElementCurve(start = Point(0.103, 1.86), end = Point(33.692, 0.0), radius = 233.0)
+                            SwitchStructureCurve(start = Point(0.103, 1.86), end = Point(33.692, 0.0), radius = 233.0)
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_270_1_9_514.kt
@@ -2,54 +2,63 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KRV43_270_1_9_514() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("KRV43-270-1:9,514"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(17.540, 0.0)),
-                SwitchJoint(JointNumber(2), Point(35.080, 0.0)),
-                SwitchJoint(JointNumber(4), Point(0.096, 1.833)),
-                SwitchJoint(JointNumber(3), Point(34.984, -1.833)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(17.540, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(35.080, 0.0)),
+                SwitchStructureJoint(JointNumber(4), Point(0.096, 1.833)),
+                SwitchStructureJoint(JointNumber(3), Point(34.984, -1.833)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.540, 0.0)),
-                            SwitchElementLine(start = Point(17.540, 0.0), end = Point(35.080, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.540, 0.0)),
+                            SwitchStructureLine(start = Point(17.540, 0.0), end = Point(35.080, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.096, 1.833), end = Point(17.540, 0.0)),
-                            SwitchElementLine(start = Point(17.540, 0.0), end = Point(35.080, 0.0)),
+                            SwitchStructureLine(start = Point(0.096, 1.833), end = Point(17.540, 0.0)),
+                            SwitchStructureLine(start = Point(17.540, 0.0), end = Point(35.080, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(6.010, 0.0)),
-                            SwitchElementCurve(start = Point(6.010, 0.0), end = Point(29.006, -1.206), radius = 220.0),
-                            SwitchElementLine(start = Point(29.006, -1.206), end = Point(34.984, -1.833)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(6.010, 0.0)),
+                            SwitchStructureCurve(
+                                start = Point(6.010, 0.0),
+                                end = Point(29.006, -1.206),
+                                radius = 220.0,
+                            ),
+                            SwitchStructureLine(start = Point(29.006, -1.206), end = Point(34.984, -1.833)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.096, 1.833), end = Point(6.0734, 1.206)),
-                            SwitchElementCurve(start = Point(6.0734, 1.206), end = Point(29.07, 0.0), radius = 220.0),
-                            SwitchElementLine(start = Point(29.07, 0.0), end = Point(35.080, 0.0)),
+                            SwitchStructureLine(start = Point(0.096, 1.833), end = Point(6.0734, 1.206)),
+                            SwitchStructureCurve(start = Point(6.0734, 1.206), end = Point(29.07, 0.0), radius = 220.0),
+                            SwitchStructureLine(start = Point(29.07, 0.0), end = Point(35.080, 0.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV54_200_1_9.kt
@@ -5,51 +5,51 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun KRV54_200_1_9() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("KRV54-200-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(17.223, 0.0)),
-                SwitchJoint(JointNumber(2), Point(34.446, 0.0)),
-                SwitchJoint(JointNumber(4), Point(0.105, 1.902)),
-                SwitchJoint(JointNumber(3), Point(34.341, -1.902)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(17.223, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(34.446, 0.0)),
+                SwitchStructureJoint(JointNumber(4), Point(0.105, 1.902)),
+                SwitchStructureJoint(JointNumber(3), Point(34.341, -1.902)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.223, 0.0)),
-                            SwitchElementLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.223, 0.0)),
+                            SwitchStructureLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.105, 1.902), end = Point(17.223, 0.0)),
-                            SwitchElementLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.105, 1.902), end = Point(17.223, 0.0)),
+                            SwitchStructureLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(6.15, 0.0)),
-                            SwitchElementCurve(start = Point(6.15, 0.0), end = Point(28.232, -1.223), radius = 200.0),
-                            SwitchElementLine(start = Point(28.232, -1.223), end = Point(34.341, -1.902)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(6.15, 0.0)),
+                            SwitchStructureCurve(start = Point(6.15, 0.0), end = Point(28.232, -1.223), radius = 200.0),
+                            SwitchStructureLine(start = Point(28.232, -1.223), end = Point(34.341, -1.902)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.105, 1.902), end = Point(6.214, 1.223)),
-                            SwitchElementCurve(start = Point(6.214, 1.223), end = Point(28.300, 0.0), radius = 200.0),
-                            SwitchElementLine(start = Point(28.300, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.105, 1.902), end = Point(6.214, 1.223)),
+                            SwitchStructureCurve(start = Point(6.214, 1.223), end = Point(28.300, 0.0), radius = 200.0),
+                            SwitchStructureLine(start = Point(28.300, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV30_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV30_270_1_9_514.kt
@@ -2,47 +2,60 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KV30_270_1_9_514_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("KV30-270-1:9,514-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(10.42, 0.0)),
-                SwitchJoint(JointNumber(6), Point(20.42, 0.0)),
-                SwitchJoint(JointNumber(2), Point(37.96, 0.0)),
-                SwitchJoint(JointNumber(3), Point(27.864, -1.833)),
-                SwitchJoint(JointNumber(4), Point(37.96, 1.833)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(10.42, 0.0)),
+                SwitchStructureJoint(JointNumber(6), Point(20.42, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(37.96, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(27.864, -1.833)),
+                SwitchStructureJoint(JointNumber(4), Point(37.96, 1.833)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(6), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(10.42, 0.0)),
-                            SwitchElementLine(start = Point(10.42, 0.0), end = Point(20.42, 0.0)),
-                            SwitchElementLine(start = Point(20.42, 0.0), end = Point(37.96, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(10.42, 0.0)),
+                            SwitchStructureLine(start = Point(10.42, 0.0), end = Point(20.42, 0.0)),
+                            SwitchStructureLine(start = Point(20.42, 0.0), end = Point(37.96, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(20.783, -1.089), radius = 198.825),
-                            SwitchElementLine(start = Point(20.783, -1.089), end = Point(27.864, -1.833)),
+                            SwitchStructureCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(20.783, -1.089),
+                                radius = 198.825,
+                            ),
+                            SwitchStructureLine(start = Point(20.783, -1.089), end = Point(27.864, -1.833)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(4)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(10.0, 0.0)),
-                            SwitchElementCurve(start = Point(10.0, 0.0), end = Point(30.783, 1.089), radius = 198.825),
-                            SwitchElementLine(start = Point(30.783, 1.089), end = Point(37.864, 1.833)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(10.0, 0.0)),
+                            SwitchStructureCurve(
+                                start = Point(10.0, 0.0),
+                                end = Point(30.783, 1.089),
+                                radius = 198.825,
+                            ),
+                            SwitchStructureLine(start = Point(30.783, 1.089), end = Point(37.864, 1.833)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV43_300_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV43_300_1_9_514.kt
@@ -5,44 +5,48 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun KV43_300_1_9_514_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("KV43-300-1:9,514-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.31, 0.0)),
-                SwitchJoint(JointNumber(6), Point(23.38, 0.0)),
-                SwitchJoint(JointNumber(2), Point(40.92, 0.0)),
-                SwitchJoint(JointNumber(3), Point(28.754, 1.834)),
-                SwitchJoint(JointNumber(4), Point(40.92, -1.834)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.31, 0.0)),
+                SwitchStructureJoint(JointNumber(6), Point(23.38, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(40.92, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(28.754, 1.834)),
+                SwitchStructureJoint(JointNumber(4), Point(40.92, -1.834)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(6), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.31, 0.0)),
-                            SwitchElementLine(start = Point(11.31, 0.0), end = Point(23.38, 0.0)),
-                            SwitchElementLine(start = Point(23.38, 0.0), end = Point(40.92, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.31, 0.0)),
+                            SwitchStructureLine(start = Point(11.31, 0.0), end = Point(23.38, 0.0)),
+                            SwitchStructureLine(start = Point(23.38, 0.0), end = Point(40.92, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(23.35, 1.265), radius = 231.0),
-                            SwitchElementLine(start = Point(23.35, 1.265), end = Point(28.754, 1.834)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(23.35, 1.265), radius = 231.0),
+                            SwitchStructureLine(start = Point(23.35, 1.265), end = Point(28.754, 1.834)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(4)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.274, 0.0)),
-                            SwitchElementCurve(start = Point(11.274, 0.0), end = Point(35.42, -1.266), radius = 231.0),
-                            SwitchElementLine(start = Point(35.42, -1.266), end = Point(40.824, -1.834)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.274, 0.0)),
+                            SwitchStructureCurve(
+                                start = Point(11.274, 0.0),
+                                end = Point(35.42, -1.266),
+                                radius = 231.0,
+                            ),
+                            SwitchStructureLine(start = Point(35.42, -1.266), end = Point(40.824, -1.834)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV54_200_1_9.kt
@@ -2,47 +2,56 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KV54_200_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("KV54-200-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
-                SwitchJoint(JointNumber(6), Point(22.4, 0.0)),
-                SwitchJoint(JointNumber(2), Point(39.623, 0.0)),
-                SwitchJoint(JointNumber(3), Point(28.195, -1.902)),
-                SwitchJoint(JointNumber(4), Point(39.518, 1.902)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchStructureJoint(JointNumber(6), Point(22.4, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(39.623, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(28.195, -1.902)),
+                SwitchStructureJoint(JointNumber(4), Point(39.518, 1.902)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(6), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.077, 0.0)),
-                            SwitchElementLine(start = Point(11.077, 0.0), end = Point(22.4, 0.0)),
-                            SwitchElementLine(start = Point(22.4, 0.0), end = Point(39.623, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.077, 0.0)),
+                            SwitchStructureLine(start = Point(11.077, 0.0), end = Point(22.4, 0.0)),
+                            SwitchStructureLine(start = Point(22.4, 0.0), end = Point(39.623, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.086, -1.223), radius = 200.0),
-                            SwitchElementLine(start = Point(22.086, -1.223), end = Point(28.195, -1.902)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.086, -1.223), radius = 200.0),
+                            SwitchStructureLine(start = Point(22.086, -1.223), end = Point(28.195, -1.902)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(4)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.323, 0.0)),
-                            SwitchElementCurve(start = Point(11.323, 0.0), end = Point(33.406, 1.223), radius = 200.0),
-                            SwitchElementLine(start = Point(33.406, 1.223), end = Point(39.518, 1.902)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.323, 0.0)),
+                            SwitchStructureCurve(
+                                start = Point(11.323, 0.0),
+                                end = Point(33.406, 1.223),
+                                radius = 200.0,
+                            ),
+                            SwitchStructureLine(start = Point(33.406, 1.223), end = Point(39.518, 1.902)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR43_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR43_1_9_514.kt
@@ -2,40 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementLine
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
-import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR43_1_9_514() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("RR43-1:9,514"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(1), Point(-17.44, 1.84)),
-                SwitchJoint(JointNumber(2), Point(17.44, -1.84)),
-                SwitchJoint(JointNumber(4), Point(-17.44, -1.84)),
-                SwitchJoint(JointNumber(3), Point(17.44, 1.84)),
+            setOf(
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(1), Point(-17.44, 1.84)),
+                SwitchStructureJoint(JointNumber(2), Point(17.44, -1.84)),
+                SwitchStructureJoint(JointNumber(4), Point(-17.44, -1.84)),
+                SwitchStructureJoint(JointNumber(3), Point(17.44, 1.84)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-17.44, 1.84), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.44, -1.84)),
+                            SwitchStructureLine(start = Point(-17.44, 1.84), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.44, -1.84)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-17.44, -1.84), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.44, 1.84)),
+                            SwitchStructureLine(start = Point(-17.44, -1.84), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.44, 1.84)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_3_078.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_3_078.kt
@@ -2,40 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementLine
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
-import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR54_1_3_078() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("RR54-1:3,078"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-6.910, 1.008)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(6.910, -1.008)),
-                SwitchJoint(JointNumber(4), Point(-6.870, -1.250)),
-                SwitchJoint(JointNumber(3), Point(6.870, 1.250)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(-6.910, 1.008)),
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(6.910, -1.008)),
+                SwitchStructureJoint(JointNumber(4), Point(-6.870, -1.250)),
+                SwitchStructureJoint(JointNumber(3), Point(6.870, 1.250)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-6.910, 1.008), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(6.910, -1.008)),
+                            SwitchStructureLine(start = Point(-6.910, 1.008), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(6.910, -1.008)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-6.870, -1.250), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(6.870, 1.250)),
+                            SwitchStructureLine(start = Point(-6.870, -1.250), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(6.870, 1.250)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_9.kt
@@ -2,36 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR54_1_9() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("RR54-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(17.223, 0.0)),
-                SwitchJoint(JointNumber(2), Point(34.446, 0.0)),
-                SwitchJoint(JointNumber(4), Point(0.105, 1.902)),
-                SwitchJoint(JointNumber(3), Point(34.341, -1.902)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(17.223, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(34.446, 0.0)),
+                SwitchStructureJoint(JointNumber(4), Point(0.105, 1.902)),
+                SwitchStructureJoint(JointNumber(3), Point(34.341, -1.902)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.223, 0.0)),
-                            SwitchElementLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.223, 0.0)),
+                            SwitchStructureLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.105, 1.902), end = Point(17.223, 0.0)),
-                            SwitchElementLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.105, 1.902), end = Point(17.223, 0.0)),
+                            SwitchStructureLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_2x1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_2x1_9.kt
@@ -5,33 +5,33 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun RR54_2x1_9() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("RR54-2x1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-11.148, -1.239)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(11.148, 1.239)),
-                SwitchJoint(JointNumber(4), Point(-11.148, 1.239)),
-                SwitchJoint(JointNumber(3), Point(11.148, -1.239)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(-11.148, -1.239)),
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(11.148, 1.239)),
+                SwitchStructureJoint(JointNumber(4), Point(-11.148, 1.239)),
+                SwitchStructureJoint(JointNumber(3), Point(11.148, -1.239)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-11.148, -1.239), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.148, 1.239)),
+                            SwitchStructureLine(start = Point(-11.148, -1.239), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.148, 1.239)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-11.148, 1.239), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.148, -1.239)),
+                            SwitchStructureLine(start = Point(-11.148, 1.239), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.148, -1.239)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_4x1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_4x1_9.kt
@@ -5,33 +5,33 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun RR54_4x1_9() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("RR54-4x1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-5.075, -1.142)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(5.075, 1.142)),
-                SwitchJoint(JointNumber(4), Point(-5.075, 1.142)),
-                SwitchJoint(JointNumber(3), Point(5.075, -1.142)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(-5.075, -1.142)),
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(5.075, 1.142)),
+                SwitchStructureJoint(JointNumber(4), Point(-5.075, 1.142)),
+                SwitchStructureJoint(JointNumber(3), Point(5.075, -1.142)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-5.075, -1.142), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(5.075, 1.142)),
+                            SwitchStructureLine(start = Point(-5.075, -1.142), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(5.075, 1.142)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-5.075, 1.142), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(5.075, -1.142)),
+                            SwitchStructureLine(start = Point(-5.075, 1.142), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(5.075, -1.142)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_1000_474_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_1000_474_1_15_5.kt
@@ -2,32 +2,38 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun SKV60_1000_474_1_15_5_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("SKV60-1000/474-1:15,5-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(13), Point(29.555, 0.0)),
-                SwitchJoint(JointNumber(16), Point(59.058, -1.745)),
-                SwitchJoint(JointNumber(17), Point(58.896, -3.553)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(13), Point(29.555, 0.0)),
+                SwitchStructureJoint(JointNumber(16), Point(59.058, -1.745)),
+                SwitchStructureJoint(JointNumber(17), Point(58.896, -3.553)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(16)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(59.058, -1.745), radius = 1000.0)
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(59.058, -1.745), radius = 1000.0)
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(17)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(58.896, -3.553), radius = 474.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(58.896, -3.553), radius = 474.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_800_423_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_800_423_1_15_5.kt
@@ -2,7 +2,11 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // This switch type may contain inaccurate point locations and wrong elements
@@ -10,26 +14,30 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // with limited understanding of the domain.
 
 fun SKV60_800_423_1_15_5_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("SKV60-800/423-1:15,5-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(16), Point(59.003, 2.105)),
-                SwitchJoint(JointNumber(17), Point(58.807, 3.967)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(16), Point(59.003, 2.105)),
+                SwitchStructureJoint(JointNumber(17), Point(58.807, 3.967)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(16)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(59.003, 2.105), radius = 800.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(59.003, 2.105), radius = 800.0)
+                        ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(17)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(58.807, 3.967), radius = 423.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(58.807, 3.967), radius = 423.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_4_8.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_4_8.kt
@@ -2,39 +2,43 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE: Joint point locations are inferred from geometry elements with just a little domain
 // knowledge and therefore this switch model may be somewhat wrong.
 
 fun SRR54_2x1_9_4_8() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("SRR54-2x1:9-4,8"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-4.482, -4.482 / 9.0)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(4.482, 4.482 / 9.0)),
-                SwitchJoint(JointNumber(3), Point(4.482, -4.482 / 9.0)),
-                SwitchJoint(JointNumber(4), Point(-4.482, 4.482 / 9.0)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(-4.482, -4.482 / 9.0)),
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(4.482, 4.482 / 9.0)),
+                SwitchStructureJoint(JointNumber(3), Point(4.482, -4.482 / 9.0)),
+                SwitchStructureJoint(JointNumber(4), Point(-4.482, 4.482 / 9.0)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-4.482, -4.482 / 9.0), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(4.482, 4.482 / 9.0)),
+                            SwitchStructureLine(start = Point(-4.482, -4.482 / 9.0), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(4.482, 4.482 / 9.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-4.482, 4.482 / 9.0), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(4.482, -4.482 / 9.0)),
+                            SwitchStructureLine(start = Point(-4.482, 4.482 / 9.0), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(4.482, -4.482 / 9.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_6_0.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_6_0.kt
@@ -2,39 +2,43 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE: Joint point locations are inferred from geometry elements with just a little domain
 // knowledge and therefore this switch model may be somewhat wrong.
 
 fun SRR54_2x1_9_6_0() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("SRR54-2x1:9-6,0"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-9.927, -9.927 / 9.0)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(9.927, 9.927 / 9.0)),
-                SwitchJoint(JointNumber(3), Point(9.927, -9.927 / 9.0)),
-                SwitchJoint(JointNumber(4), Point(-9.927, 9.927 / 9.0)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(-9.927, -9.927 / 9.0)),
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(9.927, 9.927 / 9.0)),
+                SwitchStructureJoint(JointNumber(3), Point(9.927, -9.927 / 9.0)),
+                SwitchStructureJoint(JointNumber(4), Point(-9.927, 9.927 / 9.0)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-9.927, -9.927 / 9.0), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(9.927, 9.927 / 9.0)),
+                            SwitchStructureLine(start = Point(-9.927, -9.927 / 9.0), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(9.927, 9.927 / 9.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-9.927, 9.927 / 9.0), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(9.927, -9.927 / 9.0)),
+                            SwitchStructureLine(start = Point(-9.927, 9.927 / 9.0), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(9.927, -9.927 / 9.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR60_2x1_9_4_8.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR60_2x1_9_4_8.kt
@@ -2,39 +2,43 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE: Joint point locations are inferred from geometry elements with just a little domain
 // knowledge and therefore this switch model may be somewhat wrong.
 
 fun SRR60_2x1_9_4_8() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("SRR60-2x1:9-4,8"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-5.087, -5.087 / 9.0)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(5.087, 5.087 / 9.0)),
-                SwitchJoint(JointNumber(3), Point(5.087, -5.087 / 9.0)),
-                SwitchJoint(JointNumber(4), Point(-5.087, 5.087 / 9.0)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(-5.087, -5.087 / 9.0)),
+                SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(5.087, 5.087 / 9.0)),
+                SwitchStructureJoint(JointNumber(3), Point(5.087, -5.087 / 9.0)),
+                SwitchStructureJoint(JointNumber(4), Point(-5.087, 5.087 / 9.0)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-5.087, -5.087 / 9.0), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(5.087, 5.087 / 9.0)),
+                            SwitchStructureLine(start = Point(-5.087, -5.087 / 9.0), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(5.087, 5.087 / 9.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(-5.087, 5.087 / 9.0), end = Point(0.0, 0.0)),
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(5.087, -5.087 / 9.0)),
+                            SwitchStructureLine(start = Point(-5.087, 5.087 / 9.0), end = Point(0.0, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(5.087, -5.087 / 9.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44.kt
@@ -2,30 +2,38 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun TYV54_200_1_4_44() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("TYV54-200-1:4,44"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
-                SwitchJoint(JointNumber(2), Point(22.086, 1.223)),
-                SwitchJoint(JointNumber(3), Point(22.086, -1.223)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(22.086, 1.223)),
+                SwitchStructureJoint(JointNumber(3), Point(22.086, -1.223)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(2)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.086, 1.223), radius = 200.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.086, 1.223), radius = 200.0)
+                        ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.086, -1.223), radius = 200.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.086, -1.223), radius = 200.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44TPE.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44TPE.kt
@@ -10,27 +10,31 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // any problems.
 
 fun TYV54_200_1_4_44TPE() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("TYV54-200-1:4,44TPE"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
-                SwitchJoint(JointNumber(2), Point(22.305, 1.236)),
-                SwitchJoint(JointNumber(3), Point(22.305, -1.236)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(22.305, 1.236)),
+                SwitchStructureJoint(JointNumber(3), Point(22.305, -1.236)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(2)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.305, 1.236), radius = 200.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.305, 1.236), radius = 200.0)
+                        ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.305, -1.236), radius = 200.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.305, -1.236), radius = 200.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46.kt
@@ -2,35 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun TYV54_225_1_6_46() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("TYV54-225-1:6,46"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(8.706, 0.0)),
-                SwitchJoint(JointNumber(2), Point(20.942, 0.941)),
-                SwitchJoint(JointNumber(3), Point(20.942, -0.941)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(8.706, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(20.942, 0.941)),
+                SwitchStructureJoint(JointNumber(3), Point(20.942, -0.941)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(17.322, 0.663), radius = 225.0),
-                            SwitchElementLine(start = Point(17.322, 0.663), end = Point(20.942, 0.941)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(17.322, 0.663), radius = 225.0),
+                            SwitchStructureLine(start = Point(17.322, 0.663), end = Point(20.942, 0.941)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(17.322, -0.663), radius = 225.0),
-                            SwitchElementLine(start = Point(17.322, 0.663), end = Point(20.942, -0.941)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(17.322, -0.663), radius = 225.0),
+                            SwitchStructureLine(start = Point(17.322, 0.663), end = Point(20.942, -0.941)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46TPE.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46TPE.kt
@@ -2,7 +2,12 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // Joint number 5 is not accurate and copied from the switch
@@ -10,32 +15,32 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // any problems.
 
 fun TYV54_225_1_6_46TPE() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("TYV54-225-1:6,46TPE"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(8.706, 0.0)),
-                SwitchJoint(JointNumber(2), Point(21.140, 0.949)),
-                SwitchJoint(JointNumber(3), Point(21.140, -0.949)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(8.706, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(21.140, 0.949)),
+                SwitchStructureJoint(JointNumber(3), Point(21.140, -0.949)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(17.421, 0.663), radius = 225.0),
-                            SwitchElementLine(start = Point(17.421, 0.663), end = Point(21.140, 0.949)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(17.421, 0.663), radius = 225.0),
+                            SwitchStructureLine(start = Point(17.421, 0.663), end = Point(21.140, 0.949)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(17.421, -0.663), radius = 225.0),
-                            SwitchElementLine(start = Point(17.421, 0.663), end = Point(21.140, -0.949)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(17.421, -0.663), radius = 225.0),
+                            SwitchStructureLine(start = Point(17.421, 0.663), end = Point(21.140, -0.949)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1500_228_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1500_228_1_9.kt
@@ -10,32 +10,34 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // with limited understanding of domain.
 
 fun UKV54_1500_228_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("UKV54-1500/228-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(7), Point(10.476, 0.0)),
-                SwitchJoint(JointNumber(8), Point(14.143, 0.0)),
-                SwitchJoint(JointNumber(10), Point(28.228, -1.480)),
-                SwitchJoint(JointNumber(11), Point(28.284, 0.256)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(7), Point(10.476, 0.0)),
+                SwitchStructureJoint(JointNumber(8), Point(14.143, 0.0)),
+                SwitchStructureJoint(JointNumber(10), Point(28.228, -1.480)),
+                SwitchStructureJoint(JointNumber(11), Point(28.284, 0.256)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(10)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(1.054, 0.0)),
-                            SwitchElementCurve(start = Point(1.054, 0.0), end = Point(19.865, 0.785), radius = 228.0),
-                            SwitchElementLine(start = Point(19.865, 0.785), end = Point(28.228, -1.480)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(1.054, 0.0)),
+                            SwitchStructureCurve(start = Point(1.054, 0.0), end = Point(19.865, 0.785), radius = 228.0),
+                            SwitchStructureLine(start = Point(19.865, 0.785), end = Point(28.228, -1.480)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(11)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(28.284, 0.256), radius = 1500.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(28.284, 0.256), radius = 1500.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_800_258_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_800_258_1_9.kt
@@ -10,31 +10,33 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // with limited understanding of domain.
 
 fun UKV54_800_258_1_9_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("UKV54-800/258-1:9-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(7), Point(9.709, 0.0)),
-                SwitchJoint(JointNumber(8), Point(14.138, 0.0)),
-                SwitchJoint(JointNumber(10), Point(28.230, 1.398)),
-                SwitchJoint(JointNumber(11), Point(28.268, -0.499)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(7), Point(9.709, 0.0)),
+                SwitchStructureJoint(JointNumber(8), Point(14.138, 0.0)),
+                SwitchStructureJoint(JointNumber(10), Point(28.230, 1.398)),
+                SwitchStructureJoint(JointNumber(11), Point(28.268, -0.499)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(10)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(19.403, 0.731), radius = 258.0),
-                            SwitchElementLine(start = Point(19.403, 0.731), end = Point(28.230, 1.398)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(19.403, 0.731), radius = 258.0),
+                            SwitchStructureLine(start = Point(19.403, 0.731), end = Point(28.230, 1.398)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(11)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(28.268, -0.499), radius = 800.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(28.268, -0.499), radius = 800.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_1000_244_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_1000_244_1_9.kt
@@ -2,33 +2,39 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun UKV60_1000_244_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("UKV60-1000/244-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(7), Point(10.074, 0.0)),
-                SwitchJoint(JointNumber(8), Point(14.141, 0.0)),
-                SwitchJoint(JointNumber(10), Point(28.290, -0.400)),
-                SwitchJoint(JointNumber(11), Point(28.217, 1.498)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(7), Point(10.074, 0.0)),
+                SwitchStructureJoint(JointNumber(8), Point(14.141, 0.0)),
+                SwitchStructureJoint(JointNumber(10), Point(28.290, -0.400)),
+                SwitchStructureJoint(JointNumber(11), Point(28.217, 1.498)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(10)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(28.290, -0.400), radius = 1000.0)
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(28.290, -0.400), radius = 1000.0)
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(11)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(28.217, 1.498), radius = 244.45)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(28.217, 1.498), radius = 244.45)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_600_281_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_600_281_1_9.kt
@@ -5,28 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun UKV60_600_281_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("UKV60-600/281-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(7), Point(8.921, 0.0)),
-                SwitchJoint(JointNumber(8), Point(14.135, 0.0)),
-                SwitchJoint(JointNumber(10), Point(28.254, -0.666)),
-                SwitchJoint(JointNumber(11), Point(28.234, 1.229)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(7), Point(8.921, 0.0)),
+                SwitchStructureJoint(JointNumber(8), Point(14.135, 0.0)),
+                SwitchStructureJoint(JointNumber(10), Point(28.254, -0.666)),
+                SwitchStructureJoint(JointNumber(11), Point(28.234, 1.229)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(10)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(28.254, -0.666), radius = 600.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(28.254, -0.666), radius = 600.0)
+                        ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(11)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(28.234, 1.229), radius = 281.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(28.234, 1.229), radius = 281.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YRV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YRV54_200_1_9.kt
@@ -5,51 +5,51 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YRV54_200_1_9() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YRV54-200-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(17.223, 0.0)),
-                SwitchJoint(JointNumber(2), Point(34.446, 0.0)),
-                SwitchJoint(JointNumber(4), Point(0.105, 1.902)),
-                SwitchJoint(JointNumber(3), Point(34.341, -1.902)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(17.223, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(34.446, 0.0)),
+                SwitchStructureJoint(JointNumber(4), Point(0.105, 1.902)),
+                SwitchStructureJoint(JointNumber(3), Point(34.341, -1.902)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.223, 0.0)),
-                            SwitchElementLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.223, 0.0)),
+                            SwitchStructureLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.105, 1.902), end = Point(17.223, 0.0)),
-                            SwitchElementLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.105, 1.902), end = Point(17.223, 0.0)),
+                            SwitchStructureLine(start = Point(17.223, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(6.15, 0.0)),
-                            SwitchElementCurve(start = Point(6.15, 0.0), end = Point(28.232, -1.223), radius = 200.0),
-                            SwitchElementLine(start = Point(28.232, -1.223), end = Point(34.341, -1.902)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(6.15, 0.0)),
+                            SwitchStructureCurve(start = Point(6.15, 0.0), end = Point(28.232, -1.223), radius = 200.0),
+                            SwitchStructureLine(start = Point(28.232, -1.223), end = Point(34.341, -1.902)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(4), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.105, 1.902), end = Point(6.214, 1.223)),
-                            SwitchElementCurve(start = Point(6.214, 1.223), end = Point(28.300, 0.0), radius = 200.0),
-                            SwitchElementLine(start = Point(28.300, 0.0), end = Point(34.446, 0.0)),
+                            SwitchStructureLine(start = Point(0.105, 1.902), end = Point(6.214, 1.223)),
+                            SwitchStructureCurve(start = Point(6.214, 1.223), end = Point(28.300, 0.0), radius = 200.0),
+                            SwitchStructureLine(start = Point(28.300, 0.0), end = Point(34.446, 0.0)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_7.kt
@@ -2,35 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV30_270_1_7_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV30-270-1:7-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(12.685, 0.0)),
-                SwitchJoint(JointNumber(2), Point(25.928, 0.0)),
-                SwitchJoint(JointNumber(3), Point(25.795, 1.872)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(12.685, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(25.928, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(25.795, 1.872)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(12.685, 0.0)),
-                            SwitchElementLine(start = Point(12.685, 0.0), end = Point(25.928, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(12.685, 0.0)),
+                            SwitchStructureLine(start = Point(12.685, 0.0), end = Point(25.928, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(25.701, 1.859), radius = 185.0),
-                            SwitchElementLine(start = Point(25.701, 1.859), end = Point(25.795, 1.872)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(25.701, 1.859), radius = 185.0),
+                            SwitchStructureLine(start = Point(25.701, 1.859), end = Point(25.795, 1.872)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_9_514.kt
@@ -2,35 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV30_270_1_9_514_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV30-270-1:9,514-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(10.422, 0.0)),
-                SwitchJoint(JointNumber(2), Point(27.962, 0.0)),
-                SwitchJoint(JointNumber(3), Point(27.866, 1.833)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(10.422, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(27.962, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(27.866, 1.833)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(10.422, 0.0)),
-                            SwitchElementLine(start = Point(10.422, 0.0), end = Point(27.962, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(10.422, 0.0)),
+                            SwitchStructureLine(start = Point(10.422, 0.0), end = Point(27.962, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.722, 1.293), radius = 236.0),
-                            SwitchElementLine(start = Point(22.722, 1.293), end = Point(27.866, 1.833)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.722, 1.293), radius = 236.0),
+                            SwitchStructureLine(start = Point(22.722, 1.293), end = Point(27.866, 1.833)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_7.kt
@@ -2,35 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV43_300_1_7_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV43-300-1:7-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(13.481, 0.0)),
-                SwitchJoint(JointNumber(2), Point(26.506, 0.0)),
-                SwitchJoint(JointNumber(3), Point(26.375, -1.842)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(13.481, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(26.506, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(26.375, -1.842)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(13.481, 0.0)),
-                            SwitchElementLine(start = Point(13.481, 0.0), end = Point(26.506, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(13.481, 0.0)),
+                            SwitchStructureLine(start = Point(13.481, 0.0), end = Point(26.506, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(26.145, -1.809), radius = 180.0),
-                            SwitchElementLine(start = Point(26.145, -1.809), end = Point(26.375, -1.842)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(26.145, -1.809), radius = 180.0),
+                            SwitchStructureLine(start = Point(26.145, -1.809), end = Point(26.375, -1.842)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9.kt
@@ -5,32 +5,36 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV43_300_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV43-300-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(12.004, 0.0)),
-                SwitchJoint(JointNumber(2), Point(28.85, 0.0)),
-                SwitchJoint(JointNumber(3), Point(28.747, -1.86)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(12.004, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(28.85, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(28.747, -1.86)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(12.004, 0.0)),
-                            SwitchElementLine(start = Point(12.004, 0.0), end = Point(28.85, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(12.004, 0.0)),
+                            SwitchStructureLine(start = Point(12.004, 0.0), end = Point(28.85, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(23.935, -1.326), radius = 216.737),
-                            SwitchElementLine(start = Point(23.935, -1.326), end = Point(28.747, -1.86)),
+                            SwitchStructureCurve(
+                                start = Point(0.0, 0.0),
+                                end = Point(23.935, -1.326),
+                                radius = 216.737,
+                            ),
+                            SwitchStructureLine(start = Point(23.935, -1.326), end = Point(28.747, -1.86)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9_514.kt
@@ -5,32 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV43_300_1_9_514_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV43-300-1:9,514-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.31, 0.0)),
-                SwitchJoint(JointNumber(2), Point(28.85, 0.0)),
-                SwitchJoint(JointNumber(3), Point(28.754, -1.833)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.31, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(28.85, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(28.754, -1.833)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.31, 0.0)),
-                            SwitchElementLine(start = Point(11.31, 0.0), end = Point(28.85, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.31, 0.0)),
+                            SwitchStructureLine(start = Point(11.31, 0.0), end = Point(28.85, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(23.35, -1.265), radius = 231.0),
-                            SwitchElementLine(start = Point(23.35, -1.265), end = Point(28.754, -1.833)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(23.35, -1.265), radius = 231.0),
+                            SwitchStructureLine(start = Point(23.35, -1.265), end = Point(28.754, -1.833)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_530_1_15.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_530_1_15.kt
@@ -2,39 +2,44 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // This switch may contain inaccurate location for joint point 3 as
 // that point was not marked in the IM file but was reasoned by a developer.
 
 fun YV43_530_1_15_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV43-530-1:15-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(15.802, 0.0)),
-                SwitchJoint(JointNumber(2), Point(43.195, 0.0)),
-                SwitchJoint(JointNumber(3), Point(42.984, -1.689)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(15.802, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(43.195, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(42.984, -1.689)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(15.802, 0.0)),
-                            SwitchElementLine(start = Point(15.802, 0.0), end = Point(43.195, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(15.802, 0.0)),
+                            SwitchStructureLine(start = Point(15.802, 0.0), end = Point(43.195, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(35.256, -1.174), radius = 530.0),
-                            SwitchElementLine(start = Point(35.256, -1.174), end = Point(42.984, -1.689)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(35.256, -1.174), radius = 530.0),
+                            SwitchStructureLine(start = Point(35.256, -1.174), end = Point(42.984, -1.689)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_165_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_165_1_7.kt
@@ -5,32 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV54_165_1_7_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV54-165-1:7-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(13.482, 0.0)),
-                SwitchJoint(JointNumber(2), Point(26.506, 0.0)),
-                SwitchJoint(JointNumber(3), Point(26.376, 1.842)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(13.482, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(26.506, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(26.376, 1.842)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(13.482, 0.0)),
-                            SwitchElementLine(start = Point(13.482, 0.0), end = Point(26.506, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(13.482, 0.0)),
+                            SwitchStructureLine(start = Point(13.482, 0.0), end = Point(26.506, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(25.09, 1.658), radius = 165.0),
-                            SwitchElementLine(start = Point(25.09, 1.658), end = Point(26.376, 1.842)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(25.09, 1.658), radius = 165.0),
+                            SwitchStructureLine(start = Point(25.09, 1.658), end = Point(26.376, 1.842)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_190_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_190_1_7.kt
@@ -2,36 +2,41 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // This switch is not in RATO4 but found from IM models
 
 fun YV54_190_1_7_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV54-190-1:7-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(13.504, 0.0)),
-                SwitchJoint(JointNumber(2), Point(27.006, 0.0)),
-                SwitchJoint(JointNumber(3), Point(26.87, -1.91)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(13.504, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(27.006, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(26.87, -1.91)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(13.504, 0.0)),
-                            SwitchElementLine(start = Point(13.504, 0.0), end = Point(27.006, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(13.504, 0.0)),
+                            SwitchStructureLine(start = Point(13.504, 0.0), end = Point(27.006, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(26.87, -1.91), radius = 190.0)),
+                        listOf(SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(26.87, -1.91), radius = 190.0)),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_200_1_9.kt
@@ -5,32 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV54_200_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV54-200-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(11.077, 0.0)),
-                SwitchJoint(JointNumber(2), Point(28.300, 0.0)),
-                SwitchJoint(JointNumber(3), Point(28.195, -1.902)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(11.077, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(28.300, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(28.195, -1.902)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(11.077, 0.0)),
-                            SwitchElementLine(start = Point(11.077, 0.0), end = Point(28.300, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(11.077, 0.0)),
+                            SwitchStructureLine(start = Point(11.077, 0.0), end = Point(28.300, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(22.086, -1.223), radius = 300.0),
-                            SwitchElementLine(start = Point(22.086, -1.223), end = Point(28.195, -1.902)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(22.086, -1.223), radius = 300.0),
+                            SwitchStructureLine(start = Point(22.086, -1.223), end = Point(28.195, -1.902)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_900_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_900_1_15_5.kt
@@ -5,30 +5,30 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV54_900_1_15_5_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV54-900-1:15,5-V"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(30.06, 0.0)),
-                SwitchJoint(JointNumber(2), Point(59.1, 0.0)),
-                SwitchJoint(JointNumber(3), Point(59.04, 1.872)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(30.06, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(59.1, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(59.04, 1.872)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(30.06, 0.0)),
-                            SwitchElementLine(start = Point(30.06, 0.0), end = Point(59.1, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(30.06, 0.0)),
+                            SwitchStructureLine(start = Point(30.06, 0.0), end = Point(59.1, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(59.04, 1.872), radius = 900.0)),
+                        listOf(SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(59.04, 1.872), radius = 900.0)),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300P_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300P_1_9.kt
@@ -10,30 +10,32 @@ import fi.fta.geoviite.infra.switchLibrary.*
 // with limited understanding of domain.
 
 fun YV60_300P_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-300P-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
-                SwitchJoint(JointNumber(2), Point(33.23, 0.0)),
-                SwitchJoint(JointNumber(3), Point(33.128, -1.835)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(16.615, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(33.23, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(33.128, -1.835)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(16.615, 0.0)),
-                            SwitchElementLine(start = Point(16.615, 0.0), end = Point(33.23, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(16.615, 0.0)),
+                            SwitchStructureLine(start = Point(16.615, 0.0), end = Point(33.23, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(33.128, -1.835), radius = 300.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(33.128, -1.835), radius = 300.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_10.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_10.kt
@@ -1,38 +1,36 @@
 package fi.fta.geoviite.infra.switchLibrary.data
 
-import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_300_1_10_V() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-300-1:10-V"),
-        id = IntId(123456),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(12.97, 0.0)),
-                SwitchJoint(JointNumber(2), Point(32.008, 0.0)),
-                SwitchJoint(JointNumber(3), Point(31.914, 1.894)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(12.97, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(32.008, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(31.914, 1.894)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(12.97, 0.0)),
-                            SwitchElementLine(start = Point(12.97, 0.0), end = Point(32.008, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(12.97, 0.0)),
+                            SwitchStructureLine(start = Point(12.97, 0.0), end = Point(32.008, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(25.876, 1.291), radius = 260.047),
-                            SwitchElementLine(start = Point(25.876, 1.291), end = Point(31.914, 1.894)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(25.876, 1.291), radius = 260.047),
+                            SwitchStructureLine(start = Point(25.876, 1.291), end = Point(31.914, 1.894)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_9.kt
@@ -2,40 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementCurve
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementLine
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
-import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_300_1_9_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-300-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
-                SwitchJoint(JointNumber(2), Point(34.430, 0.0)),
-                SwitchJoint(JointNumber(3), Point(34.321, -1.967)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(16.615, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(34.430, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(34.321, -1.967)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(16.615, 0.0)),
-                            SwitchElementLine(start = Point(16.615, 0.0), end = Point(34.430, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(16.615, 0.0)),
+                            SwitchStructureLine(start = Point(16.615, 0.0), end = Point(34.430, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(33.128, -1.835), radius = 300.0),
-                            SwitchElementLine(start = Point(33.128, -1.835), end = Point(34.321, -1.967)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(33.128, -1.835), radius = 300.0),
+                            SwitchStructureLine(start = Point(33.128, -1.835), end = Point(34.321, -1.967)),
                         ),
                 ),
             ),
@@ -46,7 +46,6 @@ fun YV60_300_1_9_V() = YV60_300_1_9_O().flipAlongYAxis().copy(type = SwitchType(
 fun YV60_300A_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType("YV60-300A-1:9-O"))
 
 fun YV60_300A_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType("YV60-300A-1:9-V"))
-
 
 fun YV60_300E_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType("YV60-300E-1:9-O"))
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_2500_1_26.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_2500_1_26.kt
@@ -5,37 +5,37 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_5000_2500_1_26_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-5000/2500-1:26-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(56.563, 0.0)),
-                SwitchJoint(JointNumber(2), Point(107.180, 0.0)),
-                SwitchJoint(JointNumber(3), Point(107.143, -1.945)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(56.563, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(107.180, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(107.143, -1.945)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(56.563, 0.0)),
-                            SwitchElementLine(start = Point(56.563, 0.0), end = Point(107.180, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(56.563, 0.0)),
+                            SwitchStructureLine(start = Point(56.563, 0.0), end = Point(107.180, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(36.979, -0.182), radius = 5000.0),
-                            SwitchElementCurve(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(36.979, -0.182), radius = 5000.0),
+                            SwitchStructureCurve(
                                 start = Point(36.979, -0.182),
                                 end = Point(105.327, -1.876),
                                 radius = 2500.0,
                             ),
-                            SwitchElementLine(start = Point(105.327, -1.876), end = Point(107.143, -1.945)),
+                            SwitchStructureLine(start = Point(105.327, -1.876), end = Point(107.143, -1.945)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_3000_1_28.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_3000_1_28.kt
@@ -5,32 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_5000_3000_1_28_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-5000/3000-1:28-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(58.220, 0.0)),
-                SwitchJoint(JointNumber(2), Point(112.039, 0.0)),
-                SwitchJoint(JointNumber(3), Point(112.005, -1.921)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(58.220, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(112.039, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(112.005, -1.921)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(58.220, 0.0)),
-                            SwitchElementLine(start = Point(58.220, 0.0), end = Point(112.039, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(58.220, 0.0)),
+                            SwitchStructureLine(start = Point(58.220, 0.0), end = Point(112.039, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(24.653, -0.074), radius = 5000.0),
-                            SwitchElementCurve(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(24.653, -0.074), radius = 5000.0),
+                            SwitchStructureCurve(
                                 start = Point(24.653, -0.074),
                                 end = Point(112.005, -1.921),
                                 radius = 3000.0,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_11_1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_11_1.kt
@@ -5,30 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_500_1_11_1_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-500-1:11,1-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(22.471, 0.0)),
-                SwitchJoint(JointNumber(2), Point(44.943, 0.0)),
-                SwitchJoint(JointNumber(3), Point(44.852, -2.016)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(22.471, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(44.943, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(44.852, -2.016)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(22.471, 0.0)),
-                            SwitchElementLine(start = Point(22.471, 0.0), end = Point(44.943, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(22.471, 0.0)),
+                            SwitchStructureLine(start = Point(22.471, 0.0), end = Point(44.943, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
-                        listOf(SwitchElementCurve(start = Point(0.0, 0.0), end = Point(44.852, -2.016), radius = 500.0)),
+                        listOf(
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(44.852, -2.016), radius = 500.0)
+                        ),
                 ),
             ),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_14.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_14.kt
@@ -2,35 +2,40 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_500_1_14_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-500-1:14-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(17.834, 0.0)),
-                SwitchJoint(JointNumber(2), Point(44.943, 0.0)),
-                SwitchJoint(JointNumber(3), Point(44.874, -1.931)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(17.834, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(44.943, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(44.874, -1.931)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(17.834, 0.0)),
-                            SwitchElementLine(start = Point(17.834, 0.0), end = Point(44.943, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(17.834, 0.0)),
+                            SwitchStructureLine(start = Point(17.834, 0.0), end = Point(44.943, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(35.623, -1.271), radius = 500.0),
-                            SwitchElementLine(start = Point(35.623, -1.271), end = Point(44.874, -1.931)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(35.623, -1.271), radius = 500.0),
+                            SwitchStructureLine(start = Point(35.623, -1.271), end = Point(44.874, -1.931)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_15_5.kt
@@ -5,33 +5,37 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_900_1_15_5_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-900-1:15,5-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(30.060, 0.0)),
-                SwitchJoint(JointNumber(2), Point(59.100, 0.0)),
-                SwitchJoint(JointNumber(3), Point(59.040, -1.870)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(30.060, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(59.100, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(59.040, -1.870)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(30.060, 0.0)),
-                            SwitchElementLine(start = Point(30.060, 0.0), end = Point(59.100, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(30.060, 0.0)),
+                            SwitchStructureLine(start = Point(30.060, 0.0), end = Point(59.100, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(1.058, 0.0)),
-                            SwitchElementCurve(start = Point(1.058, 0.0), end = Point(59.002, -1.867), radius = 900.0),
-                            SwitchElementLine(start = Point(59.002, -1.867), end = Point(59.040, -1.870)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(1.058, 0.0)),
+                            SwitchStructureCurve(
+                                start = Point(1.058, 0.0),
+                                end = Point(59.002, -1.867),
+                                radius = 900.0,
+                            ),
+                            SwitchStructureLine(start = Point(59.002, -1.867), end = Point(59.040, -1.870)),
                         ),
                 ),
             ),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_18.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_18.kt
@@ -5,32 +5,32 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_900_1_18_O() =
-    SwitchStructure(
+    SwitchStructureData(
         type = SwitchType("YV60-900-1:18-O"),
         presentationJointNumber = JointNumber(1),
         joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(25.999, 0.0)),
-                SwitchJoint(JointNumber(2), Point(59.700, 0.0)),
-                SwitchJoint(JointNumber(3), Point(59.648, -1.869)),
+            setOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(25.999, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(59.700, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(59.648, -1.869)),
             ),
         alignments =
             listOf(
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
                     elements =
                         listOf(
-                            SwitchElementLine(start = Point(0.0, 0.0), end = Point(25.999, 0.0)),
-                            SwitchElementLine(start = Point(25.999, 0.0), end = Point(59.700, 0.0)),
+                            SwitchStructureLine(start = Point(0.0, 0.0), end = Point(25.999, 0.0)),
+                            SwitchStructureLine(start = Point(25.999, 0.0), end = Point(59.700, 0.0)),
                         ),
                 ),
-                SwitchAlignment(
+                SwitchStructureAlignment(
                     jointNumbers = listOf(JointNumber(1), JointNumber(3)),
                     elements =
                         listOf(
-                            SwitchElementCurve(start = Point(0.0, 0.0), end = Point(50.941, -1.386), radius = 900.0),
-                            SwitchElementLine(start = Point(50.941, -1.386), end = Point(59.648, -1.869)),
+                            SwitchStructureCurve(start = Point(0.0, 0.0), end = Point(50.941, -1.386), radius = 900.0),
+                            SwitchStructureLine(start = Point(50.941, -1.386), end = Point(59.648, -1.869)),
                         ),
                 ),
             ),

--- a/infra/src/main/resources/db/migration/prod/V103__simplify_switch_structure_versioning.sql
+++ b/infra/src/main/resources/db/migration/prod/V103__simplify_switch_structure_versioning.sql
@@ -71,7 +71,6 @@ alter table common.switch_structure
   enable trigger version_row_trigger,
   enable trigger version_update_trigger;
 
--- select common.create_timed_fetch_function('common', 'switch_structure');
 select common.create_timed_fetch_function('common', 'switch_joint');
 select common.create_timed_fetch_function('common', 'switch_alignment');
 select common.create_timed_fetch_function('common', 'switch_element');

--- a/infra/src/main/resources/db/migration/prod/V103__simplify_switch_structure_versioning.sql
+++ b/infra/src/main/resources/db/migration/prod/V103__simplify_switch_structure_versioning.sql
@@ -1,0 +1,140 @@
+create table common.switch_structure_version_joint
+(
+  switch_structure_id      int                     not null,
+  switch_structure_version int                     not null,
+  number                   int                     not null,
+  location                 postgis.geometry(point) not null,
+  primary key (switch_structure_id, switch_structure_version, number),
+  foreign key (switch_structure_id, switch_structure_version) references common.switch_structure_version (id, version)
+);
+comment on table common.switch_structure_version_joint
+  is 'Switch structure joint, versioned with parent structure';
+
+create table common.switch_structure_version_alignment
+(
+  switch_structure_id      int   not null,
+  switch_structure_version int   not null,
+  alignment_index          int   not null,
+  joint_numbers            int[] not null,
+  primary key (switch_structure_id, switch_structure_version, alignment_index),
+  foreign key (switch_structure_id, switch_structure_version) references common.switch_structure_version (id, version)
+);
+comment on table common.switch_structure_version_alignment
+  is 'Switch structure alignment, versioned with parent structure';
+
+create table common.switch_structure_version_element
+(
+  switch_structure_id      int                        not null,
+  switch_structure_version int                        not null,
+  alignment_index          int                        not null,
+  element_index            int                        not null,
+  type                     common.switch_element_type not null,
+  start_point              postgis.geometry(point)    not null,
+  end_point                postgis.geometry(point)    not null,
+  curve_radius             decimal(12, 6)             null,
+  primary key (switch_structure_id, switch_structure_version, alignment_index, element_index),
+  foreign key (switch_structure_id, switch_structure_version)
+    references common.switch_structure_version (id, version),
+  foreign key (switch_structure_id, switch_structure_version, alignment_index)
+    references common.switch_structure_version_alignment (switch_structure_id, switch_structure_version, alignment_index)
+);
+comment on table common.switch_structure_version_element
+  is 'Switch structure element, versioned with parent structure. Describes a piece of geometry within an alignment.';
+
+alter table common.switch_structure
+  disable trigger version_row_trigger,
+  disable trigger version_update_trigger;
+
+-- These are the only cases of updating switch structures thus far. Here, only the joints were updated.
+-- In the new structure-based versioning, we need to have separate parent versions for the change as well.
+insert into common.switch_structure_version
+  (id, type, presentation_joint_number, version, change_user, change_time, deleted)
+select distinct on (structure.id)
+  structure.id,
+  structure.type,
+  structure.presentation_joint_number,
+  2 as version,
+  joint.change_user as change_user,
+  joint.change_time as change_time,
+  false as deleted
+  from common.switch_structure structure
+    inner join common.switch_joint_version joint
+               on structure.id = joint.switch_structure_id and joint.version = 2;
+
+-- Update the main table to match the new versions as well
+update common.switch_structure
+set version = sv.version, change_time = sv.change_time, change_user = sv.change_user
+  from common.switch_structure_version sv
+  where sv.version = 2 and switch_structure.id = sv.id;
+
+alter table common.switch_structure
+  enable trigger version_row_trigger,
+  enable trigger version_update_trigger;
+
+-- select common.create_timed_fetch_function('common', 'switch_structure');
+select common.create_timed_fetch_function('common', 'switch_joint');
+select common.create_timed_fetch_function('common', 'switch_alignment');
+select common.create_timed_fetch_function('common', 'switch_element');
+
+-- Insert new switch joint versions by structure versions
+insert into common.switch_structure_version_joint
+  (switch_structure_id, switch_structure_version, number, location)
+select
+  structure.id as switch_structure_id,
+  structure.version as switch_structure_version,
+  joint.number,
+  joint.location
+  from common.switch_structure_version structure
+    left join common.switch_joint_at(structure.change_time) joint on joint.switch_structure_id = structure.id;
+
+-- Create new alignment versions into temp table to maintain old id-links
+create temporary table alignment_tmp as
+select
+  structure.id as switch_structure_id,
+  structure.version as switch_structure_version,
+  alignment.id as alignment_id,
+      row_number() over (partition by structure.id, structure.version order by alignment.id) as alignment_index,
+  alignment.joint_numbers
+  from common.switch_structure_version structure
+    left join common.switch_alignment_at(structure.change_time) alignment
+              on alignment.switch_structure_id = structure.id;
+
+-- Insert new alignment versions by structure versions
+insert into common.switch_structure_version_alignment
+  (switch_structure_id, switch_structure_version, alignment_index, joint_numbers)
+select
+  switch_structure_id,
+  switch_structure_version,
+  alignment_index,
+  joint_numbers
+  from alignment_tmp;
+
+-- Insert new element versions by structure versions
+insert into common.switch_structure_version_element
+  (switch_structure_id, switch_structure_version, alignment_index, element_index, type, start_point, end_point,
+   curve_radius)
+select
+  structure.id as switch_structure_id,
+  structure.version as switch_structure_version,
+  alignment.alignment_index,
+      row_number()
+      over (partition by structure.id, structure.version, element.alignment_id order by element.element_index) as element_index,
+  element.type,
+  element.start_point,
+  element.end_point,
+  element.curve_radius
+  from common.switch_structure_version structure
+    left join alignment_tmp alignment
+              on structure.id = alignment.switch_structure_id and structure.version = alignment.switch_structure_version
+    left join common.switch_element_at(structure.change_time) element on element.alignment_id = alignment.alignment_id;
+
+-- Remove old tables
+drop function common.switch_joint_at(timestamp with time zone);
+drop function common.switch_element_at(timestamp with time zone);
+drop function common.switch_alignment_at(timestamp with time zone);
+drop table common.switch_element_version;
+drop table common.switch_element;
+drop table common.switch_alignment_version;
+drop table common.switch_alignment;
+drop table common.switch_joint_version;
+drop table common.switch_joint;

--- a/infra/src/main/resources/db/migration/repeatable/R__08.01_fix_table_comments.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__08.01_fix_table_comments.sql
@@ -1,5 +1,4 @@
 comment on table geometry.plan is 'Geometry Plan: parsed structural data from a plan';
 comment on table geometry.plan_file is 'Original Geometry Plan file contents';
 
-comment on table common.switch_joint is 'Switch structure joint: a joint point of a common.switch_structure';
 comment on table common.switch_owner is 'Switch owners';

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDataGeneration.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDataGeneration.kt
@@ -1,6 +1,10 @@
 package fi.fta.geoviite.infra
 
+import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
 import kotlin.math.abs
 
 inline fun <reified T : Enum<T>> getSomeValue(index: Int): T {
@@ -14,3 +18,9 @@ inline fun <reified T : Enum<T>> getSomeNullableValue(index: Int): T? {
 }
 
 fun <T> getSomeOid(seed: Int): Oid<T> = Oid("${abs(seed % 1000)}.${abs(seed * 2 % 1000)}.${abs(seed * 3 % 1000)}")
+
+inline fun <reified T> someIntId() = IntId<T>(1)
+
+inline fun <reified T> someVersion() = RowVersion(someIntId<T>(), 1)
+
+fun asSwitchStructure(data: SwitchStructureData) = SwitchStructure(someVersion(), data)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelParsingIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelParsingIT.kt
@@ -48,7 +48,7 @@ constructor(
 ) : DBTestBase() {
     private val coordinateSystemNameToSrid = geographyService.getCoordinateSystemNameToSridMapping()
     private val switchStructuresByType = switchStructureDao.fetchSwitchStructures().associateBy { it.type }
-    private val switchTypeNameAliases = switchStructureDao.getInframodelAliases()
+    private val switchTypeNameAliases = switchStructureDao.getInfraModelAliases()
 
     @Test
     fun decodeFile1() {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -60,6 +60,11 @@ import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchLinkingAtEnd
 import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -69,11 +74,6 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1501,7 +1501,7 @@ constructor(
                     change.number == JointNumber(jointNumber) && change.locationTrackId == locationTrackId
                 }
 
-            assertNotNull(joint)
+            assertNotNull(joint, "Expected to find change: joint=$jointNumber switch=$switchId track=$locationTrackId actualChanges=${switchChange.changedJoints}")
         }
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/FittedSwitchTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/FittedSwitchTest.kt
@@ -6,8 +6,8 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.degreesToRads
 import fi.fta.geoviite.infra.math.rotateAroundOrigin
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.alignment
@@ -33,7 +33,7 @@ class FittedSwitchTest {
     }
 
     private fun createAlignmentBySwitchAlignment(
-        switchAlignment: SwitchAlignment,
+        switchAlignment: SwitchStructureAlignment,
         translation: Point,
         rotation: Double,
     ): LayoutAlignment {
@@ -90,15 +90,15 @@ class FittedSwitchTest {
             fitSwitch(
                 jointsInLayoutSpace =
                     listOf(
-                        SwitchJoint(
+                        SwitchStructureJoint(
                             JointNumber(1),
                             alignmentContainingSwitchSegments.segments[1].alignmentPoints.first().toPoint(),
                         ),
-                        SwitchJoint(
+                        SwitchStructureJoint(
                             JointNumber(5),
                             alignmentContainingSwitchSegments.segments[2].alignmentPoints.first().toPoint(),
                         ),
-                        SwitchJoint(
+                        SwitchStructureJoint(
                             JointNumber(2),
                             alignmentContainingSwitchSegments.segments[3].alignmentPoints.first().toPoint(),
                         ),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
@@ -25,11 +25,11 @@ import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.tracklayout.GeometrySource
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
@@ -81,7 +81,7 @@ constructor(
 ) : DBTestBase() {
 
     lateinit var switchStructure: SwitchStructure
-    lateinit var switchAlignment_1_5_2: SwitchAlignment
+    lateinit var switchAlignment_1_5_2: SwitchStructureAlignment
 
     @BeforeEach
     fun setup() {
@@ -1806,7 +1806,7 @@ fun suggestedSwitchJointMatch(
         locationTrackId,
         segmentIndex,
         m,
-        SwitchJoint(JointNumber(1), Point(1.0, 2.0)),
+        SwitchStructureJoint(JointNumber(1), Point(1.0, 2.0)),
         SuggestedSwitchJointMatchType.START,
         0.1,
         0.1,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingTest.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.linking.switches
 
+import fi.fta.geoviite.infra.asSwitchStructure
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
@@ -7,7 +8,7 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
 import fi.fta.geoviite.infra.math.interpolate
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.switchLibrary.data.YV60_300_1_10_V
 import fi.fta.geoviite.infra.switchLibrary.data.YV60_300_1_9_O
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
@@ -27,10 +28,10 @@ import fi.fta.geoviite.infra.tracklayout.someSegment
 import fi.fta.geoviite.infra.tracklayout.switchLinkingAtEnd
 import fi.fta.geoviite.infra.tracklayout.switchLinkingAtHalf
 import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 class SwitchLinkingTest {
     private var testLayoutSwitchId = IntId<LayoutSwitch>(0)
@@ -297,14 +298,14 @@ class SwitchLinkingTest {
 
     @Test
     fun `should find joint matches for suggested switch`() {
-        val switch = YV60_300_1_10_V()
+        val switch = asSwitchStructure(YV60_300_1_10_V())
 
         val joints =
             listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(5.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(10.0, 0.0)),
-                SwitchJoint(JointNumber(3), Point(5.0, 5.0)),
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(5), Point(5.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(10.0, 0.0)),
+                SwitchStructureJoint(JointNumber(3), Point(5.0, 5.0)),
             )
 
         val locationTrack1 = locationTrack(IntId(1), id = IntId(1), draft = false)
@@ -342,10 +343,13 @@ class SwitchLinkingTest {
 
     @Test
     fun `should match suggested switch with inner segment`() {
-        val switch = YV60_300_1_10_V()
+        val switch = asSwitchStructure(YV60_300_1_10_V())
 
         val joints =
-            listOf(SwitchJoint(JointNumber(1), Point(5.25, 0.0)), SwitchJoint(JointNumber(2), Point(14.75, 0.0)))
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(5.25, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(14.75, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -370,10 +374,13 @@ class SwitchLinkingTest {
 
     @Test
     fun `should match suggested switch with inner segment even if its further away`() {
-        val switch = YV60_300_1_10_V()
+        val switch = asSwitchStructure(YV60_300_1_10_V())
 
         val joints =
-            listOf(SwitchJoint(JointNumber(1), Point(4.75, 0.0)), SwitchJoint(JointNumber(2), Point(15.25, 0.0)))
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(4.75, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(15.25, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -398,9 +405,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should match with closest segment end point when there are multiple matches`() {
-        val switch = YV60_300_1_10_V()
-
-        val joints = listOf(SwitchJoint(JointNumber(1), Point(0.6, 0.0)), SwitchJoint(JointNumber(2), Point(10.6, 0.0)))
+        val switch = asSwitchStructure(YV60_300_1_10_V())
+        val joints =
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.6, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(10.6, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -425,10 +435,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should prefer segment end points over normal ones`() {
-        val switch = YV60_300_1_10_V()
-
+        val switch = asSwitchStructure(YV60_300_1_10_V())
         val joints =
-            listOf(SwitchJoint(JointNumber(1), Point(0.25, 0.0)), SwitchJoint(JointNumber(2), Point(9.75, 0.0)))
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.25, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(9.75, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -451,10 +463,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should never match with segment end point for the first joint`() {
-        val switch = YV60_300_1_10_V()
-
+        val switch = asSwitchStructure(YV60_300_1_10_V())
         val joints =
-            listOf(SwitchJoint(JointNumber(1), Point(3.9995, 0.0)), SwitchJoint(JointNumber(2), Point(10.0, 0.0)))
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(3.9995, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(10.0, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -480,10 +494,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should never match with the first point for last joint`() {
-        val switch = YV60_300_1_10_V()
-
+        val switch = asSwitchStructure(YV60_300_1_10_V())
         val joints =
-            listOf(SwitchJoint(JointNumber(1), Point(0.0, 0.0)), SwitchJoint(JointNumber(2), Point(11.0005, 0.0)))
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(11.0005, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -510,10 +526,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should match with alignment regardless of direction`() {
-        val switch = YV60_300_1_10_V()
-
+        val switch = asSwitchStructure(YV60_300_1_10_V())
         val joints =
-            listOf(SwitchJoint(JointNumber(1), Point(10.0, 0.0)), SwitchJoint(JointNumber(2), Point(15.0, 0.0)))
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(10.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(15.0, 0.0)),
+            )
 
         val locationTrack1 = locationTrack(IntId(1), id = IntId(1), draft = false)
         val alignment1 =
@@ -583,9 +601,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should match with alignment if joint is on the line`() {
-        val switch = YV60_300_1_10_V()
-
-        val joints = listOf(SwitchJoint(JointNumber(1), Point(0.0, 0.0)), SwitchJoint(JointNumber(2), Point(11.0, 0.0)))
+        val switch = asSwitchStructure(YV60_300_1_10_V())
+        val joints =
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(11.0, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -615,9 +636,12 @@ class SwitchLinkingTest {
 
     @Test
     fun `should match with alignment even if there's no point close by`() {
-        val switch = YV60_300_1_10_V()
-
-        val joints = listOf(SwitchJoint(JointNumber(1), Point(0.0, 0.0)), SwitchJoint(JointNumber(2), Point(11.5, 0.0)))
+        val switch = asSwitchStructure(YV60_300_1_10_V())
+        val joints =
+            listOf(
+                SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                SwitchStructureJoint(JointNumber(2), Point(11.5, 0.0)),
+            )
 
         val locationTrack = locationTrack(IntId(1), id = IntId(1), draft = false)
 
@@ -700,7 +724,7 @@ class SwitchLinkingTest {
     @Test
     fun shouldFindMatchForYVSwitch() {
         val yvTurnRatio = 1.967 / 34.321 // ~ 0.06
-        val switchStructure = YV60_300_1_9_O().copy(id = IntId(1))
+        val switchStructure = asSwitchStructure(YV60_300_1_9_O())
         val locationTrack152 =
             locationTrackAndAlignment(
                 segment(from = segmentPoint(-200.0, 0.0), to = Point(-100.0, 0.0)),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -40,12 +40,13 @@ import fi.fta.geoviite.infra.math.Point4DZM
 import fi.fta.geoviite.infra.math.boundingBoxCombining
 import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.publication.PublishedVersions
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementCurve
-import fi.fta.geoviite.infra.switchLibrary.SwitchElementLine
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.GENERATED
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
@@ -60,69 +61,75 @@ private val rand = Random(SEED)
 
 fun switchStructureYV60_300_1_9(): SwitchStructure {
     return SwitchStructure(
-        id = IntId(55),
-        type = SwitchType("YV60-300-1:9-O"),
-        presentationJointNumber = JointNumber(1),
-        joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(5), Point(16.615, 0.0)),
-                SwitchJoint(JointNumber(2), Point(34.430, 0.0)),
-                SwitchJoint(JointNumber(3), Point(34.321, -1.967)),
-            ),
-        alignments =
-            listOf(
-                SwitchAlignment(
-                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
-                    elements =
-                        listOf(
-                            SwitchElementLine(IndexedId(1, 1), Point(0.0, 0.0), Point(16.615, 0.0)),
-                            SwitchElementLine(IndexedId(1, 2), Point(16.615, 0.0), Point(34.430, 0.0)),
+        version = RowVersion(IntId(55), 1),
+        data =
+            SwitchStructureData(
+                type = SwitchType("YV60-300-1:9-O"),
+                presentationJointNumber = JointNumber(1),
+                joints =
+                    setOf(
+                        SwitchStructureJoint(JointNumber(1), Point(0.0, 0.0)),
+                        SwitchStructureJoint(JointNumber(5), Point(16.615, 0.0)),
+                        SwitchStructureJoint(JointNumber(2), Point(34.430, 0.0)),
+                        SwitchStructureJoint(JointNumber(3), Point(34.321, -1.967)),
+                    ),
+                alignments =
+                    listOf(
+                        SwitchStructureAlignment(
+                            jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                            elements =
+                                listOf(
+                                    SwitchStructureLine(Point(0.0, 0.0), Point(16.615, 0.0)),
+                                    SwitchStructureLine(Point(16.615, 0.0), Point(34.430, 0.0)),
+                                ),
                         ),
-                ),
-                SwitchAlignment(
-                    jointNumbers = listOf(JointNumber(1), JointNumber(3)),
-                    elements =
-                        listOf(
-                            SwitchElementCurve(IndexedId(2, 1), Point(0.0, 0.0), Point(33.128, -1.835), radius = 300.0),
-                            SwitchElementLine(IndexedId(2, 2), Point(33.128, -1.835), Point(34.321, -1.967)),
+                        SwitchStructureAlignment(
+                            jointNumbers = listOf(JointNumber(1), JointNumber(3)),
+                            elements =
+                                listOf(
+                                    SwitchStructureCurve(Point(0.0, 0.0), Point(33.128, -1.835), radius = 300.0),
+                                    SwitchStructureLine(Point(33.128, -1.835), Point(34.321, -1.967)),
+                                ),
                         ),
-                ),
+                    ),
             ),
     )
 }
 
 fun switchStructureRR54_4x1_9() =
     SwitchStructure(
-        id = IntId(133),
-        type = SwitchType("RR54-4x1:9"),
-        presentationJointNumber = JointNumber(5),
-        joints =
-            listOf(
-                SwitchJoint(JointNumber(1), Point(-5.075, -1.142)),
-                SwitchJoint(JointNumber(5), Point(0.0, 0.0)),
-                SwitchJoint(JointNumber(2), Point(5.075, 1.142)),
-                SwitchJoint(JointNumber(4), Point(-5.075, 1.142)),
-                SwitchJoint(JointNumber(3), Point(5.075, -1.142)),
-            ),
-        alignments =
-            listOf(
-                SwitchAlignment(
-                    jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
-                    elements =
-                        listOf(
-                            SwitchElementLine(IndexedId(3, 1), Point(-5.075, -1.142), Point(0.0, 0.0)),
-                            SwitchElementLine(IndexedId(3, 2), Point(0.0, 0.0), Point(5.075, 1.142)),
+        version = RowVersion(IntId(133), 1),
+        data =
+            SwitchStructureData(
+                type = SwitchType("RR54-4x1:9"),
+                presentationJointNumber = JointNumber(5),
+                joints =
+                    setOf(
+                        SwitchStructureJoint(JointNumber(1), Point(-5.075, -1.142)),
+                        SwitchStructureJoint(JointNumber(5), Point(0.0, 0.0)),
+                        SwitchStructureJoint(JointNumber(2), Point(5.075, 1.142)),
+                        SwitchStructureJoint(JointNumber(4), Point(-5.075, 1.142)),
+                        SwitchStructureJoint(JointNumber(3), Point(5.075, -1.142)),
+                    ),
+                alignments =
+                    listOf(
+                        SwitchStructureAlignment(
+                            jointNumbers = listOf(JointNumber(1), JointNumber(5), JointNumber(2)),
+                            elements =
+                                listOf(
+                                    SwitchStructureLine(Point(-5.075, -1.142), Point(0.0, 0.0)),
+                                    SwitchStructureLine(Point(0.0, 0.0), Point(5.075, 1.142)),
+                                ),
                         ),
-                ),
-                SwitchAlignment(
-                    jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
-                    elements =
-                        listOf(
-                            SwitchElementLine(IndexedId(4, 1), Point(-5.075, 1.142), Point(0.0, 0.0)),
-                            SwitchElementLine(IndexedId(4, 2), Point(0.0, 0.0), Point(-5.075, 1.142)),
+                        SwitchStructureAlignment(
+                            jointNumbers = listOf(JointNumber(4), JointNumber(5), JointNumber(3)),
+                            elements =
+                                listOf(
+                                    SwitchStructureLine(Point(-5.075, 1.142), Point(0.0, 0.0)),
+                                    SwitchStructureLine(Point(0.0, 0.0), Point(-5.075, 1.142)),
+                                ),
                         ),
-                ),
+                    ),
             ),
     )
 
@@ -185,7 +192,7 @@ fun segmentsFromSwitchStructure(
 fun segmentsFromSwitchAlignment(
     start: IPoint,
     switchId: IntId<LayoutSwitch>,
-    alignment: SwitchAlignment,
+    alignment: SwitchStructureAlignment,
 ): List<LayoutSegment> {
     val jointNumbers = alignment.jointNumbers
     val elements = alignment.elements
@@ -1119,7 +1126,7 @@ fun switchLinkingAt(locationTrackId: DomainId<LocationTrack>, segmentIndex: Int,
         m = m,
         alignmentId = null,
         distance = 0.1,
-        switchJoint = SwitchJoint(JointNumber(jointNumber), Point(0.0, 0.0)),
+        switchJoint = SwitchStructureJoint(JointNumber(jointNumber), Point(0.0, 0.0)),
         distanceToAlignment = 0.1,
         matchType = SuggestedSwitchJointMatchType.LINE,
     )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -32,10 +32,10 @@ import fi.fta.geoviite.infra.math.AngularUnit
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.pointDistanceToLine
 import fi.fta.geoviite.infra.math.rotateAroundOrigin
-import fi.fta.geoviite.infra.switchLibrary.SwitchAlignment
-import fi.fta.geoviite.infra.switchLibrary.SwitchElement
-import fi.fta.geoviite.infra.switchLibrary.SwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureElement
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.tracklayout.GeometrySource
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
@@ -282,11 +282,11 @@ fun switchStructureToGeometryAlignment(
 }
 
 private fun alignmentElementsFromSwitchAlignment(
-    switchAlignment: SwitchAlignment,
+    switchAlignment: SwitchStructureAlignment,
     switchAngle: Double,
     switchOrig: Point,
     switchId: DomainId<GeometrySwitch>,
-    switchJoints: List<SwitchJoint>,
+    switchJoints: Set<SwitchStructureJoint>,
 ): List<GeometryElement> {
     val switchJointsByNumber = switchJoints.associateBy { it.number }
     val switchJointData =
@@ -311,7 +311,7 @@ private fun alignmentElementsFromSwitchAlignment(
 }
 
 private fun matchSwitchDataToElement(
-    switchElement: SwitchElement,
+    switchElement: SwitchStructureElement,
     switchJointData: List<SwitchJointData>,
     switchId: DomainId<GeometrySwitch>,
 ): SwitchData {
@@ -337,10 +337,10 @@ fun getTransformedPoint(
 
 data class SwitchJointData(
     val switchId: DomainId<GeometrySwitch>,
-    val startSwitchJoint: SwitchJoint,
-    val endSwitchJoint: SwitchJoint,
+    val startSwitchJoint: SwitchStructureJoint,
+    val endSwitchJoint: SwitchStructureJoint,
 ) {
-    fun isInsideSwitchJoint(switchElement: SwitchElement): Boolean {
+    fun isInsideSwitchJoint(switchElement: SwitchStructureElement): Boolean {
         logger.info(
             "Matching switch element (${switchElement.start},${switchElement.end}) to ${startSwitchJoint.number}-${endSwitchJoint.number}"
         )


### PR DESCRIPTION
Aika iso muutosköntti mutta lähinnä tuon structuren vaikutusten / renamejen korjailuja, jotka on kaikkialla aika samanlaisia. Oleelliset jutut kasottavaksi (kommentoin nämä myös itse tiedostoihin):

Itse tietokantamigra joka muuttaa switch structuren versionnin
SwitchStructuren uusi kotlin-malli
SwitchStructure repeatable migran muutokset