### PR TITLE
GVT-2977 (part 3): Bump react-toastify to 11.0.3

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,7 @@
                 "react-i18next": "~15.4.0",
                 "react-redux": "~9.2.0",
                 "react-router-dom": "~7.1.5",
-                "react-toastify": "~10.0.4",
+                "react-toastify": "~11.0.3",
                 "react-widgets": "~5.8.6",
                 "redux": "~5.0.1",
                 "redux-persist": "~6.0.0",
@@ -9080,14 +9080,15 @@
             }
         },
         "node_modules/react-toastify": {
-            "version": "10.0.6",
-            "license": "MIT",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
+            "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
             "dependencies": {
-                "clsx": "^2.1.0"
+                "clsx": "^2.1.1"
             },
             "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
+                "react": "^18 || ^19",
+                "react-dom": "^18 || ^19"
             }
         },
         "node_modules/react-transition-group": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -70,7 +70,7 @@
         "react-i18next": "~15.4.0",
         "react-redux": "~9.2.0",
         "react-router-dom": "~7.1.5",
-        "react-toastify": "~10.0.4",
+        "react-toastify": "~11.0.3",
         "react-widgets": "~5.8.6",
         "redux": "~5.0.1",
         "redux-persist": "~6.0.0",

--- a/ui/src/geoviite-design-lib/snackbar/snackbar.scss
+++ b/ui/src/geoviite-design-lib/snackbar/snackbar.scss
@@ -1,8 +1,18 @@
 @use 'vayla-design-lib' as vayla-design;
 
 .Toastify {
+    & {
+        --toastify-text-color-light: #000;
+        --toastify-font-family: vayla-design.$font-family;
+        --toastify-toast-min-height: 54px;
+    }
+
     &--animate {
         animation-fill-mode: both;
+    }
+
+    &__toast {
+        width: auto;
     }
 
     &__toast-content {
@@ -50,6 +60,7 @@
     }
 
     &__toast-container {
+        display: block;
         z-index: 9999;
         position: fixed;
         min-width: 320px;
@@ -126,7 +137,6 @@
         border: 1px solid vayla-design.$color-red-light;
         background: vayla-design.$color-red-lighter;
         display: flex;
-        justify-content: space-between;
 
         .icon {
             fill: vayla-design.$color-red-dark;

--- a/ui/src/geoviite-design-lib/snackbar/snackbar.tsx
+++ b/ui/src/geoviite-design-lib/snackbar/snackbar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Id, toast, ToastOptions } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.minimal.css';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import './snackbar.scss';
 import styles from './snackbar.scss';


### PR DESCRIPTION
The default stylesheet is auto-injected in the new version of react-toastify and uses css-parameters. The goal was keep the previous look, feel and functionality of the toasts.

Migration changes are described here: https://fkhadra.github.io/react-toastify/migration-v11/