### PR TITLE
GVT-2726 Ratko push for designs, part II

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -122,7 +122,7 @@ constructor(
                 val oids = trackNumberDao.fetchExternalIds(layoutContext.branch, trackNumberIds)
                 trackNumbers.associate { trackNumber ->
                     trackNumber.id as IntId to
-                        TrackNumberDetails(trackNumber, geocodingContexts[trackNumber.id], oids[trackNumber.id])
+                        TrackNumberDetails(trackNumber, geocodingContexts[trackNumber.id], oids[trackNumber.id]?.oid)
                 }
             }
 
@@ -207,7 +207,7 @@ constructor(
                 allTrackNumberRequests.map { reqs ->
                     val trackNumberId = reqs.first().trackNumber.id
                     val trackNumber = requireNotNull(trackNumbers[trackNumberId])
-                    reqs to TrackNumberDetails(trackNumber, geocodingContexts[trackNumberId], oids[trackNumberId])
+                    reqs to TrackNumberDetails(trackNumber, geocodingContexts[trackNumberId], oids[trackNumberId]?.oid)
                 }
             }
             .map { (trackNumberRequests, trackNumberDetails) ->
@@ -604,7 +604,7 @@ constructor(
                     val extIds =
                         locationTrackDao.fetchExternalIds(LayoutBranch.main, distinctTracks.map { it.id as IntId })
                     distinctTracks.zip(descriptions).associate {
-                        it.first.id to LocationTrackDetails(it.second, extIds[it.first.id])
+                        it.first.id to LocationTrackDetails(it.second, extIds[it.first.id]?.oid)
                     }
                 }
         else null

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.common
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
+import fi.fta.geoviite.infra.publication.RatkoPlanItemId
 import fi.fta.geoviite.infra.util.assertSanitized
 
 data class Oid<T> @JsonCreator(mode = DELEGATING) constructor(private val value: String) : CharSequence by value {
@@ -18,3 +19,12 @@ data class Oid<T> @JsonCreator(mode = DELEGATING) constructor(private val value:
 
     @JsonValue override fun toString(): String = value
 }
+
+data class RatkoExternalId<T>(val oid: Oid<T>, val planItemId: RatkoPlanItemId?)
+
+sealed class FullRatkoExternalId<T>(open val oid: Oid<T>)
+
+data class MainBranchRatkoExternalId<T>(override val oid: Oid<T>) : FullRatkoExternalId<T>(oid)
+
+data class DesignRatkoExternalId<T>(override val oid: Oid<T>, val planItemId: RatkoPlanItemId) :
+    FullRatkoExternalId<T>(oid)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -674,3 +674,5 @@ data class PreparedPublicationRequest(
     val message: FreeTextWithNewLines,
     val cause: PublicationCause,
 )
+
+data class RatkoPlanItemId(val id: Int)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -2097,7 +2097,7 @@ class PublicationDao(
                 and publication_time < (
                 select publication_time from publication.publication where id = :publication_id
               )
-              order by publication_time
+              order by publication_time desc
               limit 1;
         """
                 .trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -2086,6 +2086,28 @@ class PublicationDao(
                 partitionDirectIndirectChanges(trackNumberRows)
             }
     }
+
+    fun getPreviouslyPublishedDesignVersion(publicationId: IntId<Publication>, designId: IntId<LayoutDesign>): Int? {
+        // language="sql"
+        val sql =
+            """
+            select previous_in_design.design_version
+              from publication.publication previous_in_design
+              where design_id = :design_id
+                and publication_time < (
+                select publication_time from publication.publication where id = :publication_id
+              )
+              order by publication_time
+              limit 1;
+        """
+                .trimIndent()
+        return jdbcTemplate.queryOptional(
+            sql,
+            mapOf("publication_id" to publicationId.intValue, "design_id" to designId.intValue),
+        ) { rs, _ ->
+            rs.getInt("design_version")
+        }
+    }
 }
 
 private fun <T> partitionDirectIndirectChanges(rows: List<Pair<Boolean, T>>) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -199,10 +199,9 @@ constructor(
                     locationTrackService.getWithAlignment(split.sourceLocationTrackVersion)
                 val oid =
                     requireNotNull(
-                        locationTrackDao.fetchExternalId(
-                            publication.layoutBranch.branch,
-                            sourceLocationTrack.id as IntId,
-                        )
+                        locationTrackDao
+                            .fetchExternalId(publication.layoutBranch.branch, sourceLocationTrack.id as IntId)
+                            ?.oid
                     ) {
                         "expected to find oid for published location track ${sourceLocationTrack.id} in publication ${id}"
                     }
@@ -264,7 +263,7 @@ constructor(
             return SplitTargetInPublication(
                 id = track.id,
                 name = track.name,
-                oid = locationTrackDao.fetchExternalId(publicationBranch, track.id),
+                oid = locationTrackDao.fetchExternalId(publicationBranch, track.id)?.oid,
                 startAddress = startAddress,
                 endAddress = endAddress,
                 operation = target.operation,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -202,7 +202,7 @@ constructor(
             ValidationVersions(target, trackNumbers, locationTracks, referenceLines, switches, kmPosts, emptyList())
         )
 
-    private fun createValidationContext(publicationSet: ValidationVersions): ValidationContext =
+    fun createValidationContext(publicationSet: ValidationVersions): ValidationContext =
         ValidationContext(
             trackNumberDao = trackNumberDao,
             referenceLineDao = referenceLineDao,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/ExternalIdDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/ExternalIdDao.kt
@@ -1,15 +1,19 @@
 package fi.fta.geoviite.infra.ratko
 
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.RatkoExternalId
+import fi.fta.geoviite.infra.publication.RatkoPlanItemId
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutRowId
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getLayoutBranch
 import fi.fta.geoviite.infra.util.getLayoutRowId
-import fi.fta.geoviite.infra.util.getOid
+import fi.fta.geoviite.infra.util.getRatkoExternalId
+import fi.fta.geoviite.infra.util.getRatkoExternalIdOrNull
 import fi.fta.geoviite.infra.util.queryOptional
 import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -17,13 +21,20 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 interface IExternalIdDao<T : LayoutAsset<T>> {
     fun getExternalIdChangeTime(): Instant
 
+    fun savePlanItemIdInExistingTransaction(branch: DesignBranch, id: IntId<T>, planItemId: RatkoPlanItemId)
+
     fun insertExternalIdInExistingTransaction(branch: LayoutBranch, id: IntId<T>, oid: Oid<T>)
 
-    fun fetchExternalId(branch: LayoutBranch, id: IntId<T>): Oid<T>?
+    fun fetchExternalId(branch: LayoutBranch, id: IntId<T>): RatkoExternalId<T>?
 
-    fun fetchExternalIds(branch: LayoutBranch, ids: List<IntId<T>>? = null): Map<IntId<T>, Oid<T>>
+    fun fetchExternalIdsWithInheritance(
+        branch: LayoutBranch,
+        ids: List<IntId<T>>? = null,
+    ): Map<IntId<T>, RatkoExternalId<T>>
 
-    fun fetchExternalIdsByBranch(id: IntId<T>): Map<LayoutBranch, Oid<T>>
+    fun fetchExternalIds(branch: LayoutBranch, ids: List<IntId<T>>? = null): Map<IntId<T>, RatkoExternalId<T>>
+
+    fun fetchExternalIdsByBranch(id: IntId<T>): Map<LayoutBranch, RatkoExternalId<T>>
 
     fun lookupByExternalId(oid: Oid<T>): LayoutRowId<T>?
 }
@@ -34,6 +45,24 @@ class ExternalIdDao<T : LayoutAsset<T>>(
     val extIdVersionTable: String,
 ) : DaoBase(jdbcTemplateParam), IExternalIdDao<T> {
     override fun getExternalIdChangeTime(): Instant = fetchLatestChangeTimeFromTable(extIdVersionTable)
+
+    override fun savePlanItemIdInExistingTransaction(branch: DesignBranch, id: IntId<T>, planItemId: RatkoPlanItemId) {
+        val sql =
+            """
+            update $extIdTable
+            set plan_item_id = :plan_item_id
+            where id = :id and layout_context_id = :layout_context_id
+        """
+                .trimIndent()
+        jdbcTemplate.update(
+            sql,
+            mapOf(
+                "id" to id.intValue,
+                "layout_context_id" to branch.official.toSqlString(),
+                "plan_item_id" to planItemId.id,
+            ),
+        )
+    }
 
     override fun insertExternalIdInExistingTransaction(branch: LayoutBranch, id: IntId<T>, oid: Oid<T>) {
         val sql =
@@ -53,38 +82,62 @@ class ExternalIdDao<T : LayoutAsset<T>>(
         )
     }
 
-    override fun fetchExternalId(branch: LayoutBranch, id: IntId<T>): Oid<T>? {
-        val sql = """select external_id from $extIdTable where id = :id and design_id is not distinct from :design_id"""
+    override fun fetchExternalId(branch: LayoutBranch, id: IntId<T>): RatkoExternalId<T>? {
+        val sql =
+            """
+               select external_id, plan_item_id
+               from $extIdTable
+               where id = :id and design_id is not distinct from :design_id;
+            """
+                .trimIndent()
         return jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue, "design_id" to branch.designId?.intValue)) {
             rs,
             _ ->
-            rs.getOid<T>("external_id")
+            rs.getRatkoExternalIdOrNull("external_id", "plan_item_id")
         }
     }
 
-    override fun fetchExternalIds(branch: LayoutBranch, ids: List<IntId<T>>?): Map<IntId<T>, Oid<T>> {
+    override fun fetchExternalIdsWithInheritance(
+        branch: LayoutBranch,
+        ids: List<IntId<T>>?,
+    ): Map<IntId<T>, RatkoExternalId<T>> = fetchExternalIds(branch, ids, withInheritance = true)
+
+    override fun fetchExternalIds(branch: LayoutBranch, ids: List<IntId<T>>?): Map<IntId<T>, RatkoExternalId<T>> =
+        fetchExternalIds(branch, ids, withInheritance = false)
+
+    private fun fetchExternalIds(
+        branch: LayoutBranch,
+        ids: List<IntId<T>>?,
+        withInheritance: Boolean,
+    ): Map<IntId<T>, RatkoExternalId<T>> {
         if (ids != null && ids.isEmpty()) {
             return mapOf()
         }
+        val designIdFragment =
+            if (withInheritance) "(design_id is null or design_id is not distinct from :design_id)"
+            else "design_id is not distinct from :design_id"
         val idsInclusionFragment = if (ids == null) "true" else "(id = any(array[:ids]))"
 
         val sql =
             """
-            select id, external_id from $extIdTable
-            where design_id is not distinct from :design_id
-              and $idsInclusionFragment"""
+            select id, external_id, plan_item_id from $extIdTable t
+            where $designIdFragment and $idsInclusionFragment
+              and not (:design_id::int is not null
+                       and design_id is null
+                       and exists (select * from $extIdTable overrider
+                                   where overrider.id = t.id and overrider.design_id = :design_id))"""
         return jdbcTemplate
             .query(sql, mapOf("design_id" to branch.designId?.intValue, "ids" to ids?.map { it.intValue })) { rs, _ ->
-                rs.getIntId<T>("id") to rs.getOid<T>("external_id")
+                rs.getIntId<T>("id") to rs.getRatkoExternalId<T>("external_id", "plan_item_id")
             }
             .associate { it }
     }
 
-    override fun fetchExternalIdsByBranch(id: IntId<T>): Map<LayoutBranch, Oid<T>> {
-        val sql = """select design_id, external_id from $extIdTable where id = :id"""
+    override fun fetchExternalIdsByBranch(id: IntId<T>): Map<LayoutBranch, RatkoExternalId<T>> {
+        val sql = """select design_id, external_id, plan_item_id from $extIdTable where id = :id"""
         return jdbcTemplate
             .query(sql, mapOf("id" to id.intValue)) { rs, _ ->
-                rs.getLayoutBranch("design_id") to rs.getOid<T>("external_id")
+                rs.getLayoutBranch("design_id") to rs.getRatkoExternalId<T>("external_id", "plan_item_id")
             }
             .associate { it }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -38,8 +38,7 @@ class RatkoController(private val ratkoServiceParam: RatkoService?, private val 
     @PreAuthorize(AUTH_EDIT_LAYOUT)
     @PostMapping("/push-designs")
     fun pushDesignChangesToRatko() {
-        // TODO implement
-        throw NotImplementedError("Not implemented")
+        ratkoService.pushDesignChangesToRatko()
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
@@ -14,6 +14,8 @@ abstract class RatkoAsset(
     open val rowMetadata: RatkoMetadata,
     open val locations: List<RatkoAssetLocation>?,
     val type: RatkoAssetType,
+    open val isPlanContext: Boolean,
+    open val planItemIds: List<Int>?,
 ) {
     abstract fun withoutGeometries(): RatkoAsset
 }
@@ -22,6 +24,8 @@ data class RatkoMetadataAsset(
     override val properties: Collection<RatkoAssetProperty>,
     override val rowMetadata: RatkoMetadata = RatkoMetadata(),
     override val locations: List<RatkoAssetLocation>,
+    override val isPlanContext: Boolean,
+    override val planItemIds: List<Int>?,
 ) :
     RatkoAsset(
         state = RatkoAssetState.IN_USE,
@@ -29,6 +33,8 @@ data class RatkoMetadataAsset(
         rowMetadata = rowMetadata,
         properties = properties,
         locations = locations,
+        isPlanContext = isPlanContext,
+        planItemIds = planItemIds,
     ) {
     override fun withoutGeometries() = this.copy(locations = locations.map { it.withoutGeometries() })
 }
@@ -42,6 +48,8 @@ constructor(
     override val rowMetadata: RatkoMetadata = RatkoMetadata(),
     override val locations: List<RatkoAssetLocation>?,
     val assetGeoms: Collection<RatkoAssetGeometry>?,
+    override val isPlanContext: Boolean,
+    override val planItemIds: List<Int>?,
 ) :
     RatkoAsset(
         state = state,
@@ -49,6 +57,8 @@ constructor(
         rowMetadata = rowMetadata,
         properties = properties,
         locations = locations,
+        isPlanContext = isPlanContext,
+        planItemIds = planItemIds,
     ) {
     override fun withoutGeometries() = this.copy(locations = locations?.map { it.withoutGeometries() })
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.ITrackMeter
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -171,7 +173,31 @@ enum class RatkoAccuracyType(@get:JsonValue val value: String) {
     @Suppress("unused") ESTIMATED_TRACK_ADDRESS("ESTIMATED TRACKADDRESS"),
 }
 
+data class RatkoPlan(
+    val id: Int?,
+    val name: String,
+    val estimatedCompletion: String,
+    val phase: RatkoPlanPhase,
+    val state: RatkoPlanState,
+)
+
+sealed class PushableLayoutBranch {
+    abstract val branch: LayoutBranch
+}
+
+data object PushableMainBranch : PushableLayoutBranch() {
+    override val branch = LayoutBranch.main
+}
+
+data class PushableDesignBranch(override val branch: DesignBranch, val planId: RatkoPlanId) : PushableLayoutBranch()
+
 data class RatkoPlanId(val id: Int)
+
+enum class RatkoPlanPhase {
+    GENERAL_PLAN,
+    RAILWAY_PLAN,
+    RAILWAY_CONSTRUCTION_PLAN,
+}
 
 enum class RatkoPlanState {
     OPEN,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
@@ -16,6 +16,8 @@ data class RatkoLocationTrack(
     val duplicateOf: String?,
     val topologicalConnectivity: RatkoTopologicalConnectivityType,
     val owner: String?,
+    val isPlanContext: Boolean,
+    val planItemIds: List<Int>?,
 )
 
 enum class RatkoLocationTrackType(@get:JsonValue val value: String) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoRouteNumberModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoRouteNumberModel.kt
@@ -11,6 +11,8 @@ data class RatkoRouteNumber(
     val description: String,
     val state: RatkoRouteNumberState,
     val rowMetadata: RatkoMetadata = RatkoMetadata(),
+    val isPlanContext: Boolean,
+    val planItemIds: List<Int>?,
 )
 
 data class RatkoRouteNumberState(val name: RatkoRouteNumberStateType)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.tracklayout
 
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
@@ -13,6 +14,7 @@ import fi.fta.geoviite.infra.logging.AccessType.FETCH
 import fi.fta.geoviite.infra.logging.AccessType.INSERT
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.RatkoPlanItemId
 import fi.fta.geoviite.infra.ratko.ExternalIdDao
 import fi.fta.geoviite.infra.ratko.IExternalIdDao
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
@@ -636,6 +638,12 @@ class LayoutSwitchDao(
                 rs.getIntId<LayoutSwitch>("switch_id")
             }
             .also { results -> logger.daoAccess(FETCH, "Switches near alignment", results) }
+    }
+
+    @Transactional
+    fun savePlanItemId(id: IntId<LayoutSwitch>, branch: DesignBranch, planItemId: RatkoPlanItemId) {
+        jdbcTemplate.setUser()
+        savePlanItemIdInExistingTransaction(branch, id, planItemId)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -18,6 +18,7 @@ import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.util.Page
+import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.page
 import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
@@ -148,7 +149,7 @@ constructor(
         possibleIds: List<IntId<LayoutSwitch>>? = null,
     ): ((term: String, item: LayoutSwitch) -> Boolean) =
         dao.fetchExternalIds(layoutContext.branch, possibleIds).let { externalIds ->
-            { term, item -> externalIds[item.id]?.toString() == term || item.id.toString() == term }
+            { term, item -> externalIds[item.id]?.oid?.toString() == term || item.id.toString() == term }
         }
 
     override fun contentMatches(term: String, item: LayoutSwitch) =
@@ -205,9 +206,8 @@ constructor(
     fun getExternalIdChangeTime(): Instant = dao.getExternalIdChangeTime()
 
     @Transactional(readOnly = true)
-    fun getExternalIdsByBranch(id: IntId<LayoutSwitch>): Map<LayoutBranch, Oid<LayoutSwitch>> {
-        return dao.fetchExternalIdsByBranch(id)
-    }
+    fun getExternalIdsByBranch(id: IntId<LayoutSwitch>): Map<LayoutBranch, Oid<LayoutSwitch>> =
+        mapNonNullValues(dao.fetchExternalIdsByBranch(id)) { (_, v) -> v.oid }
 }
 
 fun pageSwitches(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.tracklayout
 
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
@@ -8,6 +9,7 @@ import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
+import fi.fta.geoviite.infra.publication.RatkoPlanItemId
 import fi.fta.geoviite.infra.ratko.ExternalIdDao
 import fi.fta.geoviite.infra.ratko.IExternalIdDao
 import fi.fta.geoviite.infra.util.LayoutAssetTable
@@ -268,6 +270,12 @@ class LayoutTrackNumberDao(
             // Ensure that the result contains all asked-for numbers, even if there are no matches
             numbers.associateWith { n -> found.filter { (number, _) -> number == n }.map { (_, v) -> v } }
         }
+    }
+
+    @Transactional
+    fun savePlanItemId(id: IntId<LayoutTrackNumber>, branch: DesignBranch, planItemId: RatkoPlanItemId) {
+        jdbcTemplate.setUser()
+        savePlanItemIdInExistingTransaction(branch, id, planItemId)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
@@ -11,6 +12,7 @@ import fi.fta.geoviite.infra.geometry.MetaDataName
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.BoundingBox
+import fi.fta.geoviite.infra.publication.RatkoPlanItemId
 import fi.fta.geoviite.infra.publication.ValidationTarget
 import fi.fta.geoviite.infra.ratko.ExternalIdDao
 import fi.fta.geoviite.infra.ratko.IExternalIdDao
@@ -550,6 +552,12 @@ class LocationTrackDao(
         return trackNumberIds.associateWith { trackNumberId ->
             versions.filter { (tnId, _) -> tnId == trackNumberId }.map { (_, trackVersions) -> trackVersions }
         }
+    }
+
+    @Transactional
+    fun savePlanItemId(id: IntId<LocationTrack>, branch: DesignBranch, planItemId: RatkoPlanItemId) {
+        jdbcTemplate.setUser()
+        savePlanItemIdInExistingTransaction(branch, id, planItemId)
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Map.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Map.kt
@@ -1,0 +1,4 @@
+package fi.fta.geoviite.infra.util
+
+fun <K, V, R> mapNonNullValues(map: Map<K, V>, transform: (Map.Entry<K, V>) -> R?): Map<K, R> =
+    map.entries.mapNotNull { e -> transform(e)?.let { r -> e.key to r } }.toMap()

--- a/infra/src/main/resources/db/migration/prod/V106__add_plan_item_ids_to_ext_ids.sql
+++ b/infra/src/main/resources/db/migration/prod/V106__add_plan_item_ids_to_ext_ids.sql
@@ -1,0 +1,17 @@
+alter table layout.track_number_external_id
+  add column plan_item_id int;
+
+alter table layout.location_track_external_id
+  add column plan_item_id int;
+
+alter table layout.switch_external_id
+  add column plan_item_id int;
+
+alter table layout.track_number_external_id_version
+  add column plan_item_id int;
+
+alter table layout.location_track_external_id_version
+  add column plan_item_id int;
+
+alter table layout.switch_external_id_version
+  add column plan_item_id int;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -468,6 +468,48 @@ constructor(
         )
     }
 
+    @Test
+    fun `getPreviouslyPublishedDesignVersion returns the most recent design version before the given publication`() {
+        val someDesign = layoutDesignDao.insert(layoutDesign(name = "foo"))
+        val pub1 =
+            publicationDao.createPublication(
+                DesignBranch.of(someDesign),
+                FreeTextWithNewLines.of("pub 1"),
+                PublicationCause.MANUAL,
+            )
+        layoutDesignDao.update(someDesign, layoutDesign(name = "bar"))
+        val pub2 =
+            publicationDao.createPublication(
+                DesignBranch.of(someDesign),
+                FreeTextWithNewLines.of("pub 2"),
+                PublicationCause.MANUAL,
+            )
+        layoutDesignDao.update(someDesign, layoutDesign(name = "spam"))
+        val pub3 =
+            publicationDao.createPublication(
+                DesignBranch.of(someDesign),
+                FreeTextWithNewLines.of("pub 3"),
+                PublicationCause.MANUAL,
+            )
+        val pub4 =
+            publicationDao.createPublication(
+                DesignBranch.of(someDesign),
+                FreeTextWithNewLines.of("pub 4"),
+                PublicationCause.MANUAL,
+            )
+        val pub5 =
+            publicationDao.createPublication(
+                DesignBranch.of(someDesign),
+                FreeTextWithNewLines.of("pub 5"),
+                PublicationCause.MANUAL,
+            )
+        assertEquals(null, publicationDao.getPreviouslyPublishedDesignVersion(pub1, someDesign))
+        assertEquals(1, publicationDao.getPreviouslyPublishedDesignVersion(pub2, someDesign))
+        assertEquals(2, publicationDao.getPreviouslyPublishedDesignVersion(pub3, someDesign))
+        assertEquals(3, publicationDao.getPreviouslyPublishedDesignVersion(pub4, someDesign))
+        assertEquals(3, publicationDao.getPreviouslyPublishedDesignVersion(pub5, someDesign))
+    }
+
     private fun insertAndCheck(
         trackNumber: LayoutTrackNumber
     ): Pair<LayoutRowVersion<LayoutTrackNumber>, LayoutTrackNumber> {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.MainBranchRatkoExternalId
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAsset
@@ -78,7 +79,13 @@ constructor(
         val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
         fakeRatko.hasSwitch(ratkoSwitch(oid))
         val ratkoSwitch = ratkoClient.getSwitchAsset(RatkoOid(oid))
-        return convertToRatkoSwitch(layoutSwitch, Oid(oid), switchStructure, switchOwners.firstOrNull(), ratkoSwitch)
+        return convertToRatkoSwitch(
+            layoutSwitch,
+            MainBranchRatkoExternalId(Oid(oid)),
+            switchStructure,
+            switchOwners.firstOrNull(),
+            ratkoSwitch,
+        )
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -11,6 +11,7 @@ import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.MeasurementMethod
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumberDescription
@@ -24,15 +25,22 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
 import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
+import fi.fta.geoviite.infra.publication.PublicationRequest
 import fi.fta.geoviite.infra.publication.PublicationRequestIds
 import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.PublicationTestSupportService
+import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.ratko.model.OperationalPointType
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetState
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrackState
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrackType
 import fi.fta.geoviite.infra.ratko.model.RatkoMeasurementMethod
+import fi.fta.geoviite.infra.ratko.model.RatkoMetadataAsset
 import fi.fta.geoviite.infra.ratko.model.RatkoNodeType
 import fi.fta.geoviite.infra.ratko.model.RatkoOperatingPointParse
+import fi.fta.geoviite.infra.ratko.model.RatkoPlan
+import fi.fta.geoviite.infra.ratko.model.RatkoPlanPhase
+import fi.fta.geoviite.infra.ratko.model.RatkoPlanState
 import fi.fta.geoviite.infra.ratko.model.RatkoPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoPointStates
 import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
@@ -40,9 +48,12 @@ import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumberStateType
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitTestDataService
+import fi.fta.geoviite.infra.tracklayout.DesignState
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
-import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutDesignDao
+import fi.fta.geoviite.infra.tracklayout.LayoutDesignName
+import fi.fta.geoviite.infra.tracklayout.LayoutDesignSaveRequest
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostService
@@ -52,6 +63,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
@@ -69,7 +81,6 @@ import fi.fta.geoviite.infra.tracklayout.asMainDraft
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
-import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.switch
@@ -79,6 +90,7 @@ import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.queryOne
 import java.time.Instant
+import java.time.LocalDate
 import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -113,6 +125,8 @@ constructor(
     val publicationDao: PublicationDao,
     val splitDao: SplitDao,
     val splitTestDataService: SplitTestDataService,
+    val layoutDesignDao: LayoutDesignDao,
+    val publicationTestSupportService: PublicationTestSupportService,
 ) : DBTestBase() {
 
     @BeforeEach
@@ -125,7 +139,8 @@ constructor(
                          layout.location_track_id,
                          layout.switch_id,
                          layout.operating_point,
-                         layout.operating_point_version
+                         layout.operating_point_version,
+                         layout.design
                   cascade;
             """
                 .trimIndent()
@@ -191,10 +206,10 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val originalTrackNumber =
             layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = true))
-        insertSomeOfficialReferenceLineFor(originalTrackNumber.id)
+        val referenceLine = insertReferenceLineFor(originalTrackNumber.id, draft = true).id
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
-        publishAndPush(trackNumbers = listOf(originalTrackNumber.id))
+        publishAndPush(trackNumbers = listOf(originalTrackNumber.id), referenceLines = listOf(referenceLine))
 
         val pushedRouteNumber = fakeRatko.getPushedRouteNumber(Oid("1.2.3.4.5"))
         assertEquals(trackNumber.value, pushedRouteNumber[0].name)
@@ -245,7 +260,7 @@ constructor(
     fun pushAndDeleteLocationTrack() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val locationTrackOriginal =
@@ -286,7 +301,7 @@ constructor(
     fun modifyLocationTrackProperties() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val locationTrackOriginal =
@@ -335,7 +350,7 @@ constructor(
     fun lengthenLocationTrack() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val locationTrackOriginal =
@@ -374,7 +389,7 @@ constructor(
     fun shortenLocationTrack() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val locationTrackOriginal =
@@ -413,7 +428,7 @@ constructor(
     fun alterLocationTrackGeometry() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val locationTrackOriginal =
@@ -460,7 +475,7 @@ constructor(
     fun `push new deleted location track without points`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val locationTrackOriginal =
@@ -492,7 +507,7 @@ constructor(
     fun pushLocationTrackMetadata() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.2.3.4.5"))
 
         val planVersion =
@@ -542,14 +557,17 @@ constructor(
         val trackNumber1 = testDBService.getUnusedTrackNumber()
         val trackNumber1Version =
             trackNumberService.saveDraft(LayoutBranch.main, trackNumber(trackNumber1, draft = true))
-        insertSomeOfficialReferenceLineFor(trackNumber1Version.id)
+        val referenceLine1 = insertReferenceLineFor(trackNumber1Version.id, draft = true).id
         val trackNumber2 = testDBService.getUnusedTrackNumber()
         val trackNumber2Version =
             trackNumberService.saveDraft(LayoutBranch.main, trackNumber(trackNumber2, draft = true))
-        insertSomeOfficialReferenceLineFor(trackNumber2Version.id)
+        val referenceLine2 = insertReferenceLineFor(trackNumber2Version.id, draft = true).id
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("2.3.4.5.6", "3.4.5.6.7"))
-        publishAndPush(trackNumbers = listOf(trackNumber1Version.id, trackNumber2Version.id))
+        publishAndPush(
+            trackNumbers = listOf(trackNumber1Version.id, trackNumber2Version.id),
+            referenceLines = listOf(referenceLine1, referenceLine2),
+        )
         val pushedRouteNumber1 = fakeRatko.getPushedRouteNumber(Oid("2.3.4.5.6"))
         val pushedRouteNumber2 = fakeRatko.getPushedRouteNumber(Oid("3.4.5.6.7"))
         assertEquals(trackNumber1.value, pushedRouteNumber1[0].name)
@@ -561,17 +579,16 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val originalTrackNumber =
             layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = true))
-        val originalReferenceLineDaoResponse = insertSomeOfficialReferenceLineFor(originalTrackNumber.id)
-        val originalReferenceLine = referenceLineDao.fetch(originalReferenceLineDaoResponse)
+        val originalReferenceLineVersion = insertReferenceLineFor(originalTrackNumber.id, draft = true)
+        val originalReferenceLine = referenceLineDao.fetch(originalReferenceLineVersion)
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
-        publishAndPush(trackNumbers = listOf(originalTrackNumber.id))
-        referenceLineService.saveDraft(
-            LayoutBranch.main,
-            originalReferenceLine,
-            alignment(segment(Point(0.0, 0.0), Point(20.0, 0.0))),
+        publishAndPush(
+            trackNumbers = listOf(originalTrackNumber.id),
+            referenceLines = listOf(originalReferenceLineVersion.id),
         )
-        publishAndPush(referenceLines = listOf(originalReferenceLineDaoResponse.id))
+        mainDraftContext.insert(originalReferenceLine, alignment(segment(Point(0.0, 0.0), Point(20.0, 0.0))))
+        publishAndPush(referenceLines = listOf(originalReferenceLineVersion.id))
         val pushedPoints = fakeRatko.getCreatedRouteNumberPoints("1.2.3.4.5")
         assertEquals(9, pushedPoints[0].size)
         assertEquals(19, pushedPoints[1].size)
@@ -736,7 +753,7 @@ constructor(
     fun removeKmPostBeforeSwitch() {
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId = layoutTrackNumberDao.save(trackNumber(trackNumber, description = "augh", draft = false)).id
-        insertSomeOfficialReferenceLineFor(trackNumberId)
+        insertReferenceLineFor(trackNumberId, draft = false)
         layoutTrackNumberDao.insertExternalId(trackNumberId, LayoutBranch.main, Oid("1.1.1.1.1"))
 
         val kmPost1 =
@@ -911,12 +928,21 @@ constructor(
     fun `push new deleted switch without data`() {
         val trackNumber = establishedTrackNumber()
 
-        val (switch, throughTrack, branchingTrack) =
-            setupDraftSwitchAndLocationTracks(
-                trackNumber.id,
-                "TV123",
-                switchStateCategory = LayoutStateCategory.NOT_EXISTING,
-            )
+        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id, "TV123")
+
+        // establish switch as existing with one publication, then delete it in another, so both
+        // publications validate but the integration has to contend with pushing an already-deleted
+        // switch
+        publicationTestSupportService.publish(
+            LayoutBranch.main,
+            publicationRequestIds(
+                locationTracks = listOf(throughTrack.id, branchingTrack.id),
+                switches = listOf(switch.id),
+            ),
+        )
+        mainDraftContext.insert(switchDao.fetch(switch).copy(stateCategory = LayoutStateCategory.NOT_EXISTING))
+        detachSwitchesFromTrack(throughTrack.id)
+        detachSwitchesFromTrack(branchingTrack.id)
 
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
         fakeRatko.acceptsNewSwitchWithoutDataGivingItOid("3.4.5.6.7")
@@ -1046,9 +1072,9 @@ constructor(
     @Test
     fun linkKmPost() {
         val trackNumber = layoutTrackNumberDao.save(trackNumber(testDBService.getUnusedTrackNumber(), draft = true))
-        insertSomeOfficialReferenceLineFor(trackNumber.id)
+        val referenceLine = insertReferenceLineFor(trackNumber.id, draft = true).id
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.2.3.4.5"))
-        publishAndPush(trackNumbers = listOf(trackNumber.id))
+        publishAndPush(trackNumbers = listOf(trackNumber.id), referenceLines = listOf(referenceLine))
         fakeRatko.hasRouteNumber(ratkoRouteNumber(id = "1.2.3.4.5"))
         val pushedPoints = fakeRatko.getCreatedRouteNumberPoints("1.2.3.4.5")
 
@@ -1399,20 +1425,135 @@ constructor(
         }
     }
 
-    private fun insertSomeOfficialReferenceLineFor(
-        trackNumberId: IntId<LayoutTrackNumber>
-    ): LayoutRowVersion<ReferenceLine> {
-        return insertOfficialReferenceLineFromPair(
-            referenceLineAndAlignment(trackNumberId, segment(Point(0.0, 0.0), Point(10.0, 0.0)), draft = false)
+    @Test
+    fun `design publication push fetches plan ID for design`() {
+        val design = testDBService.createDesignBranch()
+        fakeRatko.acceptsNewDesignGivingItId(123)
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("aoeu")),
+        )
+        ratkoService.pushChangesToRatko(design)
+        assertEquals(123, layoutDesignDao.fetch(design.designId).ratkoId?.id)
+    }
+
+    @Test
+    fun `design updates get sent with design publication push`() {
+        val design = testDBService.createDesignBranch()
+        fakeRatko.acceptsNewDesignGivingItId(123)
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("aoeu")),
+        )
+        layoutDesignDao.update(
+            design.designId,
+            LayoutDesignSaveRequest(
+                name = LayoutDesignName("diipa daapa"),
+                estimatedCompletion = LocalDate.parse("2022-02-02"),
+                designState = DesignState.ACTIVE,
+            ),
+        )
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("aoeu")),
+        )
+        ratkoService.pushChangesToRatko(design)
+        layoutDesignDao.update(
+            design.designId,
+            LayoutDesignSaveRequest(
+                name = LayoutDesignName("uuba aaba"),
+                estimatedCompletion = LocalDate.parse("2023-02-02"),
+                designState = DesignState.COMPLETED,
+            ),
+        )
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("aoeu")),
+        )
+        ratkoService.pushChangesToRatko(design)
+        assertEquals(
+            listOf(
+                RatkoPlan(
+                    id = 123,
+                    name = "uuba aaba",
+                    estimatedCompletion = "2023-02-02T12:00Z",
+                    phase = RatkoPlanPhase.RAILWAY_PLAN,
+                    state = RatkoPlanState.COMPLETED,
+                )
+            ),
+            fakeRatko.getUpdatesToDesign(123),
         )
     }
 
-    private fun insertOfficialReferenceLineFromPair(
-        pair: Pair<ReferenceLine, LayoutAlignment>
-    ): LayoutRowVersion<ReferenceLine> {
-        val alignmentVersion = alignmentDao.insert(pair.second)
-        return referenceLineDao.save(pair.first.copy(alignmentVersion = alignmentVersion))
+    @Test
+    fun `multiple pushes don't unnecessarily send updates to design`() {
+        val design = testDBService.createDesignBranch()
+        fakeRatko.acceptsNewDesignGivingItId(123)
+        publishAndPush()
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("aoeu")),
+        )
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("uuba aaba")),
+        )
+        ratkoService.pushChangesToRatko(design)
+        assertEquals(listOf<RatkoPlan>(), fakeRatko.getUpdatesToDesign(123))
     }
+
+    @Test
+    fun `pushing location tracks and switches created in design works`() {
+        val design = testDBService.createDesignBranch()
+        val designDraft = testDBService.testContext(design, PublicationState.DRAFT)
+
+        val trackNumber = establishedTrackNumber("1.1.1.1.1")
+        val switch =
+            designDraft.insert(switch(joints = listOf(LayoutSwitchJoint(JointNumber(1), Point(1.0, 0.0), null)))).id
+        val locationTrack =
+            designDraft
+                .insert(
+                    locationTrack(trackNumber.id),
+                    alignment(
+                        segment(Point(0.0, 0.0), Point(1.0, 0.0)),
+                        segment(Point(1.0, 0.0), Point(10.0, 0.0))
+                            .copy(switchId = switch, startJointNumber = JointNumber(1)),
+                    ),
+                )
+                .id
+        fakeRatko.acceptsNewLocationTrackGivingItOid("2.2.2.2.2")
+        fakeRatko.acceptsNewSwitchGivingItOid("3.3.3.3.3")
+        publicationService.publishManualPublication(
+            design,
+            PublicationRequest(
+                publicationRequestIds(locationTracks = listOf(locationTrack), switches = listOf(switch)),
+                message = FreeTextWithNewLines.of("aoeu"),
+            ),
+        )
+
+        fakeRatko.acceptsNewDesignGivingItId(123)
+        fakeRatko.providesPlanItemIdsInDesign(123)
+        ratkoService.pushChangesToRatko(design)
+        val pushedLocationTrack = fakeRatko.getLastPushedLocationTrack("2.2.2.2.2")
+        val pushedSwitch = fakeRatko.getLastPushedSwitch("3.3.3.3.3")
+        assertTrue(pushedSwitch.isPlanContext)
+        assertEquals(pushedSwitch.planItemIds!![0], switchDao.fetchExternalId(design, switch)?.planItemId?.id)
+        assertTrue(pushedLocationTrack.isPlanContext)
+        assertEquals(
+            pushedLocationTrack.planItemIds!![0],
+            locationTrackDao.fetchExternalId(design, locationTrack)?.planItemId?.id,
+        )
+        assertEquals(listOf<RatkoMetadataAsset>(), fakeRatko.getPushedMetadata(locationTrackOid = "2.2.2.2.2"))
+    }
+
+    private fun insertReferenceLineFor(
+        trackNumberId: IntId<LayoutTrackNumber>,
+        draft: Boolean,
+    ): LayoutRowVersion<ReferenceLine> =
+        (if (draft) mainDraftContext else mainOfficialContext).insert(
+            referenceLine(trackNumberId),
+            alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
+        )
 
     private fun detachSwitchesFromTrack(locationTrackId: IntId<LocationTrack>) {
         val locationTrack = locationTrackDao.getOrThrow(MainLayoutContext.draft, locationTrackId)
@@ -1422,6 +1563,7 @@ constructor(
     }
 
     private fun publishAndPush(
+        branch: LayoutBranch = LayoutBranch.main,
         trackNumbers: List<IntId<LayoutTrackNumber>> = listOf(),
         referenceLines: List<IntId<ReferenceLine>> = listOf(),
         locationTracks: List<IntId<LocationTrack>> = listOf(),
@@ -1436,17 +1578,8 @@ constructor(
                 switches = switches,
                 kmPosts = kmPosts,
             )
-        publicationService.updateExternalId(LayoutBranch.main, ids)
-        val versions = publicationService.getValidationVersions(LayoutBranch.main, ids)
-        val calculatedChanges = publicationService.getCalculatedChanges(versions)
-        publicationService.publishChanges(
-            LayoutBranch.main,
-            versions,
-            calculatedChanges,
-            FreeTextWithNewLines.of(""),
-            PublicationCause.MANUAL,
-        )
-        ratkoService.pushChangesToRatko(LayoutBranch.main)
+        publicationService.publishManualPublication(branch, PublicationRequest(ids, FreeTextWithNewLines.of("")))
+        ratkoService.pushChangesToRatko(branch)
     }
 
     private data class EstablishedTrackNumber(
@@ -1463,7 +1596,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberVersion = layoutTrackNumberDao.save(trackNumber(trackNumber, draft = false))
         trackNumberService.insertExternalId(LayoutBranch.main, trackNumberVersion.id, Oid(oidString))
-        insertSomeOfficialReferenceLineFor(trackNumberVersion.id)
+        insertReferenceLineFor(trackNumberVersion.id, draft = false)
         fakeRatko.hasRouteNumber(ratkoRouteNumber(oidString))
         return EstablishedTrackNumber(
             daoResponse = trackNumberVersion,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/TestRatkoAsset.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/TestRatkoAsset.kt
@@ -34,6 +34,8 @@ data class InterfaceRatkoSwitch(
     val state: RatkoAssetState?,
     val properties: List<RatkoAssetProperty>?,
     val locations: List<RatkoAssetLocation>?,
+    val isPlanContext: Boolean,
+    val planItemIds: List<Int>?,
 )
 
 data class InterfaceRatkoLocationTrack(
@@ -47,6 +49,8 @@ data class InterfaceRatkoLocationTrack(
     val rowMetadata: RatkoMetadata,
     val duplicateOf: String?,
     val topologicalConnectivity: RatkoTopologicalConnectivityType,
+    val isPlanContext: Boolean,
+    val planItemIds: List<Int>?,
 )
 
 data class InterfaceRatkoRouteNumber(
@@ -78,6 +82,7 @@ fun ratkoLocationTrack(
     rowMetadata: RatkoMetadata = RatkoMetadata(),
     duplicateOf: String? = null,
     topologicalConnectivityType: RatkoTopologicalConnectivityType = RatkoTopologicalConnectivityType.NONE,
+    planItemIds: List<Int>? = null,
 ) =
     InterfaceRatkoLocationTrack(
         id,
@@ -90,6 +95,8 @@ fun ratkoLocationTrack(
         rowMetadata,
         duplicateOf,
         topologicalConnectivityType,
+        planItemIds = planItemIds,
+        isPlanContext = planItemIds != null && !planItemIds.isEmpty(),
     )
 
 fun ratkoSwitch(
@@ -98,6 +105,7 @@ fun ratkoSwitch(
     properties: List<RatkoAssetProperty>? = listOf(),
     locations: List<RatkoAssetLocation>? = listOf(),
     assetGeoms: List<InterfaceRatkoAssetGeometry>? = listOf(),
+    planItemIds: List<Int>? = null,
 ): InterfaceRatkoSwitch =
     InterfaceRatkoSwitch(
         id = oid,
@@ -105,4 +113,6 @@ fun ratkoSwitch(
         properties = properties,
         locations = locations,
         assetGeoms = assetGeoms,
+        planItemIds = planItemIds,
+        isPlanContext = planItemIds != null && !planItemIds.isEmpty(),
     )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -65,7 +65,7 @@ constructor(
         val newExternalId = externalIdForTrackNumber()
         trackNumberService.insertExternalId(LayoutBranch.main, trackNumber.id, newExternalId)
 
-        assertEquals(newExternalId, trackNumberDao.fetchExternalId(LayoutBranch.main, trackNumber.id))
+        assertEquals(newExternalId, trackNumberDao.fetchExternalId(LayoutBranch.main, trackNumber.id)?.oid)
     }
 
     @Test


### PR DESCRIPTION
Ei vieläkään ihan kokonainen kokonaisuus, mutta onpahan kohta, jossa sentään Ratko-vienti nyt ainakin lokaalissa testauksessa ihan jopa toimii (vaihteille ja sijaintiraiteille), ja pitempi panttaaminen olisi tehnyt tästä vielä enemmän omegapullarin.

Ratko edustaa suunnitelmatilaisuutta olioilla niin, että:
- Ensiksi luodaan suunnitelma: Vastaava kuin Geoviitteen LayoutDesign
- Suunnitelmaan luodaan planItemeitä, joille Ratko kertoo ID:n. Tämä on jotakuinkin vastaavana käsitettävä operaatio kuin OIDin allokointi, ja siitä syystä planItemId onkin samassa taulussa kuin OID.
- Kullekin suunnitelmaan luotavalle oliolle kerrotaan että isPlanContext: true, ja sen planItemId (tämä tieto menee jostain syystä taulukkoon; en tiedä, mitä tarkoittaisi, jos olioon liittyisi useampi kuin yksi planItemId)

Perusajatukset:

- Meidän kontolle tulee nyt siis kaksi uutta ulkoista ID:tä: Suunnitelmien plan_id, ja suunnitelmaolioiden plan_item_id. Toisin kuin OIDien kanssa, näiden molempien allokoinnit Ratkosta tehdään mahdollisimman myöhään, siis Ratko-puskussa itsessään; mutta samoin kuin OIDeilla, allokoinnit tehdään yksi kerrallaan, ja tallennetaan välittömästi kun ID on saatu.
- Puskemiskelpoista haaraa edustaa luokka PushableLayoutBranch: Kun sellainen on saatu, tiedetään että tätä puskua varten on viety Ratkoon tarvittavat tiedot, että sinne pystyy luomaan olioita tässä haarassa
- Täyttä ulkoista ID:tä edustaa luokka FullRatkoExternalId: Kun sellainen on saatu, tiedetään että tämä olio pystytään ID-tietojen suhteen puskemaan