### PR TITLE
GVT-2919: Ratanumeron alku- ja loppusijainnille näytetään kohdistusnappulat vaikka ratanumerolla ei olisi geometriaa ++

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -81,8 +81,14 @@ data class AlignmentAddresses(
 data class AlignmentStartAndEnd<T>(val id: IntId<T>, val start: AlignmentEndPoint?, val end: AlignmentEndPoint?) {
     companion object {
         fun <T> of(id: IntId<T>, alignment: IAlignment, geocodingContext: GeocodingContext?): AlignmentStartAndEnd<T> {
-            val start = alignment.start?.let { p -> AlignmentEndPoint(p, geocodingContext?.getAddress(p)?.first) }
-            val end = alignment.end?.let { p -> AlignmentEndPoint(p, geocodingContext?.getAddress(p)?.first) }
+            val start =
+                alignment.start?.let { p ->
+                    AlignmentEndPoint(p, geocodingContext?.getAddress(p)?.let(::getAddressIfIWithin))
+                }
+            val end =
+                alignment.end?.let { p ->
+                    AlignmentEndPoint(p, geocodingContext?.getAddress(p)?.let(::getAddressIfIWithin))
+                }
             return AlignmentStartAndEnd(id, start, end)
         }
     }
@@ -785,6 +791,9 @@ private fun intersection(edge: PolyLineEdge, projection: Line) =
         ?: throw GeocodingFailureException(
             "Projection line parallel to segment: edge=${edge.start}-${edge.end} projection=${projection.start}-${projection.end}"
         )
+
+private fun getAddressIfIWithin(address: Pair<TrackMeter, IntersectType>): TrackMeter? =
+    if (address.second == WITHIN) address.first else null
 
 const val PROJECTION_LINE_LENGTH = 100.0
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -489,7 +489,8 @@
                 "can-be-reverted": "Luonnoksen hylkääminen palauttaa ratanumeron ja pituusmittauslinjan takaisin uusimpaan viralliseen tilaan. Ratanumero ja pituusmittauslinja poistetaan jos niitä ei ole vielä julkaistu Ratkoon.",
                 "revert-succeeded": "Ratanumeron ja pituusmittauslinjan luonnokset hylätty.",
                 "revert-failed": "Luonnosten hylkääminen epäonnistui."
-            }
+            },
+            "unpublished": "Julkaisematon"
         },
         "km-post": {
             "layout": {
@@ -686,7 +687,7 @@
             "not-a-duplicate": "Ei duplikaatti",
             "change-info-heading": "Lokitiedot",
             "type": "Raidetyyppi",
-            "identifier": "Tunniste",
+            "identifier": "OID",
             "track-location-heading": "Raiteen sijaintitiedot",
             "start-point": "Alkupiste",
             "end-point": "Loppupiste",

--- a/ui/src/geoviite-design-lib/track-meter/track-meter.tsx
+++ b/ui/src/geoviite-design-lib/track-meter/track-meter.tsx
@@ -27,9 +27,11 @@ const TrackMeter: React.FC<TrackMeterProps> = ({
     return onClickAction ? (
         <span className={styles['track-meter-value-container']}>
             {displayedValue}
-            <a className={styles['position-pin-container']} onClick={onClickAction}>
-                <Icons.Target size={IconSize.SMALL} />
-            </a>
+            {trackMeter && (
+                <a className={styles['position-pin-container']} onClick={onClickAction}>
+                    <Icons.Target size={IconSize.SMALL} />
+                </a>
+            )}
         </span>
     ) : (
         <React.Fragment>{displayedValue}</React.Fragment>

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -19,6 +19,7 @@ import { Precision, roundToPrecision } from 'utils/rounding';
 import { formatToTM35FINString } from 'utils/geography-utils';
 import Infobox from 'tool-panel/infobox/infobox';
 import {
+    AlignmentEndPoint,
     LAYOUT_SRID,
     LayoutLocationTrack,
     LayoutSwitchId,
@@ -107,6 +108,29 @@ const isSplittablePoint = (
         sp.switchId !== undefined &&
         sp.switchId !== trackStartSwitchId &&
         sp.switchId !== trackEndSwitchId
+    );
+};
+
+type LocationTrackEndpointAddressInfoProps = {
+    endpoint: AlignmentEndPoint | undefined;
+    locationTrack: LayoutLocationTrack | undefined;
+};
+
+const LocationTrackEndpointAddressInfo: React.FC<LocationTrackEndpointAddressInfoProps> = ({
+    endpoint,
+    locationTrack,
+}) => {
+    const { t } = useTranslation();
+    return (
+        <React.Fragment>
+            {endpoint?.address ? (
+                <NavigableTrackMeter trackMeter={endpoint.address} location={endpoint.point} />
+            ) : locationTrack?.boundingBox ? (
+                <span>{t('tool-panel.location-track.unresolvable')}</span>
+            ) : (
+                <span>{t('tool-panel.location-track.no-geometry')}</span>
+            )}
+        </React.Fragment>
     );
 };
 
@@ -378,26 +402,18 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                             <InfoboxField
                                 qaId="location-track-start-track-meter"
                                 label={t('tool-panel.location-track.start-location')}>
-                                {startAndEndPoints?.start?.address ? (
-                                    <NavigableTrackMeter
-                                        trackMeter={startAndEndPoints?.start?.address}
-                                        location={startAndEndPoints?.start?.point}
-                                    />
-                                ) : (
-                                    t('tool-panel.location-track.unresolvable')
-                                )}
+                                <LocationTrackEndpointAddressInfo
+                                    endpoint={startAndEndPoints?.start}
+                                    locationTrack={locationTrack}
+                                />
                             </InfoboxField>
                             <InfoboxField
                                 qaId="location-track-end-track-meter"
                                 label={t('tool-panel.location-track.end-location')}>
-                                {startAndEndPoints?.end?.address ? (
-                                    <NavigableTrackMeter
-                                        trackMeter={startAndEndPoints?.end?.address}
-                                        location={startAndEndPoints?.end?.point}
-                                    />
-                                ) : (
-                                    t('tool-panel.location-track.unresolvable')
-                                )}
+                                <LocationTrackEndpointAddressInfo
+                                    endpoint={startAndEndPoints?.end}
+                                    locationTrack={locationTrack}
+                                />
                             </InfoboxField>
 
                             {linkingState === undefined && (
@@ -545,7 +561,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                 value={
                                     startAndEndPoints.start
                                         ? formatToTM35FINString(startAndEndPoints.start.point)
-                                        : t('tool-panel.location-track.unset')
+                                        : t('tool-panel.location-track.no-geometry')
                                 }
                             />
                             <InfoboxField
@@ -556,7 +572,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                 value={
                                     startAndEndPoints.end
                                         ? formatToTM35FINString(startAndEndPoints?.end.point)
-                                        : t('tool-panel.location-track.unset')
+                                        : t('tool-panel.location-track.no-geometry')
                                 }
                             />
                         </React.Fragment>

--- a/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
@@ -10,19 +10,27 @@ import { ShowMoreButton } from 'show-more-button/show-more-button';
 import { MAP_POINT_CLOSEUP_BBOX_OFFSET } from 'map/map-utils';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
 
-const formatJointTrackMeter = (
-    jointTrackMeter: SwitchJointTrackMeter,
-    addressPlaceHolder: string,
-) => {
+type JointTrackMeterProps = {
+    jointTrackMeter: SwitchJointTrackMeter;
+    addressPlaceHolder: string;
+};
+
+const JointTrackMeter: React.FC<JointTrackMeterProps> = ({
+    jointTrackMeter,
+    addressPlaceHolder,
+}) => {
+    const { t } = useTranslation();
     return (
         <span>
-            {jointTrackMeter.trackMeter && (
+            {jointTrackMeter.trackMeter ? (
                 <NavigableTrackMeter
                     trackMeter={jointTrackMeter.trackMeter}
                     location={jointTrackMeter.location}
                     mapNavigationBboxOffset={MAP_POINT_CLOSEUP_BBOX_OFFSET}
                     placeholder={addressPlaceHolder}
                 />
+            ) : (
+                t('tool-panel.switch.layout.no-location')
             )}
             <br />
             <LocationTrackLink
@@ -69,7 +77,10 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                         <li
                             key={pja.locationTrackId}
                             className={styles['switch-infobox-track-meters__track-meter']}>
-                            {formatJointTrackMeter(pja, addressMissingText)}
+                            <JointTrackMeter
+                                jointTrackMeter={pja}
+                                addressPlaceHolder={addressMissingText}
+                            />
                         </li>
                     ))}
                 </ol>
@@ -91,7 +102,10 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                                         className={
                                             styles['switch-infobox-track-meters__track-meter']
                                         }>
-                                        {formatJointTrackMeter(a, addressMissingText)}
+                                        <JointTrackMeter
+                                            jointTrackMeter={a}
+                                            addressPlaceHolder={addressMissingText}
+                                        />
                                     </li>
                                 ))}
                             </ol>

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styles from './track-number-infobox.scss';
 import Infobox from 'tool-panel/infobox/infobox';
 import {
+    AlignmentEndPoint,
     LAYOUT_SRID,
     LayoutReferenceLine,
     LayoutTrackNumber,
@@ -57,6 +58,25 @@ type TrackNumberInfoboxProps = {
     visibilities: TrackNumberInfoboxVisibilities;
     onVisibilityChange: (visibilities: TrackNumberInfoboxVisibilities) => void;
     onHighlightItem: (item: HighlightedAlignment | undefined) => void;
+};
+
+type TrackNumberEndpointAddressInfoProps = {
+    endpoint: AlignmentEndPoint | undefined;
+};
+
+const TrackNumberEndpointAddressInfo: React.FC<TrackNumberEndpointAddressInfoProps> = ({
+    endpoint,
+}) => {
+    const { t } = useTranslation();
+    return (
+        <React.Fragment>
+            {endpoint?.address ? (
+                <NavigableTrackMeter trackMeter={endpoint.address} location={endpoint.point} />
+            ) : (
+                <span>{t('tool-panel.reference-line.no-geometry')}</span>
+            )}
+        </React.Fragment>
+    );
 };
 
 const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
@@ -185,6 +205,9 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                                 id={trackNumber.id}
                                 branch={layoutContext.branch}
                                 changeTimes={changeTimes}
+                                getFallbackTextIfNoOid={() =>
+                                    t('tool-panel.track-number.unpublished')
+                                }
                             />
                         }
                     />
@@ -219,9 +242,8 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                             qaId="track-number-start-track-meter"
                             label={t('tool-panel.reference-line.start-location')}
                             value={
-                                <NavigableTrackMeter
-                                    trackMeter={startAndEndPoints?.start?.address}
-                                    location={startAndEndPoints?.start?.point}
+                                <TrackNumberEndpointAddressInfo
+                                    endpoint={startAndEndPoints?.start}
                                 />
                             }
                         />
@@ -229,10 +251,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                             qaId="track-number-end-track-meter"
                             label={t('tool-panel.reference-line.end-location')}
                             value={
-                                <NavigableTrackMeter
-                                    trackMeter={startAndEndPoints?.end?.address}
-                                    location={startAndEndPoints?.end?.point}
-                                />
+                                <TrackNumberEndpointAddressInfo endpoint={startAndEndPoints?.end} />
                             }
                         />
                         {linkingState === undefined && referenceLine && (
@@ -303,7 +322,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                             value={
                                 startAndEndPoints?.start
                                     ? formatToTM35FINString(startAndEndPoints.start.point)
-                                    : ''
+                                    : t('tool-panel.reference-line.no-geometry')
                             }
                         />
                         <InfoboxField
@@ -314,7 +333,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                             value={
                                 startAndEndPoints?.end
                                     ? formatToTM35FINString(startAndEndPoints.end.point)
-                                    : ''
+                                    : t('tool-panel.reference-line.no-geometry')
                             }
                         />
                         <InfoboxButtons>


### PR DESCRIPTION
Toinen kaninkoloinen muka-pikkutiketti. Alkuperäinen tiketti siis kuului, että geometriattomille pituusmittauslinjan rataosoitteille näkyi kohdistusikoni vaikka geometriaa ja siten alun ja lopun rataosoitteita ei ollut. Tämä korjattu universaalimmin varsinaiseen `<TrackMeter>`-komponenttiin. Tämän lisäksi korjailtu liitännäisinä seuraavat:
* Lisätty pituusmittauslinjan ja vaihteen rataosoitetietoihin placeholderit, jotka kertovat osoitteen puuttumisesta sen sijaan, että näyttäisivät vain tyhjää
  * Pituusmittauslinjalle lisätty myös placeholder mikäli alun ja lopun koordinaattisijainnit puuttuvat
* Parannettu sijaintiraiteen alun ja lopun rataosoitteiden placeholdereita:
  * Mikäli raiteelta puuttuu geometria kokonaan, rataosoitesijainnit sanovat "Raiteella ei ole geometriaa" (aiemmin niissä luki "Ei laskettavissa")
  * Mikäli raiteen alku- tai loppusijainti on ennen pituusmittauslinjan alkua tai sen lopun jälkeen, rataosoitesijainnit sanovat "Ei laskettavissa" (aiemmin näytti väärin pituusmittauslinjan alun/lopun rataosoitteen)
* Korjattu sijaintiraiteen alku- ja loppusijaintien bäkkärihaku palauttamaan fiksumpia arvoja rataosoitteiksi mikäli alku- tai loppusijainti ei osu pituusmittauslinjalle