### PR TITLE
GVT-2746: Bugeja raidegeometrian kilometripylvään infoboksissa

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -523,7 +523,8 @@
                 "linking": {
                     "title": "Linkitys",
                     "is-linked-label": "Linkitetty",
-                    "km-post-label": "Tasakilometripiste",
+                    "km-post-label-singular": "Tasakilometripiste",
+                    "km-post-label-plural": "Tasakilometripisteet",
                     "choose-km-post-msg": "Valitse tasakilometripiste, johon linkitetään",
                     "start-linking-command": "Aloita linkitys",
                     "link-command": "Linkitä",

--- a/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
+++ b/ui/src/geoviite-design-lib/km-post/km-post-badge.tsx
@@ -46,7 +46,7 @@ export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
         trackNumber: trackNumber?.number,
     });
     return (
-        <div
+        <span
             className={classes}
             title={trackNumber ? onTrackNumberTranslation : ''}
             onClick={onClick}>
@@ -54,6 +54,6 @@ export const KmPostBadge: React.FC<KmPostBadgeProps> = ({
             <span>{`${kmPost.kmNumber} ${
                 showTrackNumberInBadge && trackNumber ? `/ ${onTrackNumberTranslation}` : ''
             }`}</span>
-        </div>
+        </span>
     );
 };

--- a/ui/src/geoviite-design-lib/linking-status/linking-status-label.scss
+++ b/ui/src/geoviite-design-lib/linking-status/linking-status-label.scss
@@ -1,7 +1,6 @@
 @use 'vayla-design-lib' as vayla-design;
 
 .linking-status-label {
-    @include vayla-design.typography-sub-heading;
     display: inline-flex;
     align-items: center;
     user-select: none;

--- a/ui/src/geoviite-design-lib/linking-status/linking-status-label.tsx
+++ b/ui/src/geoviite-design-lib/linking-status/linking-status-label.tsx
@@ -17,8 +17,8 @@ export const LinkingStatusLabel: React.FC<LinkingStatusLabelProps> = ({
     );
 
     return (
-        <div className={classes}>
-            <span>{t(isLinked ? 'yes' : 'no')}</span>
-        </div>
+        <span className={classes}>
+            <span>{isLinked ? t('yes') : t('no')}</span>
+        </span>
     );
 };

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.scss
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.scss
@@ -12,14 +12,6 @@
         padding: 4px 8px;
     }
 
-    &__not-linked-text {
-        background-color: vayla-design.$color-red-lighter;
-    }
-
-    &__linked-text {
-        background-color: vayla-design.$color-green-lighter;
-    }
-
     &__linking-container {
         padding: 8px 0 8px 4px;
     }

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -61,7 +61,6 @@ import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
 import { LinkingStatusLabel } from 'geoviite-design-lib/linking-status/linking-status-label';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
-import { isNil } from 'utils/type-utils';
 
 function createLinkingGeometryWithAlignmentParameters(
     alignmentLinking: LinkingGeometryWithAlignment,
@@ -213,7 +212,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
             changeTimes.layoutReferenceLine,
         ],
     );
-    const isLinked = linkedAlignmentIds?.includes(geometryAlignment.id);
+    const isLinked = linkedAlignmentIds ? linkedAlignmentIds.includes(geometryAlignment.id) : false;
 
     const handleTrackNumberSave = refreshTrackNumberSelection(
         draftLayoutContext(layoutContext),
@@ -303,7 +302,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                         label={t('tool-panel.alignment.geometry.is-linked')}
                         className={styles['geometry-alignment-infobox__linked-status']}
                         value={
-                            linkedAlignmentIdsStatus === LoaderStatus.Ready && !isNil(isLinked) ? (
+                            linkedAlignmentIdsStatus === LoaderStatus.Ready ? (
                                 <LinkingStatusLabel isLinked={isLinked} />
                             ) : (
                                 <Spinner />

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -59,6 +59,7 @@ import { Radio } from 'vayla-design-lib/radio/radio';
 import { ChangeTimes } from 'common/common-slice';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
+import { LinkingStatusLabel } from 'geoviite-design-lib/linking-status/linking-status-label';
 
 function createLinkingGeometryWithAlignmentParameters(
     alignmentLinking: LinkingGeometryWithAlignment,
@@ -152,7 +153,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
         React.useState<MapAlignmentType>('LOCATION_TRACK');
 
     const linkingInProgress = linkingState?.state === 'setup' || linkingState?.state === 'allSet';
-    const isLinked = geometryAlignment.id && linkedAlignmentIds.includes(geometryAlignment.id);
+    const isLinked = linkedAlignmentIds.includes(geometryAlignment.id);
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
 
     const planStatus = useLoader(
@@ -301,20 +302,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                         qaId="geometry-alignment-linked"
                         label={t('tool-panel.alignment.geometry.is-linked')}
                         className={styles['geometry-alignment-infobox__linked-status']}
-                        value={
-                            isLinked ? (
-                                <span className={styles['geometry-alignment-infobox__linked-text']}>
-                                    {t('yes')}
-                                </span>
-                            ) : (
-                                <span
-                                    className={
-                                        styles['geometry-alignment-infobox__not-linked-text']
-                                    }>
-                                    {t('no')}
-                                </span>
-                            )
-                        }
+                        value={<LinkingStatusLabel isLinked={isLinked} />}
                     />
 
                     {linkedLocationTracks && linkedLocationTracks.length > 0 && (

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -17,7 +17,7 @@ import {
     linkGeometryWithLocationTrack,
     linkGeometryWithReferenceLine,
 } from 'linking/linking-api';
-import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
+import { GeometryPlanId } from 'geometry/geometry-model';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { LocationTrackEditDialogContainer } from 'tool-panel/location-track/dialog/location-track-edit-dialog';
@@ -40,7 +40,7 @@ import {
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { LINKING_DOTS } from 'map/layers/utils/layer-visibility-limits';
 import LocationTrackNames from './location-track-names';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoader, useLoaderWithStatus } from 'utils/react-utils';
 import ReferenceLineNames from 'tool-panel/geometry-alignment/reference-line-names';
 import { TrackNumberEditDialogContainer } from 'tool-panel/track-number/dialog/track-number-edit-dialog';
 import { OnSelectOptions, OptionalUnselectableItemCollections } from 'selection/selection-model';
@@ -60,6 +60,8 @@ import { ChangeTimes } from 'common/common-slice';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
 import { LinkingStatusLabel } from 'geoviite-design-lib/linking-status/linking-status-label';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { isNil } from 'utils/type-utils';
 
 function createLinkingGeometryWithAlignmentParameters(
     alignmentLinking: LinkingGeometryWithAlignment,
@@ -146,14 +148,12 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     onContentVisibilityChange,
 }) => {
     const { t } = useTranslation();
-    const [linkedAlignmentIds, setLinkedAlignmentIds] = React.useState<GeometryAlignmentId[]>([]);
     const [showAddLocationTrackDialog, setShowAddLocationTrackDialog] = React.useState(false);
     const [showAddTrackNumberDialog, setShowAddTrackNumberDialog] = React.useState(false);
     const [linkingAlignmentType, setLinkingAlignmentType] =
         React.useState<MapAlignmentType>('LOCATION_TRACK');
 
     const linkingInProgress = linkingState?.state === 'setup' || linkingState?.state === 'allSet';
-    const isLinked = linkedAlignmentIds.includes(geometryAlignment.id);
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
 
     const planStatus = useLoader(
@@ -203,17 +203,17 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
             selectedLayoutLocationTrack &&
             !selectedLocationTrackInfoboxExtras?.partOfUnfinishedSplit);
 
-    React.useEffect(() => {
-        getLinkedAlignmentIdsInPlan(planId, layoutContext).then((linkedIds) => {
-            setLinkedAlignmentIds(linkedIds);
-        });
-    }, [
-        planId,
-        layoutContext.publicationState,
-        layoutContext.branch,
-        changeTimes.layoutLocationTrack,
-        changeTimes.layoutReferenceLine,
-    ]);
+    const [linkedAlignmentIds, linkedAlignmentIdsStatus] = useLoaderWithStatus(
+        () => getLinkedAlignmentIdsInPlan(planId, layoutContext),
+        [
+            planId,
+            layoutContext.publicationState,
+            layoutContext.branch,
+            changeTimes.layoutLocationTrack,
+            changeTimes.layoutReferenceLine,
+        ],
+    );
+    const isLinked = linkedAlignmentIds?.includes(geometryAlignment.id);
 
     const handleTrackNumberSave = refreshTrackNumberSelection(
         draftLayoutContext(layoutContext),
@@ -302,7 +302,13 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                         qaId="geometry-alignment-linked"
                         label={t('tool-panel.alignment.geometry.is-linked')}
                         className={styles['geometry-alignment-infobox__linked-status']}
-                        value={<LinkingStatusLabel isLinked={isLinked} />}
+                        value={
+                            linkedAlignmentIdsStatus === LoaderStatus.Ready && !isNil(isLinked) ? (
+                                <LinkingStatusLabel isLinked={isLinked} />
+                            ) : (
+                                <Spinner />
+                            )
+                        }
                     />
 
                     {linkedLocationTracks && linkedLocationTracks.length > 0 && (

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
@@ -15,6 +15,13 @@
     visibility: hidden;
 }
 
+.km-post-infobox-linking-infobox__currently-linked-km-posts {
+    display: grid;
+    grid-template-columns: max-content max-content max-content;
+    row-gap: 10px;
+    column-gap: 10px;
+}
+
 .geometry-km-post-linking-infobox__layout-km-posts {
     border: 1px solid vayla-design.$color-white-darker;
     border-radius: 4px;

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.scss
@@ -17,9 +17,12 @@
 
 .km-post-infobox-linking-infobox__currently-linked-km-posts {
     display: grid;
-    grid-template-columns: max-content max-content max-content;
-    row-gap: 10px;
-    column-gap: 10px;
+    grid-template-columns: max-content;
+    row-gap: 6px;
+
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .geometry-km-post-linking-infobox__layout-km-posts {

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -32,6 +32,8 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
 import { createEmptyItemCollections } from 'selection/selection-store';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { compareByField } from 'utils/array-utils';
+import { isNil } from 'utils/type-utils';
 
 type GeometryKmPostLinkingInfoboxProps = {
     geometryKmPost: LayoutKmPost;
@@ -84,7 +86,11 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                           .flatMap((linkStatus) => linkStatus.linkedKmPosts);
 
                       return getKmPosts(kmPostIds, layoutContext).then((posts) =>
-                          posts.filter((kp) => kp.state !== 'DELETED'),
+                          posts
+                              .filter((kp) => kp.state !== 'DELETED')
+                              .toSorted((kp1, kp2) =>
+                                  compareByField(kp1, kp2, (kp) => kp.kmNumber),
+                              ),
                       );
                   })
                 : undefined,
@@ -171,25 +177,27 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                     <InfoboxField
                         label={t('tool-panel.km-post.geometry.linking.km-post-label')}
                         value={
-                            <span
+                            <ol
                                 className={
                                     styles[
                                         'km-post-infobox-linking-infobox__currently-linked-km-posts'
                                     ]
                                 }>
-                                {!!linkedLayoutKmPosts &&
+                                {!isNil(linkedLayoutKmPosts) &&
                                     linkedLayoutKmPosts.map((kmPost) => (
-                                        <KmPostBadge
-                                            key={kmPost.id}
-                                            trackNumber={trackNumbers?.find(
-                                                (tn) => tn.id === kmPost.trackNumberId,
-                                            )}
-                                            kmPost={kmPost}
-                                            status={KmPostBadgeStatus.DEFAULT}
-                                            onClick={() => selectLayoutKmPost(kmPost.id)}
-                                        />
+                                        <li key={kmPost.id}>
+                                            <KmPostBadge
+                                                trackNumber={trackNumbers?.find(
+                                                    (tn) => tn.id === kmPost.trackNumberId,
+                                                )}
+                                                kmPost={kmPost}
+                                                status={KmPostBadgeStatus.DEFAULT}
+                                                showTrackNumberInBadge={true}
+                                                onClick={() => selectLayoutKmPost(kmPost.id)}
+                                            />
+                                        </li>
                                     ))}
-                            </span>
+                            </ol>
                         }
                     />
                     {!linkingState && (

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -33,7 +33,6 @@ import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/tr
 import { createEmptyItemCollections } from 'selection/selection-store';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { compareByField } from 'utils/array-utils';
-import { isNil } from 'utils/type-utils';
 
 type GeometryKmPostLinkingInfoboxProps = {
     geometryKmPost: LayoutKmPost;
@@ -77,7 +76,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
     const [searchTerm, setSearchTerm] = React.useState('');
     const [showAddDialog, setShowAddDialog] = React.useState(false);
 
-    const [linkedLayoutKmPosts, linkedLayoutKmPostsLoaderStatus] = useLoaderWithStatus(
+    const [fetchedLinkedLayourKmPosts, linkedLayoutKmPostsLoaderStatus] = useLoaderWithStatus(
         () =>
             planId
                 ? getPlanLinkStatus(planId, layoutContext).then((planStatus) => {
@@ -96,6 +95,7 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                 : undefined,
         [planId, kmPostChangeTime, layoutContext, geometryKmPost.sourceId],
     );
+    const linkedLayoutKmPosts = fetchedLinkedLayourKmPosts ?? [];
 
     const geometryPlan = usePlanHeader(planId);
 
@@ -152,6 +152,10 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
     );
 
     const selectLayoutKmPost = createSelectAction();
+    const linkedKmPostsLabel =
+        linkedLayoutKmPosts.length > 1
+            ? t('tool-panel.km-post.geometry.linking.km-post-label-plural')
+            : t('tool-panel.km-post.geometry.linking.km-post-label-singular');
 
     return (
         <React.Fragment>
@@ -166,7 +170,6 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                         qaId="geometry-km-post-linked"
                         label={t('tool-panel.km-post.geometry.linking.is-linked-label')}
                         value={
-                            !!linkedLayoutKmPosts &&
                             linkedLayoutKmPostsLoaderStatus === LoaderStatus.Ready ? (
                                 <LinkingStatusLabel isLinked={linkedLayoutKmPosts.length > 0} />
                             ) : (
@@ -174,17 +177,17 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                             )
                         }
                     />
-                    <InfoboxField
-                        label={t('tool-panel.km-post.geometry.linking.km-post-label')}
-                        value={
-                            <ol
-                                className={
-                                    styles[
-                                        'km-post-infobox-linking-infobox__currently-linked-km-posts'
-                                    ]
-                                }>
-                                {!isNil(linkedLayoutKmPosts) &&
-                                    linkedLayoutKmPosts.map((kmPost) => (
+                    {linkedLayoutKmPosts.length > 0 && (
+                        <InfoboxField
+                            label={linkedKmPostsLabel}
+                            value={
+                                <ol
+                                    className={
+                                        styles[
+                                            'km-post-infobox-linking-infobox__currently-linked-km-posts'
+                                        ]
+                                    }>
+                                    {linkedLayoutKmPosts.map((kmPost) => (
                                         <li key={kmPost.id}>
                                             <KmPostBadge
                                                 trackNumber={trackNumbers?.find(
@@ -197,9 +200,10 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                                             />
                                         </li>
                                     ))}
-                            </ol>
-                        }
-                    />
+                                </ol>
+                            }
+                        />
+                    )}
                     {!linkingState && (
                         <PrivilegeRequired privilege={EDIT_LAYOUT}>
                             <InfoboxButtons>

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -1,11 +1,11 @@
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import * as React from 'react';
 import Infobox from 'tool-panel/infobox/infobox';
-import { LayoutKmPost } from 'track-layout/track-layout-model';
+import { LayoutKmPost, LayoutKmPostId } from 'track-layout/track-layout-model';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { useTranslation } from 'react-i18next';
-import { useLoader } from 'utils/react-utils';
+import { LoaderStatus, useLoader, useLoaderWithStatus } from 'utils/react-utils';
 import { getPlanLinkStatus, linkKmPost } from 'linking/linking-api';
 import { GeometryKmPostId, GeometryPlanId } from 'geometry/geometry-model';
 import { draftLayoutContext, LayoutContext, TimeStamp } from 'common/common-model';
@@ -20,7 +20,6 @@ import { KmPostBadge, KmPostBadgeStatus } from 'geoviite-design-lib/km-post/km-p
 import { getKmPostForLinking, getKmPosts } from 'track-layout/layout-km-post-api';
 import { TextField, TextFieldVariant } from 'vayla-design-lib/text-field/text-field';
 import { KmPostEditDialogContainer } from 'tool-panel/km-post/dialog/km-post-edit-dialog';
-import { filterNotEmpty } from 'utils/array-utils';
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import {
     refereshKmPostSelection,
@@ -29,6 +28,10 @@ import {
 } from 'track-layout/track-layout-react-utils';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
+import { createEmptyItemCollections } from 'selection/selection-store';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
 
 type GeometryKmPostLinkingInfoboxProps = {
     geometryKmPost: LayoutKmPost;
@@ -44,6 +47,15 @@ type GeometryKmPostLinkingInfoboxProps = {
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
 };
+
+function createSelectAction() {
+    const delegates = createDelegates(TrackLayoutActions);
+    return (kmPostId: LayoutKmPostId) =>
+        delegates.onSelect({
+            ...createEmptyItemCollections(),
+            kmPosts: [kmPostId],
+        });
+}
 
 const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> = ({
     geometryKmPost,
@@ -63,19 +75,23 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
     const [searchTerm, setSearchTerm] = React.useState('');
     const [showAddDialog, setShowAddDialog] = React.useState(false);
 
-    const planStatus = useLoader(
-        () => (planId ? getPlanLinkStatus(planId, layoutContext) : undefined),
-        [planId, kmPostChangeTime, layoutContext],
-    );
-    const geometryPlan = usePlanHeader(planId);
+    const [linkedLayoutKmPosts, linkedLayoutKmPostsLoaderStatus] = useLoaderWithStatus(
+        () =>
+            planId
+                ? getPlanLinkStatus(planId, layoutContext).then((planStatus) => {
+                      const kmPostIds = planStatus.kmPosts
+                          .filter((linkStatus) => linkStatus.id === geometryKmPost.sourceId)
+                          .flatMap((linkStatus) => linkStatus.linkedKmPosts);
 
-    const linkedLayoutKmPosts = useLoader(() => {
-        if (!planStatus) return undefined;
-        const kmPostIds = planStatus.kmPosts
-            .filter((linkStatus) => linkStatus.id === geometryKmPost.sourceId)
-            .flatMap((linkStatus) => linkStatus.linkedKmPosts);
-        return getKmPosts(kmPostIds, layoutContext).then((posts) => posts.filter(filterNotEmpty));
-    }, [planStatus, geometryKmPost.sourceId]);
+                      return getKmPosts(kmPostIds, layoutContext).then((posts) =>
+                          posts.filter((kp) => kp.state !== 'DELETED'),
+                      );
+                  })
+                : undefined,
+        [planId, kmPostChangeTime, layoutContext, geometryKmPost.sourceId],
+    );
+
+    const geometryPlan = usePlanHeader(planId);
 
     const kmPosts =
         useLoader(async () => {
@@ -129,6 +145,8 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
         onUnselect,
     );
 
+    const selectLayoutKmPost = createSelectAction();
+
     return (
         <React.Fragment>
             <Infobox
@@ -142,25 +160,36 @@ const GeometryKmPostLinkingInfobox: React.FC<GeometryKmPostLinkingInfoboxProps> 
                         qaId="geometry-km-post-linked"
                         label={t('tool-panel.km-post.geometry.linking.is-linked-label')}
                         value={
-                            linkedLayoutKmPosts !== undefined && (
-                                <LinkingStatusLabel isLinked={linkedLayoutKmPosts?.length > 0} />
+                            !!linkedLayoutKmPosts &&
+                            linkedLayoutKmPostsLoaderStatus === LoaderStatus.Ready ? (
+                                <LinkingStatusLabel isLinked={linkedLayoutKmPosts.length > 0} />
+                            ) : (
+                                <Spinner />
                             )
                         }
                     />
                     <InfoboxField
                         label={t('tool-panel.km-post.geometry.linking.km-post-label')}
                         value={
-                            linkedLayoutKmPosts &&
-                            linkedLayoutKmPosts.map((kmPost) => (
-                                <KmPostBadge
-                                    key={kmPost.id}
-                                    trackNumber={trackNumbers?.find(
-                                        (tn) => tn.id === kmPost.trackNumberId,
-                                    )}
-                                    kmPost={kmPost}
-                                    status={KmPostBadgeStatus.DEFAULT}
-                                />
-                            ))
+                            <span
+                                className={
+                                    styles[
+                                        'km-post-infobox-linking-infobox__currently-linked-km-posts'
+                                    ]
+                                }>
+                                {!!linkedLayoutKmPosts &&
+                                    linkedLayoutKmPosts.map((kmPost) => (
+                                        <KmPostBadge
+                                            key={kmPost.id}
+                                            trackNumber={trackNumbers?.find(
+                                                (tn) => tn.id === kmPost.trackNumberId,
+                                            )}
+                                            kmPost={kmPost}
+                                            status={KmPostBadgeStatus.DEFAULT}
+                                            onClick={() => selectLayoutKmPost(kmPost.id)}
+                                        />
+                                    ))}
+                            </span>
                         }
                     />
                     {!linkingState && (


### PR DESCRIPTION
Alkuperäisellä tiketillä oltiin mainittu seuraavat bugit, jotka korjattu täällä:
- Listaus näyttää myös poistettuja layout-puolen km-pylväitä (enää näytetään vain olemassaolevat)
- Jos sama geometriapuolen km-pylväs on linkitetty useampaan layout-puolen kilometripylvääseen, kilometripylväät piirtyvät kiinni toisiinsa (piirtyvät nyt gridiin samoin kuin layout-puolen kilometripylväät vasemmassa palkissa)

Tämän lisäksi huomattu muutama erillinen issue, jotka korjattu:
- Badgeista ei pystynyt navigoimaan linkitettyyn kilometripylvääseen klikkaamalla badgea (nyt pystyy)
- KM-pylvään Linkitetty-kentän arvot oli kirjoitettu aiemmin all-capseilla ("KYLLÄ"/"EI"), kun muualla ne olivat kirjoitettu "Kyllä"/"Ei" (yhdistetty "Kyllä"/"Ei"-muotoon)
- Sekä geometrian kilometripylväiden että alignmentien Linkitetty-kenttä näytti hetken aikaa aina pakotetusti arvoa "Ei" ennen kuin oikea arvo saatiin ladattua, esim. refreshin jälkeen (jumpattu hakuja ja näytetään spinneri haun ollessa kesken)
- Geometria-alignmentin linkitysinfoboksissa Linkitetty-kentän arvot tehtiin käsin. Korvattu ne `LinkingStatusLabel`-komponentilla, jota geometrian KM-pylväiden infoboksissa käytettiin tähän jo