### PR TITLE
GVT-2977 (part 4): Remove React 19 blocking use-resize-observer dependency

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -31,14 +31,11 @@
                 "react-widgets": "~5.8.6",
                 "redux": "~5.0.1",
                 "redux-persist": "~6.0.0",
-                "ts-debounce": "~4.0.0",
-                "use-resize-observer": "~9.1.0"
+                "ts-debounce": "~4.0.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@jest/globals": "~29.7.0",
-                "@swc/core": "^1.10.14",
-                "@swc/jest": "^0.2.37",
                 "@teamsupercell/typings-for-css-modules-loader": "~2.5.2",
                 "@types/js-cookie": "~3.0.4",
                 "@types/node": "~22.13.1",
@@ -1155,17 +1152,6 @@
                 }
             }
         },
-        "node_modules/@jest/create-cache-key-function": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^29.6.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/@jest/environment": {
             "version": "29.7.0",
             "dev": true,
@@ -1471,10 +1457,6 @@
                 "tslib": "2"
             }
         },
-        "node_modules/@juggle/resize-observer": {
-            "version": "3.4.0",
-            "license": "Apache-2.0"
-        },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.4",
             "dev": true,
@@ -1639,6 +1621,8 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.17"
@@ -1682,6 +1666,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1689,28 +1674,16 @@
         "node_modules/@swc/counter": {
             "version": "0.1.3",
             "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@swc/jest": {
-            "version": "0.2.37",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/create-cache-key-function": "^29.7.0",
-                "@swc/counter": "^0.1.3",
-                "jsonc-parser": "^3.2.0"
-            },
-            "engines": {
-                "npm": ">= 7.0.0"
-            },
-            "peerDependencies": {
-                "@swc/core": "*"
-            }
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@swc/types": {
             "version": "0.1.17",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3"
             }
@@ -2006,8 +1979,7 @@
         },
         "node_modules/@types/rbush": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
-            "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ=="
+            "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.2.57",
@@ -4290,8 +4262,7 @@
         },
         "node_modules/earcut": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
-            "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw=="
+            "license": "ISC"
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -7441,11 +7412,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jsonc-parser": {
-            "version": "3.3.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
             "dev": true,
@@ -8147,8 +8113,7 @@
         },
         "node_modules/ol": {
             "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ol/-/ol-10.4.0.tgz",
-            "integrity": "sha512-gv3voS4wgej1WVvdCz2ZIBq3lPWy8agaf0094E79piz8IGQzHiOWPs2in1pdoPmuTNvcqGqyUFG3IbxNE6n08g==",
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "@types/rbush": "4.0.0",
                 "color-rgba": "^3.0.0",
@@ -8446,8 +8411,7 @@
         },
         "node_modules/pbf": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-            "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "resolve-protobuf-schema": "^2.1.0"
             },
@@ -8770,8 +8734,7 @@
         },
         "node_modules/protocol-buffers-schema": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-            "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+            "license": "MIT"
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -8871,8 +8834,7 @@
         },
         "node_modules/quickselect": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-            "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
+            "license": "ISC"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -8925,8 +8887,7 @@
         },
         "node_modules/rbush": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
-            "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+            "license": "MIT",
             "dependencies": {
                 "quickselect": "^3.0.0"
             }
@@ -8943,7 +8904,8 @@
         },
         "node_modules/react-datepicker": {
             "version": "6.9.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-6.9.0.tgz",
+            "integrity": "sha512-QTxuzeem7BUfVFWv+g5WuvzT0c5BPo+XTCNbMTZKSZQLU+cMMwSUHwspaxuIcDlwNcOH0tiJ+bh1fJ2yxOGYWA==",
             "dependencies": {
                 "@floating-ui/react": "^0.26.2",
                 "clsx": "^2.1.0",
@@ -8958,7 +8920,8 @@
         },
         "node_modules/react-datepicker/node_modules/date-fns": {
             "version": "3.6.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+            "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -9005,7 +8968,8 @@
         },
         "node_modules/react-onclickoutside": {
             "version": "6.13.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.1.tgz",
+            "integrity": "sha512-LdrrxK/Yh9zbBQdFbMTXPp3dTSN9B+9YJQucdDu3JNKRrbdU+H+/TVONJoWtOwy4II8Sqf1y/DTI6w/vGPYW0w==",
             "funding": {
                 "type": "individual",
                 "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
@@ -9081,8 +9045,7 @@
         },
         "node_modules/react-toastify": {
             "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
-            "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
+            "license": "MIT",
             "dependencies": {
                 "clsx": "^2.1.1"
             },
@@ -9412,8 +9375,7 @@
         },
         "node_modules/resolve-protobuf-schema": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-            "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+            "license": "MIT",
             "dependencies": {
                 "protocol-buffers-schema": "^3.3.1"
             }
@@ -11047,17 +11009,6 @@
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
-            }
-        },
-        "node_modules/use-resize-observer": {
-            "version": "9.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "@juggle/resize-observer": "^3.3.1"
-            },
-            "peerDependencies": {
-                "react": "16.8.0 - 18",
-                "react-dom": "16.8.0 - 18"
             }
         },
         "node_modules/use-sync-external-store": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -74,7 +74,6 @@
         "react-widgets": "~5.8.6",
         "redux": "~5.0.1",
         "redux-persist": "~6.0.0",
-        "ts-debounce": "~4.0.0",
-        "use-resize-observer": "~9.1.0"
+        "ts-debounce": "~4.0.0"
     }
 }

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -37,7 +37,6 @@ import { createDebug1mPointsLayer } from './layers/debug/debug-1m-points-layer';
 import { createClassName } from 'vayla-design-lib/utils';
 import { ChangeTimes } from 'common/common-slice';
 import { createTrackNumberDiagramLayer } from 'map/layers/highlight/track-number-diagram-layer';
-import useResizeObserver from 'use-resize-observer';
 import { createGeometryAlignmentLayer } from 'map/layers/geometry/geometry-alignment-layer';
 import { createGeometryKmPostLayer } from 'map/layers/geometry/geometry-km-post-layer';
 import { createKmPostLayer } from 'map/layers/km-post/km-post-layer';
@@ -85,6 +84,7 @@ import { createPublicationCandidateLayer } from 'map/layers/preview/publication-
 import { PublicationCandidate } from 'publication/publication-model';
 import { DesignPublicationMode } from 'preview/preview-tool-bar';
 import { createDeletedPublicationCandidateIconLayer } from 'map/layers/preview/deleted-publication-candidate-icon-layer';
+import { useResizeObserver } from 'utils/use-resize-observer';
 
 declare global {
     interface Window {

--- a/ui/src/utils/use-resize-observer.ts
+++ b/ui/src/utils/use-resize-observer.ts
@@ -1,0 +1,31 @@
+import { useEffect, RefObject } from 'react';
+
+type ResizeDimensions = {
+    width: number;
+    height: number;
+};
+
+type ResizeObserverOptions = {
+    ref: RefObject<HTMLElement>;
+    onResize: (size: ResizeDimensions) => void;
+};
+
+export function useResizeObserver({ ref, onResize }: ResizeObserverOptions) {
+    useEffect(() => {
+        const observer = new ResizeObserver(([entry]) => {
+            if (entry) {
+                const dimensions: ResizeDimensions = {
+                    width: entry.contentRect.width,
+                    height: entry.contentRect.height,
+                };
+                onResize(dimensions);
+            }
+        });
+
+        if (ref.current) {
+            observer.observe(ref.current);
+        }
+
+        return () => observer.disconnect();
+    }, [ref, onResize]);
+}

--- a/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
+++ b/ui/src/vayla-design-lib/closeable-modal/closeable-modal.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { Dimensions, Point } from 'model/geometry';
-import useResizeObserver from 'use-resize-observer';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { useResizeObserver } from 'utils/use-resize-observer';
 
 const DEFAULT_MARGIN_BETWEEN_ANCHOR_ELEMENT_AND_MODAL = 6;
 
@@ -334,7 +334,7 @@ export const CloseableModal: React.FC<CloseableModalProps> = ({
     React.useEffect(updateModalPosition, [anchorElementRef, modalRef, children]);
 
     useResizeObserver({
-        ref: document.body,
+        ref: React.useRef<HTMLElement>(document.body),
         onResize: updateModalPosition,
     });
 

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -17,7 +17,6 @@ import {
 import { getLocationTrackStartAndEnd } from 'track-layout/layout-location-track-api';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
-import useResizeObserver from 'use-resize-observer';
 import { OnSelectOptions } from 'selection/selection-model';
 import { BoundingBox } from 'model/geometry';
 import { processLayoutGeometries } from 'vertical-geometry/util';
@@ -30,6 +29,7 @@ import {
 import { getMaxTimestamp } from 'utils/date-utils';
 import { useUserHasPrivilege } from 'store/hooks';
 import { VIEW_GEOMETRY_FILE } from 'user/user-model';
+import { useResizeObserver } from 'utils/use-resize-observer';
 
 type VerticalGeometryDiagramHolderProps = {
     alignmentId: VerticalGeometryDiagramAlignmentId;


### PR DESCRIPTION
This package seemed to be relatively small & unmaintained -> same functionality implemented without a dependency