### PR TITLE
GVT-2957 Defer recreating primary keys after asset re-versioning

### DIFF
--- a/infra/src/main/resources/db/migration/prod/V99_02__redo_id_structure_for_track_number_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_02__redo_id_structure_for_track_number_version.sql
@@ -5,8 +5,7 @@ alter table publication.track_number
   drop constraint publication_track_number_track_number_version_fk;
 
 alter table layout.track_number_version
-  drop constraint track_number_version_pkey,
-  add constraint track_number_version_pkey primary key (id, layout_context_id, version);
+  drop constraint track_number_version_pkey;
 
 alter table publication.track_number
   add column layout_context_id text;
@@ -39,6 +38,9 @@ set version = track_number_version_change.new_version, id = official_id
   where track_number_version.layout_context_id = track_number_version_change.layout_context_id
     and track_number_version.id = track_number_version_change.id
     and track_number_version.version = track_number_version_change.old_version;
+
+alter table layout.track_number_version
+  add constraint track_number_version_pkey primary key (id, layout_context_id, version);
 
 alter table publication.track_number
   add constraint publication_track_number_track_number_version_fk

--- a/infra/src/main/resources/db/migration/prod/V99_04__redo_id_structure_for_reference_line_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_04__redo_id_structure_for_reference_line_version.sql
@@ -5,8 +5,7 @@ alter table publication.reference_line
   drop constraint publication_reference_line_reference_line_version_fk;
 
 alter table layout.reference_line_version
-  drop constraint reference_line_version_pkey,
-  add constraint reference_line_version_pkey primary key (id, layout_context_id, version);
+  drop constraint reference_line_version_pkey;
 
 alter table publication.reference_line
   add column layout_context_id text;
@@ -38,6 +37,9 @@ set version = reference_line_version_change.new_version, id = official_id
   where reference_line_version.layout_context_id = reference_line_version_change.layout_context_id
     and reference_line_version.id = reference_line_version_change.id
     and reference_line_version.version = reference_line_version_change.old_version;
+
+alter table layout.reference_line_version
+  add constraint reference_line_version_pkey primary key (id, layout_context_id, version);
 
 alter table publication.reference_line
   add constraint publication_reference_line_reference_line_version_fk

--- a/infra/src/main/resources/db/migration/prod/V99_06__redo_id_structure_for_location_track_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_06__redo_id_structure_for_location_track_version.sql
@@ -7,8 +7,7 @@ alter table publication.switch_location_tracks
   drop constraint publication_switch_location_tracks_location_track_version_fk;
 
 alter table layout.location_track_version
-  drop constraint location_track_version_pkey,
-  add constraint location_track_version_pkey primary key (id, layout_context_id, version);
+  drop constraint location_track_version_pkey;
 
 alter table publication.location_track
   add column layout_context_id text;
@@ -51,6 +50,9 @@ set version = location_track_version_change.new_version, id = official_id
   where location_track_version.layout_context_id = location_track_version_change.layout_context_id
     and location_track_version.id = location_track_version_change.id
     and location_track_version.version = location_track_version_change.old_version;
+
+alter table layout.location_track_version
+  add constraint location_track_version_pkey primary key (id, layout_context_id, version);
 
 alter table publication.location_track
   add constraint publication_location_track_location_track_version_fk

--- a/infra/src/main/resources/db/migration/prod/V99_08__redo_id_structure_for_switch_joint_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_08__redo_id_structure_for_switch_joint_version.sql
@@ -8,7 +8,7 @@ where switch_joint_version.switch_id = switch_version.id
   and switch_joint_version.switch_version = switch_version.version;
 
 alter table layout.switch_joint_version
-  drop constraint switch_joint_version_pkey,
-  add constraint switch_joint_version_pkey primary key (switch_id, switch_layout_context_id, number, version);
+  drop constraint switch_joint_version_pkey;
 
--- actual re-versioning happens together with switches, as it depends on switch versions
+-- actual re-versioning happens together with switches, as it depends on switch versions; primary key is added back
+-- after re-versioning

--- a/infra/src/main/resources/db/migration/prod/V99_10__redo_id_structure_for_switch_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_10__redo_id_structure_for_switch_version.sql
@@ -5,8 +5,7 @@ alter table publication.switch
   drop constraint publication_switch_switch_version_fk;
 
 alter table layout.switch_version
-  drop constraint switch_version_pkey,
-  add constraint switch_version_pkey primary key (id, layout_context_id, version);
+  drop constraint switch_version_pkey;
 
 alter table publication.switch
   add column layout_context_id text;
@@ -58,6 +57,9 @@ set version = switch_version_change.new_version, id = official_id
     and switch_version.id = switch_version_change.id
     and switch_version.version = switch_version_change.old_version;
 
+alter table layout.switch_version
+  add constraint switch_version_pkey primary key (id, layout_context_id, version);
+
 update layout.switch_joint_version
 set version = sjvc.new_joint_version, switch_version = sjvc.new_switch_version, switch_id = sjvc.switch_official_id
   from switch_joint_version_change sjvc
@@ -66,6 +68,9 @@ set version = sjvc.new_joint_version, switch_version = sjvc.new_switch_version, 
     and switch_joint_version.switch_version = sjvc.old_switch_version
     and switch_joint_version.version = sjvc.old_joint_version
     and switch_joint_version.number = sjvc.number;
+
+alter table layout.switch_joint_version
+  add constraint switch_joint_version_pkey primary key (switch_id, switch_layout_context_id, number, version);
 
 -- Constraint will be recreated in redo_id_structure_for_switch after we recreate switch's pkey.
 -- We need to update this table here because it's where we have easy access to the switch official IDs.

--- a/infra/src/main/resources/db/migration/prod/V99_12__redo_id_structure_for_km_post_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V99_12__redo_id_structure_for_km_post_version.sql
@@ -5,8 +5,7 @@ alter table publication.km_post
   drop constraint publication_km_post_km_post_version_fk;
 
 alter table layout.km_post_version
-  drop constraint km_post_version_pkey,
-  add constraint km_post_version_pkey primary key (id, layout_context_id, version);
+  drop constraint km_post_version_pkey;
 
 alter table publication.km_post
   add column layout_context_id text;
@@ -37,6 +36,9 @@ set version = km_post_version_change.new_version, id = official_id
   where km_post_version.layout_context_id = km_post_version_change.layout_context_id
     and km_post_version.id = km_post_version_change.id
     and km_post_version.version = km_post_version_change.old_version;
+
+alter table layout.km_post_version
+  add constraint km_post_version_pkey primary key (id, layout_context_id, version);
 
 alter table publication.km_post
   add constraint publication_km_post_km_post_version_fk


### PR DESCRIPTION
ID-remontin versiohistorioiden uudelleenlaskennat tehdään tauluittain yksittäisillä update-komennoilla, eli sellaista ongelmaa niissä ei postgressissa ajettuna voi olla, että komento semanttisella tasolla sotkeutuisi jalkoihinsa rivejä päivittäessään (kts. klassinen Halloween problem); mutta se on mahdollista, että riippuen siitä, missä järjestyksessä päivitys sattuu rivejä käsittelemään, taulu sisältää väliaikaisesti useamman rivin samalla avaimella.

Tämä ongelma sattui näkymään switch_joint_version-taulussa, mutta ihan yhtä hyvinhän jokaisella oliotyypillä on mahdollista, että vaikkapa aiemmin oli olemassa jostain oliosta main_officialin versiot 3, 4, ja 5, ja päivityksen jälkeen 1, 2, ja 3; ja päivitys sattuu trollaamaan päivittämällä ensimmäiseksi alkuperäisen version 5 versioksi 3, ja kaatumalla sitten duplikaattirviin, vaikka se olisi kyllä ihan hyvin osannut jatkaa päivittämistä ja vaihtaa sitten myös 4->2 ja 3->1 entisten versiotietojen perusteella.

Fiksaantuu helpoiten siirtämällä avaimien määritykset versiopäivitysten jälkeen.