### PR TITLE
GVT-2976 Fix findLocationTracksLinkedToSwitchAtMoment draft handling

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -524,16 +524,21 @@ class LayoutSwitchDao(
               location_track.draft,
               location_track.version,
               location_track_external_id.external_id
-            from layout.switch_at(:moment) switch
-              inner join layout.location_track_at(:moment) location_track on not location_track.draft
+            from (select * from layout.location_track_version lt
+                  where lt.layout_context_id = 'main_official'
+                    and change_time <= :moment
+                    and not exists (select * from layout.location_track_version future_lt
+                                    where future_lt.id = lt.id
+                                      and future_lt.layout_context_id = lt.layout_context_id
+                                      and future_lt.version > lt.version
+                                      and future_lt.change_time <= :moment)) location_track
               inner join layout.segment_version segment 
                 on segment.alignment_id = location_track.alignment_id 
                   and segment.alignment_version = location_track.alignment_version
               left join layout.location_track_external_id
                 on location_track.id = location_track_external_id.id
                   and location_track.layout_context_id = location_track_external_id.layout_context_id
-            where switch.id = :switch_id 
-                and (segment.switch_id = :switch_id
+            where (segment.switch_id = :switch_id
                   or (location_track.topology_start_switch_id = :switch_id 
                     and location_track.topology_start_switch_joint_number = :topology_joint_number
                   )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDaoIT.kt
@@ -10,6 +10,9 @@ import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.error.DeletingFailureException
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.util.getInstant
+import fi.fta.geoviite.infra.util.queryOne
+import java.time.Instant
 import kotlin.test.assertContains
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -224,5 +227,60 @@ constructor(private val switchDao: LayoutSwitchDao, private val locationTrackDao
             null,
             switchDao.findLocationTracksLinkedToSwitches(MainLayoutContext.draft, listOf(switch))[switch],
         )
+    }
+
+    @Test
+    fun `findLocationTracksLinkedToSwitchAtMoment handles changing connectivity over time`() {
+        val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        val switch = mainOfficialContext.insert(switch()).id
+        val connectedAlignment =
+            alignment(
+                segment(Point(0.0, 0.0), Point(1.0, 1.0)).copy(switchId = switch, startJointNumber = JointNumber(1))
+            )
+        val disconnectedAlignment = alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0)))
+
+        val lt1o1 = mainOfficialContext.insert(locationTrack(trackNumber), connectedAlignment)
+        val lt2o1 = mainOfficialContext.insert(locationTrack(trackNumber), connectedAlignment)
+        val lt3o1 = mainOfficialContext.insert(locationTrack(trackNumber), connectedAlignment)
+        val lt1d1 = mainDraftContext.copyFrom(lt1o1)
+        val lt1o2 = mainOfficialContext.insert(locationTrackDao.fetch(lt1o1), disconnectedAlignment)
+        val lt1o3 = mainOfficialContext.insert(locationTrackDao.fetch(lt1o1), connectedAlignment)
+
+        fun tracksLinkedAtVersionSaveTime(version: LayoutRowVersion<LocationTrack>) =
+            switchDao
+                .findLocationTracksLinkedToSwitchAtMoment(
+                    LayoutBranch.main,
+                    switch,
+                    JointNumber(123),
+                    locationTrackVersionChangeTime(version),
+                )
+                .map { it.id }
+                .toSet()
+
+        assertEquals(setOf(lt1o1.id), tracksLinkedAtVersionSaveTime(lt1o1))
+        assertEquals(setOf(lt1o1.id, lt2o1.id), tracksLinkedAtVersionSaveTime(lt2o1))
+        assertEquals(setOf(lt1o1.id, lt2o1.id, lt3o1.id), tracksLinkedAtVersionSaveTime(lt3o1))
+        assertEquals(setOf(lt1o1.id, lt2o1.id, lt3o1.id), tracksLinkedAtVersionSaveTime(lt1d1))
+        assertEquals(setOf(lt2o1.id, lt3o1.id), tracksLinkedAtVersionSaveTime(lt1o2))
+        assertEquals(setOf(lt1o1.id, lt2o1.id, lt3o1.id), tracksLinkedAtVersionSaveTime(lt1o3))
+    }
+
+    private fun locationTrackVersionChangeTime(version: LayoutRowVersion<LocationTrack>): Instant {
+        val sql =
+            """
+            select change_time from layout.location_track_version
+            where id = :id and layout_context_id = :layout_context_id and version = :version
+        """
+                .trimIndent()
+        return jdbc.queryOne(
+            sql,
+            mapOf(
+                "id" to version.id.intValue,
+                "layout_context_id" to version.context.toSqlString(),
+                "version" to version.version,
+            ),
+        ) { rs, _ ->
+            rs.getInstant("change_time")
+        }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -380,6 +380,9 @@ constructor(
             )
         locationTrackService.insertExternalId(LayoutBranch.main, locationTrack3.id, locationTrack3Oid)
 
+        // add confuser draft; should have no effect
+        mainDraftContext.insert(mainOfficialContext.fetch(locationTrack1.id)!!)
+
         val linkedLocationTracks =
             switchDao.findLocationTracksLinkedToSwitchAtMoment(
                 LayoutBranch.main,


### PR DESCRIPTION
En lähde hotfiksissä poistamaan näitä ajanhetkihakufunktioita (switch_at(), location_track_at()), ja ehkä voisi miettiä, pystyisikö ne korjaamaan kohtuudella vaikka jollakin konteksti+ajanhetki-hauilla, mutta siis pelkässä ajanhetkihaussahan ei ole ID-remontin jälkeen ikinä mitään järkeä. Tässä kommitissa poistuvatkin niiden viimeiset varsinaiset käytöt: Loput mitä koodikannasta löytyy, ovat migraatiohistoriassa.