### PR TITLE
General: Use SWC as the TypeScript loader in webpack

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -65,6 +65,7 @@
                 "sass": "~1.71.0",
                 "sass-loader": "~14.1.0",
                 "source-map-loader": "~5.0.0",
+                "swc-loader": "^0.2.6",
                 "ts-jest": "~29.1.1",
                 "ts-loader": "~9.5.1",
                 "ts-node": "~10.9.1",
@@ -11896,6 +11897,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/swc-loader": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.6.tgz",
+            "integrity": "sha512-9Zi9UP2YmDpgmQVbyOPJClY0dwf58JDyDMQ7uRc4krmc72twNI2fvlBWHLqVekBpPc7h5NJkGVT1zNDxFrqhvg==",
+            "dev": true,
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            },
+            "peerDependencies": {
+                "@swc/core": "^1.2.147",
+                "webpack": ">=2"
             }
         },
         "node_modules/symbol-tree": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
         "sass": "~1.71.0",
         "sass-loader": "~14.1.0",
         "source-map-loader": "~5.0.0",
+        "swc-loader": "^0.2.6",
         "ts-jest": "~29.1.1",
         "ts-loader": "~9.5.1",
         "ts-node": "~10.9.1",

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -140,7 +140,7 @@ module.exports = (env) => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: 'ts-loader',
+                    loader: 'swc-loader',
                 },
                 {
                     test: /\.(png|jp(e*)g|gif|woff|woff2|ttf|eot|ico|otf)$/,


### PR DESCRIPTION
SWC (https://swc.rs/) is a drop-in replacement for typescript transpiling, while being a lot faster (2-3x speedup on my machine in this codebase compared to normal ts-transpiler).