### PR TITLE
General: Disable SWC in jest unit tests

### DIFF
--- a/ui/jest.config.json
+++ b/ui/jest.config.json
@@ -11,7 +11,7 @@
         "**/*.test.ts"
     ],
     "transform": {
-        "^.+\\.(t|j)sx?$": "@swc/jest"
+        "^.+\\.(t|j)sx?$": "ts-jest"
     },
     "moduleNameMapper": {
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,8 +14,6 @@
     "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@jest/globals": "~29.7.0",
-        "@swc/core": "^1.10.14",
-        "@swc/jest": "^0.2.37",
         "@teamsupercell/typings-for-css-modules-loader": "~2.5.2",
         "@types/js-cookie": "~3.0.4",
         "@types/node": "~22.13.1",

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -24,7 +24,9 @@
             "*": [
                 "./src/*"
             ]
-        }
+        },
+        "allowJs": true,
+        "checkJs": true
     },
     "include": [
         "./src/**/*",


### PR DESCRIPTION
* SWC is only a transpiler meaning that TS type-check errors from tests were not reported.
* SWC usage in tests seems to cause some issues when running node 20 with new ui package versions
* => Reverted to previous ts-node
* TS compiler options were added as the newer TS version seems to warn about js imports (which are configured to be used in jest tests for resources)