### PR TITLE
GVT-2783: Poistettua vaihdetta ei pitäisi voida linkittää ++

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -179,6 +179,7 @@ constructor(
         suggestedSwitch: SuggestedSwitch,
         switchId: IntId<LayoutSwitch>,
     ): LayoutRowVersion<LayoutSwitch> {
+        verifySwitchExists(branch, switchId)
         suggestedSwitch.geometrySwitchId?.let(::verifyPlanNotHidden)
         val originalTracks =
             suggestedSwitch.trackLinks.keys.associateWith { id ->
@@ -361,6 +362,15 @@ constructor(
                 message = "Cannot link a plan that is hidden",
                 localizedMessageKey = "plan-hidden",
             )
+    }
+
+    private fun verifySwitchExists(branch: LayoutBranch, switchId: IntId<LayoutSwitch>) {
+        if (!switchService.getOrThrow(branch.draft, switchId).exists) {
+            throw LinkingFailureException(
+                message = "Cannot link to a deleted layout switch",
+                localizedMessageKey = "switch-deleted",
+            )
+        }
     }
 }
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -33,6 +33,7 @@
             "plan-hidden": "Linkitystä ei voida tehdä, koska suunnitelma on poistettu",
             "unfinished-splits": "Linkitystä ei voida tehdä, koska raiteen jakaminen ei ole valmis",
             "location-track-deleted": "Linkitystä ei voida tehdä, koska sijaintiraide on Poistettu-tilassa",
+            "switch-deleted": "Linkitystä ei voida tehdä, koska vaihde on poistettu",
             "invalid-gk-srid": "Asetettu koordinaattijärjestelmä (EPSG:{{srid}}) ei ole GK-koordinaattijärjestelmä",
             "invalid-gk-location": "Sijainnin määritys on virheellinen: {{y}} N {{x}} E (EPSG:{{srid}})"
         },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -482,6 +482,7 @@
             "start-address": "Alkusijainti (km + m)",
             "cannot-shorten-deleted-track-number": "Poistettua ratanumeroa ei voi lyhentää",
             "no-geometry": "Ratanumerolla ei ole geometriaa",
+            "cant-edit-while-linking": "Ratanumeron tietoja ei voi muokata linkitystilassa",
             "revert-dialog": {
                 "revert-draft-confirm": "Hylätäänkö luonnos?",
                 "can-be-reverted": "Luonnoksen hylkääminen palauttaa ratanumeron ja pituusmittauslinjan takaisin uusimpaan viralliseen tilaan. Ratanumero ja pituusmittauslinja poistetaan jos niitä ei ole vielä julkaistu Ratkoon.",
@@ -558,8 +559,11 @@
                 "unpublished": "Julkaisematon",
                 "start-switch-placing": "Aloita linkitys",
                 "switch-placing-help": "Klikkaa kartalta sijainti, johon haluat linkittää vaihteen",
+                "cant-link-deleted": "Poistettua vaihdetta ei voi linkittää",
                 "no-location": "Ei sijaintia",
-                "joint-number": "Piste {{number}}"
+                "joint-number": "Piste {{number}}",
+                "switch-not-existing": "Vaihde on poistettu",
+                "cant-edit-while-linking": "Vaihteen tietoja ei voi muokata linkitystilassa"
             },
             "geometry": {
                 "geometry-title": "Raidegeometria: vaihde",
@@ -589,7 +593,8 @@
                 "unknown": "Ei tiedossa",
                 "geometry-plan-title": "Infra model metatiedot",
                 "manual-linking-info": "Manuaalisesti linkitettävään vaihteeseen ei liity suunnitelman vaihdetta, vaan linkitys tehdään lähtötietojen perusteella.",
-                "no-linkable-switches": "Sopivia vaihteita ei löytynyt linkitettäväksi."
+                "no-linkable-switches": "Sopivia vaihteita ei löytynyt linkitettäväksi.",
+                "layout-switch-not-existing": "Valittu vaihde on poistettu"
             }
         },
         "reference-line": {
@@ -802,7 +807,9 @@
             "splitting-blocks-geometry-changes": "Raiteen geometriaa ei voi muokata koska sen jakaminen on kesken",
             "cannot-shorten-deleted-track": "Poistettua raidetta ei voi lyhentää",
             "unsupported-state-for-splitting": "Vain \"Käytössä\"-tilaisen raiteen voi jakaa",
-            "no-geometry": "Raiteella ei ole geometriaa"
+            "no-geometry": "Raiteella ei ole geometriaa",
+            "cant-edit-while-splitting": "Raiteen tietoja ei voi muokata koska sen jakaminen on kesken",
+            "cant-edit-while-linking": "Raiteen tietoja ei voi muokata linkitystilassa"
         },
         "disabled": {
             "activity-disabled-in-official-mode": "Toiminto on aktiivinen vain luonnostilassa."

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -110,7 +110,7 @@ export const trackMeterIsValid = (trackMeter: string) => TRACK_METER_REGEX.test(
 
 const splitTrackMeterIntoComponents = (trackMeterString: string) => {
     const components = trackMeterString.match(TRACK_METER_REGEX);
-    
+
     return {
         kms: components?.[1]?.padStart(4, '0'),
         letters: components?.[2],
@@ -170,7 +170,6 @@ export type JointNumber = string;
 export type Oid = string;
 export type Srid = string;
 export type SwitchStructureId = string;
-export type SwitchAlignmentId = string;
 export type VerticalCoordinateSystem = string;
 export type SwitchOwnerId = string;
 export type LocationTrackOwnerId = string;
@@ -194,7 +193,6 @@ export type SwitchElement = {
 };
 
 export type SwitchAlignment = {
-    id: SwitchAlignmentId;
     jointNumbers: JointNumber[];
     elements: SwitchElement[];
 };

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -122,8 +122,8 @@ export type GeometryLinkingAlignmentLockParameters = {
 };
 
 export type LayoutAlignmentTypeAndId =
-    | { type: 'LOCATION_TRACK'; id: LocationTrackId }
-    | { type: 'REFERENCE_LINE'; id: ReferenceLineId };
+    | { type: MapAlignmentType.LocationTrack; id: LocationTrackId }
+    | { type: MapAlignmentType.ReferenceLine; id: ReferenceLineId };
 
 export type LinkingGeometryWithAlignment = LinkingBaseType & {
     type: LinkingType.LinkingGeometryWithAlignment;

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -149,8 +149,9 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     const { t } = useTranslation();
     const [showAddLocationTrackDialog, setShowAddLocationTrackDialog] = React.useState(false);
     const [showAddTrackNumberDialog, setShowAddTrackNumberDialog] = React.useState(false);
-    const [linkingAlignmentType, setLinkingAlignmentType] =
-        React.useState<MapAlignmentType>('LOCATION_TRACK');
+    const [linkingAlignmentType, setLinkingAlignmentType] = React.useState<MapAlignmentType>(
+        MapAlignmentType.LocationTrack,
+    );
 
     const linkingInProgress = linkingState?.state === 'setup' || linkingState?.state === 'allSet';
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
@@ -236,12 +237,18 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     function lockAlignment() {
         if (linkingAlignmentType === 'LOCATION_TRACK' && selectedLayoutLocationTrack) {
             onLockAlignment({
-                alignment: { id: selectedLayoutLocationTrack.id, type: 'LOCATION_TRACK' },
+                alignment: {
+                    id: selectedLayoutLocationTrack.id,
+                    type: MapAlignmentType.LocationTrack,
+                },
                 type: linkingTypeBySegmentCount(selectedLayoutLocationTrack),
             });
         } else if (linkingAlignmentType === 'REFERENCE_LINE' && selectedLayoutReferenceLine) {
             onLockAlignment({
-                alignment: { id: selectedLayoutReferenceLine.id, type: 'REFERENCE_LINE' },
+                alignment: {
+                    id: selectedLayoutReferenceLine.id,
+                    type: MapAlignmentType.ReferenceLine,
+                },
                 type: linkingTypeBySegmentCount(selectedLayoutReferenceLine),
             });
         }
@@ -329,15 +336,23 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                     <Radio
                                         qaId={'location-track-linking'}
                                         disabled={isNotPreliminary(linkingState.state)}
-                                        checked={linkingAlignmentType === 'LOCATION_TRACK'}
-                                        onChange={() => setLinkingAlignmentType('LOCATION_TRACK')}>
+                                        checked={
+                                            linkingAlignmentType === MapAlignmentType.LocationTrack
+                                        }
+                                        onChange={() =>
+                                            setLinkingAlignmentType(MapAlignmentType.LocationTrack)
+                                        }>
                                         {t('tool-panel.alignment.geometry.location-track')}
                                     </Radio>
                                     <Radio
                                         qaId={'reference-line-linking'}
                                         disabled={isNotPreliminary(linkingState.state)}
-                                        checked={linkingAlignmentType === 'REFERENCE_LINE'}
-                                        onChange={() => setLinkingAlignmentType('REFERENCE_LINE')}>
+                                        checked={
+                                            linkingAlignmentType === MapAlignmentType.ReferenceLine
+                                        }
+                                        onChange={() =>
+                                            setLinkingAlignmentType(MapAlignmentType.ReferenceLine)
+                                        }>
                                         {t('tool-panel.alignment.geometry.reference-line')}
                                     </Radio>
                                 </div>

--- a/ui/src/tool-panel/infobox/infobox.tsx
+++ b/ui/src/tool-panel/infobox/infobox.tsx
@@ -5,7 +5,6 @@ import { Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
-import { useTranslation } from 'react-i18next';
 
 export enum InfoBoxVariant {
     BLUE = 'infobox--blue',
@@ -22,6 +21,7 @@ export type InfoboxProps = {
     iconHidden?: boolean;
     onEdit?: () => void;
     qaId?: string;
+    disabledReason?: string | undefined;
 };
 
 const Infobox: React.FC<InfoboxProps> = ({
@@ -31,15 +31,13 @@ const Infobox: React.FC<InfoboxProps> = ({
     contentVisible,
     onContentVisibilityChange,
     qaId,
+    disabledReason,
     iconDisabled = false,
     iconHidden = false,
     onEdit,
     ...props
 }: InfoboxProps) => {
-    const { t } = useTranslation();
-    const iconTitle = iconDisabled
-        ? t('tool-panel.disabled.activity-disabled-in-official-mode')
-        : '';
+    const iconTitle = iconDisabled ? disabledReason : '';
 
     const classes = createClassName(styles.infobox, variant && styles[variant], className);
     const titleClasses = createClassName(

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -42,6 +42,7 @@ type LocationTrackBasicInfoInfoboxContainerProps = {
     visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
     openEditLocationTrackDialog: () => void;
     editingDisabled: boolean;
+    editingDisabledReason: string | undefined;
 };
 
 export const LocationTrackBasicInfoInfoboxContainer: React.FC<
@@ -74,6 +75,7 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
     visibilityChange,
     openEditLocationTrackDialog,
     editingDisabled,
+    editingDisabledReason,
     onSelect,
     showArea,
 }) => {
@@ -129,6 +131,7 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
             title={t('tool-panel.location-track.basic-info-heading')}
             onEdit={openEditLocationTrackDialog}
             iconDisabled={editingDisabled}
+            disabledReason={editingDisabledReason}
             qa-id="location-track-infobox">
             <InfoboxContent>
                 <InfoboxField
@@ -176,8 +179,8 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                         locationTrack.duplicateOf
                             ? t('tool-panel.location-track.duplicate-of')
                             : extraInfo?.duplicates?.length ?? 0 > 0
-                            ? t('tool-panel.location-track.has-duplicates')
-                            : t('tool-panel.location-track.not-a-duplicate')
+                              ? t('tool-panel.location-track.has-duplicates')
+                              : t('tool-panel.location-track.not-a-duplicate')
                     }
                     value={
                         <LocationTrackInfoboxDuplicateOf

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { LayoutLocationTrack } from 'track-layout/track-layout-model';
 import { LinkingState } from 'linking/linking-model';
 import {
@@ -63,6 +64,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     onVerticalGeometryDiagramVisibilityChange,
     onHighlightItem,
 }: LocationTrackInfoboxProps) => {
+    const { t } = useTranslation();
     const trackNumber = useTrackNumber(locationTrack.trackNumberId, layoutContext);
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
@@ -71,6 +73,18 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
 
     const editingDisabled =
         layoutContext.publicationState === 'OFFICIAL' || !!linkingState || !!splittingState;
+    const editingDisabledReason = () => {
+        if (layoutContext.publicationState !== 'DRAFT') {
+            return t('tool-panel.disabled.activity-disabled-in-official-mode');
+        }
+        if (linkingState !== undefined) {
+            return t('tool-panel.location-track.cant-edit-while-linking');
+        }
+        if (splittingState !== undefined) {
+            return t('tool-panel.location-track.cant-edit-while-splitting');
+        }
+        return undefined;
+    };
 
     function openEditLocationTrackDialog() {
         setShowEditDialog(true);
@@ -99,6 +113,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 layoutContext={layoutContext}
                 trackNumber={trackNumber}
                 editingDisabled={editingDisabled}
+                editingDisabledReason={editingDisabledReason()}
                 visibilities={visibilities}
                 visibilityChange={visibilityChange}
                 openEditLocationTrackDialog={openEditLocationTrackDialog}

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -23,6 +23,7 @@ import {
     LayoutLocationTrack,
     LayoutSwitchId,
     LayoutTrackNumber,
+    MapAlignmentType,
     SplitPoint,
     SwitchSplitPoint,
 } from 'track-layout/track-layout-model';
@@ -424,7 +425,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 getEndLinkPoints(
                                                     locationTrack.id,
                                                     layoutContext,
-                                                    'LOCATION_TRACK',
+                                                    MapAlignmentType.LocationTrack,
                                                     changeTimes.layoutLocationTrack,
                                                 ).then(onStartLocationTrackGeometryChange);
                                             }}>
@@ -464,7 +465,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                             )}
                             <EnvRestricted restrictTo="test">
                                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                    {isMainDraft && (
+                                    {isMainDraft && !linkingState && (
                                         <React.Fragment>
                                             {locationTrack.isDraft &&
                                                 !extraInfo?.partOfUnfinishedSplit && (

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -98,7 +98,11 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
     const switchStructure = useSwitchStructure(suggestedSwitch?.switchStructureId);
     const [showAddSwitchDialog, setShowAddSwitchDialog] = React.useState(false);
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
-    const selectedLayoutSwitch = useSwitch(linkingState?.layoutSwitchId, layoutContext);
+    const selectedLayoutSwitch = useSwitch(
+        linkingState?.layoutSwitchId,
+        layoutContext,
+        switchChangeTime,
+    );
     const selectedLayoutSwitchStructure = useSwitchStructure(
         selectedLayoutSwitch?.switchStructureId,
     );

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Infobox from 'tool-panel/infobox/infobox';
-import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import { useTranslation } from 'react-i18next';
 import styles from './switch-infobox.scss';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
@@ -36,6 +36,7 @@ import { GeometrySwitchLinkingInfoboxVisibilities } from 'track-layout/track-lay
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { SwitchBadge, SwitchBadgeStatus } from 'geoviite-design-lib/switch/switch-badge';
+import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
 
 type GeometrySwitchLinkingInfoboxProps = {
     geometrySwitchId?: GeometrySwitchId;
@@ -92,8 +93,8 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         suggestedSwitchResult === undefined
             ? undefined
             : 'switch' in suggestedSwitchResult
-            ? suggestedSwitchResult.switch
-            : undefined;
+              ? suggestedSwitchResult.switch
+              : undefined;
     const switchStructure = useSwitchStructure(suggestedSwitch?.switchStructureId);
     const [showAddSwitchDialog, setShowAddSwitchDialog] = React.useState(false);
     const [linkingCallInProgress, setLinkingCallInProgress] = React.useState(false);
@@ -108,12 +109,12 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         switchStructure.id === selectedLayoutSwitch.switchStructureId
             ? SwitchTypeMatch.Exact
             : suggestedSwitch &&
-              selectedLayoutSwitchStructure &&
-              switchStructure &&
-              switchStructure.baseType === selectedLayoutSwitchStructure.baseType &&
-              switchStructure.hand === selectedLayoutSwitchStructure.hand
-            ? SwitchTypeMatch.Similar
-            : SwitchTypeMatch.Invalid;
+                selectedLayoutSwitchStructure &&
+                switchStructure &&
+                switchStructure.baseType === selectedLayoutSwitchStructure.baseType &&
+                switchStructure.hand === selectedLayoutSwitchStructure.hand
+              ? SwitchTypeMatch.Similar
+              : SwitchTypeMatch.Invalid;
 
     const [switchTypeDifferenceIsConfirmed, setSwitchTypeDifferenceIsConfirmed] =
         React.useState(false);
@@ -130,7 +131,8 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
         selectedLayoutSwitch &&
         isValidLayoutSwitch &&
         linkingState?.state === 'allSet' &&
-        !linkingCallInProgress;
+        !linkingCallInProgress &&
+        selectedLayoutSwitch.stateCategory !== 'NOT_EXISTING';
 
     React.useEffect(() => setSwitchTypeDifferenceIsConfirmed(false), [selectedLayoutSwitch]);
 
@@ -163,6 +165,13 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
             }
         }
     }
+
+    const linkingDisabledReason = () => {
+        if (selectedLayoutSwitch?.stateCategory === 'NOT_EXISTING') {
+            return t('tool-panel.switch.geometry.layout-switch-not-existing');
+        }
+        return undefined;
+    };
 
     return (
         <React.Fragment>
@@ -269,12 +278,21 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                                 <Button
                                     size={ButtonSize.SMALL}
                                     disabled={!canLink}
+                                    title={linkingDisabledReason()}
                                     isProcessing={linkingCallInProgress}
                                     qa-id="link-geometry-switch"
                                     onClick={link}>
                                     {t('tool-panel.switch.geometry.save-link')}
                                 </Button>
                             </InfoboxButtons>
+                            {linkingState.switchSource === 'PREDEFINED' &&
+                                layoutSwitch?.stateCategory === 'NOT_EXISTING' && (
+                                    <InfoboxContentSpread>
+                                        <MessageBox type={'ERROR'}>
+                                            {t('tool-panel.switch.layout.cant-link-deleted')}
+                                        </MessageBox>
+                                    </InfoboxContentSpread>
+                                )}
                         </React.Fragment>
                     )}
                 </InfoboxContent>

--- a/ui/src/tool-panel/switch/switch-joint-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox.tsx
@@ -91,7 +91,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
         return badges.length > 0 ? (
             badges
         ) : (
-            <span key={'nein'} className={styles['switch-joint-infobox__no-alignments']}>
+            <span className={styles['switch-joint-infobox__no-alignments']}>
                 {t('tool-panel.switch.layout.no-alignments')}
             </span>
         );

--- a/ui/src/tool-panel/switch/switch-joint-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox.tsx
@@ -91,7 +91,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
         return badges.length > 0 ? (
             badges
         ) : (
-            <span className={styles['switch-joint-infobox__no-alignments']}>
+            <span key={'nein'} className={styles['switch-joint-infobox__no-alignments']}>
                 {t('tool-panel.switch.layout.no-alignments')}
             </span>
         );
@@ -106,43 +106,36 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
                 <dd className={styles['switch-joint-infobox__joint-title']}>
                     {t('tool-panel.switch.layout.joint-alignments-location-tracks-title')}
                 </dd>
-                {switchAlignments.map((a) => {
-                    return (
-                        <React.Fragment key={a.id}>
-                            <dt className={styles['switch-joint-infobox__joint-alignments-title']}>
-                                {a.jointNumbers.map((j) => switchJointNumberToString(j)).join('-')}
-                            </dt>
-                            <dd className={styles['switch-joint-infobox__location-tracks']}>
-                                <div>{getLocationTracksForJointNumbers(a.jointNumbers)}</div>
-                            </dd>
-                        </React.Fragment>
-                    );
-                })}
+                {switchAlignments.map((a) => (
+                    <React.Fragment key={a.jointNumbers.join('_')}>
+                        <dt className={styles['switch-joint-infobox__joint-alignments-title']}>
+                            {a.jointNumbers.map((j) => switchJointNumberToString(j)).join('-')}
+                        </dt>
+                        <dd className={styles['switch-joint-infobox__location-tracks']}>
+                            <div>{getLocationTracksForJointNumbers(a.jointNumbers)}</div>
+                        </dd>
+                    </React.Fragment>
+                ))}
                 {displayedLocationTracksEndingAtJoint.length > 0 && (
-                    <>
+                    <React.Fragment>
                         <dt className={styles['switch-joint-infobox__joint-title']}>
                             {t('tool-panel.switch.layout.joint-number-title')}
                         </dt>
                         <dd className={styles['switch-joint-infobox__joint-title']}>
                             {t('tool-panel.switch.layout.location-tracks-end-at-joint-title')}
                         </dd>
-                        {displayedLocationTracksEndingAtJoint?.map((a) => {
-                            return (
-                                <React.Fragment key={a.jointNumber}>
-                                    <dt
-                                        className={
-                                            styles['switch-joint-infobox__joint-points-title']
-                                        }>
-                                        {switchJointNumberToString(a.jointNumber)}.{' '}
-                                        {t('tool-panel.switch.layout.point')}
-                                    </dt>
-                                    <dd className={styles['switch-joint-infobox__location-tracks']}>
-                                        <div>{getLocationTrackBadges(a.locationTrackIds)}</div>
-                                    </dd>
-                                </React.Fragment>
-                            );
-                        })}
-                    </>
+                        {displayedLocationTracksEndingAtJoint?.map((a) => (
+                            <React.Fragment key={a.jointNumber}>
+                                <dt className={styles['switch-joint-infobox__joint-points-title']}>
+                                    {switchJointNumberToString(a.jointNumber)}.{' '}
+                                    {t('tool-panel.switch.layout.point')}
+                                </dt>
+                                <dd className={styles['switch-joint-infobox__location-tracks']}>
+                                    <div>{getLocationTrackBadges(a.locationTrackIds)}</div>
+                                </dd>
+                            </React.Fragment>
+                        ))}
+                    </React.Fragment>
                 )}
             </dl>
         </React.Fragment>

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -13,6 +13,7 @@ import {
     LayoutSwitchId,
     LayoutTrackNumberId,
     LocationTrackId,
+    MapAlignmentType,
 } from 'track-layout/track-layout-model';
 import { LinkingState, LinkingType, SuggestedSwitch } from 'linking/linking-model';
 import { SelectedGeometryItem } from 'selection/selection-model';
@@ -44,6 +45,7 @@ import { GeometrySwitchInfoboxContainer } from 'tool-panel/switch/dialog/geometr
 import { LocationTrackTaskListContainer } from 'tool-panel/location-track/location-track-task-list/location-track-task-list-container';
 import { TabHeader, TabHeaderSize } from 'geoviite-design-lib/tab-header/tab-header';
 import { LayoutContext } from 'common/common-model';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 type ToolPanelProps = {
     planIds: GeometryPlanId[];
@@ -91,6 +93,17 @@ type ToolPanelTab = {
 
 const isSameAsset = (a: ToolPanelAsset | undefined, b: ToolPanelAsset | undefined) =>
     !!a && !!b && a.id === b.id && a.type === b.type;
+
+const linkingStateLayoutAlignmentTabType = (type: MapAlignmentType) => {
+    switch (type) {
+        case MapAlignmentType.LocationTrack:
+            return 'LOCATION_TRACK';
+        case MapAlignmentType.ReferenceLine:
+            return 'TRACK_NUMBER';
+        default:
+            return exhaustiveMatchingGuard(type);
+    }
+};
 
 const ToolPanel: React.FC<ToolPanelProps> = ({
     planIds,
@@ -429,9 +442,13 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         let lockToAsset;
 
         if (linkingState?.type === LinkingType.LinkingAlignment) {
+            const tabTypeToFind = linkingStateLayoutAlignmentTabType(
+                linkingState.layoutAlignment.type,
+            );
+
             lockToAsset = tabs.find(
                 (t) =>
-                    t.asset.type === 'LOCATION_TRACK' &&
+                    t.asset.type === tabTypeToFind &&
                     t.asset.id === linkingState.layoutAlignment.id,
             )?.asset;
         } else if (

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -5,6 +5,7 @@ import {
     LAYOUT_SRID,
     LayoutReferenceLine,
     LayoutTrackNumber,
+    MapAlignmentType,
 } from 'track-layout/track-layout-model';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
@@ -154,6 +155,17 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
         }
     };
 
+    const editingDisabled = isOfficial || !!linkingState;
+    const editingDisabledReason = () => {
+        if (isOfficial) {
+            return t('tool-panel.disabled.activity-disabled-in-official-mode');
+        }
+        if (linkingState !== undefined) {
+            return t('tool-panel.track-number.cant-edit-while-linking');
+        }
+        return undefined;
+    };
+
     return (
         <React.Fragment>
             <Infobox
@@ -162,7 +174,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                 title={t('tool-panel.track-number.general-title')}
                 qa-id="track-number-infobox"
                 onEdit={() => setShowEditDialog(true)}
-                iconDisabled={isOfficial}>
+                iconDisabled={editingDisabled}
+                disabledReason={editingDisabledReason()}>
                 <InfoboxContent>
                     <InfoboxField
                         qaId="track-number-oid"
@@ -199,7 +212,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                     title={t('tool-panel.reference-line.basic-info-heading')}
                     qa-id="reference-line-location-infobox"
                     onEdit={() => setShowEditDialog(true)}
-                    iconDisabled={isOfficial}>
+                    iconDisabled={editingDisabled}
+                    disabledReason={editingDisabledReason()}>
                     <InfoboxContent>
                         <InfoboxField
                             qaId="track-number-start-track-meter"
@@ -233,7 +247,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                                             getEndLinkPoints(
                                                 referenceLine.id,
                                                 layoutContext,
-                                                'REFERENCE_LINE',
+                                                MapAlignmentType.ReferenceLine,
                                                 changeTimes.layoutReferenceLine,
                                             ).then(onStartReferenceLineGeometryChange);
                                         }}>

--- a/ui/src/track-layout/layout-map-api.ts
+++ b/ui/src/track-layout/layout-map-api.ts
@@ -167,13 +167,13 @@ export async function getMapAlignmentsByTiles(
 
     return [
         ...(await getAlignmentDataHolder(
-            'REFERENCE_LINE',
+            MapAlignmentType.ReferenceLine,
             rlPolyLines,
             layoutContext,
             changeTimes,
         )),
         ...(await getAlignmentDataHolder(
-            'LOCATION_TRACK',
+            MapAlignmentType.LocationTrack,
             ltPolyLines,
             layoutContext,
             changeTimes,
@@ -212,7 +212,12 @@ export async function getReferenceLineMapAlignmentsByTiles(
         mapTiles.map((tile) => getPolyLines(tile, changeTime, layoutContext, 'REFERENCE_LINES')),
     ).then((p) => p.flat());
 
-    return getAlignmentDataHolder('REFERENCE_LINE', polyLines, layoutContext, changeTimes);
+    return getAlignmentDataHolder(
+        MapAlignmentType.ReferenceLine,
+        polyLines,
+        layoutContext,
+        changeTimes,
+    );
 }
 
 export async function getSelectedLocationTrackMapAlignmentByTiles(
@@ -232,7 +237,12 @@ export async function getSelectedLocationTrackMapAlignmentByTiles(
         ),
     ).then((lines) => lines.flat());
 
-    return getAlignmentDataHolder('LOCATION_TRACK', polyLines, layoutContext, changeTimes);
+    return getAlignmentDataHolder(
+        MapAlignmentType.LocationTrack,
+        polyLines,
+        layoutContext,
+        changeTimes,
+    );
 }
 
 export async function getLocationTrackMapAlignmentsByTiles(
@@ -246,14 +256,19 @@ export async function getLocationTrackMapAlignmentsByTiles(
         ),
     ).then((lines) => lines.flat());
 
-    return getAlignmentDataHolder('LOCATION_TRACK', polyLines, layoutContext, changeTimes);
+    return getAlignmentDataHolder(
+        MapAlignmentType.LocationTrack,
+        polyLines,
+        layoutContext,
+        changeTimes,
+    );
 }
 
 type MapLayoutAlignmentDataHolder<M extends MapAlignmentType> = M extends 'LOCATION_TRACK'
     ? LocationTrackAlignmentDataHolder
     : M extends 'REFERENCE_LINE'
-    ? ReferenceLineAlignmentDataHolder
-    : never;
+      ? ReferenceLineAlignmentDataHolder
+      : never;
 
 async function getAlignmentDataHolder<M extends MapAlignmentType>(
     type: M,

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -77,13 +77,16 @@ export type ReferenceLineId = Brand<string, 'ReferenceLineId'>;
 export type LocationTrackId = Brand<string, 'LocationTrackId'>;
 export type LocationTrackType = 'MAIN' | 'SIDE' | 'TRAP' | 'CHORD';
 export type MapAlignmentSource = 'LAYOUT' | 'GEOMETRY';
-export type MapAlignmentType = 'LOCATION_TRACK' | 'REFERENCE_LINE';
 export type TopologicalConnectivityType = 'NONE' | 'START' | 'END' | 'START_AND_END';
 export type LocationTrackDescriptionSuffixMode =
     | 'NONE'
     | 'SWITCH_TO_SWITCH'
     | 'SWITCH_TO_BUFFER'
     | 'SWITCH_TO_OWNERSHIP_BOUNDARY';
+export enum MapAlignmentType {
+    LocationTrack = 'LOCATION_TRACK',
+    ReferenceLine = 'REFERENCE_LINE',
+}
 
 export type LayoutAssetFields = {
     version?: RowVersion;


### PR DESCRIPTION
Perus pikkutiketin kaninkolopullari. Tiketin alkuperäinen pointti oli se, että on mahdollista linkittää uudestaan vaihde, joka on jo poistettu. Tuo on estetty tällä pullarilla sekä frontin että bäkkärin puolelta, mutta sen lisäksi liitännäisinä ja liitännäisten liitännäisinä täällä on tehty seuraavat jutut:
* Disabloitu vaihteen, sijaintiraiteen ja pituusmittauslinjan muokkausnappulat infobokseissa linkitystilan ollessa päällä (aiemmin niitä pystyi painamaan, joten esim. vaihteen pystyi poistamaan itse kesken linkityksen)
* Toteutettu fiksumpi disabled-syyn näyttäminen infoboksien muokkausnappuloille (syy oli aiemmin kovakoodattu sellaiseksi, että luultiin että napit olisi disabloitu vain nykytilassa)
* Ratanumeron toolpanelin tab lukitaan nyt kunnolla kun ratanumeroa ollaan poistamassa (aiemmin ei lukittu, ja yritettiin lukita ka. id:llä ollut sijaintiraide -> jos samalla id:llä olevat sijaintiraide ja ratanumero olisi olleet valittuna, ratanumeron lyhentäminen olisi pakottanut sijaintiraiteen tabin aktiiviseksi)