### PR TITLE
GVT-2726 Fix detecting changed switches from same km location track changes

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -338,19 +338,20 @@ constructor(
         val indirectChanges = changes.indirectChanges
         val switchChangesBySameKmLocationTrackChange =
             (changes.directChanges.locationTrackChanges + changes.indirectChanges.locationTrackChanges)
-                .map { locationTrackChange ->
-                    calculatedChangesService.getSwitchChangesFromChangedLocationTrackKmsByLocationTrackChange(
+                .flatMap { locationTrackChange ->
+                    calculatedChangesService.getChangedSwitchesFromChangedLocationTrackKms(
                         versions,
                         locationTrackChange,
                     )
                 }
-                .flatten()
-                .map { it.switchId }
+                .distinct()
         return PublicationRequestIds(
             trackNumbers = indirectChanges.trackNumberChanges.map { it.trackNumberId },
             referenceLines = listOf(),
             locationTracks = indirectChanges.locationTrackChanges.map { it.locationTrackId },
-            switches = indirectChanges.switchChanges.map { it.switchId } + switchChangesBySameKmLocationTrackChange,
+            switches =
+                (indirectChanges.switchChanges.map { it.switchId } + switchChangesBySameKmLocationTrackChange)
+                    .distinct(),
             kmPosts = listOf(),
         )
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationUtils.kt
@@ -19,6 +19,9 @@ import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.switchLibrary.SwitchBaseType
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
+import fi.fta.geoviite.infra.tracklayout.LayoutAssetDao
+import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSegment
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
@@ -533,3 +536,10 @@ fun findJointPoint(
         }
     }
 }
+
+fun <T : LayoutAsset<T>> getObjectFromValidationVersions(
+    versions: List<LayoutRowVersion<T>>,
+    dao: LayoutAssetDao<T>,
+    target: ValidationTarget,
+    id: IntId<T>,
+): T? = (versions.find { it.id == id } ?: dao.fetchVersion(target.baseContext, id))?.let(dao::fetch)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -202,7 +202,7 @@ constructor(
             ValidationVersions(target, trackNumbers, locationTracks, referenceLines, switches, kmPosts, emptyList())
         )
 
-    fun createValidationContext(publicationSet: ValidationVersions): ValidationContext =
+    private fun createValidationContext(publicationSet: ValidationVersions): ValidationContext =
         ValidationContext(
             trackNumberDao = trackNumberDao,
             referenceLineDao = referenceLineDao,


### PR DESCRIPTION
Palautetaan PublicationValidationService#createValidationContext privaatiksi, koska niinhän se juurikin on, että validointikonteksti ei satu olemaan juuri oikealla tavalla toimiva olio tätä laskutoimitusta varten: Sehän kun räjäyttäisi tämän koodin, jos yritettäisiin laskea, mitä muutoksia tulee suunnitelmassa tehdyn olion luomisen hylkäämisestä.

Muuten siis sama logiikka kuin mitä aiemminkin yritin: Ratko-integraatio lähettää kaikki vaihteet, jotka ovat linkitetty samalle ratakilometrille kuin mikä tahansa muutos raiteella, vaikka vaihteella itsellään ei olisi varsinaisesti muuttunut mitään; ja koska päätös siitä, mille olioille haetaan suunnitelman OIDit, tehdään jo tässä julkaisun yhteydessä, tässä pitää myös tietää osata hakea näille vaihteille OIDit.