### PR TITLE
GVT-2956 & GVT-2959: Etusivun julkaisukorttien korjaus

### DIFF
--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -104,8 +104,8 @@ function latestFailureByLayoutBranch(
     return [
         ...failures
             .reduce((mapByPublication, publication) => {
-                if (!mapByPublication.has(publication.layoutBranch)) {
-                    mapByPublication.set(publication.layoutBranch, publication);
+                if (!mapByPublication.has(publication.layoutBranch.branch)) {
+                    mapByPublication.set(publication.layoutBranch.branch, publication);
                 }
                 return mapByPublication;
             }, new Map<LayoutBranch, PublicationDetails>())

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -70,7 +70,10 @@ const bulkTransferStateIcon = (bulkTransferState: BulkTransferState | undefined)
 export const PublicationListRow: React.FC<PublicationListRowProps> = ({ publication }) => {
     const { t } = useTranslation();
 
-    const design = useLayoutDesign(getChangeTimes().layoutDesign, publication.layoutBranch)?.name;
+    const design = useLayoutDesign(
+        getChangeTimes().layoutDesign,
+        publication.layoutBranch.branch,
+    )?.name;
 
     const [menuOpen, setMenuOpen] = React.useState(false);
     const [splitDetailsDialogOpen, setSplitDetailsDialogOpen] = React.useState(false);
@@ -123,7 +126,7 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({ publicat
                     <span className={styles['publication-list-item__text']}>
                         {(() => {
                             const text = formatDateFull(publication.publicationTime);
-                            return publication.layoutBranch === 'MAIN' ? (
+                            return publication.layoutBranch.branch === 'MAIN' ? (
                                 <Link to={`/publications/${publication.id}`}>{text}</Link>
                             ) : (
                                 text

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -1,8 +1,10 @@
 import {
     AssetId,
+    DesignBranch,
     JointNumber,
     KmNumber,
-    LayoutBranch,
+    LayoutDesignId,
+    MainBranch,
     Oid,
     Range,
     RowVersion,
@@ -182,11 +184,25 @@ export type Split = SplitHeader & {
     relinkedSwitches: LayoutSwitchId[];
 };
 
+type PublishedInMain = {
+    branch: MainBranch;
+    designBranch: undefined;
+    designVersion: undefined;
+};
+
+type PublishedInDesign = {
+    branch: DesignBranch;
+    designBranch: LayoutDesignId;
+    designVersion: number;
+};
+
+export type PublishedInBranch = PublishedInMain | PublishedInDesign;
+
 export type PublicationDetails = {
     id: PublicationId;
     publicationTime: TimeStamp;
     publicationUser: string;
-    layoutBranch: LayoutBranch;
+    layoutBranch: PublishedInBranch;
     trackNumbers: PublishedTrackNumber[];
     referenceLines: PublishedReferenceLine[];
     locationTracks: PublishedLocationTrack[];

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -47,7 +47,7 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
 
     const design = useLayoutDesign(
         getChangeTimes().layoutDesign,
-        failedPublication.layoutBranch,
+        failedPublication.layoutBranch.branch,
     )?.name;
 
     if (!error) {


### PR DESCRIPTION
Main-branchin julkaisukortin linkit olivat kadonneet ja suunnitelmajulkaisujen kortti heitti bäkkärivirhettä tietyillä käyttäjärooleilla. Ne korjattu täällä. En tosin korjannut tuota suunnitelajulkaisujen korttien bäkkärivirhettä mitenkään eksplisiittisesti -- tuntui siltä, että se vain korjautui tuon linkkikorjauksen yhteydessä ainakin lokaalisti. Testataan main-mergen jälkeen miten oikeasti kävi