### PR TITLE
GVT-2976 Recreate timed fetch functions

### DIFF
--- a/infra/src/main/resources/db/migration/prod/V110_recreate_timed_fetch_functions.sql
+++ b/infra/src/main/resources/db/migration/prod/V110_recreate_timed_fetch_functions.sql
@@ -1,0 +1,7 @@
+select common.create_timed_fetch_function('layout', 'track_number');
+select common.create_timed_fetch_function('layout', 'reference_line');
+select common.create_timed_fetch_function('layout', 'location_track');
+select common.create_timed_fetch_function('layout', 'alignment');
+select common.create_timed_fetch_function('layout', 'switch');
+select common.create_timed_fetch_function('layout', 'km_post');
+


### PR DESCRIPTION
Nämä funktiot näemmä tosiaan toimii aikalailla suoriltaan niin kuin pitäisikin, olisi siis voinut uudelleenluoda jo ID-remontin yhteydessä.

Sillä tavalla nämä kylläkin sopivat huonosti yhteen uuden rakenteen ja Geoviitteen kehityshistorian kanssa, että jos hakee luonnostilaisia olioita, niin näistä funktioista tulee nyt ulos historian aikana (ennen ID-remonttia) Geoviitteessä luodut ja julkaistut oliot: Niiden viimeinen luonnosversio ennen julkaisuahan muuttui suoraan viralliseksi versioksi, eli niistä ei tullut deleted-lipullisia rivejä versiotauluun.

(Poistojen keksiminen versiotauluun olisi tietenkin ihan täysin mahdollista tehdä vieläkin, mutta tuskin maksaa vaivaa.)