### PR TITLE
GVT-2893 (part 3): Improve test by overwriting original thread context value within reactive context

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/ThreadContextMiddlewareIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/ThreadContextMiddlewareIT.kt
@@ -61,6 +61,15 @@ class ThreadContextMiddlewareTest {
         val result =
             middlewareFunc.filter(clientRequest, mockExchangeFunction).doOnSubscribe {
                 ThreadContext.put(someOtherKey, someOtherValue)
+
+                // Overwrite the originalKey in reactive context to test that the value is also
+                // restored to the previous value outside the reactive context.
+                assertEquals(originalValue, ThreadContext.get(originalKey))
+
+                val modifiedValue = originalValue + "modified"
+                ThreadContext.put(originalKey, modifiedValue)
+
+                assertEquals(modifiedValue, ThreadContext.get(originalKey))
             }
 
         StepVerifier.create(result).expectNextCount(1).verifyComplete()


### PR DESCRIPTION
Review-lisäys, ks. https://github.com/finnishtransportagency/geoviite/pull/1607#discussion_r1930347046