### PR TITLE
GVT-2964: Enable eslint eqeqeq rule

### DIFF
--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -43,6 +43,7 @@ export default [
             ],
             'react/no-unknown-property': [1, {ignore: ['qa-id', 'qa-resolution']}],
             'react/prop-types': 0,
+            'eqeqeq': ['warn', 'always'],
         },
     },
 ];

--- a/ui/src/api/api-fetch.ts
+++ b/ui/src/api/api-fetch.ts
@@ -71,12 +71,12 @@ export function queryParams(params: Record<string, unknown>): string {
     const stringifiedParameters = Object.keys(params)
         .map((key) => {
             const value = params[key];
-            return value != undefined
+            return value !== undefined && value !== null
                 ? `${key}=${encodeURIComponent(value.toString())}`
                 : undefined;
         })
-        .filter((p) => p != undefined);
-    return stringifiedParameters.length == 0 ? '' : `?${stringifiedParameters.join('&')}`;
+        .filter((p) => p !== undefined);
+    return stringifiedParameters.length === 0 ? '' : `?${stringifiedParameters.join('&')}`;
 }
 
 const wrapApiErrorResponse = Symbol('wrap api error response');

--- a/ui/src/cache/cache.ts
+++ b/ui/src/cache/cache.ts
@@ -32,7 +32,7 @@ export function cache<TKey, TVal>(maxSize?: number): Cache<TKey, TVal> {
         get: (key: TKey) => items.get(key) || undefined,
         getOrCreate: (key: TKey, createNew: () => TVal) => {
             const val = cache.get(key);
-            if (val != undefined) {
+            if (val !== undefined) {
                 hitCount++;
                 return val;
             }
@@ -42,7 +42,7 @@ export function cache<TKey, TVal>(maxSize?: number): Cache<TKey, TVal> {
             return newVal;
         },
         put: (key: TKey, val: TVal) => {
-            while (maxSize != undefined && items.size > maxSize) {
+            while (maxSize !== undefined && items.size > maxSize) {
                 // remove portion of the items
                 cache.removeOldItems(Math.ceil(maxSize * 0.1));
             }
@@ -85,6 +85,7 @@ export function asyncCache<TKey, TVal>(): AsyncCache<TKey, TVal> {
         setChangeTime(changeTime);
         return cache.has(key) ? (cache.get(key) as Promise<TVal>) : put(key, getter());
     };
+
     function getMany<TId>(
         changeTime: TimeStamp | undefined,
         ids: TId[],
@@ -108,7 +109,7 @@ export function asyncCache<TKey, TVal>(): AsyncCache<TKey, TVal> {
     }
 
     function setChangeTime(changeTime: TimeStamp | undefined) {
-        if (changeTime != undefined) {
+        if (changeTime !== undefined) {
             const newChangeTime = toDate(changeTime);
             if (newChangeTime > ownChangeTime) {
                 ownChangeTime = newChangeTime;

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -110,10 +110,11 @@ export const trackMeterIsValid = (trackMeter: string) => TRACK_METER_REGEX.test(
 
 const splitTrackMeterIntoComponents = (trackMeterString: string) => {
     const components = trackMeterString.match(TRACK_METER_REGEX);
+    
     return {
-        kms: components && components[1]?.padStart(4, '0'),
-        letters: components && components[2],
-        meters: components && components[3],
+        kms: components?.[1]?.padStart(4, '0'),
+        letters: components?.[2],
+        meters: components?.[3],
     };
 };
 

--- a/ui/src/data-products/data-products-utils.ts
+++ b/ui/src/data-products/data-products-utils.ts
@@ -55,7 +55,7 @@ export const getLocationTrackOptions = (
         .filter((lt) => !selectedTrack || lt.id !== selectedTrack.id)
         .map((lt) => ({
             name: `${lt.name}, ${
-                descriptions.find((desc) => desc.id == lt.id)?.description ?? '-'
+                descriptions.find((desc) => desc.id === lt.id)?.description ?? '-'
             }`,
             value: lt,
             qaId: `location-track-${lt.id}`,
@@ -67,7 +67,7 @@ export function getVisibleErrorsByProp<T>(
     prop: keyof T,
 ): string[] {
     return committedFields.includes(prop)
-        ? validationIssues.filter((error) => error.field == prop).map((error) => error.reason)
+        ? validationIssues.filter((error) => error.field === prop).map((error) => error.reason)
         : [];
 }
 

--- a/ui/src/data-products/element-list/element-table-item.tsx
+++ b/ui/src/data-products/element-list/element-table-item.tsx
@@ -119,19 +119,19 @@ export const ElementTableItem: React.FC<ElementTableItemProps> = ({
                     {roundToPrecision(length, Precision.measurementMeterDistance)}
                 </td>
                 <td className={styles['data-product-table__column--number']}>
-                    {curveRadiusStart != undefined &&
+                    {curveRadiusStart !== undefined &&
                         roundToPrecision(curveRadiusStart, Precision.radiusMeters)}
                 </td>
                 <td className={styles['data-product-table__column--number']}>
-                    {curveRadiusEnd != undefined &&
+                    {curveRadiusEnd !== undefined &&
                         roundToPrecision(curveRadiusEnd, Precision.radiusMeters)}
                 </td>
                 <td className={styles['data-product-table__column--number']}>
-                    {cantStart != undefined &&
+                    {cantStart !== undefined &&
                         roundToPrecision(cantStart, Precision.cantMillimeters)}
                 </td>
                 <td className={styles['data-product-table__column--number']}>
-                    {cantEnd != undefined && roundToPrecision(cantEnd, Precision.cantMillimeters)}
+                    {cantEnd !== undefined && roundToPrecision(cantEnd, Precision.cantMillimeters)}
                 </td>
                 <td className={styles['data-product-table__column--number']}>
                     {roundToPrecision(angleStart, Precision.angle6Decimals)}

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-table-item.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-table-item.tsx
@@ -107,14 +107,14 @@ export const KilometerLengthTableItem: React.FC<KilometerLengthsTableItemProps> 
                 <td>
                     {!showingPreciseLocation &&
                         hasLayoutLocation &&
-                        layoutGeometrySource == 'IMPORTED' &&
+                        layoutGeometrySource === 'IMPORTED' &&
                         t('data-products.km-lengths.table.imported-warning')}
                     {showingPreciseLocation &&
                         gkLocation?.source === 'FROM_LAYOUT' &&
                         t('data-products.km-lengths.table.imported-warning')}
 
                     {hasLayoutLocation &&
-                        layoutGeometrySource == 'GENERATED' &&
+                        layoutGeometrySource === 'GENERATED' &&
                         t('data-products.km-lengths.table.generated-warning')}
                 </td>
             </tr>

--- a/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
+++ b/ui/src/data-products/kilometer-lengths/kilometer-lengths-view.tsx
@@ -28,7 +28,7 @@ export const KilometerLengthsView = () => {
         ? findIndex(state.endKm, state.kmLengths) + 1
         : state.kmLengths.length;
     const kmLengths =
-        startIndex === 0 && endIndex == state.kmLengths.length
+        startIndex === 0 && endIndex === state.kmLengths.length
             ? state.kmLengths
             : state.kmLengths.slice(startIndex, endIndex);
 

--- a/ui/src/environment/env-restricted.tsx
+++ b/ui/src/environment/env-restricted.tsx
@@ -27,8 +27,8 @@ export const EnvRestricted: React.FC<EnvRestrictedProps> = ({
 
     const show = envName
         ? strict
-            ? envName == restrictTo
-            : slackRestrictionRules[restrictTo].some((e) => e == envName)
+            ? envName === restrictTo
+            : slackRestrictionRules[restrictTo].some((e) => e === envName)
         : defaultShow;
 
     return <React.Fragment>{show && children}</React.Fragment>;

--- a/ui/src/geoviite-design-lib/infra-model-download/infra-model-download-button.tsx
+++ b/ui/src/geoviite-design-lib/infra-model-download/infra-model-download-button.tsx
@@ -27,8 +27,8 @@ export const InfraModelDownloadButton = React.forwardRef<
             preLoadedPlanHeader
                 ? Promise.resolve(preLoadedPlanHeader)
                 : planId
-                  ? getGeometryPlanHeader(planId)
-                  : undefined,
+                ? getGeometryPlanHeader(planId)
+                : undefined,
         [planId, preLoadedPlanHeader],
     );
 
@@ -37,7 +37,7 @@ export const InfraModelDownloadButton = React.forwardRef<
             <Button
                 icon={Icons.Download}
                 onClick={() => {
-                    if (planHeader != undefined) {
+                    if (planHeader !== undefined) {
                         if (planHeader.source === 'PAIKANNUSPALVELU') {
                             setConfirmVisible(true);
                         } else {

--- a/ui/src/geoviite-design-lib/message-box/message-box.tsx
+++ b/ui/src/geoviite-design-lib/message-box/message-box.tsx
@@ -21,7 +21,7 @@ export const MessageBox: React.FC<MessageBoxProps> = ({
 
     const classes = createClassName(
         styles['message-box'],
-        pop != undefined && styles['message-box--poppable'],
+        pop !== undefined && styles['message-box--poppable'],
         pop && styles['message-box--popped'],
         showingError && styles['message-box--error'],
     );

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -196,7 +196,7 @@ const infraModelSlice = createSlice({
             );
             if (
                 !state.committedFields.includes(propEdit.key) &&
-                !state.validationIssues.some((error) => error.field == propEdit.key)
+                !state.validationIssues.some((error) => error.field === propEdit.key)
             ) {
                 // Valid value entered for a field, mark that field as committed
                 state.committedFields = [...state.committedFields, propEdit.key];

--- a/ui/src/infra-model/list/infra-model-list-store.ts
+++ b/ui/src/infra-model/list/infra-model-list-store.ts
@@ -101,7 +101,7 @@ export const infraModelListReducers = {
         state.searchState = 'search';
     },
     onPlanChangeTimeChange: function (state: InfraModelListState) {
-        if (state.searchState == 'idle') state.searchState = 'start';
+        if (state.searchState === 'idle') state.searchState = 'start';
     },
     onPlanFetchError: function (
         state: InfraModelListState,
@@ -116,7 +116,7 @@ export const infraModelListReducers = {
     ) {
         // Accept latest result only
         if (
-            state.searchState == 'search' &&
+            state.searchState === 'search' &&
             objectEquals(params.searchParams, state.searchParams)
         ) {
             state.searchState = 'idle';

--- a/ui/src/infra-model/list/infra-model-search-result-row.tsx
+++ b/ui/src/infra-model/list/infra-model-search-result-row.tsx
@@ -31,7 +31,9 @@ export const InfraModelSearchResultRow: React.FC<InfraModelSearchResultRowProps>
 
     function linkingSummaryDate(planId: GeometryPlanId) {
         const linkingSummary = linkingSummaries.get(planId);
-        return linkingSummary?.linkedAt == undefined ? '' : formatDateFull(linkingSummary.linkedAt);
+        return linkingSummary?.linkedAt === undefined
+            ? ''
+            : formatDateFull(linkingSummary.linkedAt);
     }
 
     const linkingSummaryUsers = (planId: GeometryPlanId) =>

--- a/ui/src/infra-model/list/infra-model-search-result.tsx
+++ b/ui/src/infra-model/list/infra-model-search-result.tsx
@@ -37,8 +37,8 @@ function toggleSortOrder(
             sortOrder === undefined
                 ? GeometrySortOrder.ASCENDING
                 : sortOrder === GeometrySortOrder.ASCENDING
-                  ? GeometrySortOrder.DESCENDING
-                  : undefined;
+                ? GeometrySortOrder.DESCENDING
+                : undefined;
 
         return {
             sortBy: o ? sortBy : GeometrySortBy.NO_SORTING,
@@ -71,7 +71,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
             return;
         }
         getGeometryPlanLinkingSummaries(newPlans).then((plansAndSummaries) => {
-            if (plansAndSummaries == undefined) {
+            if (plansAndSummaries === undefined) {
                 return;
             }
             setLinkingSummaries((currentLinkingSummaries) => {
@@ -99,7 +99,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
     }
 
     function getSortingIcon(): IconComponent {
-        return props.searchParams.sortOrder == GeometrySortOrder.ASCENDING
+        return props.searchParams.sortOrder === GeometrySortOrder.ASCENDING
             ? Icons.Ascending
             : Icons.Descending;
     }
@@ -130,7 +130,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                 </div>
             </div>
             <div className="infra-model-list-search-result__table">
-                <Table wide isLoading={props.searchState != 'idle'}>
+                <Table wide isLoading={props.searchState !== 'idle'}>
                     <thead>
                         <tr>
                             <Th
@@ -157,7 +157,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.FILE_NAME
+                                    props.searchParams.sortBy === GeometrySortBy.FILE_NAME
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -168,7 +168,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.TRACK_NUMBER
+                                    props.searchParams.sortBy === GeometrySortBy.TRACK_NUMBER
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -179,7 +179,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.KM_START
+                                    props.searchParams.sortBy === GeometrySortBy.KM_START
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -190,7 +190,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.KM_END
+                                    props.searchParams.sortBy === GeometrySortBy.KM_END
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -201,7 +201,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.PLAN_PHASE
+                                    props.searchParams.sortBy === GeometrySortBy.PLAN_PHASE
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -212,7 +212,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.DECISION_PHASE
+                                    props.searchParams.sortBy === GeometrySortBy.DECISION_PHASE
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -223,7 +223,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.CREATED_AT
+                                    props.searchParams.sortBy === GeometrySortBy.CREATED_AT
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -234,7 +234,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.UPLOADED_AT
+                                    props.searchParams.sortBy === GeometrySortBy.UPLOADED_AT
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -245,7 +245,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.LINKED_AT
+                                    props.searchParams.sortBy === GeometrySortBy.LINKED_AT
                                         ? getSortingIcon()
                                         : undefined
                                 }
@@ -256,7 +256,7 @@ export const InfraModelSearchResult: React.FC<InfraModelSearchResultProps> = (
                             </Th>
                             <Th
                                 icon={
-                                    props.searchParams.sortBy == GeometrySortBy.LINKED_BY
+                                    props.searchParams.sortBy === GeometrySortBy.LINKED_BY
                                         ? getSortingIcon()
                                         : undefined
                                 }

--- a/ui/src/infra-model/tabs/infra-model-tabs.tsx
+++ b/ui/src/infra-model/tabs/infra-model-tabs.tsx
@@ -34,7 +34,7 @@ const InfraModelTabs: React.FC<TabsProps> = ({ activeTab }) => {
 
     // Handle search plans side effect
     React.useEffect(() => {
-        if (state.searchState == 'start') {
+        if (state.searchState === 'start') {
             infraModelListDelegates.onPlanFetchStart();
             getGeometryPlanHeadersBySearchTerms(
                 state.pageSize,

--- a/ui/src/infra-model/view/form/fields/infra-model-project-field.tsx
+++ b/ui/src/infra-model/view/form/fields/infra-model-project-field.tsx
@@ -21,7 +21,7 @@ export const ProjectDropdown: React.FC<ProjectDropdownProps> = ({
 }) => {
     const { t } = useTranslation();
     const [projects, projectLoaderStatus] = useLoaderWithStatus(getProjects, [id]);
-    return projectLoaderStatus != LoaderStatus.Ready ? (
+    return projectLoaderStatus !== LoaderStatus.Ready ? (
         <Spinner />
     ) : (
         <FieldLayout
@@ -42,7 +42,7 @@ export const ProjectDropdown: React.FC<ProjectDropdownProps> = ({
                             : []
                     }
                     onChange={(projectId) => {
-                        projectId && projectId != id && setProject(projectId);
+                        projectId && projectId !== id && setProject(projectId);
                     }}
                     onAddClick={onAddProject}
                 />

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -101,7 +101,7 @@ function getKmRangePresentation(kmPosts: GeometryKmPost[]): string {
         .map((p) => p.kmNumber)
         .filter(filterNotEmpty)
         .sort((a, b) => a.localeCompare(b));
-    if (sorted.length == 0) return '';
+    if (sorted.length === 0) return '';
     else return `${first(sorted)} - ${last(sorted)}`;
 }
 
@@ -241,7 +241,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
             ? validationIssues
                   .filter(
                       (error) =>
-                          error.field == prop && error.type === FieldValidationIssueType.ERROR,
+                          error.field === prop && error.type === FieldValidationIssueType.ERROR,
                   )
                   .map((error) => {
                       return t(`im-form.${error.reason}`);
@@ -386,7 +386,7 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                                         )}
                                         onChange={(authorId) => {
                                             authorId &&
-                                                authorId != geometryPlan.author?.id &&
+                                                authorId !== geometryPlan.author?.id &&
                                                 changeInOverrideParametersField(
                                                     authorId,
                                                     'authorId',

--- a/ui/src/infra-model/view/infra-model-import-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-import-loader.tsx
@@ -31,7 +31,7 @@ export const InfraModelImportLoader: React.FC<InfraModelImportLoaderProps> = ({ 
         }
     };
     const onValidate: () => void = async () => {
-        if (pvDocumentId && pvDocumentId == initPVDocumentId) {
+        if (pvDocumentId && pvDocumentId === initPVDocumentId) {
             props.setLoading(true);
             await getValidationIssuesForPVDocument(pvDocumentId, overrideParams)
                 .then(props.onValidation)

--- a/ui/src/infra-model/view/infra-model-upload-loader.tsx
+++ b/ui/src/infra-model/view/infra-model-upload-loader.tsx
@@ -50,7 +50,7 @@ export const InfraModelUploadLoader: React.FC<InfraModelUploadLoaderProps> = ({ 
         if (file) {
             props.setSaving(true);
             return await saveInfraModelFile(file, extraParams, overrideParams)
-                .then((response) => response != undefined)
+                .then((response) => response !== undefined)
                 .finally(() => {
                     props.setSaving(false);
                 });

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -65,7 +65,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
           ]
         : [];
     const handleFileMenuItemChange = (item: string) => {
-        if (item == 'fix-encoding') setShowChangeCharsetDialog(true);
+        if (item === 'fix-encoding') setShowChangeCharsetDialog(true);
     };
 
     const onSaveClick = async () => {
@@ -105,8 +105,10 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     };
 
     const fileName = geometryPlan?.fileName || '';
-    const toolbarName = `${isNewPlan && fileName.length > 0 ? `${t('im-form.toolbar.upload')}: ` : ''}${fileName}`;
-    const showMap = props.validationResponse?.planLayout != undefined;
+    const toolbarName = `${
+        isNewPlan && fileName.length > 0 ? `${t('im-form.toolbar.upload')}: ` : ''
+    }${fileName}`;
+    const showMap = props.validationResponse?.planLayout !== undefined;
 
     return (
         <div className={styles['infra-model-upload']}>

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -323,7 +323,7 @@ export type LayoutSwitchSaveRequest = {
 
 export type SwitchRelinkingValidationResult = {
     id: LayoutSwitchId;
-    successfulSuggestion: SwitchRelinkingSuggestion;
+    successfulSuggestion?: SwitchRelinkingSuggestion;
     validationIssues: LayoutValidationIssue[];
 };
 

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -78,8 +78,8 @@ export const linkingReducers = {
         { payload: linkPoint }: PayloadAction<LinkPoint>,
     ): void {
         if (
-            state.linkingState?.type == LinkingType.LinkingAlignment ||
-            state.linkingState?.type == LinkingType.LinkingGeometryWithAlignment
+            state.linkingState?.type === LinkingType.LinkingAlignment ||
+            state.linkingState?.type === LinkingType.LinkingGeometryWithAlignment
         ) {
             state.linkingState.layoutAlignmentInterval = createUpdatedInterval(
                 state.linkingState.layoutAlignmentInterval,
@@ -94,8 +94,8 @@ export const linkingReducers = {
         { payload: linkPoint }: PayloadAction<LinkPoint>,
     ): void {
         if (
-            state.linkingState?.type == LinkingType.LinkingGeometryWithAlignment ||
-            state.linkingState?.type == LinkingType.LinkingGeometryWithEmptyAlignment
+            state.linkingState?.type === LinkingType.LinkingGeometryWithAlignment ||
+            state.linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment
         ) {
             state.linkingState.geometryAlignmentInterval = createUpdatedInterval(
                 state.linkingState.geometryAlignmentInterval,
@@ -110,8 +110,8 @@ export const linkingReducers = {
         { payload: linkPoint }: PayloadAction<LinkPoint>,
     ): void {
         if (
-            state.linkingState?.type == LinkingType.LinkingAlignment ||
-            state.linkingState?.type == LinkingType.LinkingGeometryWithAlignment
+            state.linkingState?.type === LinkingType.LinkingAlignment ||
+            state.linkingState?.type === LinkingType.LinkingGeometryWithAlignment
         ) {
             state.linkingState.layoutAlignmentInterval = createUpdatedInterval(
                 state.linkingState.layoutAlignmentInterval,
@@ -127,8 +127,8 @@ export const linkingReducers = {
         { payload: linkPoint }: PayloadAction<LinkPoint>,
     ): void {
         if (
-            state.linkingState?.type == LinkingType.LinkingGeometryWithAlignment ||
-            state.linkingState?.type == LinkingType.LinkingGeometryWithEmptyAlignment
+            state.linkingState?.type === LinkingType.LinkingGeometryWithAlignment ||
+            state.linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment
         ) {
             state.linkingState.geometryAlignmentInterval = createUpdatedInterval(
                 state.linkingState.geometryAlignmentInterval,
@@ -144,10 +144,10 @@ export const linkingReducers = {
         { payload: linkPoint }: PayloadAction<LinkPoint>,
     ): void {
         if (
-            (state.linkingState?.type == LinkingType.LinkingGeometryWithAlignment ||
-                state.linkingState?.type == LinkingType.LinkingGeometryWithEmptyAlignment) &&
-            (state.linkingState.geometryAlignmentInterval.start?.id == linkPoint.id ||
-                state.linkingState.geometryAlignmentInterval.end?.id == linkPoint.id)
+            (state.linkingState?.type === LinkingType.LinkingGeometryWithAlignment ||
+                state.linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment) &&
+            (state.linkingState.geometryAlignmentInterval.start?.id === linkPoint.id ||
+                state.linkingState.geometryAlignmentInterval.end?.id === linkPoint.id)
         ) {
             state.linkingState.geometryAlignmentInterval = createUpdatedIntervalRemovePoint(
                 state.linkingState.geometryAlignmentInterval,
@@ -162,10 +162,10 @@ export const linkingReducers = {
         { payload: linkPoint }: PayloadAction<LinkPoint>,
     ): void {
         if (
-            (state.linkingState?.type == LinkingType.LinkingAlignment ||
-                state.linkingState?.type == LinkingType.LinkingGeometryWithAlignment) &&
-            (state.linkingState.layoutAlignmentInterval.start?.id == linkPoint.id ||
-                state.linkingState.layoutAlignmentInterval.end?.id == linkPoint.id)
+            (state.linkingState?.type === LinkingType.LinkingAlignment ||
+                state.linkingState?.type === LinkingType.LinkingGeometryWithAlignment) &&
+            (state.linkingState.layoutAlignmentInterval.start?.id === linkPoint.id ||
+                state.linkingState.layoutAlignmentInterval.end?.id === linkPoint.id)
         ) {
             state.linkingState.layoutAlignmentInterval = createUpdatedIntervalRemovePoint(
                 state.linkingState.layoutAlignmentInterval,
@@ -329,7 +329,7 @@ function validateLinkingState(state: LinkingState): LinkingState {
 }
 
 function isSameLinkPoint(p1: LinkPoint, p2: LinkPoint): boolean {
-    return p1.x == p2.x && p1.y == p2.y;
+    return p1.x === p2.x && p1.y === p2.y;
 }
 
 function intervalHasLength(interval: LinkInterval): boolean {
@@ -406,7 +406,7 @@ function isConnectorTooSteep(
         const layoutDirection = layoutPoint.direction;
         const geometryDirection = geometryPoint.direction;
         const connectDirection =
-            direction == 'LayoutToGeometry'
+            direction === 'LayoutToGeometry'
                 ? directionBetweenPoints(layoutPoint, geometryPoint)
                 : directionBetweenPoints(geometryPoint, layoutPoint);
         return (
@@ -420,7 +420,7 @@ function isSharpAngle(
     directionRads1: number | undefined,
     directionRads2: number | undefined,
 ): boolean {
-    if (directionRads1 == undefined || directionRads2 == undefined) return false;
+    if (directionRads1 === undefined || directionRads2 === undefined) return false;
     else return angleDiffRads(directionRads1, directionRads2) > Math.PI / 2;
 }
 

--- a/ui/src/linking/linking-utils.ts
+++ b/ui/src/linking/linking-utils.ts
@@ -37,9 +37,9 @@ export function getLocationTracksEndingAtJoints(
                         // it is considered as an ending alignment.
                         const existsInOtherJoints = joints.some(
                             (otherJoint) =>
-                                otherJoint.number != outerJoint.number &&
+                                otherJoint.number !== outerJoint.number &&
                                 otherJoint.accurateMatches.some(
-                                    (outerMatch) => outerMatch.locationTrackId == locationTrackId,
+                                    (outerMatch) => outerMatch.locationTrackId === locationTrackId,
                                 ),
                         );
                         return !existsInOtherJoints;
@@ -59,7 +59,7 @@ export function getMatchingLocationTrackIdsForJoints(
         return [first(jointsOfAlignment), last(jointsOfAlignment)]
             .filter(filterNotEmpty)
             .every((joint) =>
-                joint.accurateMatches.some((m) => m.locationTrackId == locationTrackId),
+                joint.accurateMatches.some((m) => m.locationTrackId === locationTrackId),
             );
     });
 }
@@ -135,26 +135,23 @@ export function combineLocationTrackIds(
     }
 
     return Object.values(
-        locationTracks.flat().reduce(
-            (acc, locationTrack) => {
-                const jointNumber = locationTrack.jointNumber;
+        locationTracks.flat().reduce((acc, locationTrack) => {
+            const jointNumber = locationTrack.jointNumber;
 
-                if (acc[jointNumber]) {
-                    acc[jointNumber] = {
-                        jointNumber: jointNumber,
-                        locationTrackIds: expectDefined(
-                            acc[jointNumber]?.locationTrackIds
-                                .concat(locationTrack.locationTrackIds)
-                                .filter(filterUnique),
-                        ),
-                    };
-                } else {
-                    acc[jointNumber] = locationTrack;
-                }
+            if (acc[jointNumber]) {
+                acc[jointNumber] = {
+                    jointNumber: jointNumber,
+                    locationTrackIds: expectDefined(
+                        acc[jointNumber]?.locationTrackIds
+                            .concat(locationTrack.locationTrackIds)
+                            .filter(filterUnique),
+                    ),
+                };
+            } else {
+                acc[jointNumber] = locationTrack;
+            }
 
-                return acc;
-            },
-            {} as { [key: JointNumber]: LocationTracksEndingAtJoint },
-        ),
+            return acc;
+        }, {} as { [key: JointNumber]: LocationTracksEndingAtJoint }),
     );
 }

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -60,7 +60,7 @@ const Main: React.FC<MainProps> = (props: MainProps) => {
                     <Route
                         path="/track-layout"
                         element={
-                            props.layoutMode == 'DEFAULT' ? (
+                            props.layoutMode === 'DEFAULT' ? (
                                 <TrackLayoutContainer />
                             ) : (
                                 <PreviewContainer />
@@ -118,7 +118,7 @@ export const MainContainer: React.FC = () => {
     }, []);
 
     React.useEffect(() => {
-        if (typeof versionFromBackend == 'string') {
+        if (typeof versionFromBackend === 'string') {
             delegates.setVersionStatus(
                 !versionInStore || versionInStore === versionFromBackend ? 'ok' : 'reload',
             );
@@ -142,7 +142,7 @@ export const MainContainer: React.FC = () => {
 
     return (
         <React.Fragment>
-            {versionStatus == 'reload' && (
+            {versionStatus === 'reload' && (
                 <Dialog
                     allowClose={false}
                     title={t('version.geoviite-updated')}
@@ -170,7 +170,7 @@ export const MainContainer: React.FC = () => {
                 />
             }
 
-            {versionStatus == 'ok' && <Main {...props} />}
+            {versionStatus === 'ok' && <Main {...props} />}
         </React.Fragment>
     );
 };

--- a/ui/src/map/layers/alignment/alignment-linking-layer.ts
+++ b/ui/src/map/layers/alignment/alignment-linking-layer.ts
@@ -371,7 +371,7 @@ function createPointTagFeature(
     pointType: 'layout' | 'geometry',
 ): Feature<OlPoint> {
     const color =
-        pointType == 'geometry'
+        pointType === 'geometry'
             ? mapStyles.selectedGeometryAlignmentInterval
             : mapStyles.selectedLayoutAlignmentInterval;
 
@@ -379,7 +379,7 @@ function createPointTagFeature(
         geometry: new OlPoint(pointToCoords(point)),
     });
 
-    const showAtLeftSide = pointType == 'geometry';
+    const showAtLeftSide = pointType === 'geometry';
     const rotationByPointDirection = point.direction ? -point.direction + Math.PI / 2 : 0;
     const rotation = rotationByPointDirection + (showAtLeftSide ? Math.PI : 0);
 
@@ -738,7 +738,7 @@ async function getLinkPointsWithAddresses<
     T extends LinkPointContainer,
     TPropertyName extends keyof T,
 >(layoutContext: LayoutContext, layoutAlignment: LayoutAlignmentTypeAndId, points: T): Promise<T> {
-    const trackNumberId = await (layoutAlignment.type == 'LOCATION_TRACK'
+    const trackNumberId = await (layoutAlignment.type === 'LOCATION_TRACK'
         ? getLocationTrack(layoutAlignment.id, draftLayoutContext(layoutContext)).then(
               (locationTrack) => locationTrack?.trackNumberId,
           )
@@ -754,7 +754,7 @@ async function getLinkPointsWithAddresses<
     const promises = propertyNames
         .map((propertyName: TPropertyName) => {
             const originalPoint = points[propertyName];
-            return originalPoint != undefined
+            return originalPoint !== undefined
                 ? // This is commented out for now to re-evaluate the linking tag feature
                   //getAddress(trackNumberId, originalPoint, 'DRAFT')
                   Promise.resolve(undefined).then((address) => ({

--- a/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
@@ -86,7 +86,7 @@ function splitToParts(
             points: pointsForSplit,
         };
 
-        const splitIsFocused = focusedSplits.some((splitInFocus) => splitInFocus == split.id);
+        const splitIsFocused = focusedSplits.some((splitInFocus) => splitInFocus === split.id);
 
         return createAlignmentFeature(
             alignmentPart,
@@ -139,7 +139,7 @@ export function createLocationTrackSplitAlignmentLayer(
     const splittingEnabled = splittingState ? !splittingState.disabled : false;
 
     const alignmentPromise: Promise<AlignmentDataHolder[]> =
-        splittingState != undefined
+        splittingState !== undefined
             ? getSelectedLocationTrackMapAlignmentByTiles(
                   changeTimes,
                   mapTiles,

--- a/ui/src/map/layers/debug/debug-1m-points-layer.ts
+++ b/ui/src/map/layers/debug/debug-1m-points-layer.ts
@@ -34,8 +34,8 @@ function addressPointToDebugData(
 }
 
 function createAddressPointFeatures(data: AlignmentAddresses): Feature<OlPoint>[] {
-    const startColor = data.startIntersect == 'WITHIN' ? 'green' : 'red';
-    const endColor = data.endIntersect == 'WITHIN' ? 'green' : 'red';
+    const startColor = data.startIntersect === 'WITHIN' ? 'green' : 'red';
+    const endColor = data.endIntersect === 'WITHIN' ? 'green' : 'red';
     const debugData = [
         addressPointToDebugData('S', startColor, data.startPoint),
         addressPointToDebugData('E', endColor, data.endPoint),

--- a/ui/src/map/layers/debug/debug-layer.ts
+++ b/ui/src/map/layers/debug/debug-layer.ts
@@ -34,7 +34,7 @@ globalThis.setDebugLayerData = (data: DebugLayerPoint[]) => {
 function createDebugFeatures(points: DebugLayerPoint[]): Feature<OlPoint>[] {
     return points
         .flatMap((point) => {
-            if (point.type == 'point') {
+            if (point.type === 'point') {
                 const feature = new Feature({
                     geometry: new OlPoint(pointToCoords(point)),
                 });

--- a/ui/src/map/layers/geometry/geometry-alignment-layer.ts
+++ b/ui/src/map/layers/geometry/geometry-alignment-layer.ts
@@ -74,7 +74,7 @@ function createAlignmentFeature(
     resolution: number,
 ): Feature<LineString> {
     const isAlignmentSelected = selection.selectedItems.geometryAlignmentIds.find(
-        ({ geometryId }) => geometryId == alignment.header.id,
+        ({ geometryId }) => geometryId === alignment.header.id,
     );
 
     const cacheKey = `${alignment.header.id}-${resolution}-${isAlignmentSelected}-${alignment.linked}`;
@@ -170,7 +170,7 @@ export function createGeometryAlignmentLayer(
         Promise.all(
             plans.map((plan: GeometryPlanLayout) => {
                 const linksPromise: Promise<GeometryAlignmentId[]> =
-                    plan.planDataType == 'TEMP'
+                    plan.planDataType === 'TEMP'
                         ? Promise.resolve([])
                         : getLinkedAlignmentIdsInPlan(plan.id, layoutContext);
                 return linksPromise.then((links) => ({

--- a/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
+++ b/ui/src/map/layers/highlight/duplicate-split-section-highlight-layer.ts
@@ -28,7 +28,7 @@ function createFeatures(
 ): Feature<LineString>[] {
     return alignments
         .flatMap((alignment) => {
-            const duplicate = duplicates.find((duplicate) => duplicate.id == alignment.header.id);
+            const duplicate = duplicates.find((duplicate) => duplicate.id === alignment.header.id);
             const overlappingStartPoint = duplicate?.status.startSplitPoint?.location;
             const overlappingEndPoint = duplicate?.status.endSplitPoint?.location;
             if (
@@ -58,7 +58,7 @@ function createFeatures(
                     const lineString = new LineString(polyline);
                     const feature = new Feature({ geometry: lineString });
 
-                    if (type == 'duplicate') {
+                    if (type === 'duplicate') {
                         if (linkedDuplicates.includes(alignment.header.id)) {
                             feature.setStyle(blueSplitSectionStyle);
                         } else {

--- a/ui/src/map/layers/switch/switch-linking-layer.ts
+++ b/ui/src/map/layers/switch/switch-linking-layer.ts
@@ -68,7 +68,7 @@ export function createSwitchLinkingLayer(
         suggestedSwitches.flatMap((suggestedSwitch) =>
             createSwitchFeatures(
                 suggestedSwitch,
-                selectedSwitches.some((switchToCheck) => switchToCheck.id == suggestedSwitch.id),
+                selectedSwitches.some((switchToCheck) => switchToCheck.id === suggestedSwitch.id),
             ),
         );
 

--- a/ui/src/map/layers/utils/alignment-layer-utils.ts
+++ b/ui/src/map/layers/utils/alignment-layer-utils.ts
@@ -52,7 +52,7 @@ export function getTickStyle(
     );
 
     return new Style({
-        geometry: new OlPoint(position == 'start' ? point1 : point2),
+        geometry: new OlPoint(position === 'start' ? point1 : point2),
         image: image,
         zIndex: style.getZIndex(),
     });
@@ -144,7 +144,7 @@ function includes(selection: ItemCollections, alignment: LayoutAlignmentHeader):
     switch (type) {
         case 'REFERENCE_LINE': {
             const tnId = alignment.trackNumberId;
-            return tnId != undefined && selection.trackNumbers.includes(tnId);
+            return tnId !== undefined && selection.trackNumbers.includes(tnId);
         }
         case 'LOCATION_TRACK': {
             return selection.locationTracks.includes(alignment.id);
@@ -165,9 +165,9 @@ export function getAlignmentHeaderStates(
     const selected = includes(selection.selectedItems, header);
     const highlighted = isHighlighted(selection, header);
     const isLinking = linkingState
-        ? (linkingState.type == LinkingType.LinkingGeometryWithAlignment ||
-              linkingState.type == LinkingType.LinkingAlignment) &&
-          linkingState.layoutAlignment.type == header.alignmentType &&
+        ? (linkingState.type === LinkingType.LinkingGeometryWithAlignment ||
+              linkingState.type === LinkingType.LinkingAlignment) &&
+          linkingState.layoutAlignment.type === header.alignmentType &&
           linkingState.layoutAlignmentInterval.start?.alignmentId === header.id
         : false;
 

--- a/ui/src/map/layers/utils/highlight-layer-utils.ts
+++ b/ui/src/map/layers/utils/highlight-layer-utils.ts
@@ -14,7 +14,7 @@ export function createHighlightFeatures(
 ): Feature<LineString>[] {
     return alignments.flatMap(({ points, header }) => {
         return linkingInfo
-            .filter((h) => h.id === header.id && h.type == header.alignmentType)
+            .filter((h) => h.id === header.id && h.type === header.alignmentType)
             .flatMap(({ ranges }) => {
                 const [firstPoint, lastPoint] = [first(points), last(points)];
                 return ranges

--- a/ui/src/map/layers/utils/layer-utils.ts
+++ b/ui/src/map/layers/utils/layer-utils.ts
@@ -321,6 +321,6 @@ export async function getPlanAndStatus(
     layoutContext: LayoutContext,
 ): Promise<PlanAndStatus | undefined> {
     if (!plan) return undefined;
-    else if (plan.planDataType == 'TEMP') return { plan, status: undefined };
+    else if (plan.planDataType === 'TEMP') return { plan, status: undefined };
     else return getPlanLinkStatus(plan.id, layoutContext).then((status) => ({ plan, status }));
 }

--- a/ui/src/map/layers/utils/switch-layer-utils.ts
+++ b/ui/src/map/layers/utils/switch-layer-utils.ts
@@ -53,7 +53,7 @@ export function getSelectedSwitchLabelRenderer(
     const strokeWidth = valid ? 1 : 2;
     const labelOffset = CIRCLE_RADIUS_SMALL + 4 + strokeWidth * 2;
     const iconSize = 14;
-    const isGeometrySwitch = layoutSwitch.dataType == 'TEMP';
+    const isGeometrySwitch = layoutSwitch.dataType === 'TEMP';
     return getCanvasRenderer(
         layoutSwitch,
         (ctx, { pixelRatio }) => {
@@ -156,7 +156,7 @@ export function getSwitchRenderer(
     const fontSize = large ? TEXT_FONT_LARGE : TEXT_FONT_SMALL;
     const circleRadius = large ? CIRCLE_RADIUS_LARGE : CIRCLE_RADIUS_SMALL;
     const textCirclePadding = 4;
-    const isGeometrySwitch = layoutSwitch.dataType == 'TEMP';
+    const isGeometrySwitch = layoutSwitch.dataType === 'TEMP';
     return getCanvasRenderer(
         layoutSwitch,
         (ctx: CanvasRenderingContext2D, { pixelRatio }: State) => {
@@ -266,8 +266,8 @@ export function suggestedSwitchHasMatchOnJoint(
 ) {
     return Object.values(suggestedSwitch.trackLinks).some(
         (link) =>
-            link.segmentJoints.some((sj) => sj.number == joint) ||
-            link.topologyJoint?.number == joint,
+            link.segmentJoints.some((sj) => sj.number === joint) ||
+            link.topologyJoint?.number === joint,
     );
 }
 
@@ -433,7 +433,7 @@ function createSwitchFeature(
     const firstJoint = expectDefined(first(layoutSwitch.joints));
 
     const presentationJoint = layoutSwitch.joints.find(
-        (joint) => joint.number == presentationJointNumber,
+        (joint) => joint.number === presentationJointNumber,
     );
 
     // Use presentation joint as main joint if possible, otherwise use first joint
@@ -468,7 +468,9 @@ function createSwitchFeature(
                       getSwitchJointStyle(
                           joint,
                           // Again, use presentation joint as main joint if found, otherwise use first one
-                          presentationJoint ? joint.number === presentationJointNumber : index == 0,
+                          presentationJoint
+                              ? joint.number === presentationJointNumber
+                              : index === 0,
                           true,
                           disabled,
                       ),
@@ -481,7 +483,7 @@ function createSwitchFeature(
                               // Again, use presentation joint as main joint if found, otherwise use first one
                               presentationJoint
                                   ? joint.number === presentationJointNumber
-                                  : index == 0,
+                                  : index === 0,
                               false,
                               disabled,
                           ),

--- a/ui/src/map/map-utils.ts
+++ b/ui/src/map/map-utils.ts
@@ -24,7 +24,7 @@ export function calculateMapTiles(view: OlView, tileSizePx: number | undefined):
     const actualResolution = view.getResolution() || first(tileResolutions);
     const tileResolutionIndex = tileResolutions.findIndex(
         (resolution, index) =>
-            (actualResolution && resolution < actualResolution) || index == LAST_RESOLUTION_INDEX,
+            (actualResolution && resolution < actualResolution) || index === LAST_RESOLUTION_INDEX,
     );
     // Use OL tile grid to calc tiles
     const tileGrid = new TileGrid({

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -263,7 +263,7 @@ const MapView: React.FC<MapViewProps> = ({
             const interactions = defaultInteractions();
             //Mouse middle click pan
             interactions.push(
-                new DragPan({ condition: (event) => event.originalEvent.which == 2 }),
+                new DragPan({ condition: (event) => event.originalEvent.which === 2 }),
             );
 
             // use in the browser window.map.getPixelFromCoordinate([x,y])
@@ -314,7 +314,7 @@ const MapView: React.FC<MapViewProps> = ({
         // Without this check the map can get into invalid state if it is
         // quickly panned (moved) back and forth, and surprisingly this
         // happens quite easily in real life.
-        if (map.viewport.source != 'Map') {
+        if (map.viewport.source !== 'Map') {
             olMap.setView(getOlViewByDomainViewport(map.viewport));
         }
     }, [olMap, map.viewport]);

--- a/ui/src/map/tools/highlight-tool.ts
+++ b/ui/src/map/tools/highlight-tool.ts
@@ -12,7 +12,7 @@ export const highlightTool: MapTool = {
                 const hitArea = getDefaultHitArea(map, coordinate);
                 const items = searchItemsFromLayers(hitArea, layers, { limit: 1 });
                 const itemsCompare = JSON.stringify(items);
-                if (currentItemsCompare != itemsCompare) {
+                if (currentItemsCompare !== itemsCompare) {
                     options.onHighlightItems(items);
                     currentItemsCompare = itemsCompare;
                 }

--- a/ui/src/preview/calculated-changes-view.tsx
+++ b/ui/src/preview/calculated-changes-view.tsx
@@ -17,7 +17,7 @@ import { CalculatedChanges } from 'publication/publication-model';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 
 const calculatedChangesIsEmpty = (calculatedChanges: GroupedCalculatedChanges) => {
-    return calculatedChanges.switches.length == 0 && calculatedChanges.locationTracks.length == 0;
+    return calculatedChanges.switches.length === 0 && calculatedChanges.locationTracks.length === 0;
 };
 
 type CalculatedChangesProps = {
@@ -83,7 +83,7 @@ export const CalculatedChangesView: React.FC<CalculatedChangesProps> = ({
                 }));
 
                 const ltChanges: Change[] = locationTrackChanges
-                    .map((ltc) => locationTracks.find((lt) => lt.id == ltc.locationTrackId))
+                    .map((ltc) => locationTracks.find((lt) => lt.id === ltc.locationTrackId))
                     .filter(filterNotEmpty)
                     .map((lt) => ({
                         trackNumberId: lt.trackNumberId,
@@ -96,7 +96,7 @@ export const CalculatedChangesView: React.FC<CalculatedChangesProps> = ({
                         .filter(filterUnique)
                         .map((tn) => ({
                             trackNumberId: tn,
-                            switch: switches.find((s) => s.id == sc.switchId),
+                            switch: switches.find((s) => s.id === sc.switchId),
                         }));
                 });
 
@@ -107,7 +107,7 @@ export const CalculatedChangesView: React.FC<CalculatedChangesProps> = ({
 
                 const calculatedChanges = Object.entries(groupedChanges)
                     .map(([key, changes]) => {
-                        const trackNumber = trackNumbers.find((tn) => tn.id == key);
+                        const trackNumber = trackNumbers.find((tn) => tn.id === key);
                         return trackNumber
                             ? {
                                   trackNumber: trackNumber,
@@ -182,7 +182,7 @@ export const CalculatedChangesView: React.FC<CalculatedChangesProps> = ({
                         </Accordion>
                     );
                 })}
-                {groupedCalculatedChanges.length == 0 && (
+                {groupedCalculatedChanges.length === 0 && (
                     <React.Fragment>{t('preview-view.no-calculated-changes-text')}</React.Fragment>
                 )}
             </div>

--- a/ui/src/preview/change-table-entry-mapping.ts
+++ b/ui/src/preview/change-table-entry-mapping.ts
@@ -109,7 +109,7 @@ export const switchToChangeTableEntry = (
     trackNumbers: LayoutTrackNumber[],
 ) => {
     const trackNumber = trackNumbers
-        .filter((tn) => layoutSwitch.trackNumberIds.some((lstn) => lstn == tn.id))
+        .filter((tn) => layoutSwitch.trackNumberIds.some((lstn) => lstn === tn.id))
         .sort()
         .map((tn) => tn.number)
         .join(', ');

--- a/ui/src/preview/preview-table.tsx
+++ b/ui/src/preview/preview-table.tsx
@@ -157,7 +157,7 @@ const PreviewTable: React.FC<PreviewTableProps> = ({
     const sortedPublicationEntries =
         sortInfo && sortInfo.direction !== SortDirection.UNSORTED
             ? [...publicationTableEntries].sort(
-                  sortInfo.direction == SortDirection.ASCENDING
+                  sortInfo.direction === SortDirection.ASCENDING
                       ? sortInfo.function
                       : negComparator(sortInfo.function),
               )

--- a/ui/src/preview/preview-view-filters.ts
+++ b/ui/src/preview/preview-view-filters.ts
@@ -17,7 +17,7 @@ export const filterByPublicationGroup = (
     publicationGroup: PublicationGroup,
 ): PublicationCandidate[] => {
     return publicationCandidates.filter(
-        (candidate) => candidate.publicationGroup?.id == publicationGroup.id,
+        (candidate) => candidate.publicationGroup?.id === publicationGroup.id,
     );
 };
 

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -175,7 +175,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const [designPublicationMode, setDesignPublicationMode] =
         React.useState<DesignPublicationMode>('PUBLISH_CHANGES');
 
-    const showCalculatedChanges = props.layoutContext.branch == 'MAIN';
+    const showCalculatedChanges = props.layoutContext.branch === 'MAIN';
 
     const onChangeDesignPublicationMode = (newMode: DesignPublicationMode) => {
         setDesignPublicationMode(newMode);
@@ -184,7 +184,7 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     const canRevertChanges =
         props.layoutContext.branch === 'MAIN' || designPublicationMode === 'PUBLISH_CHANGES';
     const canCancelChanges =
-        props.layoutContext.branch !== 'MAIN' && designPublicationMode == 'MERGE_TO_MAIN';
+        props.layoutContext.branch !== 'MAIN' && designPublicationMode === 'MERGE_TO_MAIN';
 
     const [mapDisplayTransitionSide, setMapDisplayTransitionSide] =
         React.useState<MapDisplayTransitionSide>('WITH_CHANGES');
@@ -600,8 +600,8 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
                                     ? officialLayoutContext(props.layoutContext)
                                     : draftMainLayoutContext()
                                 : mapDisplayTransitionSide === 'WITH_CHANGES'
-                                  ? draftLayoutContext(props.layoutContext)
-                                  : officialLayoutContext(props.layoutContext)
+                                ? draftLayoutContext(props.layoutContext)
+                                : officialLayoutContext(props.layoutContext)
                         }
                     />
                 </MapContext.Provider>

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -262,7 +262,7 @@ export const getPublicationsAsTableItems = (
     sortBy?: PublicationDetailsTableSortField,
     order?: SortDirection,
 ) => {
-    const isSorted = order != SortDirection.UNSORTED;
+    const isSorted = order !== SortDirection.UNSORTED;
 
     const params = queryParams({
         from: from ? from.toISOString() : undefined,
@@ -281,7 +281,7 @@ export const getPublicationsCsvUri = (
     sortBy?: PublicationDetailsTableSortField,
     order?: SortDirection,
 ): string => {
-    const isSorted = order != SortDirection.UNSORTED;
+    const isSorted = order !== SortDirection.UNSORTED;
 
     const params = queryParams({
         from: fromDate ? fromDate.toISOString() : undefined,

--- a/ui/src/publication/table/publication-table.tsx
+++ b/ui/src/publication/table/publication-table.tsx
@@ -55,7 +55,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
     const sortedPublicationTableItems =
         sortInfo && sortInfo.direction !== SortDirection.UNSORTED
             ? [...items].sort(
-                  sortInfo.direction == SortDirection.ASCENDING
+                  sortInfo.direction === SortDirection.ASCENDING
                       ? sortInfo.sortFunction
                       : negComparator(sortInfo.sortFunction),
               )

--- a/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
+++ b/ui/src/selection-panel/geometry-plan-panel/geometry-plan-panel.tsx
@@ -209,7 +209,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
     };
 
     const subHeader =
-        planHeader.source == 'PAIKANNUSPALVELU'
+        planHeader.source === 'PAIKANNUSPALVELU'
             ? t(`enum.PlanSource.${planHeader.source}`)
             : undefined;
     return (
@@ -251,7 +251,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         onToggleKmPostVisibility,
                                     ),
                                 )}
-                                {planLayout.kmPosts.length == 0 && (
+                                {planLayout.kmPosts.length === 0 && (
                                     <span className={styles['geometry-plan-panel__no-entities']}>
                                         {t('selection-panel.no-kmposts')}
                                     </span>
@@ -280,7 +280,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         onToggleAlignmentVisibility,
                                     ),
                                 )}
-                                {planLayout.alignments.length == 0 && (
+                                {planLayout.alignments.length === 0 && (
                                     <span className={styles['geometry-plan-panel__no-entities']}>
                                         {t('selection-panel.no-alignments')}
                                     </span>
@@ -309,7 +309,7 @@ export const GeometryPlanPanel: React.FC<GeometryPlanProps> = ({
                                         onToggleSwitchVisibility,
                                     ),
                                 )}
-                                {planLayout.switches.length == 0 && (
+                                {planLayout.switches.length === 0 && (
                                     <span className={styles['geometry-plan-panel__no-entities']}>
                                         {t('selection-panel.no-switches')}
                                     </span>
@@ -340,7 +340,7 @@ function createKmPostRow(
     );
 
     const kmPostStatus = linkStatus?.kmPosts?.some(
-        (k) => k.id == planKmPost.sourceId && k.linkedKmPosts?.length > 0,
+        (k) => k.id === planKmPost.sourceId && k.linkedKmPosts?.length > 0,
     )
         ? KmPostBadgeStatus.LINKED
         : KmPostBadgeStatus.UNLINKED;
@@ -387,7 +387,7 @@ function createAlignmentRow(
     onToggleAlignmentVisibility: (payload: ToggleAlignmentPayload) => void,
 ): React.ReactElement {
     const alignmentStatus = linkStatus?.alignments?.some(
-        (s) => s.id == alignment.header.id && s.isLinked,
+        (s) => s.id === alignment.header.id && s.isLinked,
     )
         ? LocationTrackBadgeStatus.LINKED
         : LocationTrackBadgeStatus.UNLINKED;
@@ -440,7 +440,7 @@ function createSwitchRow(
     onToggleSwitchVisibility: (payload: ToggleSwitchPayload) => void,
 ): React.ReactElement {
     const switchStatus = linkStatus?.switches?.some(
-        (s) => s.id == planSwitch.sourceId && s.isLinked,
+        (s) => s.id === planSwitch.sourceId && s.isLinked,
     )
         ? SwitchBadgeStatus.LINKED
         : SwitchBadgeStatus.UNLINKED;

--- a/ui/src/selection-panel/km-posts-panel/km-posts-panel.tsx
+++ b/ui/src/selection-panel/km-posts-panel/km-posts-panel.tsx
@@ -47,7 +47,7 @@ export const KmPostsPanel: React.FC<KmPostsPanelProps> = ({
             <ol className={styles['km-posts-panel__km-posts']}>
                 {visibleKmPosts.map((kmPost) => {
                     const isSelected = selectedKmPosts?.some(
-                        (selectedPost) => selectedPost == kmPost.id,
+                        (selectedPost) => selectedPost === kmPost.id,
                     );
                     const status = () => {
                         if (disabled) return KmPostBadgeStatus.DISABLED;

--- a/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
+++ b/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
@@ -46,7 +46,7 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
         } else if (sortedLocationTracks.length <= showMoreMax) {
             const indexes =
                 selectedLocationTracks?.map((selectedId) =>
-                    sortedLocationTracks.findIndex((lt) => lt.id == selectedId),
+                    sortedLocationTracks.findIndex((lt) => lt.id === selectedId),
                 ) || [];
 
             if (Math.max(...indexes) >= max) {
@@ -75,7 +75,7 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
                 qa-id="location-tracks-list">
                 {visibleTracks.map((track) => {
                     const isSelected = selectedLocationTracks?.some(
-                        (selectedId) => selectedId == track.id,
+                        (selectedId) => selectedId === track.id,
                     );
                     const itemClassName = createClassName(
                         'location-tracks-panel__location-track',

--- a/ui/src/selection-panel/reference-line-panel/reference-lines-panel.tsx
+++ b/ui/src/selection-panel/reference-line-panel/reference-lines-panel.tsx
@@ -64,14 +64,14 @@ const ReferenceLinesPanel: React.FC<ReferenceLinesPanelProps> = ({
                 qa-id="reference-lines-list">
                 {visibleLines.map((line) => {
                     const isSelected = selectedTrackNumbers?.some(
-                        (selectedId) => selectedId == line.trackNumberId,
+                        (selectedId) => selectedId === line.trackNumberId,
                     );
                     const itemClassName = createClassName(
                         'reference-lines-panel__reference-line',
                         canSelectReferenceLine &&
                             'reference-lines-panel__reference-line--can-select',
                     );
-                    const trackNumber = trackNumbers?.find((tn) => tn.id == line.trackNumberId);
+                    const trackNumber = trackNumbers?.find((tn) => tn.id === line.trackNumberId);
                     const status = () => {
                         if (disabled) return ReferenceLineBadgeStatus.DISABLED;
                         else if (isSelected) return ReferenceLineBadgeStatus.SELECTED;

--- a/ui/src/selection-panel/selection-panel-geometry-section.tsx
+++ b/ui/src/selection-panel/selection-panel-geometry-section.tsx
@@ -123,7 +123,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                     visibleSources,
                     selectedTrackNumbers,
                     undefined,
-                    grouping == GeometryPlanGrouping.ByProject
+                    grouping === GeometryPlanGrouping.ByProject
                         ? GeometrySortBy.PROJECT_NAME
                         : GeometrySortBy.NAME,
                     GeometrySortOrder.ASCENDING,
@@ -197,17 +197,17 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
     };
 
     const visibleProjectIds = planHeadersDisplayableInPanel
-        .filter((plan) => visiblePlans.some((visiblePlan) => visiblePlan.id == plan.id))
+        .filter((plan) => visiblePlans.some((visiblePlan) => visiblePlan.id === plan.id))
         .map((plan) => plan.project.id)
         .filter(filterUnique);
 
     function setProjectVisibility(projectId: ProjectId, newVisibility: boolean) {
         const projectPlans = planHeadersDisplayableInPanel.filter(
-            (plan) => plan.project.id == projectId,
+            (plan) => plan.project.id === projectId,
         );
         if (!newVisibility) {
             const visibleProjectPlans = visiblePlansInView.filter((visiblePlan) =>
-                projectPlans.some((projectPlan) => projectPlan.id == visiblePlan.id),
+                projectPlans.some((projectPlan) => projectPlan.id === visiblePlan.id),
             );
             visibleProjectPlans.forEach(onTogglePlanVisibility);
         } else {
@@ -227,7 +227,7 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
 
                 <GeometryPlanFilterMenuContainer />
                 <Eye
-                    disabled={disabled || planHeadersDisplayableInPanel.length == 0}
+                    disabled={disabled || planHeadersDisplayableInPanel.length === 0}
                     onVisibilityToggle={toggleAllPlanVisibilities}
                     visibility={visiblePlansInView.length > 0}
                 />
@@ -237,12 +237,12 @@ const SelectionPanelGeometrySection: React.FC<GeometryPlansPanelProps> = ({
                     styles['selection-panel__content'],
                     styles['selection-panel__content--unpadded'],
                 )}>
-                {planHeadersDisplayableInPanel.length == planHeaderCount &&
+                {planHeadersDisplayableInPanel.length === planHeaderCount &&
                     planHeadersDisplayableInPanel.map((h, index, allPlans) => {
                         const isSameAsPrevProject =
                             h.project.id === allPlans[index - 1]?.project?.id;
                         const showProjectRow =
-                            grouping == GeometryPlanGrouping.ByProject && !isSameAsPrevProject;
+                            grouping === GeometryPlanGrouping.ByProject && !isSameAsPrevProject;
                         const projectIsVisible = visibleProjectIds.includes(h.project.id);
                         return (
                             <React.Fragment key={h.id}>

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -197,7 +197,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     }, [changeTimes.layoutTrackNumber, visibleTrackNumberIds.join()]);
 
     const filterByTrackNumberId = (tn: LayoutTrackNumberId) =>
-        selectedTrackNumberIds.length == 0 || selectedTrackNumberIds.some((s) => s === tn);
+        selectedTrackNumberIds.length === 0 || selectedTrackNumberIds.some((s) => s === tn);
 
     const filteredLocationTracks = locationTracks.filter((a) =>
         filterByTrackNumberId(a.trackNumberId),

--- a/ui/src/selection-panel/switch-panel/switch-panel.tsx
+++ b/ui/src/selection-panel/switch-panel/switch-panel.tsx
@@ -33,7 +33,7 @@ const SwitchPanel: React.FC<SwitchPanelProps> = ({
             <ol className={styles['switch-panel__switches']}>
                 {switches.length <= max &&
                     sortedSwitches.map((switchItem) => {
-                        const isSelected = selectedSwitches?.some((p) => p == switchItem.id);
+                        const isSelected = selectedSwitches?.some((p) => p === switchItem.id);
                         return (
                             <li key={switchItem.id}>
                                 <SwitchBadge

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
@@ -37,7 +37,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
     React.useEffect(() => {
         const visibleTrackNumbers =
             trackNumbers.length > max && selectedTrackNumbers.length
-                ? trackNumbers.filter((tn) => selectedTrackNumbers.some((stn) => stn == tn.id))
+                ? trackNumbers.filter((tn) => selectedTrackNumbers.some((stn) => stn === tn.id))
                 : [...trackNumbers];
 
         setSortedTrackNumbers(visibleTrackNumbers.sort(fieldComparator((tn) => tn.number)));
@@ -52,7 +52,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
             {sortedTrackNumbers.length <= max && (
                 <ol className={styles['track-number-panel__track-numbers']}>
                     {sortedTrackNumbers.map((trackNumber) => {
-                        const isSelected = selectedTrackNumbers?.some((s) => s == trackNumber.id);
+                        const isSelected = selectedTrackNumbers?.some((s) => s === trackNumber.id);
                         return (
                             <li className={trackNumberClassNames} key={trackNumber.id}>
                                 <div>

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -59,7 +59,7 @@ function getNewIdCollection<TId extends string>(
 ): TId[] {
     // Default to not modifying selection if newItems isn't provided.
     // The isExactSelection flag being set is a special case. Empty selections should be respected then
-    if (newIds == undefined) return ids;
+    if (newIds === undefined) return ids;
 
     if (flags.isIncremental) {
         return deduplicate([...newIds, ...ids]);
@@ -125,14 +125,14 @@ function getNewItemCollectionUsingCustomId<TEntity, TId>(
     flags: OnSelectFlags,
     getId: (item: TEntity) => TId,
 ): TEntity[] {
-    if (newItems == undefined) {
+    if (newItems === undefined) {
         return items;
     }
 
     if (flags.isIncremental) {
         return [...newItems, ...items].filter(filterUniqueById(getId));
     } else if (flags.isToggle) {
-        return newItems.filter((newItem) => !items.find((item) => getId(item) == getId(newItem)));
+        return newItems.filter((newItem) => !items.find((item) => getId(item) === getId(newItem)));
     } else {
         return newItems;
     }

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -187,7 +187,7 @@ async function getOptions(
 
     const locationTrackOptions = searchResult.locationTracks.map((locationTrack) => {
         const description =
-            locationTrackDescriptions?.find((d) => d.id == locationTrack.id)?.description ?? '';
+            locationTrackDescriptions?.find((d) => d.id === locationTrack.id)?.description ?? '';
 
         return createLocationTrackOptionItem(locationTrack, description);
     });
@@ -567,7 +567,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         </PrivilegeRequired>
                     )}
                 </div>
-                {layoutContext.publicationState == 'DRAFT' && (
+                {layoutContext.publicationState === 'DRAFT' && (
                     <PrivilegeRequired privilege={EDIT_LAYOUT}>
                         <Button
                             disabled={!canEnterPreview}

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -44,7 +44,7 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
     const visiblePlans = useTrackLayoutAppSelector((state) => state.selection.visiblePlans);
 
     function isVisible(planId: GeometryPlanId) {
-        return visiblePlans.some((plan) => plan.id == planId);
+        return visiblePlans.some((plan) => plan.id === planId);
     }
 
     function togglePlanVisibility(

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
@@ -170,7 +170,7 @@ export const GeometryAlignmentLinkingReferenceLineCandidates: React.FC<
     }, [selectedLayoutReferenceLine, referenceLines]);
 
     React.useEffect(() => {
-        const ref = referenceLineRefs.find((r) => r.id == selectedLayoutReferenceLine?.id);
+        const ref = referenceLineRefs.find((r) => r.id === selectedLayoutReferenceLine?.id);
 
         if (ref) {
             ref.ref.current?.scrollIntoView({
@@ -181,8 +181,8 @@ export const GeometryAlignmentLinkingReferenceLineCandidates: React.FC<
     }, [selectedLayoutReferenceLine]);
 
     const referenceLineElements = referenceLines?.map((line) => {
-        const isSelected = line.id == selectedLayoutReferenceLine?.id;
-        const ref = referenceLineRefs.find((r) => r.id == line.id);
+        const isSelected = line.id === selectedLayoutReferenceLine?.id;
+        const ref = referenceLineRefs.find((r) => r.id === line.id);
         const trackNumber = trackNumbers?.find((tn) => tn.id === line.trackNumberId);
 
         const trackNumberExists = ref && trackNumber;
@@ -330,7 +330,7 @@ export const GeometryAlignmentLinkingLocationTrackCandidates: React.FC<
     }, [selectedLayoutLocationTrack, locationTracks]);
 
     React.useEffect(() => {
-        const ref = locationTrackRefs.find((r) => r.id == selectedLayoutLocationTrack?.id);
+        const ref = locationTrackRefs.find((r) => r.id === selectedLayoutLocationTrack?.id);
         if (ref) {
             ref.ref.current?.scrollIntoView({
                 behavior: 'smooth',
@@ -340,8 +340,8 @@ export const GeometryAlignmentLinkingLocationTrackCandidates: React.FC<
     }, [selectedLayoutLocationTrack]);
 
     const locationTrackElements = locationTracks?.map((track) => {
-        const isSelected = track.id == selectedLayoutLocationTrack?.id;
-        const ref = locationTrackRefs.find((r) => r.id == track.id);
+        const isSelected = track.id === selectedLayoutLocationTrack?.id;
+        const ref = locationTrackRefs.find((r) => r.id === track.id);
 
         const alignmentExists = ref;
         const hasSearchInput = layoutLocationTrackSearchInput.length > 0;
@@ -417,7 +417,7 @@ export const GeometryAlignmentLinkingLocationTrackCandidates: React.FC<
 
                 {isLoading && <Spinner />}
 
-                {!isLoading && displayedLocationTrackElementsAmount == 0 && (
+                {!isLoading && displayedLocationTrackElementsAmount === 0 && (
                     <span className={styles['geometry-alignment-infobox__no-matches']}>
                         {t('tool-panel.alignment.geometry.no-linkable-location-tracks')}
                     </span>

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -193,7 +193,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
 
     const canLink =
         !linkingCallInProgress &&
-        linkingState?.state == 'allSet' &&
+        linkingState?.state === 'allSet' &&
         !selectedLocationTrackInfoboxExtras?.partOfUnfinishedSplit;
 
     const canLockAlignment =
@@ -232,6 +232,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
             ? LinkingType.LinkingGeometryWithAlignment
             : LinkingType.LinkingGeometryWithEmptyAlignment;
     }
+
     function lockAlignment() {
         if (linkingAlignmentType === 'LOCATION_TRACK' && selectedLayoutLocationTrack) {
             onLockAlignment({
@@ -264,7 +265,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                 const linkingParameters =
                     createLinkingGeometryWithAlignmentParameters(linkingState);
 
-                await (linkingState.layoutAlignment.type == 'LOCATION_TRACK'
+                await (linkingState.layoutAlignment.type === 'LOCATION_TRACK'
                     ? linkGeometryWithLocationTrack(layoutContext.branch, linkingParameters)
                     : linkGeometryWithReferenceLine(layoutContext.branch, linkingParameters));
 
@@ -273,10 +274,10 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                 );
 
                 onStopLinking();
-            } else if (linkingState?.type == LinkingType.LinkingGeometryWithEmptyAlignment) {
+            } else if (linkingState?.type === LinkingType.LinkingGeometryWithEmptyAlignment) {
                 const linkingParameters =
                     createLinkingGeometryWithEmptyAlignmentParameters(linkingState);
-                await (linkingState.layoutAlignment.type == 'LOCATION_TRACK'
+                await (linkingState.layoutAlignment.type === 'LOCATION_TRACK'
                     ? linkGeometryWithEmptyLocationTrack(layoutContext.branch, linkingParameters)
                     : linkGeometryWithEmptyReferenceLine(layoutContext.branch, linkingParameters));
 

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -102,7 +102,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
     const debouncedKmNumber = useDebouncedState(state.kmPost?.kmNumber, 300);
     const firstInputRef = React.useRef<HTMLInputElement>(null);
     const [nonDraftDeleteConfirmationVisible, setNonDraftDeleteConfirmationVisible] =
-        React.useState<boolean>(state.kmPost?.state == 'DELETED');
+        React.useState<boolean>(state.kmPost?.state === 'DELETED');
     const [draftDeleteConfirmationVisible, setDraftDeleteConfirmationVisible] =
         React.useState<boolean>();
     const trackNumbers = useTrackNumbersIncludingDeleted(
@@ -209,7 +209,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
     function getVisibleErrorsByProp(prop: keyof KmPostEditFields) {
         return state.allFieldsCommitted || state.committedFields.includes(prop)
             ? state.validationIssues
-                  .filter((issue) => issue.field == prop && issue.type === 'ERROR')
+                  .filter((issue) => issue.field === prop && issue.type === 'ERROR')
                   .map((issue) => t(`km-post-dialog.${issue.reason}`))
             : [];
     }
@@ -217,7 +217,7 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
     function getVisibleWarningsByProp(prop: keyof KmPostEditFields) {
         return state.allFieldsCommitted || state.committedFields.includes(prop)
             ? state.validationIssues
-                  .filter((issue) => issue.field == prop && issue.type === 'WARNING')
+                  .filter((issue) => issue.field === prop && issue.type === 'WARNING')
                   .map((issue) => t(`km-post-dialog.${issue.reason}`))
             : [];
     }
@@ -336,8 +336,8 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                                     wide
                                     searchable
                                     disabled={
-                                        props.prefilledTrackNumberId != undefined ||
-                                        props.kmPostId != undefined
+                                        props.prefilledTrackNumberId !== undefined ||
+                                        props.kmPostId !== undefined
                                     }
                                 />
                             }

--- a/ui/src/tool-panel/km-post/geometry-km-post-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-infobox-linking-container.tsx
@@ -48,7 +48,7 @@ const GeometryKmPostLinkingContainer: React.FC<GeometryKmPostLinkingContainerPro
             layoutKmPost={selectedLayoutKmPost}
             kmPostChangeTime={kmPostChangeTime}
             linkingState={
-                state.linkingState?.type == LinkingType.LinkingKmPost
+                state.linkingState?.type === LinkingType.LinkingKmPost
                     ? state.linkingState
                     : undefined
             }

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -72,7 +72,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
     const linkedLayoutKmPosts = useLoader(() => {
         if (!planStatus) return undefined;
         const kmPostIds = planStatus.kmPosts
-            .filter((linkStatus) => linkStatus.id == geometryKmPost.sourceId)
+            .filter((linkStatus) => linkStatus.id === geometryKmPost.sourceId)
             .flatMap((linkStatus) => linkStatus.linkedKmPosts);
         return getKmPosts(kmPostIds, layoutContext).then((posts) => posts.filter(filterNotEmpty));
     }, [planStatus, geometryKmPost.sourceId]);
@@ -142,7 +142,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                         qaId="geometry-km-post-linked"
                         label={t('tool-panel.km-post.geometry.linking.is-linked-label')}
                         value={
-                            linkedLayoutKmPosts != undefined && (
+                            linkedLayoutKmPosts !== undefined && (
                                 <LinkingStatusLabel isLinked={linkedLayoutKmPosts?.length > 0} />
                             )
                         }
@@ -242,11 +242,11 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                                                 kmPost={layoutKmPostOption}
                                                 trackNumber={trackNumbers?.find(
                                                     (tn) =>
-                                                        tn.id == layoutKmPostOption.trackNumberId,
+                                                        tn.id === layoutKmPostOption.trackNumberId,
                                                 )}
                                                 showTrackNumberInBadge={true}
                                                 status={
-                                                    layoutKmPostOption.id == layoutKmPost?.id
+                                                    layoutKmPostOption.id === layoutKmPost?.id
                                                         ? KmPostBadgeStatus.SELECTED
                                                         : KmPostBadgeStatus.DEFAULT
                                                 }

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -116,7 +116,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         LayoutLocationTrack | undefined
     >(undefined);
     const [nonDraftDeleteConfirmationVisible, setNonDraftDeleteConfirmationVisible] =
-        React.useState<boolean>(state.locationTrack?.state == 'DELETED');
+        React.useState<boolean>(state.locationTrack?.state === 'DELETED');
     const [draftDeleteConfirmationVisible, setDraftDeleteConfirmationVisible] =
         React.useState<boolean>();
     const [locationTrackDescriptionSuffixMode, setLocationTrackDescriptionSuffixMode] =
@@ -274,7 +274,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     function getVisibleErrorsByProp(prop: keyof LocationTrackSaveRequest) {
         return state.allFieldsCommitted || state.committedFields.includes(prop)
             ? state.validationIssues
-                  .filter((issue) => issue.field == prop)
+                  .filter((issue) => issue.field === prop)
                   .map((issue) => t(`location-track-dialog.${issue.reason}`))
             : [];
     }

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -80,8 +80,9 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
     const { t } = useTranslation();
 
     const locationTrackOwners = useLoader(() => getLocationTrackOwners(), []);
+
     function getLocationTrackOwnerName(ownerId: LocationTrackOwnerId) {
-        const name = locationTrackOwners?.find((o) => o.id == ownerId)?.name;
+        const name = locationTrackOwners?.find((o) => o.id === ownerId)?.name;
         return name ?? '-';
     }
 
@@ -123,7 +124,7 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
 
     return (
         <Infobox
-            contentVisible={visibilities.basic && extraInfoLoadingStatus != LoaderStatus.Loading}
+            contentVisible={visibilities.basic && extraInfoLoadingStatus !== LoaderStatus.Loading}
             onContentVisibilityChange={() => visibilityChange('basic')}
             title={t('tool-panel.location-track.basic-info-heading')}
             onEdit={openEditLocationTrackDialog}
@@ -175,8 +176,8 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                         locationTrack.duplicateOf
                             ? t('tool-panel.location-track.duplicate-of')
                             : extraInfo?.duplicates?.length ?? 0 > 0
-                              ? t('tool-panel.location-track.has-duplicates')
-                              : t('tool-panel.location-track.not-a-duplicate')
+                            ? t('tool-panel.location-track.has-duplicates')
+                            : t('tool-panel.location-track.not-a-duplicate')
                     }
                     value={
                         <LocationTrackInfoboxDuplicateOf

--- a/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
@@ -79,7 +79,7 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
                     indicator={ProgressIndicatorType.Area}
                     inProgress={elementFetchStatus !== LoaderStatus.Ready}
                     inline={false}>
-                    {sections && sections.length == 0 ? (
+                    {sections && sections.length === 0 ? (
                         <p className={'infobox__text'}>
                             {t(
                                 'tool-panel.alignment-plan-sections.no-geometries-for-location-track',

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
@@ -136,7 +136,7 @@ function validateIsPartialDuplicate(
     const isPartialDuplicate = duplicate.duplicateStatus.match === 'PARTIAL';
     const overLappingLength = duplicate.duplicateStatus.overlappingLength;
     const nonOverlappingLength =
-        (overLappingLength != undefined && duplicate.length - overLappingLength) || undefined;
+        (overLappingLength !== undefined && duplicate.length - overLappingLength) || undefined;
     if (
         isPartialDuplicate &&
         overLappingLength !== undefined &&
@@ -161,12 +161,12 @@ function validateHasShortNonOverlappingLength(
 ): LocationTrackDuplicateNotice | undefined {
     const overLappingLength = duplicate.duplicateStatus.overlappingLength;
     const nonOverlappingLength =
-        (overLappingLength != undefined && duplicate.length - overLappingLength) || undefined;
+        (overLappingLength !== undefined && duplicate.length - overLappingLength) || undefined;
     const shortNonOverlappingLength =
-        nonOverlappingLength != undefined &&
+        nonOverlappingLength !== undefined &&
         nonOverlappingLength <
             PARTIAL_DUPLICATE_EXPECTED_MINIMUM_NON_OVERLAPPING_PART_LENGTH_METERS;
-    if (shortNonOverlappingLength && nonOverlappingLength != undefined) {
+    if (shortNonOverlappingLength && nonOverlappingLength !== undefined) {
         return {
             translationKey: 'tool-panel.location-track.short-non-overlapping-length-warning',
             translationParams: {

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -76,6 +76,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
         setShowEditDialog(true);
         onDataChange();
     }
+
     function closeEditLocationTrackDialog() {
         setShowEditDialog(false);
         onDataChange();
@@ -164,7 +165,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 />
             )}
 
-            {layoutContext.branch == 'MAIN' && showRatkoPushDialog && (
+            {layoutContext.branch === 'MAIN' && showRatkoPushDialog && (
                 <LocationTrackRatkoPushDialog
                     layoutContext={layoutContext}
                     locationTrackId={locationTrack.id}

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -231,7 +231,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                 ) {
                     const switches = splitInitializationParameters?.switches || [];
                     const getSwitchName = (switchId: LayoutSwitchId) =>
-                        switches.find((sw) => sw.switchId == switchId)?.name;
+                        switches.find((sw) => sw.switchId === switchId)?.name;
                     const endPointTerm = t('tool-panel.location-track.splitting.endpoint');
                     const noNameErrorTerm = 'ERROR: no name';
                     const startSplitPointName =

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -105,7 +105,7 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
             locationTrackId,
         );
         const switchIds = relinkingResults
-            .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion === null)
+            .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion === undefined)
             .map((s) => s.id);
         const switches = await getSwitches(switchIds, draftLayoutContext(layoutContext));
 

--- a/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
+++ b/ui/src/tool-panel/location-track/location-track-task-list/location-track-task-list-container.tsx
@@ -68,7 +68,7 @@ export const LocationTrackTaskListContainer: React.FC = () => {
     }, [layoutContext.branch, layoutContext.publicationState]);
 
     return createPortal(
-        locationTrackList?.type == LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION ? (
+        locationTrackList?.type === LocationTrackTaskListType.RELINKING_SWITCH_VALIDATION ? (
             <SwitchRelinkingValidationTaskList
                 layoutContext={layoutContext}
                 locationTrackId={locationTrackList.locationTrackId}
@@ -105,7 +105,7 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
             locationTrackId,
         );
         const switchIds = relinkingResults
-            .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion == null)
+            .filter((r) => r.validationIssues.length > 0 || r.successfulSuggestion === null)
             .map((s) => s.id);
         const switches = await getSwitches(switchIds, draftLayoutContext(layoutContext));
 
@@ -119,7 +119,7 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
 
     const onClick = (layoutSwitch: LayoutSwitch) => {
         const presJointNumber = switchStructures?.find(
-            (s) => s.id == layoutSwitch.switchStructureId,
+            (s) => s.id === layoutSwitch.switchStructureId,
         )?.presentationJointNumber;
 
         const switchLocation = presJointNumber
@@ -130,8 +130,8 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
     };
 
     const loadingInProgress =
-        locationTrackLoadingStatus == LoaderStatus.Loading ||
-        switchesLoadingStatus == LoaderStatus.Loading;
+        locationTrackLoadingStatus === LoaderStatus.Loading ||
+        switchesLoadingStatus === LoaderStatus.Loading;
 
     return (
         <div className={styles['switch-relinking-validation-task-list']}>
@@ -160,9 +160,9 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                         </span>
                         <ul className={styles['switch-relinking-validation-task-list__switches']}>
                             {switches.map((lSwitch) => {
-                                const selected = selectedSwitches.some((sId) => sId == lSwitch.id);
+                                const selected = selectedSwitches.some((sId) => sId === lSwitch.id);
                                 const switchRelinkingResult = relinkingResults?.find(
-                                    (e) => e.id == lSwitch.id,
+                                    (e) => e.id === lSwitch.id,
                                 );
 
                                 const errors =
@@ -207,7 +207,7 @@ const SwitchRelinkingValidationTaskList: React.FC<SwitchRelinkingValidationTaskL
                         </ul>
                     </React.Fragment>
                 )}
-                {!loadingInProgress && switches && switches.length == 0 && (
+                {!loadingInProgress && switches && switches.length === 0 && (
                     <div
                         className={
                             styles['switch-relinking-validation-task-list__message-container']

--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -122,7 +122,7 @@ const findDuplicateStartingAt = (duplicates: SplitDuplicateTrack[], splitPoint: 
     return duplicates.find((duplicate) => {
         const duplicateSplitPoint = duplicate.status.startSplitPoint;
         return (
-            duplicateSplitPoint != undefined && splitPointsAreSame(splitPoint, duplicateSplitPoint)
+            duplicateSplitPoint !== undefined && splitPointsAreSame(splitPoint, duplicateSplitPoint)
         );
     });
 };
@@ -133,7 +133,7 @@ export function getAllowedSwitchesFromState(state: SplittingState) {
     const endSwitchId =
         state.endSplitPoint.type === 'SWITCH_SPLIT_POINT' && state.endSplitPoint.switchId;
     return state.trackSwitches.filter(
-        (sw) => sw.switchId != startSwitchId && sw.switchId != endSwitchId,
+        (sw) => sw.switchId !== startSwitchId && sw.switchId !== endSwitchId,
     );
 }
 
@@ -319,7 +319,7 @@ export const splitReducers = {
                         ? undefined
                         : state.splittingState.highlightedSplit,
                 highlightedSplitPoint:
-                    splitPoint == state.splittingState.highlightedSplitPoint
+                    splitPoint === state.splittingState.highlightedSplitPoint
                         ? undefined
                         : state.splittingState.highlightedSplitPoint,
             };
@@ -492,11 +492,11 @@ function getNameForTarget(
                 ? getLocationTrackName(startSwitch.name, endSwitch.name)
                 : '',
         descriptionBase:
-            startSwitch != undefined &&
-            startSwitch.nearestOperatingPoint != undefined &&
-            endSwitch != undefined &&
-            endSwitch.nearestOperatingPoint != undefined &&
-            startSwitch.nearestOperatingPoint.name != endSwitch.nearestOperatingPoint.name
+            startSwitch !== undefined &&
+            startSwitch.nearestOperatingPoint !== undefined &&
+            endSwitch !== undefined &&
+            endSwitch.nearestOperatingPoint !== undefined &&
+            startSwitch.nearestOperatingPoint.name !== endSwitch.nearestOperatingPoint.name
                 ? getLocationTrackDescription(
                       startSwitch.nearestOperatingPoint,
                       endSwitch.nearestOperatingPoint,

--- a/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
@@ -41,7 +41,7 @@ export const LocationTrackSplitRelinkingNotice: React.FC<
                         </div>
                     </MessageBox>
                 )}
-            {switchRelinkingLoadingState == LoaderStatus.Loading && (
+            {switchRelinkingLoadingState === LoaderStatus.Loading && (
                 <MessageBox>
                     <span className={styles['location-track-infobox__validate-switch-relinking']}>
                         {t('tool-panel.location-track.splitting.validation-in-progress')}

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -153,12 +153,12 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
         split.descriptionBase !== '',
     );
     const startSwitchMatchingError = switchIssues.find(
-        (error) => error.reason == START_SPLIT_POINT_NOT_MATCHING_ERROR,
+        (error) => error.reason === START_SPLIT_POINT_NOT_MATCHING_ERROR,
     );
     const endSwitchMatchingError = switchIssues.find(
-        (error) => error.reason == END_SPLIT_POINT_NOT_MATCHING_ERROR,
+        (error) => error.reason === END_SPLIT_POINT_NOT_MATCHING_ERROR,
     );
-    const duplicate = allDuplicateLocationTracks.find((d) => d.id == split.duplicateTrackId);
+    const duplicate = allDuplicateLocationTracks.find((d) => d.id === split.duplicateTrackId);
 
     // TODO: Adding any kind of dependency array causes infinite re-render loops, find out why
     React.useEffect(() => {
@@ -173,18 +173,18 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     const nameErrorsVisible = nameCommitted && nameIssues.length > 0;
     const descriptionErrorsVisible = descriptionCommitted && descriptionIssues.length > 0;
 
-    const isPartialDuplicate = split.duplicateStatus?.match == 'PARTIAL';
+    const isPartialDuplicate = split.duplicateStatus?.match === 'PARTIAL';
     const duplicateLength = duplicate?.length;
     const overlappingDuplicateLength = split.duplicateStatus?.overlappingLength;
     const nonOverlappingDuplicateLength =
         (duplicateLength !== undefined &&
-            overlappingDuplicateLength != undefined &&
+            overlappingDuplicateLength !== undefined &&
             duplicateLength - overlappingDuplicateLength) ||
         undefined;
 
     const isShortNonOverlappingDuplicateLength =
         isPartialDuplicate &&
-        nonOverlappingDuplicateLength != undefined &&
+        nonOverlappingDuplicateLength !== undefined &&
         nonOverlappingDuplicateLength <
             PARTIAL_DUPLICATE_EXPECTED_MINIMUM_NON_OVERLAPPING_PART_LENGTH_METERS;
 
@@ -194,7 +194,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
         nonOverlappingDuplicateLength: number | undefined,
         isShortNonOverlappingDuplicateLength: boolean,
     ) {
-        if (operation == 'TRANSFER') {
+        if (operation === 'TRANSFER') {
             const isPartialTooltip = t(
                 'tool-panel.location-track.splitting.is-partial-duplicate-tooltip',
                 {
@@ -299,7 +299,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                             className={createClassName(
                                 styles['location-track-infobox__split-switch-error-msg'],
                                 styles['location-track-infobox__split-switch-error-msg--start'],
-                                startSwitchMatchingError.type == FieldValidationIssueType.ERROR &&
+                                startSwitchMatchingError.type === FieldValidationIssueType.ERROR &&
                                     styles['location-track-infobox__split-switch-error-msg--error'],
                             )}>
                             {t(
@@ -364,7 +364,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                                         `tool-panel.location-track.splitting.operation.${split.operation}`,
                                     )}
 
-                                    {split.operation == 'TRANSFER' && (
+                                    {split.operation === 'TRANSFER' && (
                                         <span
                                             className={createClassName(
                                                 styles[
@@ -464,7 +464,7 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                             className={createClassName(
                                 styles['location-track-infobox__split-switch-error-msg'],
                                 styles['location-track-infobox__split-switch-error-msg--end'],
-                                endSwitchMatchingError.type == FieldValidationIssueType.ERROR &&
+                                endSwitchMatchingError.type === FieldValidationIssueType.ERROR &&
                                     styles['location-track-infobox__split-switch-error-msg--error'],
                             )}>
                             {t(

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -384,7 +384,7 @@ export const LocationTrackSplittingInfobox: React.FC<LocationTrackSplittingInfob
             const duplicateTrackIsUsedInSplit = allSplits.some(
                 (split) => split.duplicateTrackId === duplicateTrack.id,
             );
-            return duplicateTrack.status.match == 'NONE' && !duplicateTrackIsUsedInSplit;
+            return duplicateTrack.status.match === 'NONE' && !duplicateTrackIsUsedInSplit;
         },
     );
     const unusedNonOverlappingDuplicateNames = unusedNonOverlappingDuplicates.map(

--- a/ui/src/tool-panel/switch/dialog/switch-draft-oid-field.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-draft-oid-field.tsx
@@ -54,7 +54,7 @@ export const SwitchDraftOidField: React.FC<SwitchDraftOidFieldProps> = ({
     const [mostRecentlyCheckedOid, setMostRecentlyCheckedOid] = useState<Oid>();
 
     const oidIsLocallyValid = draftOid !== '' && validateDraftOid(draftOid).length === 0;
-    const loadingOidPresence = oidIsLocallyValid && draftOid != mostRecentlyCheckedOid;
+    const loadingOidPresence = oidIsLocallyValid && draftOid !== mostRecentlyCheckedOid;
     useRateLimitedTwoPartEffect(
         () => (oidIsLocallyValid ? getSwitchOidPresence(draftOid) : undefined),
         (newOidPresence) => {
@@ -146,7 +146,7 @@ export function validateDraftOid(oid: Oid): FieldValidationIssue<LayoutSwitchSav
         });
     } else {
         const oidEnd = oid.slice(SWITCH_OID_REQUIRED_PREFIX.length);
-        if (oidEnd != `${parseInt(oidEnd)}`) {
+        if (oidEnd !== `${parseInt(oidEnd)}`) {
             errors.push({
                 field: 'draftOid',
                 reason: 'invalid-draft-oid',

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -127,7 +127,7 @@ export const SwitchEditDialog = ({
     const isExistingSwitch = !!switchId;
 
     const switchStructureChanged =
-        isExistingSwitch && switchStructureId != existingSwitch?.switchStructureId;
+        isExistingSwitch && switchStructureId !== existingSwitch?.switchStructureId;
 
     const canSetDeleted = isExistingSwitch && !!existingSwitch?.hasOfficial;
     const stateCategoryOptions = layoutStateCategories
@@ -135,9 +135,9 @@ export const SwitchEditDialog = ({
         .map((sc) => ({ ...sc, qaId: sc.value }));
 
     const conflictingSwitch = useLoader(async () => {
-        if (validateSwitchName(switchName).length == 0) {
+        if (validateSwitchName(switchName).length === 0) {
             const switches = await getSwitchesByName(draftLayoutContext(layoutContext), switchName);
-            return switches.find((s) => s.id != existingSwitch?.id);
+            return switches.find((s) => s.id !== existingSwitch?.id);
         } else {
             return undefined;
         }
@@ -290,7 +290,7 @@ export const SwitchEditDialog = ({
     function getVisibleErrorsByProp(prop: keyof LayoutSwitchSaveRequest) {
         if (visitedFields.includes(prop)) {
             return validationIssues
-                .filter((error) => error.field == prop)
+                .filter((error) => error.field === prop)
                 .map(({ reason }) => t(`switch-dialog.${reason}`));
         }
         return [];

--- a/ui/src/tool-panel/switch/geometry-switch-linking-candidates.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-candidates.tsx
@@ -76,8 +76,8 @@ export const GeometrySwitchLinkingCandidates: React.FC<GeometrySwitchLinkingCand
                     );
                 })}
 
-                {loadingStatus == LoaderStatus.Loading && <Spinner />}
-                {loadingStatus == LoaderStatus.Ready && switches?.length == 0 && (
+                {loadingStatus === LoaderStatus.Loading && <Spinner />}
+                {loadingStatus === LoaderStatus.Ready && switches?.length === 0 && (
                     <span className={styles['geometry-switch-infobox__no-matches']}>
                         {t('tool-panel.switch.geometry.no-linkable-switches')}
                     </span>

--- a/ui/src/tool-panel/switch/geometry-switch-linking-errors.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-errors.tsx
@@ -27,8 +27,8 @@ export const GeometrySwitchLinkingErrors: React.FC<GeometrySwitchLinkingErrorsPr
         <InfoboxContentSpread>
             <MessageBox
                 pop={
-                    selectedLayoutSwitchStructure != undefined &&
-                    switchTypeMatch == SwitchTypeMatch.Invalid
+                    selectedLayoutSwitchStructure !== undefined &&
+                    switchTypeMatch === SwitchTypeMatch.Invalid
                 }>
                 <div className={styles['geometry-switch-infobox__switch-type-warning-msg']}>
                     {t('tool-panel.switch.geometry.cannot-link-invalid-switch-type', {
@@ -39,8 +39,8 @@ export const GeometrySwitchLinkingErrors: React.FC<GeometrySwitchLinkingErrorsPr
             </MessageBox>
             <MessageBox
                 pop={
-                    selectedLayoutSwitchStructure != undefined &&
-                    switchTypeMatch == SwitchTypeMatch.Similar
+                    selectedLayoutSwitchStructure !== undefined &&
+                    switchTypeMatch === SwitchTypeMatch.Similar
                 }>
                 <div className={styles['geometry-switch-infobox__switch-type-warning-msg']}>
                     {t('tool-panel.switch.geometry.switch-type-differs-warning', {

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -92,8 +92,8 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         suggestedSwitchResult === undefined
             ? undefined
             : 'switch' in suggestedSwitchResult
-              ? suggestedSwitchResult.switch
-              : undefined;
+            ? suggestedSwitchResult.switch
+            : undefined;
     const switchStructure = useSwitchStructure(suggestedSwitch?.switchStructureId);
     const [showAddSwitchDialog, setShowAddSwitchDialog] = React.useState(false);
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
@@ -105,15 +105,15 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         suggestedSwitch &&
         switchStructure &&
         selectedLayoutSwitch &&
-        switchStructure.id == selectedLayoutSwitch.switchStructureId
+        switchStructure.id === selectedLayoutSwitch.switchStructureId
             ? SwitchTypeMatch.Exact
             : suggestedSwitch &&
-                selectedLayoutSwitchStructure &&
-                switchStructure &&
-                switchStructure.baseType == selectedLayoutSwitchStructure.baseType &&
-                switchStructure.hand == selectedLayoutSwitchStructure.hand
-              ? SwitchTypeMatch.Similar
-              : SwitchTypeMatch.Invalid;
+              selectedLayoutSwitchStructure &&
+              switchStructure &&
+              switchStructure.baseType === selectedLayoutSwitchStructure.baseType &&
+              switchStructure.hand === selectedLayoutSwitchStructure.hand
+            ? SwitchTypeMatch.Similar
+            : SwitchTypeMatch.Invalid;
 
     const [switchTypeDifferenceIsConfirmed, setSwitchTypeDifferenceIsConfirmed] =
         React.useState(false);
@@ -122,10 +122,10 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
             ? suggestedSwitchResult.failure
             : undefined;
     const isValidLayoutSwitch =
-        suggestedSwitch != undefined &&
+        suggestedSwitch !== undefined &&
         selectedLayoutSwitch &&
-        (switchTypeMatch == SwitchTypeMatch.Exact ||
-            (switchTypeMatch == SwitchTypeMatch.Similar && switchTypeDifferenceIsConfirmed));
+        (switchTypeMatch === SwitchTypeMatch.Exact ||
+            (switchTypeMatch === SwitchTypeMatch.Similar && switchTypeDifferenceIsConfirmed));
     const canLink =
         selectedLayoutSwitch &&
         isValidLayoutSwitch &&

--- a/ui/src/tool-panel/switch/switch-infobox-container.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox-container.tsx
@@ -38,7 +38,7 @@ export const SwitchInfoboxContainer: React.FC<SwitchInfoboxContainerProps> = ({
             onSelect={delegates.onSelect}
             onUnselect={delegates.onUnselect}
             placingSwitchLinkingState={
-                trackLayoutState.linkingState?.type == LinkingType.PlacingSwitch
+                trackLayoutState.linkingState?.type === LinkingType.PlacingSwitch
                     ? trackLayoutState.linkingState
                     : undefined
             }

--- a/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
@@ -47,10 +47,10 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
     const [showOtherJoints, setShowOtherJoints] = React.useState(false);
 
     const presentationJointAddress = jointTrackMeters.filter(
-        (jtm) => jtm.jointNumber == presentationJoint,
+        (jtm) => jtm.jointNumber === presentationJoint,
     );
     const otherJointsAddress = groupBy(
-        jointTrackMeters.filter((jtm) => jtm.jointNumber != presentationJoint),
+        jointTrackMeters.filter((jtm) => jtm.jointNumber !== presentationJoint),
         (i) => i.jointNumber,
     );
 

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -177,7 +177,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
         getSwitchPresentationJoint(layoutSwitch, structure.presentationJointNumber)?.location;
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
-    const canStartPlacing = placingSwitchLinkingState == undefined && layoutSwitch != undefined;
+    const canStartPlacing = placingSwitchLinkingState === undefined && layoutSwitch !== undefined;
 
     function isOfficial(): boolean {
         return layoutContext.publicationState === 'OFFICIAL';
@@ -189,7 +189,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
     }
 
     function getOwnerName(ownerId: SwitchOwnerId | undefined) {
-        const name = switchOwners?.find((o) => o.id == ownerId)?.name;
+        const name = switchOwners?.find((o) => o.id === ownerId)?.name;
         return name ?? '-';
     }
 

--- a/ui/src/tool-panel/tool-panel-container.tsx
+++ b/ui/src/tool-panel/tool-panel-container.tsx
@@ -36,13 +36,14 @@ const ToolPanelContainer: React.FC<ToolPanelContainerProps> = ({ setHoveredOverI
             switches: [layoutSwitch.id],
         });
         delegates.showLayers(['switch-linking-layer']);
-    }, []);
+    },
+    []);
 
     const infoboxVisibilities = useTrackLayoutAppSelector((state) => state.infoboxVisibilities);
 
     React.useEffect(() => {
         const linkingState = store.linkingState;
-        if (linkingState?.type == LinkingType.PlacingSwitch && linkingState.location) {
+        if (linkingState?.type === LinkingType.PlacingSwitch && linkingState.location) {
             getSuggestedSwitchForLayoutSwitchPlacing(
                 store.layoutContext.branch,
                 linkingState.location,

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -74,11 +74,11 @@ export const TrackNumberEditDialogContainer: React.FC<TrackNumberEditDialogConta
     const editReferenceLine = useTrackNumberReferenceLine(trackNumberId, layoutContext);
     const isNewDraft = !!editReferenceLine && !editReferenceLine.hasOfficial;
 
-    if (trackNumbers !== undefined && trackNumberId == editReferenceLine?.trackNumberId) {
+    if (trackNumbers !== undefined && trackNumberId === editReferenceLine?.trackNumberId) {
         return (
             <TrackNumberEditDialog
                 layoutContext={layoutContext}
-                inEditTrackNumber={trackNumbers.find((tn) => tn.id == trackNumberId)}
+                inEditTrackNumber={trackNumbers.find((tn) => tn.id === trackNumberId)}
                 inEditReferenceLine={editReferenceLine}
                 trackNumbers={trackNumbers}
                 isNewDraft={isNewDraft}

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-store.ts
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-store.ts
@@ -141,7 +141,7 @@ export function getErrors(
     key: keyof TrackNumberSaveRequest,
 ): FieldValidationIssue<TrackNumberSaveRequest>[] {
     return state.committedFields.includes(key)
-        ? state.validationIssues.filter((e) => e.field == key)
+        ? state.validationIssues.filter((e) => e.field === key)
         : [];
 }
 

--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -86,7 +86,7 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
                     indicator={ProgressIndicatorType.Area}
                     inProgress={elementFetchStatus !== LoaderStatus.Ready}
                     inline={false}>
-                    {sections && sections.length == 0 ? (
+                    {sections && sections.length === 0 ? (
                         <p className={'infobox__text'}>
                             {t(
                                 'tool-panel.alignment-plan-sections.no-geometries-for-reference-line',

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -136,7 +136,7 @@ function mapAlignmentUri(
     alignmentType: MapAlignmentType,
     content?: string,
 ): string {
-    const type = alignmentType == 'LOCATION_TRACK' ? 'location-track' : 'reference-line';
+    const type = alignmentType === 'LOCATION_TRACK' ? 'location-track' : 'reference-line';
     const baseUri = `${TRACK_LAYOUT_URI}/map/${contextInUri(layoutContext)}/${type}`;
     return content ? `${baseUri}/${content}` : baseUri;
 }
@@ -252,8 +252,8 @@ export async function getLocationTrackMapAlignmentsByTiles(
 type MapLayoutAlignmentDataHolder<M extends MapAlignmentType> = M extends 'LOCATION_TRACK'
     ? LocationTrackAlignmentDataHolder
     : M extends 'REFERENCE_LINE'
-      ? ReferenceLineAlignmentDataHolder
-      : never;
+    ? ReferenceLineAlignmentDataHolder
+    : never;
 
 async function getAlignmentDataHolder<M extends MapAlignmentType>(
     type: M,
@@ -401,7 +401,7 @@ export async function getEndLinkPoints(
                     ? undefined
                     : alignmentEndpointsToLinkPoint(startPoints[0], startPoints[1]),
             end:
-                endPoints[0] === undefined || endPoints[1] === undefined || endPoints.length != 2
+                endPoints[0] === undefined || endPoints[1] === undefined || endPoints.length !== 2
                     ? undefined
                     : alignmentEndpointsToLinkPoint(endPoints[1], endPoints[0]),
         }));
@@ -464,8 +464,8 @@ export async function getGeometryLinkPointsByTiles(
                 boundingBoxContains(bounds, p) &&
                 (segmentMValues.includes(p.m) ||
                     resolution <= 1 ||
-                    Math.floor(p.m) % resolution == 0 ||
-                    alwaysIncludePoints.some((alwaysIncludePoint) => alwaysIncludePoint.m == p.m)),
+                    Math.floor(p.m) % resolution === 0 ||
+                    alwaysIncludePoints.some((alwaysIncludePoint) => alwaysIncludePoint.m === p.m)),
         );
         return createLinkPoints(
             {
@@ -514,7 +514,9 @@ async function getLocationTrackPolyline(
 
     return await locationTrackPolyLineCache.get(changeTime, tileKey, () =>
         getNullable<AlignmentPolyLine>(
-            `${mapUri(layoutContext)}/location-track/${locationTrackId}/alignment-polyline${params}`,
+            `${mapUri(
+                layoutContext,
+            )}/location-track/${locationTrackId}/alignment-polyline${params}`,
         ),
     );
 }
@@ -533,7 +535,9 @@ export async function getTrackMeter(
 
     return trackNumberTrackMeterCache.get(
         changeTime,
-        `${trackNumberId}_${layoutContext.publicationState}_${layoutContext.branch}_${pointString(location)}`,
+        `${trackNumberId}_${layoutContext.publicationState}_${layoutContext.branch}_${pointString(
+            location,
+        )}`,
         () => {
             return getNullable<TrackMeter>(
                 `${geocodingUri(layoutContext)}/address/${trackNumberId}${params}`,

--- a/ui/src/track-layout/layout-track-number-api.ts
+++ b/ui/src/track-layout/layout-track-number-api.ts
@@ -46,7 +46,7 @@ export async function getTrackNumberById(
     changeTime?: TimeStamp,
 ): Promise<LayoutTrackNumber | undefined> {
     return getTrackNumbers(layoutContext, changeTime, true).then((trackNumbers) =>
-        trackNumbers.find((trackNumber) => trackNumber.id == trackNumberId),
+        trackNumbers.find((trackNumber) => trackNumber.id === trackNumberId),
     );
 }
 

--- a/ui/src/track-layout/track-layout-container.tsx
+++ b/ui/src/track-layout/track-layout-container.tsx
@@ -19,7 +19,7 @@ export const TrackLayoutContainer: React.FC = () => {
         [getChangeTimes().layoutDesign, designId],
     );
     const currentDesignExists =
-        designLoadStatus == LoaderStatus.Ready && currentDesign != undefined;
+        designLoadStatus === LoaderStatus.Ready && currentDesign !== undefined;
     const isEnabled = trackLayoutState.layoutContextMode !== 'DESIGN' || currentDesignExists;
 
     return (

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -164,10 +164,11 @@ export type SplitPoint = SwitchSplitPoint | EndpointSplitPoint;
 export function splitPointsAreSame(point1: SplitPoint, point2: SplitPoint): boolean {
     switch (point1.type) {
         case 'SWITCH_SPLIT_POINT':
-            return point2.type == 'SWITCH_SPLIT_POINT' && point2.switchId == point1.switchId;
+            return point2.type === 'SWITCH_SPLIT_POINT' && point2.switchId === point1.switchId;
         case 'ENDPOINT_SPLIT_POINT':
             return (
-                point2.type == 'ENDPOINT_SPLIT_POINT' && point2.endpointType == point1.endpointType
+                point2.type === 'ENDPOINT_SPLIT_POINT' &&
+                point2.endpointType === point1.endpointType
             );
     }
 }
@@ -367,7 +368,7 @@ export function getSwitchPresentationJoint(
     layoutSwitch: LayoutSwitch,
     presentationJointNumber: JointNumber,
 ): LayoutSwitchJoint | undefined {
-    return layoutSwitch.joints.find((joint) => joint.number == presentationJointNumber);
+    return layoutSwitch.joints.find((joint) => joint.number === presentationJointNumber);
 }
 
 export type LayoutSwitchJointMatch = {

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -277,8 +277,8 @@ function filterItemSelectOptions(
 ): OnSelectOptions {
     const selectableItemTypes = getSelectableItemTypes(state.splittingState, state.linkingState);
 
-    if (state.linkingState?.type == LinkingType.LinkingSwitch) {
-        if (options.suggestedSwitches?.length == 0) {
+    if (state.linkingState?.type === LinkingType.LinkingSwitch) {
+        if (options.suggestedSwitches?.length === 0) {
             options.suggestedSwitches = undefined;
         }
     }
@@ -319,7 +319,7 @@ const trackLayoutSlice = createSlice({
         },
 
         onClickLocation: (state: TrackLayoutState, action: PayloadAction<Point>): void => {
-            if (state.linkingState?.type == LinkingType.PlacingSwitch) {
+            if (state.linkingState?.type === LinkingType.PlacingSwitch) {
                 state.linkingState.location = action.payload;
             } else {
                 mapReducers.onClickLocation(state.map, action);
@@ -331,7 +331,7 @@ const trackLayoutSlice = createSlice({
             const firstSwitchId = ifDefined(action.payload.switches, first);
             if (state.splittingState && firstSwitchId) {
                 const allowedSwitch = state.splittingState.trackSwitches.find(
-                    (sw) => sw.switchId == firstSwitchId,
+                    (sw) => sw.switchId === firstSwitchId,
                 );
 
                 if (allowedSwitch) {
@@ -519,8 +519,8 @@ const trackLayoutSlice = createSlice({
                 designId !== undefined
                     ? 'DESIGN'
                     : state.layoutContext.publicationState === 'OFFICIAL'
-                      ? 'MAIN_OFFICIAL'
-                      : 'MAIN_DRAFT';
+                    ? 'MAIN_OFFICIAL'
+                    : 'MAIN_DRAFT';
         },
         onLayoutModeChange: (
             state: TrackLayoutState,
@@ -586,7 +586,7 @@ function getLayoutContext(
 ): LayoutContext {
     if (layoutContextMode === 'DESIGN' && designId) {
         return draftDesignLayoutContext(designId);
-    } else if (layoutContextMode == 'MAIN_DRAFT') {
+    } else if (layoutContextMode === 'MAIN_DRAFT') {
         return draftMainLayoutContext();
     } else {
         return officialMainLayoutContext();

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -33,7 +33,7 @@ function filterByIdInOrNotIn<T, Id>(
     yesIn: boolean,
 ): (item: T) => boolean {
     const othersSet = new Set(others);
-    return (item: T) => yesIn == othersSet.has(getId(item));
+    return (item: T) => yesIn === othersSet.has(getId(item));
 }
 
 /**
@@ -57,7 +57,7 @@ export function filterUniqueById<T, TId>(getId: (item: T) => TId): (item: T) => 
  * keys.filter(filterUnique)
  */
 export function filterUnique<T>(item: T, index: number, array: T[]): boolean {
-    return array.findIndex((item2) => item2 == item) == index;
+    return array.findIndex((item2) => item2 === item) === index;
 }
 
 export function flatten<T>(list: T[][]): T[] {
@@ -95,7 +95,7 @@ export function timeStampComparator<T>(
         if (!aTime) return 1;
         if (!bTime) return -1;
 
-        return aTime < bTime ? -1 : aTime == bTime ? 0 : 1;
+        return aTime < bTime ? -1 : aTime === bTime ? 0 : 1;
     };
 }
 
@@ -145,9 +145,9 @@ export function compareByField<T, S>(v1: T, v2: T, getter: (obj: T) => S): numbe
 }
 
 export function compare<T>(f1: T, f2: T): number {
-    if (f1 == undefined && f2 == undefined) return 0;
-    else if (f1 == undefined) return -1;
-    else if (f2 == undefined) return 1;
+    if (f1 === undefined && f2 === undefined) return 0;
+    else if (f1 === undefined || f1 === null) return -1;
+    else if (f2 === undefined || f2 === null) return 1;
     else if (f1 < f2) return -1;
     else if (f2 < f1) return 1;
     else return 0;
@@ -177,15 +177,15 @@ export function itemsEqual<T>(
 ): boolean {
     return (
         items1 === items2 || // object equality
-        (items1?.length == 0 && items2?.length == 0) || // empty arrays // contains equal items
-        (items1 != undefined &&
-            items2 != undefined &&
+        (items1?.length === 0 && items2?.length === 0) || // empty arrays // contains equal items
+        (items1 !== undefined &&
+            items2 !== undefined &&
             items1.length === items2.length &&
             // a collection cannot have an item that does not exist in another
             !items1.some(
                 (item1: T) =>
                     !items2.find((item2) =>
-                        itemEqualsFunc ? itemEqualsFunc(item1, item2) : item1 == item2,
+                        itemEqualsFunc ? itemEqualsFunc(item1, item2) : item1 === item2,
                     ),
             ))
     );
@@ -193,7 +193,7 @@ export function itemsEqual<T>(
 
 export function minOf<T>(values: T[], comparator: (v1: T, v2: T) => number): T | undefined {
     return values.reduce<T | undefined>((old, candidate, index) => {
-        if (index == 0 || comparator(old as T, candidate) > 0) {
+        if (index === 0 || comparator(old as T, candidate) > 0) {
             return candidate;
         } else {
             return old;
@@ -203,7 +203,7 @@ export function minOf<T>(values: T[], comparator: (v1: T, v2: T) => number): T |
 
 export function maxOf<T>(values: T[], comparator: (v1: T, v2: T) => number): T | undefined {
     return values.reduce<T | undefined>((old, candidate, index) => {
-        if (index == 0 || comparator(old as T, candidate) < 0) {
+        if (index === 0 || comparator(old as T, candidate) < 0) {
             return candidate;
         } else {
             return old;
@@ -230,7 +230,7 @@ export function indexIntoMap<Id, Obj extends { id: Id }>(objs: Obj[]): Map<Id, O
 }
 
 export function minimumIndexBy<T, B>(objs: readonly T[], by: (obj: T) => B): number | undefined {
-    if (objs.length == 0) {
+    if (objs.length === 0) {
         return undefined;
     }
     const values = objs.map((obj) => by(obj));
@@ -265,7 +265,7 @@ export function findInsertionIndex<T>(
     isInsertBefore: (v: T) => boolean,
 ): number {
     const i = things.findIndex(isInsertBefore);
-    return i == -1 ? things.length : i;
+    return i === -1 ? things.length : i;
 }
 
 export function insertAtIndex<T>(things: readonly T[], thing: T, index: number): T[] {
@@ -273,7 +273,7 @@ export function insertAtIndex<T>(things: readonly T[], thing: T, index: number):
 }
 
 export const findById = <T extends { id: string }>(objs: T[], id: string): T | undefined =>
-    objs.find((obj) => obj.id == id);
+    objs.find((obj) => obj.id === id);
 
 /**
  * Like Object.entries, but with the assumption that the argument doesn't contain any fields not mentioned in its

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -1,6 +1,9 @@
 import { TimeStamp } from 'common/common-model';
 import { expectDefined } from 'utils/type-utils';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+type EmptyObject = {};
+
 export const first = <T>(arr: readonly T[]) => arr[0];
 export const last = <T>(arr: readonly T[]) => arr[arr.length - 1];
 
@@ -68,7 +71,10 @@ export function negComparator<T>(comparator: (v1: T, v2: T) => number): (v1: T, 
     return (v1: T, v2: T) => comparator(v1, v2) * -1;
 }
 
-export function fieldComparator<T, S>(getter: (obj: T) => S): (v1: T, v2: T) => number {
+export function fieldComparator<
+    T extends EmptyObject | undefined,
+    S extends EmptyObject | undefined,
+>(getter: (obj: T) => S): (v1: T, v2: T) => number {
     return (v1: T, v2: T) => compareByField(v1, v2, getter);
 }
 
@@ -99,9 +105,10 @@ export function timeStampComparator<T>(
     };
 }
 
-export function multiFieldComparator<T extends unknown[], S>(
-    ...getters: { [K in keyof T]: (obj: T[K]) => S }
-): (v1: T[number], v2: T[number]) => number {
+export function multiFieldComparator<
+    T extends (EmptyObject | undefined)[],
+    S extends EmptyObject | undefined,
+>(...getters: { [K in keyof T]: (obj: T[K]) => S }): (v1: T[number], v2: T[number]) => number {
     return (v1: T[number], v2: T[number]) => {
         return getters.reduce((previousComparisonResult, nextGetter) => {
             return previousComparisonResult !== 0
@@ -130,24 +137,34 @@ export function arraysEqual<T>(arr1: T[], arr2: T[]) {
     return JSON.stringify(arr1) === JSON.stringify(arr2);
 }
 
-export const compareByFields = <T, S>(s1: T, s2: T, ...getters: ((s: T) => S)[]) =>
+export const compareByFields = <
+    T extends EmptyObject | undefined,
+    S extends EmptyObject | undefined,
+>(
+    s1: T,
+    s2: T,
+    ...getters: ((s: T) => S)[]
+) =>
     getters.reduce(
         (previousValue, getter) =>
             previousValue === 0 ? compareByField(s1, s2, getter) : previousValue,
         0,
     );
 
-export function compareByField<T, S>(v1: T, v2: T, getter: (obj: T) => S): number {
+export function compareByField<
+    T extends EmptyObject | undefined,
+    S extends EmptyObject | undefined,
+>(v1: T, v2: T, getter: (obj: T) => S): number {
     const f1 = getter(v1);
     const f2 = getter(v2);
 
     return compare(f1, f2);
 }
 
-export function compare<T>(f1: T, f2: T): number {
+export function compare<T extends EmptyObject | undefined>(f1: T, f2: T): number {
     if (f1 === undefined && f2 === undefined) return 0;
-    else if (f1 === undefined || f1 === null) return -1;
-    else if (f2 === undefined || f2 === null) return 1;
+    else if (f1 === undefined) return -1;
+    else if (f2 === undefined) return 1;
     else if (f1 < f2) return -1;
     else if (f2 < f1) return 1;
     else return 0;

--- a/ui/src/utils/date-utils.ts
+++ b/ui/src/utils/date-utils.ts
@@ -7,7 +7,7 @@ export const currentDay = startOfToday();
 export const currentYear = getYear(currentDay);
 
 function isDate(date: Date | TimeStamp): date is Date {
-    return typeof date != 'string';
+    return typeof date !== 'string';
 }
 
 export function formatDateFull(date: Date | TimeStamp): string {
@@ -56,7 +56,7 @@ export function compareDates(d1: Date | undefined, d2: Date | undefined): number
         return 1; // consider undefined more heavyweight
     } else if (!d2) {
         return -1; // consider undefined more heavyweight
-    } else if (d1.getTime() == d2.getTime()) {
+    } else if (d1.getTime() === d2.getTime()) {
         return 0;
     } else if (d1 < d2) {
         return -1;

--- a/ui/src/utils/enum-localization-utils.ts
+++ b/ui/src/utils/enum-localization-utils.ts
@@ -156,7 +156,7 @@ export const switchTrapPoints: LocalizedEnum<TrapPoint>[] = [
 ];
 
 export const translateSwitchTrapPoint = (trapPoint: TrapPoint) =>
-    switchTrapPoints.find((option) => option.value == trapPoint)?.name;
+    switchTrapPoints.find((option) => option.value === trapPoint)?.name;
 
 export function switchJointNumberToString(joint: JointNumber): string {
     return joint.substring(6);

--- a/ui/src/utils/math-utils.ts
+++ b/ui/src/utils/math-utils.ts
@@ -32,9 +32,9 @@ export function getPartialPolyLine(
     const start = findOrInterpolateXY(points, startM);
     const end = findOrInterpolateXY(points, endM);
     // If both ends are interpolated between the same 2 points or are the same point, return nothing
-    if (start == undefined || end == undefined || start.low >= end.high) return [];
-    const midStart = start.low == start.high ? start.high + 1 : start.high;
-    const midEnd = end.low == end.high ? end.low : end.low + 1;
+    if (start === undefined || end === undefined || start.low >= end.high) return [];
+    const midStart = start.low === start.high ? start.high + 1 : start.high;
+    const midEnd = end.low === end.high ? end.low : end.low + 1;
     const midPoints =
         midStart >= 0 && midStart < midEnd
             ? points.slice(midStart, midEnd).map((p) => [p.x, p.y])
@@ -123,7 +123,7 @@ export function distance(p1: Point, p2: Point): number {
 
 export function distToSegmentSquared(p: Point, start: Point, end: Point) {
     const l2 = distanceSquared(start, end);
-    if (l2 == 0) return distanceSquared(p, start);
+    if (l2 === 0) return distanceSquared(p, start);
     let t = ((p.x - start.x) * (end.x - start.x) + (p.y - start.y) * (end.y - start.y)) / l2;
     t = Math.max(0, Math.min(1, t));
     return distanceSquared(p, {

--- a/ui/src/utils/object-utils.ts
+++ b/ui/src/utils/object-utils.ts
@@ -3,12 +3,12 @@ export function objectEquals(o1: unknown, o2: unknown): boolean {
 }
 
 export function mapOptional<T, S>(o: T | undefined, mapper: (o: T) => S): S | undefined {
-    return o != undefined ? mapper(o) : undefined;
+    return o !== undefined ? mapper(o) : undefined;
 }
 
 export function mapOptionalAsync<T, S>(
     o: T | undefined,
     mapper: (o: T) => Promise<S | undefined>,
 ): Promise<S | undefined> {
-    return o != undefined ? mapper(o) : Promise.resolve(undefined);
+    return o !== undefined ? mapper(o) : Promise.resolve(undefined);
 }

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -117,7 +117,7 @@ export function useRateLimitedLoaderWithStatus<TEntity>(
     // asynchronously and status will then be set to "loading", but it is more precise to set and
     // return "initialize" status synchronously.
     const loaderStatus = depsAreChanged ? LoaderStatus.Initialized : loaderStatusInState;
-    if (loaderStatus != loaderStatusInState) {
+    if (loaderStatus !== loaderStatusInState) {
         setLoaderStatusInState(loaderStatus);
     }
 
@@ -311,14 +311,11 @@ export function useRateLimitedEffect(
             lastFireTime.current = now;
             return effect();
         } else {
-            nextWakeup.current = setTimeout(
-                () => {
-                    lastFireTime.current = Date.now();
-                    lastDestructor.current = effect();
-                    nextWakeup.current = undefined;
-                },
-                waitBetweenCalls - (now - lastFireTime.current),
-            );
+            nextWakeup.current = setTimeout(() => {
+                lastFireTime.current = Date.now();
+                lastDestructor.current = effect();
+                nextWakeup.current = undefined;
+            }, waitBetweenCalls - (now - lastFireTime.current));
             return () => {
                 if (lastDestructor.current !== undefined) {
                     lastDestructor.current();
@@ -373,16 +370,13 @@ export function useTraceProps(componentName: string, props: PropsType) {
     const prev = useRef(props);
 
     useEffect(() => {
-        const changedProps = Object.entries(props).reduce(
-            (acc, [k, v]) => {
-                if (prev.current[k] !== v) {
-                    acc[k] = { old: prev.current[k], new: v };
-                }
+        const changedProps = Object.entries(props).reduce((acc, [k, v]) => {
+            if (prev.current[k] !== v) {
+                acc[k] = { old: prev.current[k], new: v };
+            }
 
-                return acc;
-            },
-            {} as { [key: string]: { old: ValueOf<PropsType>; new: ValueOf<PropsType> } },
-        );
+            return acc;
+        }, {} as { [key: string]: { old: ValueOf<PropsType>; new: ValueOf<PropsType> } });
 
         if (Object.keys(changedProps).length > 0) {
             console.log(`[${componentName}] Changed props:`, changedProps);

--- a/ui/src/utils/string-utils.ts
+++ b/ui/src/utils/string-utils.ts
@@ -11,7 +11,7 @@ export function isEqualWithoutWhitespace(str1: string, str2: string): boolean {
 }
 
 export function isEmpty(str: string) {
-    return str.length == 0 || isNilOrBlank(str);
+    return str.length === 0 || isNilOrBlank(str);
 }
 
 export const isEqualIgnoreCase = (str1: string, str2: string): boolean =>

--- a/ui/src/utils/type-utils.ts
+++ b/ui/src/utils/type-utils.ts
@@ -12,10 +12,9 @@ export type ValueOf<T> = T[keyof T];
 export type GetElementType<T> = T extends (infer TItem)[] ? TItem : never;
 
 type GetStringKeyTypes<TKeys> = TKeys extends string ? TKeys : never;
-type EnsureAllKeys<TAllKeys, TGivenKeys> =
-    Exclude<TAllKeys, TGivenKeys> extends never
-        ? TGivenKeys
-        : `Key '${GetStringKeyTypes<Exclude<TAllKeys, TGivenKeys>>}' is missing!`;
+type EnsureAllKeys<TAllKeys, TGivenKeys> = Exclude<TAllKeys, TGivenKeys> extends never
+    ? TGivenKeys
+    : `Key '${GetStringKeyTypes<Exclude<TAllKeys, TGivenKeys>>}' is missing!`;
 
 /**
  * This function provides type checking to make sure that the given
@@ -45,7 +44,8 @@ export const exhaustiveMatchingGuard = (_: never): never => {
     throw new Error('Should not have reached this code');
 };
 
-export const isNil = <T>(object: T | undefined | null) => object === undefined || object === null;
+export const isNil = <T>(object: T | undefined | null): object is undefined | null =>
+    object === undefined || object === null;
 
 // Prefer actual nil checks, only use this if you KNOW the index exists
 export const expectDefined = <T>(thing: T): NonNullable<T> => {

--- a/ui/src/utils/validation-utils.ts
+++ b/ui/src/utils/validation-utils.ts
@@ -29,7 +29,7 @@ export function isPropEditFieldCommitted<T, TKey extends keyof T>(
     return (
         propEdit.editingExistingValue ||
         (!committedFields.includes(propEdit.key) &&
-            !validationIssues.some((issue) => issue.field == propEdit.key))
+            !validationIssues.some((issue) => issue.field === propEdit.key))
     );
 }
 

--- a/ui/src/vayla-design-lib/badge/badge.tsx
+++ b/ui/src/vayla-design-lib/badge/badge.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import styles from './checkbox.scss';
-import { createClassName } from 'vayla-design-lib/utils';
-import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 
 export type BadgeProps = {
     foo?: string;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Badge: React.FC<BadgeProps> = ({ children, ...props }: BadgeProps) => {
+export const Badge: React.FC<BadgeProps> = (_: BadgeProps) => {
     return <div>Badge</div>;
 };

--- a/ui/src/vayla-design-lib/button/button.tsx
+++ b/ui/src/vayla-design-lib/button/button.tsx
@@ -67,7 +67,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
         styles[variant],
         className,
         Icon && styles['button--has-icon'],
-        iconPosition == ButtonIconPosition.END && styles['button--icon-at-end'],
+        iconPosition === ButtonIconPosition.END && styles['button--icon-at-end'],
         size && styles[size],
         !props.children && styles['button--no-label'],
         isProcessing && styles['button--has-animation'],

--- a/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/button-examples.tsx
@@ -15,7 +15,7 @@ export const ButtonExamples: React.FC = () => {
     const [person, setPerson] = React.useState<ExamplePerson | undefined>();
 
     function toggleProcessing(key: string) {
-        setButtonProcessing(key == buttonProcessing ? undefined : key);
+        setButtonProcessing(key === buttonProcessing ? undefined : key);
     }
 
     return (
@@ -60,7 +60,7 @@ export const ButtonExamples: React.FC = () => {
                                                 size={size}
                                                 variant={variant}
                                                 isProcessing={
-                                                    isProcessing || buttonProcessing == key
+                                                    isProcessing || buttonProcessing === key
                                                 }
                                                 onClick={() => toggleProcessing(key)}>
                                                 Button
@@ -81,7 +81,8 @@ export const ButtonExamples: React.FC = () => {
                                                 variant={variant}
                                                 icon={Icons.Append}
                                                 isProcessing={
-                                                    isProcessing || buttonProcessing == key + 'icon'
+                                                    isProcessing ||
+                                                    buttonProcessing === key + 'icon'
                                                 }
                                                 onClick={() => toggleProcessing(key + 'icon')}>
                                                 Button
@@ -104,7 +105,7 @@ export const ButtonExamples: React.FC = () => {
                                                 icon={Icons.Append}
                                                 isProcessing={
                                                     isProcessing ||
-                                                    buttonProcessing == key + 'icon-only'
+                                                    buttonProcessing === key + 'icon-only'
                                                 }
                                                 onClick={() => toggleProcessing(key + 'icon-only')}
                                             />
@@ -117,7 +118,7 @@ export const ButtonExamples: React.FC = () => {
                                                 icon={Icons.Append}
                                                 isProcessing={
                                                     isProcessing ||
-                                                    buttonProcessing == key + 'icon-only'
+                                                    buttonProcessing === key + 'icon-only'
                                                 }
                                             />
                                         </td>

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -181,9 +181,9 @@ export const Dropdown = function <TItemValue>({
     function focusSelectedItem() {
         if (options) {
             const selectedIndex = filteredOptions.findIndex(
-                (option) => option.value == props.value,
+                (option) => option.value === props.value,
             );
-            if (selectedIndex == -1) {
+            if (selectedIndex === -1) {
                 setOptionFocusIndex(showEmptyOption ? -1 : 0);
             } else {
                 setOptionFocusIndex(selectedIndex);
@@ -239,8 +239,8 @@ export const Dropdown = function <TItemValue>({
         return createClassName(
             styles['dropdown__list-item'],
             item?.disabled && styles['dropdown__list-item--disabled'],
-            item?.value == props.value && styles['dropdown__list-item--selected'],
-            index == optionFocusIndex && styles['dropdown__list-item--focused'],
+            item?.value === props.value && styles['dropdown__list-item--selected'],
+            index === optionFocusIndex && styles['dropdown__list-item--focused'],
         );
     }
 
@@ -257,7 +257,7 @@ export const Dropdown = function <TItemValue>({
     }
 
     function handleInputKeyPress(e: React.KeyboardEvent<HTMLInputElement>) {
-        if (!searchable && e.code == 'Space') {
+        if (!searchable && e.code === 'Space') {
             openListAndFocusSelectedItem();
             e.preventDefault();
         }
@@ -314,7 +314,7 @@ export const Dropdown = function <TItemValue>({
 
     // Set initial "hasFocus"
     React.useEffect(() => {
-        setHasFocus(document.activeElement == inputRef.current);
+        setHasFocus(document.activeElement === inputRef.current);
     });
 
     // Scroll to focused option
@@ -342,7 +342,7 @@ export const Dropdown = function <TItemValue>({
             options
                 ? Math.max(
                       0,
-                      options.findIndex((option) => option.value == props.value),
+                      options.findIndex((option) => option.value === props.value),
                   )
                 : 0,
         );
@@ -357,7 +357,7 @@ export const Dropdown = function <TItemValue>({
                             className={getItemClassName(undefined, -1)}
                             onClick={unselect}
                             title={props.unselectText || 'Ei valittu'}
-                            ref={optionFocusIndex == -1 ? focusedOptionRef : undefined}>
+                            ref={optionFocusIndex === -1 ? focusedOptionRef : undefined}>
                             <span className={styles['dropdown__list-item-icon']}>
                                 <Icons.Selected size={IconSize.SMALL} />
                             </span>
@@ -375,7 +375,7 @@ export const Dropdown = function <TItemValue>({
                                 onClick={(event) => handleItemClick(item, event)}
                                 title={item.name}
                                 aria-disabled={!!item.disabled}
-                                ref={optionFocusIndex == index ? focusedOptionRef : undefined}>
+                                ref={optionFocusIndex === index ? focusedOptionRef : undefined}>
                                 <span className={styles['dropdown__list-item-icon']}>
                                     <Icons.Selected size={IconSize.SMALL} />
                                 </span>
@@ -384,7 +384,7 @@ export const Dropdown = function <TItemValue>({
                                 </span>
                             </li>
                         ))}
-                    {searchTerm && !isLoading && filteredOptions.length == 0 && (
+                    {searchTerm && !isLoading && filteredOptions.length === 0 && (
                         <li
                             title="Ei vaihtoehtoja"
                             className={createClassName(

--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -181,7 +181,7 @@ const SvgIcon: SvgIconComponent = ({
 
     const parsedSize = parseSize(svg) || [24, 24];
     const sizeProps =
-        size == IconSize.ORIGINAL
+        size === IconSize.ORIGINAL
             ? {
                   width: parsedSize[0],
                   height: parsedSize[1],

--- a/ui/src/vayla-design-lib/progress/progress-indicator-wrapper.tsx
+++ b/ui/src/vayla-design-lib/progress/progress-indicator-wrapper.tsx
@@ -24,11 +24,11 @@ export const ProgressIndicatorWrapper: React.FC<ProgressIndicatorWrapperProps> =
     const className = createClassName(
         styles['progress-indicator-wrapper'],
         inline && styles['progress-indicator-wrapper--inline'],
-        indicator == ProgressIndicatorType.Default &&
+        indicator === ProgressIndicatorType.Default &&
             styles['progress-indicator-wrapper--default-indicator'],
-        indicator == ProgressIndicatorType.Subtle &&
+        indicator === ProgressIndicatorType.Subtle &&
             styles['progress-indicator-wrapper--subtle-indicator'],
-        indicator == ProgressIndicatorType.Area &&
+        indicator === ProgressIndicatorType.Area &&
             styles['progress-indicator-wrapper--area-indicator'],
         inProgress && styles['progress-indicator-wrapper--in-progress'],
     );

--- a/ui/src/vayla-design-lib/text-area/text-area-autoresizing.tsx
+++ b/ui/src/vayla-design-lib/text-area/text-area-autoresizing.tsx
@@ -23,7 +23,7 @@ export const TextAreaAutoResizing: React.FC<TextAreaProps> = ({
 
     // Set initial "hasFocus"
     React.useEffect(() => {
-        setHasFocus(document.activeElement == inputRef.current);
+        setHasFocus(document.activeElement === inputRef.current);
     });
 
     const className = createClassName(

--- a/ui/src/vertical-geometry/height-graph.tsx
+++ b/ui/src/vertical-geometry/height-graph.tsx
@@ -28,7 +28,7 @@ export const HeightGraph: React.FC<HeightGraphProps> = ({ coordinates, kmHeights
     };
     for (const { trackMeterHeights } of kmHeights) {
         for (const { height, m } of trackMeterHeights) {
-            if (height == undefined) {
+            if (height === undefined) {
                 finishLineIfStarted();
             } else {
                 linePoints.push([mToX(coordinates, m), heightToY(coordinates, height)]);

--- a/ui/src/vertical-geometry/height-lines.tsx
+++ b/ui/src/vertical-geometry/height-lines.tsx
@@ -23,7 +23,7 @@ function chooseVerticalTickLength(
         const maxMidTickIndex = Math.floor((topTickHeight - tickLength / 2) / tickLength);
         return maxMidTickIndex - minMidTickIndex < maxVerticalTickCount;
     });
-    return tickHeightIndexR == -1 ? undefined : verticalTickLengthsMeter[tickHeightIndexR];
+    return tickHeightIndexR === -1 ? undefined : verticalTickLengthsMeter[tickHeightIndexR];
 }
 
 function heightTicks(coordinates: Coordinates) {
@@ -34,7 +34,7 @@ function heightTicks(coordinates: Coordinates) {
         coordinates.bottomHeightTick,
         coordinates.topHeightTick,
     );
-    return tickLength == undefined
+    return tickLength === undefined
         ? [coordinates.bottomHeightTick, coordinates.topHeightTick]
         : (() => {
               const firstMidTick =
@@ -59,6 +59,7 @@ function enumerateInStepsUpTo(start: number, stepSize: number, upTo: number) {
 export interface HeightLinesProps {
     coordinates: Coordinates;
 }
+
 export const HeightLabels: React.FC<HeightLinesProps> = ({ coordinates }) => (
     <>
         <rect

--- a/ui/src/vertical-geometry/labeled-ticks.tsx
+++ b/ui/src/vertical-geometry/labeled-ticks.tsx
@@ -92,7 +92,7 @@ const PlanLinkingDividers: React.FC<{
                             />
 
                             {/* The last plan linking summary won't have the divider that starts the next one. */}
-                            {i == planLinkingSummary.length - 1 && (
+                            {i === planLinkingSummary.length - 1 && (
                                 <LinkingDivider
                                     coordinates={coordinates}
                                     dividerPositionX={mToX(coordinates, summary.endM)}

--- a/ui/src/vertical-geometry/pvi-geometry.tsx
+++ b/ui/src/vertical-geometry/pvi-geometry.tsx
@@ -320,7 +320,8 @@ export const PviGeometry: React.FC<PviGeometryProps> = ({
     const pastRightmostPviInViewR = geometry.findIndex(
         (s) => s.point && s.point.station >= coordinates.endM,
     );
-    const rightPviI = pastRightmostPviInViewR == -1 ? geometry.length - 1 : pastRightmostPviInViewR;
+    const rightPviI =
+        pastRightmostPviInViewR === -1 ? geometry.length - 1 : pastRightmostPviInViewR;
 
     if (leftPviI === 0 && firstItem.start && firstItem.point) {
         pvis.push(
@@ -332,7 +333,7 @@ export const PviGeometry: React.FC<PviGeometryProps> = ({
         );
     }
 
-    if (rightPviI == geometry.length - 1 && lastItem) {
+    if (rightPviI === geometry.length - 1 && lastItem) {
         pvis.push(
             <RightMostEndingLine
                 key={pviKey++}

--- a/ui/src/vertical-geometry/snapped-point.ts
+++ b/ui/src/vertical-geometry/snapped-point.ts
@@ -81,7 +81,7 @@ function getSnapOverChart(
     fileName?: string;
 } {
     const closest = closestGeometrySnapPoint(xCoordinateM, geometry, drawTangents);
-    if (closest == undefined || !withinSnapDistance(closest.m)) {
+    if (closest === undefined || !withinSnapDistance(closest.m)) {
         const approximated = approximatedPoint(xCoordinateM);
         return {
             snapTarget: 'didNotSnap',
@@ -122,7 +122,7 @@ export function getSnappedPoint(
 
     const approximatedPoint = (maybeApproximateM: number) => {
         const kmIndex = findTrackMeterIndexContainingM(maybeApproximateM, trackKmHeights);
-        if (kmIndex == undefined) {
+        if (kmIndex === undefined) {
             return undefined;
         }
         const height = approximateHeightAt(maybeApproximateM, kmIndex, trackKmHeights);
@@ -147,7 +147,7 @@ export function getSnappedPoint(
                   drawTangentArrows,
               );
 
-    if (height == undefined || address == undefined) {
+    if (height === undefined || address === undefined) {
         return undefined;
     }
 
@@ -170,7 +170,7 @@ function toGeometrySnapPoint(
     stationPoint: StationPoint,
     type: 'intersectionPoint' | 'endPoint',
 ) {
-    return stationPoint.address == undefined
+    return stationPoint.address === undefined
         ? undefined
         : {
               m: stationPoint.station,
@@ -180,6 +180,7 @@ function toGeometrySnapPoint(
               type,
           };
 }
+
 function closestGeometrySnapPoint(
     m: number,
     geometry: VerticalGeometryDiagramDisplayItem[],
@@ -199,7 +200,7 @@ function closestGeometrySnapPoint(
         ].filter(filterNotEmpty),
     );
     const minIndex = minimumIndexBy(allGeometryPoints, (snapPoint) => Math.abs(m - snapPoint.m));
-    return minIndex == undefined ? undefined : allGeometryPoints[minIndex];
+    return minIndex === undefined ? undefined : allGeometryPoints[minIndex];
 }
 
 function closestRulerTickM(m: number, trackKmHeights: TrackKmHeights[]) {

--- a/ui/src/vertical-geometry/track-meter-index.ts
+++ b/ui/src/vertical-geometry/track-meter-index.ts
@@ -30,12 +30,12 @@ export function findTrackMeterIndexContainingM(
     // if this the last track km on the alignment, then the last track meter is a sentinel sent by the backend to mark
     // the alignment's end, and can be considered to have zero length; hence, if we're past it, we've fallen past the
     // alignment
-    if (kmIndex == kmHeights.length - 1 && meterIndex == -1) {
+    if (kmIndex === kmHeights.length - 1 && meterIndex === -1) {
         return undefined;
     }
     // otherwise, meterIndex will be -1 exactly if we were on a track km's last meter
     const right =
-        meterIndex == -1 ? { kmIndex: kmIndex + 1, meterIndex: 0 } : { kmIndex, meterIndex };
+        meterIndex === -1 ? { kmIndex: kmIndex + 1, meterIndex: 0 } : { kmIndex, meterIndex };
 
     const left = previousSingleTrackMeterIndex(right, kmHeights);
     return !left ? undefined : { left, right };
@@ -45,9 +45,9 @@ function previousSingleTrackMeterIndex(
     { kmIndex, meterIndex }: SingleTrackMeterIndex,
     kmHeights: TrackKmHeights[],
 ): SingleTrackMeterIndex | undefined {
-    if (meterIndex == 0 && kmIndex == 0) {
+    if (meterIndex === 0 && kmIndex === 0) {
         return undefined;
-    } else if (meterIndex == 0) {
+    } else if (meterIndex === 0) {
         return {
             kmIndex: kmIndex - 1,
             meterIndex: expectDefined(kmHeights[kmIndex - 1]).trackMeterHeights.length - 1,

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -21,7 +21,7 @@ type AdjacentVerticalGeometryItems = [
 
 export function approximateHeightAtM(m: number, kmHeights: TrackKmHeights[]): number | undefined {
     const index = findTrackMeterIndexContainingM(m, kmHeights);
-    if (index == undefined) {
+    if (index === undefined) {
         return undefined;
     }
     return approximateHeightAt(m, index, kmHeights);
@@ -35,10 +35,10 @@ export function approximateHeightAt(
     const [leftMeter, rightMeter] = getTrackMeterPairAroundIndex(index, kmHeights);
     // We don't try to extrapolate heights; this is why the back-end puts in some extra effort to make sure to send
     // heights to cover all intervals where we might want to display heights (and hence can always interpolate)
-    if (rightMeter.height == undefined) {
+    if (rightMeter.height === undefined) {
         return leftMeter.height;
     }
-    if (leftMeter.height == undefined) {
+    if (leftMeter.height === undefined) {
         return rightMeter.height;
     }
     const proportion = (m - leftMeter.m) / (rightMeter.m - leftMeter.m);

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -71,7 +71,7 @@ async function getVerticalGeometry(
 ): Promise<VerticalGeometryItem[] | undefined> {
     return 'planId' in alignmentId
         ? getGeometryPlanVerticalGeometry(changeTimes.geometryPlan, alignmentId.planId).then(
-              (geometries) => geometries?.filter((g) => g.alignmentId == alignmentId.alignmentId),
+              (geometries) => geometries?.filter((g) => g.alignmentId === alignmentId.alignmentId),
           )
         : getLocationTrackVerticalGeometry(
               changeTimes.layoutLocationTrack,

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -142,7 +142,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
     const onWheel: (e: WheelEvent) => void = (e) => {
         e.preventDefault();
         const elementLeft = ref.current?.getBoundingClientRect()?.x;
-        if (elementLeft == undefined) {
+        if (elementLeft === undefined) {
             return;
         }
 
@@ -168,7 +168,7 @@ export const VerticalGeometryDiagram: React.FC<VerticalGeometryDiagramProps> = (
 
     const onDoubleClick: React.EventHandler<React.MouseEvent<unknown>> = (e) => {
         const elementLeft = ref.current?.getBoundingClientRect()?.x;
-        if (elementLeft == undefined) {
+        if (elementLeft === undefined) {
             return;
         }
 


### PR DESCRIPTION
Lähinnä `=`-merkkien lisäämistä. Kommentoin paikat joissa joku muukin fiksi.

Toi sääntö on warn-tasoisena, eli softa kyllä kääntyy vaikka tähän uuteen sääntöön jääkin jotain kiinni. Sinänsä mielekkäämpi ehkä devatessa, ja ainakin nyt näin aluksi, kun osassa haaroista ei tätä vielä ole ollut käytössä, niin buildien pitäisi myös mennä pilvessä läpi.

Ajoin E2E:t lokaalisti, menivät läpi. Pitänee kuitenkin hakkailla vähän sitä sun tätä ominaisuutta UI:ssa, jos siellä nyt jokin outo undefined/null chekki toimi aiemmin muttei enää tyyppitarkistuksenkin jälkeen.