### PR TITLE
GVT-2951 Add draft OID to switches

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.linking.switches
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LocationAccuracy
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.geometry.GeometrySwitch
@@ -31,6 +32,7 @@ data class LayoutSwitchSaveRequest(
     val stateCategory: LayoutStateCategory,
     val ownerId: IntId<SwitchOwner>,
     val trapPoint: Boolean?,
+    val draftOid: Oid<LayoutSwitch>?,
 )
 
 data class FittedSwitchJointMatch(
@@ -117,3 +119,11 @@ data class GeometrySwitchFittingFailure(val failure: GeometrySwitchSuggestionFai
     GeometrySwitchFittingResult()
 
 data class GeometrySwitchFittingException(val failure: GeometrySwitchSuggestionFailureReason) : RuntimeException()
+
+data class SwitchOidPresence(val existsInRatko: Boolean?, val existsInGeoviiteAs: GeoviiteSwitchOidPresence?)
+
+data class GeoviiteSwitchOidPresence(
+    val id: IntId<LayoutSwitch>,
+    val stateCategory: LayoutStateCategory,
+    val name: SwitchName,
+)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -176,6 +176,12 @@ fun validateSwitchNameDuplication(
     }
 }
 
+fun validateSwitchOidDuplication(switch: LayoutSwitch, oidDuplicate: LayoutSwitch?): List<LayoutValidationIssue> {
+    return if (oidDuplicate != null && oidDuplicate.id != switch.id) {
+        listOf(validationError("$VALIDATION_SWITCH.duplicate-oid"))
+    } else listOf()
+}
+
 fun validateLocationTrackNameDuplication(
     track: LocationTrack,
     trackNumber: TrackNumber?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -396,7 +396,14 @@ constructor(
                     validationContext.getSwitchesByName(switch.name),
                     validationContext.target.type,
                 )
-            return referenceIssues + structureIssues + duplicationIssues
+            val oidDuplicationIssues =
+                validateSwitchOidDuplication(
+                    switch,
+                    switch.draftOid?.let(switchDao::lookupByExternalId)?.let { row ->
+                        switchDao.get(row.context, row.id)
+                    },
+                )
+            return referenceIssues + structureIssues + duplicationIssues + oidDuplicationIssues
         }
 
     private fun validateReferenceLine(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LocationAccuracy
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.geometry.GeometrySwitch
 import fi.fta.geoviite.infra.math.Point
@@ -22,6 +23,7 @@ data class LayoutSwitch(
     val trapPoint: Boolean?,
     val ownerId: IntId<SwitchOwner>?,
     val source: GeometrySource,
+    val draftOid: Oid<LayoutSwitch>?,
     @JsonIgnore override val contextData: LayoutContextData<LayoutSwitch>,
 ) : LayoutAsset<LayoutSwitch>(contextData) {
     @JsonIgnore val exists = !stateCategory.isRemoved()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchController.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.linking.switches.LayoutSwitchSaveRequest
+import fi.fta.geoviite.infra.linking.switches.SwitchOidPresence
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.PublicationValidationService
@@ -164,4 +165,9 @@ class LayoutSwitchController(
     fun getSwitchOids(@PathVariable("id") id: IntId<LayoutSwitch>): Map<LayoutBranch, Oid<LayoutSwitch>> {
         return switchService.getExternalIdsByBranch(id)
     }
+
+    @PreAuthorize(AUTH_VIEW_LAYOUT)
+    @GetMapping("/oid_presence/{oid}")
+    fun getSwitchOidPresence(@PathVariable("oid") oid: Oid<LayoutSwitch>): SwitchOidPresence =
+        switchService.checkOidPresence(oid)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -170,6 +170,7 @@ class LayoutSwitchDao(
                 cancelled,
                 design_id,
                 source,
+                draft_oid,
                 origin_design_id
             )
             values (
@@ -185,6 +186,7 @@ class LayoutSwitchDao(
               :cancelled,
               :design_id,
               :source::layout.geometry_source,
+              :draft_oid,
               :origin_design_id
             )
             on conflict (id, layout_context_id) do update set
@@ -196,6 +198,7 @@ class LayoutSwitchDao(
               owner_id = excluded.owner_id,
               cancelled = excluded.cancelled,
               source = excluded.source,
+              draft_oid = excluded.draft_oid,
               origin_design_id = excluded.origin_design_id
             returning id, design_id, draft, version
         """
@@ -217,6 +220,7 @@ class LayoutSwitchDao(
                     "cancelled" to item.isCancelled,
                     "design_id" to item.contextData.designId?.intValue,
                     "source" to item.source.name,
+                    "draft_oid" to item.draftOid?.toString(),
                     "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
                 ),
             ) { rs, _ ->
@@ -308,6 +312,7 @@ class LayoutSwitchDao(
               sv.owner_id,
               sv.source,
               origin_design_id,
+              sv.draft_oid,
               exists(select * from layout.switch official_sv
                      where official_sv.id = sv.id
                        and (official_sv.design_id is null or official_sv.design_id = sv.design_id)
@@ -363,6 +368,7 @@ class LayoutSwitchDao(
               joint_x_values,
               joint_y_values,
               joint_location_accuracies,
+              s.draft_oid,
               exists(select * from layout.switch official_sv
                      where official_sv.id = s.id
                        and (official_sv.design_id is null or official_sv.design_id = s.design_id)
@@ -405,6 +411,7 @@ class LayoutSwitchDao(
             trapPoint = rs.getBooleanOrNull("trap_point"),
             ownerId = rs.getIntIdOrNull("owner_id"),
             source = rs.getEnum("source"),
+            draftOid = rs.getOidOrNull("draft_oid"),
             contextData =
                 rs.getLayoutContextData(
                     "id",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -125,6 +125,7 @@ fun toLayoutSwitch(switch: GeometrySwitch, toMapCoordinate: Transformation): Lay
             ownerId = null,
             source = GeometrySource.PLAN,
             contextData = LayoutContextData.newDraft(LayoutBranch.main, id = null),
+            draftOid = null,
         )
 
 fun toLayoutSwitches(

--- a/infra/src/main/resources/db/migration/prod/V104__add_draft_oid_to_switch.sql
+++ b/infra/src/main/resources/db/migration/prod/V104__add_draft_oid_to_switch.sql
@@ -1,0 +1,4 @@
+alter table layout.switch
+  add column draft_oid text;
+alter table layout.switch_version
+  add column draft_oid text;

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1532,6 +1532,7 @@
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",
                 "duplicate-name-draft-in-main": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella luonnostilassa",
+                "duplicate-oid": "Vaihteelle asetettu OID on jo käytössä",
                 "track-linkage": {
                     "front-joint-not-connected": "Vaihteen etujatkokselta ei jatku raidetta",
                     "front-joint-only-duplicate-connected": "Vaihteen etujatkokselta jatkuu vain duplikaatiksi merkittyjä raiteita",
@@ -1858,6 +1859,9 @@
     "switch-dialog": {
         "title-new": "Uusi vaihde",
         "basic-info-heading": "Perustiedot",
+        "switch-draft-oid": "OID",
+        "switch-draft-oid-unset": "Asetetaan julkaistaessa",
+        "open-switch-draft-field": "Aseta nyt",
         "switch-name": "Vaihdetunnus",
         "state-category": "Tilakategoria",
         "switch-type": "Vaihdetyyppi",
@@ -1877,6 +1881,9 @@
         "name-max-limit": "Vaihdetunnus voi olla korkeintaan 20 merkkiä pitkä",
         "mandatory-field": "Pakollinen kenttä",
         "invalid-name": "Virheellinen vaihdetunnus",
+        "invalid-draft-oid": "Tieto ei ole muodoltaan vaihteen OID",
+        "ratko-connection-is-down": "Ratkoon ei saada yhteyttä OIDin olemassaolon tarkistamiseen",
+        "oid-doesnt-exist-in-ratko": "OIDia ei löyty Ratkosta",
         "mandatory-fields-missing": "Pakollisia kenttiä puuttuu",
         "save-in-progress": "Tallennetaan",
         "title-edit": "Muokkaa vaihteen tietoja",
@@ -1890,8 +1897,10 @@
         "confirm-switch-save": "Haluatko varmasti tallentaa muutokset?",
         "confirm-switch-delete": "Haluatko poistaa vaihteen paikannuspohjasta?",
         "name-in-use": "Huomaa, että paikannuspohjassa on toinen vaihde samalla tunnuksella",
+        "oid-in-use": "Huomaa, että paikannuspohjassa on toinen vaihde samalla OID:lla",
         "move-to-edit": "Voit siirtyä muokkaamaan vaihdetta {{name}} tästä",
         "name-in-use-deleted": "Huomaa, että paikannuspohjassa on poistettu vaihde samalla tunnuksella",
+        "oid-in-use-deleted": "Huomaa, että paikannuspohjassa on poistettu vaihde samalla OID:lla",
         "move-to-edit-deleted": "Voit siirtyä palauttamaan poistetun vaihteen tästä"
     },
     "workspace-dialog": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -625,7 +625,14 @@ constructor(
                 MainLayoutContext.draft,
                 switchService.insertSwitch(
                     LayoutBranch.main,
-                    LayoutSwitchSaveRequest(SwitchName("TEST"), IntId(1), LayoutStateCategory.EXISTING, IntId(1), false),
+                    LayoutSwitchSaveRequest(
+                        SwitchName("TEST"),
+                        IntId(1),
+                        LayoutStateCategory.EXISTING,
+                        IntId(1),
+                        false,
+                        draftOid = null,
+                    ),
                 ),
             )
         publish(publicationService, switches = listOf(switch.id as IntId), trackNumbers = listOf(tn1, tn2))
@@ -641,6 +648,7 @@ constructor(
                         LayoutStateCategory.NOT_EXISTING,
                         IntId(2),
                         true,
+                        draftOid = null,
                     ),
                 ),
             )
@@ -673,7 +681,14 @@ constructor(
     @Test
     fun `Changing specific switch field returns only that field`() {
         val saveReq =
-            LayoutSwitchSaveRequest(SwitchName("TEST"), IntId(1), LayoutStateCategory.EXISTING, IntId(1), false)
+            LayoutSwitchSaveRequest(
+                SwitchName("TEST"),
+                IntId(1),
+                LayoutStateCategory.EXISTING,
+                IntId(1),
+                false,
+                draftOid = null,
+            )
 
         val switch =
             switchService.getOrThrow(MainLayoutContext.draft, switchService.insertSwitch(LayoutBranch.main, saveReq))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -432,7 +432,14 @@ constructor(
     @Test
     fun switchIdIsReturnedWhenAddingNewSwitch() {
         val switch =
-            LayoutSwitchSaveRequest(SwitchName("XYZ-987"), IntId(5), EXISTING, ownerId = IntId(3), trapPoint = null)
+            LayoutSwitchSaveRequest(
+                SwitchName("XYZ-987"),
+                IntId(5),
+                EXISTING,
+                ownerId = IntId(3),
+                trapPoint = null,
+                draftOid = null,
+            )
         val switchId = switchService.insertSwitch(LayoutBranch.main, switch)
         val fetchedSwitch = switchService.get(MainLayoutContext.draft, switchId)!!
         assertNull(switchService.get(MainLayoutContext.official, switchId))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -928,6 +928,7 @@ fun switch(
     draft: Boolean = false,
     ownerId: IntId<SwitchOwner>? = switchOwnerVayla().id,
     contextData: LayoutContextData<LayoutSwitch> = createMainContext(id, draft),
+    draftOid: Oid<LayoutSwitch>? = null,
 ) =
     LayoutSwitch(
         sourceId = null,
@@ -939,6 +940,7 @@ fun switch(
         ownerId = ownerId,
         source = GENERATED,
         contextData = contextData,
+        draftOid = draftOid,
     )
 
 fun <T : LayoutAsset<T>> createMainContext(id: IntId<T>?, draft: Boolean): LayoutContextData<T> =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -168,6 +168,7 @@ fun layoutSwitch(name: String, jointPoints: List<Point>, switchStructure: Switch
         ownerId = switchOwnerVayla().id,
         source = GeometrySource.GENERATED,
         contextData = LayoutContextData.newOfficial(LayoutBranch.main),
+        draftOid = null,
     )
 
 fun switchJoint(location: Point) =

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -28,6 +28,7 @@ import {
     JointNumber,
     KmNumber,
     LocationTrackOwnerId,
+    Oid,
     Range,
     Srid,
     SwitchOwnerId,
@@ -317,6 +318,7 @@ export type LayoutSwitchSaveRequest = {
     stateCategory: LayoutStateCategory;
     ownerId: SwitchOwnerId;
     trapPoint?: boolean;
+    draftOid?: Oid;
 };
 
 export type SwitchRelinkingValidationResult = {

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import styles from './preview-view.scss';
 import { useTranslation } from 'react-i18next';
-import { useLoader, useTwoPartEffectWithStatus } from 'utils/react-utils';
+import { useLoader, useTwoPartEffect } from 'utils/react-utils';
 import {
     getCalculatedChanges,
     getPublicationCandidates,
@@ -200,7 +200,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
             [props.changeTimes, props.layoutContext.branch, designPublicationMode],
         ) ?? false;
 
-    useTwoPartEffectWithStatus(
+    useTwoPartEffect(
         () =>
             getPublicationCandidates(
                 props.layoutContext.branch,

--- a/ui/src/tool-panel/switch/dialog/switch-draft-oid-field.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-draft-oid-field.tsx
@@ -1,0 +1,158 @@
+import styles from './switch-edit-dialog.scss';
+import React, { useState } from 'react';
+import { TextField } from 'vayla-design-lib/text-field/text-field';
+import { Link } from 'vayla-design-lib/link/link';
+import { Oid, TimeStamp } from 'common/common-model';
+import { useTranslation } from 'react-i18next';
+import { LoaderStatus, useLoaderWithStatus, useRateLimitedTwoPartEffect } from 'utils/react-utils';
+import {
+    getSwitchOidPresence,
+    getSwitchOids,
+    SwitchOidPresence,
+} from 'track-layout/layout-switch-api';
+import { FieldValidationIssue, FieldValidationIssueType } from 'utils/validation-utils';
+import { LayoutSwitchSaveRequest } from 'linking/linking-model';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { moveToEditLinkText } from 'tool-panel/switch/dialog/switch-edit-dialog';
+import { LayoutSwitchId } from 'track-layout/track-layout-model';
+import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
+
+const SWITCH_OID_REQUIRED_PREFIX = '1.2.246.578.3.117.';
+
+type SwitchDraftOidFieldProps = {
+    switchId: LayoutSwitchId | undefined;
+    changeTime: TimeStamp;
+    draftOid: Oid;
+    setDraftOid: (oid: Oid) => void;
+    setDraftOidExistsInRatko: (exists: boolean) => void;
+    errors: string[];
+    visitField: () => void;
+    draftOidFieldOpen: boolean;
+    setDraftOidFieldOpen: (open: boolean) => void;
+    onEdit: (id: LayoutSwitchId) => void;
+};
+
+export const SwitchDraftOidField: React.FC<SwitchDraftOidFieldProps> = ({
+    switchId,
+    changeTime,
+    draftOid,
+    setDraftOid,
+    setDraftOidExistsInRatko,
+    errors,
+    visitField,
+    draftOidFieldOpen,
+    setDraftOidFieldOpen,
+    onEdit,
+}) => {
+    const { t } = useTranslation();
+    const [existingSwitchOid, existingSwitchOidLoaderStatus] = useLoaderWithStatus(
+        () => switchId && getSwitchOids(switchId, changeTime).then((oids) => oids['MAIN']),
+        [switchId, changeTime],
+    );
+
+    const [oidPresence, setOidPresence] = useState<SwitchOidPresence>();
+    const [mostRecentlyCheckedOid, setMostRecentlyCheckedOid] = useState<Oid>();
+
+    const oidIsLocallyValid = draftOid !== '' && validateDraftOid(draftOid).length === 0;
+    const loadingOidPresence = oidIsLocallyValid && draftOid != mostRecentlyCheckedOid;
+    useRateLimitedTwoPartEffect(
+        () => (oidIsLocallyValid ? getSwitchOidPresence(draftOid) : undefined),
+        (newOidPresence) => {
+            setMostRecentlyCheckedOid(draftOid);
+            setOidPresence(newOidPresence);
+            setDraftOidExistsInRatko(newOidPresence.existsInRatko === true);
+        },
+        500,
+        [draftOid],
+    );
+
+    const existingInGeoviite = oidPresence?.existsInGeoviiteAs;
+    return existingSwitchOid !== undefined ||
+        existingSwitchOidLoaderStatus !== LoaderStatus.Ready ? (
+        <React.Fragment />
+    ) : (
+        <FieldLayout
+            label={`${t('switch-dialog.switch-draft-oid')} *`}
+            errors={errors}
+            value={
+                draftOidFieldOpen ? (
+                    <React.Fragment>
+                        <TextField
+                            qa-id="switch-draft-oid"
+                            value={draftOid}
+                            onChange={(e) => setDraftOid(e.target.value)}
+                            hasError={errors.length > 0}
+                            onBlur={visitField}
+                            wide
+                        />
+
+                        {loadingOidPresence && <Spinner />}
+                        {!loadingOidPresence && oidPresence && oidIsLocallyValid && (
+                            <>
+                                {oidPresence.existsInRatko === undefined && (
+                                    <div className={styles['switch-edit-dialog__error-color']}>
+                                        {t('switch-dialog.ratko-connection-is-down')}
+                                    </div>
+                                )}
+                                {oidPresence.existsInRatko === false && (
+                                    <div className={styles['switch-edit-dialog__error-color']}>
+                                        {t('switch-dialog.oid-doesnt-exist-in-ratko')}
+                                    </div>
+                                )}
+                                {existingInGeoviite !== undefined && (
+                                    <>
+                                        <div className={styles['switch-edit-dialog__alert-color']}>
+                                            {existingInGeoviite.stateCategory === 'NOT_EXISTING'
+                                                ? t('switch-dialog.oid-in-use-deleted')
+                                                : t('switch-dialog.oid-in-use')}
+                                        </div>
+                                        <Link
+                                            className={styles['switch-edit-dialog__alert']}
+                                            onClick={() => {
+                                                setDraftOid('');
+                                                setDraftOidFieldOpen(false);
+                                                onEdit(existingInGeoviite.id);
+                                            }}>
+                                            {moveToEditLinkText(t, existingInGeoviite)}
+                                        </Link>
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </React.Fragment>
+                ) : (
+                    <div>
+                        <span>{t('switch-dialog.switch-draft-oid-unset')}</span>
+                        <Link style={{ float: 'right' }} onClick={() => setDraftOidFieldOpen(true)}>
+                            {t('switch-dialog.open-switch-draft-field')}
+                        </Link>
+                    </div>
+                )
+            }
+        />
+    );
+};
+
+export function validateDraftOid(oid: Oid): FieldValidationIssue<LayoutSwitchSaveRequest>[] {
+    if (oid === '') {
+        return [];
+    }
+    const errors: FieldValidationIssue<LayoutSwitchSaveRequest>[] = [];
+    if (!oid.startsWith(SWITCH_OID_REQUIRED_PREFIX)) {
+        errors.push({
+            field: 'draftOid',
+            reason: 'invalid-draft-oid',
+            type: FieldValidationIssueType.ERROR,
+        });
+    } else {
+        const oidEnd = oid.slice(SWITCH_OID_REQUIRED_PREFIX.length);
+        if (oidEnd != `${parseInt(oidEnd)}`) {
+            errors.push({
+                field: 'draftOid',
+                reason: 'invalid-draft-oid',
+                type: FieldValidationIssueType.ERROR,
+            });
+        }
+    }
+    return errors;
+}

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.scss
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.scss
@@ -23,3 +23,8 @@
     @include vayla-design.typography-caption;
     color: vayla-design.$color-lemon-dark;
 }
+
+.switch-edit-dialog__error-color {
+    @include vayla-design.typography-caption;
+    color: vayla-design.$color-red-default;
+}

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -26,6 +26,7 @@ import {
     SwitchOwnerId,
     SwitchStructure,
     SwitchStructureId,
+    TimeStamp,
 } from 'common/common-model';
 import { getSwitchOwners, getSwitchStructures } from 'common/common-api';
 import { layoutStateCategories, switchTrapPoints } from 'utils/enum-localization-utils';
@@ -42,7 +43,12 @@ import { Link } from 'vayla-design-lib/link/link';
 import { getSaveDisabledReasons } from 'track-layout/track-layout-react-utils';
 import SwitchRevertConfirmationDialog from './switch-revert-confirmation-dialog';
 import { first } from 'utils/array-utils';
-import { useTrackLayoutAppSelector } from 'store/hooks';
+import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
+import {
+    SwitchDraftOidField,
+    validateDraftOid,
+} from 'tool-panel/switch/dialog/switch-draft-oid-field';
+import { TFunction } from 'i18next';
 
 const SWITCH_NAME_REGEX = /^[A-ZÄÖÅa-zäöå0-9 \-_/]+$/g;
 
@@ -61,6 +67,7 @@ export const SwitchEditDialogContainer = ({
 }: SwitchDialogContainerProps) => {
     const [editSwitchId, setEditSwitchId] = React.useState<LayoutSwitchId | undefined>(switchId);
     const layoutContext = useTrackLayoutAppSelector((state) => state.layoutContext);
+    const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
     return (
         <SwitchEditDialog
             layoutContext={layoutContext}
@@ -71,6 +78,7 @@ export const SwitchEditDialogContainer = ({
             onClose={onClose}
             onSave={onSave}
             onEdit={(id) => setEditSwitchId(id)}
+            changeTime={changeTimes.layoutSwitch}
         />
     );
 };
@@ -82,6 +90,7 @@ type SwitchDialogProps = {
     onClose: () => void;
     onSave?: (switchId: LayoutSwitchId) => void;
     onEdit: (id: LayoutSwitchId) => void;
+    changeTime: TimeStamp;
 };
 
 export const SwitchEditDialog = ({
@@ -91,6 +100,7 @@ export const SwitchEditDialog = ({
     onClose,
     onSave,
     onEdit,
+    changeTime,
 }: SwitchDialogProps) => {
     const { t } = useTranslation();
     const [showStructureChangeConfirmationDialog, setShowStructureChangeConfirmationDialog] =
@@ -99,6 +109,8 @@ export const SwitchEditDialog = ({
         React.useState(false);
     const [showDeleteDraftConfirmDialog, setShowDeleteDraftConfirmDialog] = React.useState(false);
     const [switchStateCategory, setSwitchStateCategory] = React.useState<LayoutStateCategory>();
+    const [switchDraftOidExistsInRatko, setSwitchDraftOidExistsInRatko] = React.useState(false);
+    const [switchDraftOid, setSwitchDraftOid] = React.useState<string>('');
     const [switchName, setSwitchName] = React.useState<string>('');
     const [trapPoint, setTrapPoint] = React.useState<TrapPoint>(TrapPoint.UNKNOWN);
     const [switchStructureId, setSwitchStructureId] = React.useState<SwitchStructureId | undefined>(
@@ -110,6 +122,7 @@ export const SwitchEditDialog = ({
     const [switchOwners, setSwitchOwners] = React.useState<SwitchOwner[]>([]);
     const [switchOwnerId, setSwitchOwnerId] = React.useState<SwitchOwnerId>();
     const [existingSwitch, setExistingSwitch] = React.useState<LayoutSwitch>();
+    const [draftOidFieldOpen, setDraftOidFieldOpen] = React.useState(false);
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const isExistingSwitch = !!switchId;
 
@@ -139,6 +152,10 @@ export const SwitchEditDialog = ({
                     setSwitchName(s.name);
                     setSwitchStructureId(s.switchStructureId);
                     setTrapPoint(booleanToTrapPoint(s.trapPoint));
+                    if (s.draftOid) {
+                        setSwitchDraftOid(s.draftOid);
+                        setDraftOidFieldOpen(true);
+                    }
                     firstInputRef.current?.focus();
                 }
             });
@@ -220,8 +237,8 @@ export const SwitchEditDialog = ({
                 stateCategory: switchStateCategory,
                 ownerId: switchOwnerId,
                 trapPoint: trapPointToBoolean(trapPoint),
+                draftOid: switchDraftOid === '' ? undefined : switchDraftOid,
             };
-
             if (existingSwitch) saveUpdatedSwitch(existingSwitch, newSwitch);
             else saveNewSwitch(newSwitch);
         }
@@ -259,11 +276,13 @@ export const SwitchEditDialog = ({
     }
 
     const validationIssues = [
+        ...validateDraftOid(switchDraftOid),
         ...validateSwitchName(switchName),
         ...validateSwitchStateCategory(switchStateCategory),
         ...validateSwitchStructureId(switchStructureId),
         ...validateSwitchOwnerId(switchOwnerId),
     ];
+    console.log({ validationIssues, visitedFields, switchDraftOid });
 
     function hasErrors(prop: keyof LayoutSwitchSaveRequest) {
         return getVisibleErrorsByProp(prop).length > 0;
@@ -283,11 +302,10 @@ export const SwitchEditDialog = ({
         onClose();
     }
 
-    const moveToEditLinkText = (s: LayoutSwitch) => {
-        return s.stateCategory === 'NOT_EXISTING'
-            ? t('switch-dialog.move-to-edit-deleted')
-            : t('switch-dialog.move-to-edit', { name: s.name });
-    };
+    const canSave =
+        validationIssues.length === 0 &&
+        !isSaving &&
+        (switchDraftOid === '' || switchDraftOidExistsInRatko);
 
     return (
         <React.Fragment>
@@ -317,7 +335,7 @@ export const SwitchEditDialog = ({
                             </Button>
                             <Button
                                 qa-id="save-switch-changes"
-                                disabled={validationIssues.length > 0 || isSaving}
+                                disabled={!canSave}
                                 isProcessing={isSaving}
                                 onClick={saveOrConfirm}
                                 title={getSaveDisabledReasons(
@@ -336,6 +354,20 @@ export const SwitchEditDialog = ({
                         <Heading size={HeadingSize.SUB}>
                             {t('switch-dialog.basic-info-heading')}
                         </Heading>
+                        {layoutContext.branch === 'MAIN' && (
+                            <SwitchDraftOidField
+                                switchId={existingSwitch?.id}
+                                changeTime={changeTime}
+                                draftOid={switchDraftOid}
+                                setDraftOid={setSwitchDraftOid}
+                                setDraftOidExistsInRatko={setSwitchDraftOidExistsInRatko}
+                                errors={getVisibleErrorsByProp('draftOid')}
+                                visitField={() => visitField('draftOid')}
+                                draftOidFieldOpen={draftOidFieldOpen}
+                                setDraftOidFieldOpen={setDraftOidFieldOpen}
+                                onEdit={onEdit}
+                            />
+                        )}
                         <FieldLayout
                             label={`${t('switch-dialog.switch-name')} *`}
                             value={
@@ -360,7 +392,7 @@ export const SwitchEditDialog = ({
                                     <Link
                                         className={styles['switch-edit-dialog__alert']}
                                         onClick={() => onEdit(conflictingSwitch.id)}>
-                                        {moveToEditLinkText(conflictingSwitch)}
+                                        {moveToEditLinkText(t, conflictingSwitch)}
                                     </Link>
                                 </>
                             )}
@@ -584,3 +616,12 @@ function validateSwitchOwnerId(
         ];
     else return [];
 }
+
+export const moveToEditLinkText = (
+    t: TFunction<'translation', undefined>,
+    s: { stateCategory: LayoutStateCategory; name: string },
+) => {
+    return s.stateCategory === 'NOT_EXISTING'
+        ? t('switch-dialog.move-to-edit-deleted')
+        : t('switch-dialog.move-to-edit', { name: s.name });
+};

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -282,7 +282,6 @@ export const SwitchEditDialog = ({
         ...validateSwitchStructureId(switchStructureId),
         ...validateSwitchOwnerId(switchOwnerId),
     ];
-    console.log({ validationIssues, visitedFields, switchDraftOid });
 
     function hasErrors(prop: keyof LayoutSwitchSaveRequest) {
         return getVisibleErrorsByProp(prop).length > 0;

--- a/ui/src/track-layout/layout-switch-api.ts
+++ b/ui/src/track-layout/layout-switch-api.ts
@@ -9,6 +9,7 @@ import {
     TimeStamp,
 } from 'common/common-model';
 import {
+    LayoutStateCategory,
     LayoutSwitch,
     LayoutSwitchId,
     LayoutSwitchJointConnection,
@@ -26,6 +27,7 @@ import {
     layoutUri,
     layoutUriByBranch,
     layoutUriWithoutContext,
+    TRACK_LAYOUT_URI,
 } from 'track-layout/track-layout-api';
 import { bboxString, pointString } from 'common/common-api';
 import { getChangeTimes, updateSwitchChangeTime } from 'common/change-time-api';
@@ -222,3 +224,17 @@ export async function getSwitchOids(
     );
     return oids ?? {};
 }
+
+export async function getSwitchOidPresence(oid: Oid): Promise<SwitchOidPresence> {
+    return getNonNull<SwitchOidPresence>(`${TRACK_LAYOUT_URI}/switches/oid_presence/${oid}`);
+}
+
+export type SwitchOidPresence = {
+    existsInRatko?: boolean;
+    existsInGeoviiteAs?: GeoviiteSwitchOidPresence;
+};
+export type GeoviiteSwitchOidPresence = {
+    id: LayoutSwitchId;
+    stateCategory: LayoutStateCategory;
+    name: string;
+};

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -268,6 +268,7 @@ export type LayoutSwitch = {
     sourceId?: GeometrySwitchId;
     trapPoint?: boolean;
     ownerId?: SwitchOwnerId;
+    draftOid?: Oid;
 } & LayoutAssetFields;
 
 export type LayoutSwitchJoint = {

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -146,11 +146,8 @@ export function useImmediateLoader<TEntity>(setter: (result: TEntity) => void): 
     };
 }
 
-/**
- * Load/fetch something asynchronously and, if the load finishes, call the given onceOnFulfilled callback with its
- * result.
- */
-export function useTwoPartEffectWithStatus<TEntity>(
+function useTwoPartEffectWithHook<TEntity>(
+    useEffect: (effect: EffectCallback, deps?: DependencyList) => void,
     loadFunc: () => Promise<TEntity> | undefined,
     onceOnFulfilled: (result: TEntity) => void,
     deps: unknown[],
@@ -182,6 +179,32 @@ export function useTwoPartEffectWithStatus<TEntity>(
     }, deps);
 
     return loaderStatus;
+}
+
+/**
+ * Load/fetch something asynchronously and, if the load finishes, call the given onceOnFulfilled callback with its
+ * result.
+ */
+export function useTwoPartEffect<TEntity>(
+    loadFunc: () => Promise<TEntity> | undefined,
+    onceOnFulfilled: (result: TEntity) => void,
+    deps: unknown[],
+): LoaderStatus {
+    return useTwoPartEffectWithHook(useEffect, loadFunc, onceOnFulfilled, deps);
+}
+
+export function useRateLimitedTwoPartEffect<TEntity>(
+    loadFunc: () => Promise<TEntity> | undefined,
+    onceOnFulfilled: (result: TEntity) => void,
+    waitBetweenCalls: number,
+    deps: unknown[],
+): LoaderStatus {
+    return useTwoPartEffectWithHook(
+        (cb, deps) => useRateLimitedEffect(cb, waitBetweenCalls, deps),
+        loadFunc,
+        onceOnFulfilled,
+        deps,
+    );
 }
 
 export function useLoaderWithTimer<TEntity>(


### PR DESCRIPTION
Vaihteille lisätään draft_oid-tieto, jolla käyttäjä voi viitata Ratkossa-mutta-ei-Geoviitteessä olevaan vaihteeseen suoraan. Ei juuri yllätyksiä taskin https://extranet.vayla.fi/jira/browse/GVT-2951 speksiin verrattuna, paitsi että: 

- Tyhjä draftOid käyttöliittymällä tulkitaan tarkoituksella nulliksi ja siten hyväksyttäväksi arvoksi
- draftOidin olemassaolo Ratkossa tarkistetaan erikseen vielä julkaisua ennen tapahtuvassa OIDien haun yhteydessä (mutta normaalitoimilla käyttäjän ei pitäisi pystyä saamaan sillä julkaisua rikki, koska käli sallii vain Ratkossa olemassaolevien draft-oidien asettamisen)