### PR TITLE
GVT-2982: Debug-karttataso raidegraafille

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1300,7 +1300,8 @@
         "geometry-km-post": "Suunnitelman tasakilometripisteet",
         "operating-points": "Liikennepaikat",
         "debug-1m": "Tasametripisteet",
-        "debug": "Debug"
+        "debug": "Debug",
+        "debug-layout-graph": "Raidegraafi"
     },
     "map-view": {
         "cluster-overlay-title": "Klusteripiste",

--- a/ui/src/map/layers/debug/debug-geometry-graph-layer.ts
+++ b/ui/src/map/layers/debug/debug-geometry-graph-layer.ts
@@ -1,0 +1,117 @@
+import Feature from 'ol/Feature';
+import { LineString, Point as OlPoint } from 'ol/geom';
+import { filterNotEmpty, filterUniqueById } from 'utils/array-utils';
+import { Circle, Stroke, Style } from 'ol/style';
+import { MapLayer } from 'map/layers/utils/layer-model';
+import { createLayer, loadLayerData, pointToCoords } from 'map/layers/utils/layer-utils';
+import VectorLayer from 'ol/layer/Vector';
+import { MapLayerName, MapTile } from 'map/map-model';
+import { LayoutEdge, LayoutGraph, LayoutNode } from 'track-layout/track-layout-model';
+import { getLayoutGraph } from 'track-layout/track-layout-api';
+import { LayoutContext } from 'common/common-model';
+import {
+    ALL_ALIGNMENTS,
+    SWITCH_LARGE_SYMBOLS,
+    SWITCH_SHOW,
+} from 'map/layers/utils/layer-visibility-limits';
+import { clamp } from 'utils/math-utils';
+
+const colors = [
+    'rgb(0, 0, 0)', // hsl(0, 0%, 0%)
+    'rgb(0, 0, 255)', // hsl(240, 100%, 50%)
+    'rgb(255, 0, 255)', // hsl(300, 100%, 50%)
+    'rgb(255, 255, 0)', // hsl(0, 100%, 50%)
+    'rgb(0, 255, 0)', // hsl(60, 100%, 50%)
+    'rgb(0, 255, 255)', // hsl(120, 100%, 50%)
+    'rgb(0, 0, 255)', // hsl(180, 100%, 50%)
+];
+
+function createNodeFeatures(points: LayoutNode[], resolution: number): Feature<OlPoint>[] {
+    return points
+        .flatMap((node) => {
+            const feature = new Feature({
+                geometry: new OlPoint(pointToCoords(node.location)),
+            });
+
+            const color = 'blue';
+            const size =
+                resolution <= SWITCH_LARGE_SYMBOLS ? 20 : resolution <= SWITCH_SHOW ? 10 : 5;
+
+            feature.setStyle(
+                new Style({
+                    image: new Circle({
+                        radius: size,
+                        stroke: new Stroke({ color, width: 2 }),
+                    }),
+                }),
+            );
+
+            return feature;
+        })
+        .filter(filterNotEmpty);
+}
+
+function createEdgeFeatures(edges: LayoutEdge[], nodes: LayoutNode[]): Feature<LineString>[] {
+    return edges
+        .flatMap((edge) => {
+            const startNode = nodes.find((n) => n.id === edge.startNode);
+            const endNode = nodes.find((n) => n.id === edge.endNode);
+
+            if (startNode && endNode) {
+                const feature = new Feature({
+                    geometry: new LineString([
+                        pointToCoords(startNode.location),
+                        pointToCoords(endNode.location),
+                    ]),
+                });
+                const color = colors[edge.tracks.length % colors.length];
+                const width = clamp(edge.tracks.length * 2, 2, 10);
+
+                feature.setStyle(
+                    new Style({
+                        stroke: new Stroke({
+                            color,
+                            width,
+                        }),
+                    }),
+                );
+
+                return feature;
+            } else return undefined;
+        })
+        .filter(filterNotEmpty);
+}
+
+const layerName: MapLayerName = 'debug-geometry-graph-layer';
+
+export function createDebugGeometryGraphLayer(
+    existingOlLayer: VectorLayer<Feature<LineString | OlPoint>> | undefined,
+    onLoadingData: (loading: boolean) => void,
+    layoutContext: LayoutContext,
+    mapTiles: MapTile[],
+    resolution: number,
+): MapLayer {
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
+
+    const updateLayerFunc = (graphTiles: LayoutGraph[]) => {
+        const flattenedNodes = graphTiles
+            .flatMap((graph) => Object.values(graph.nodes))
+            .filter(filterUniqueById((n: LayoutNode) => n.id));
+        const flattenedEdges = graphTiles
+            .flatMap((graph) => Object.values(graph.edges))
+            .filter(filterUniqueById((e: LayoutEdge) => e.id));
+        return [
+            ...createNodeFeatures(flattenedNodes, resolution),
+            ...createEdgeFeatures(flattenedEdges, flattenedNodes),
+        ];
+    };
+
+    const tiledPromises =
+        resolution <= ALL_ALIGNMENTS
+            ? mapTiles.map((tile) => getLayoutGraph(layoutContext, tile.area))
+            : [Promise.resolve<LayoutGraph>({ nodes: {}, edges: {}, context: layoutContext })];
+
+    loadLayerData(source, isLatest, onLoadingData, Promise.all(tiledPromises), updateLayerFunc);
+
+    return { name: layerName, layer: layer };
+}

--- a/ui/src/map/layers/utils/layer-visibility-limits.ts
+++ b/ui/src/map/layers/utils/layer-visibility-limits.ts
@@ -40,6 +40,7 @@ const mapLayerOrder: MapLayerName[] = [
     'operating-points-layer',
     'debug-1m-points-layer',
     'debug-layer',
+    'debug-geometry-graph-layer',
 ];
 
 export const mapLayerZIndexes = mapLayerOrder.reduce(

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -50,7 +50,8 @@ export type MapLayerName =
     | 'virtual-km-post-linking-layer'
     | 'virtual-hide-geometry-layer'
     | 'publication-candidate-layer'
-    | 'deleted-publication-candidate-icon-layer';
+    | 'deleted-publication-candidate-icon-layer'
+    | 'debug-geometry-graph-layer';
 
 export type MapViewportSource = 'Map';
 
@@ -111,7 +112,8 @@ export type MapLayerMenuItemName =
     | 'geometry-km-post'
     | 'operating-points'
     | 'debug-1m'
-    | 'debug';
+    | 'debug'
+    | 'debug-layout-graph';
 
 export type TrackNumberDiagramLayerSetting = {
     [key: LayoutTrackNumberId]: {

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -110,6 +110,7 @@ const layerMenuItemMapLayers: Record<MapLayerMenuItemName, MapLayerName[]> = {
     'operating-points': ['operating-points-layer'],
     'debug-1m': ['debug-1m-points-layer'],
     'debug': ['debug-layer'],
+    'debug-layout-graph': ['debug-geometry-graph-layer'],
 };
 
 export const initialMapState: Map = {
@@ -132,6 +133,7 @@ export const initialMapState: Map = {
         'location-track-selected-alignment-layer',
         'location-track-split-alignment-layer',
         'reference-line-selected-alignment-layer',
+        'debug-geometry-graph-layer',
     ],
     layerMenu: {
         layout: [
@@ -187,6 +189,7 @@ export const initialMapState: Map = {
         debug: [
             { name: 'debug-1m', visible: false },
             { name: 'debug', visible: false },
+            { name: 'debug-layout-graph', visible: false },
         ],
     },
     layerSettings: {

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -87,6 +87,7 @@ import { createPublicationCandidateLayer } from 'map/layers/preview/publication-
 import { PublicationCandidate } from 'publication/publication-model';
 import { DesignPublicationMode } from 'preview/preview-tool-bar';
 import { createDeletedPublicationCandidateIconLayer } from 'map/layers/preview/deleted-publication-candidate-icon-layer';
+import { createDebugGeometryGraphLayer } from 'map/layers/debug/debug-geometry-graph-layer';
 
 declare global {
     interface Window {
@@ -679,6 +680,14 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'debug-layer':
                         return createDebugLayer(existingOlLayer as VectorLayer<Feature<OlPoint>>);
+                    case 'debug-geometry-graph-layer':
+                        return createDebugGeometryGraphLayer(
+                            existingOlLayer as VectorLayer<Feature<LineString | OlPoint>>,
+                            (loading) => onLayerLoading(layerName, loading),
+                            layoutContext,
+                            mapTiles,
+                            resolution,
+                        );
                     case 'virtual-km-post-linking-layer': // Virtual map layers
                     case 'virtual-hide-geometry-layer':
                         return undefined;

--- a/ui/src/track-layout/track-layout-api.ts
+++ b/ui/src/track-layout/track-layout-api.ts
@@ -1,5 +1,8 @@
 import { LayoutBranch, LayoutContext } from 'common/common-model';
-import { API_URI } from 'api/api-fetch';
+import { API_URI, getNonNull } from 'api/api-fetch';
+import { BoundingBox } from 'model/geometry';
+import { bboxString } from 'common/common-api';
+import { LayoutGraph } from 'track-layout/track-layout-model';
 
 type LayoutDataType =
     | 'track-numbers'
@@ -44,3 +47,8 @@ export function layoutUriWithoutContext(dataType: LayoutDataType, id?: string): 
 export function contextInUri(layoutContext: LayoutContext): string {
     return `${layoutContext.branch.toLowerCase()}/${layoutContext.publicationState.toLowerCase()}`;
 }
+
+export const getLayoutGraph = (context: LayoutContext, bbox: BoundingBox): Promise<LayoutGraph> =>
+    getNonNull<LayoutGraph>(
+        `${TRACK_LAYOUT_URI}/layout-graph/${contextInUri(context)}?bbox=${bboxString(bbox)}`,
+    );

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -11,6 +11,7 @@ import {
     DataType,
     JointNumber,
     KmNumber,
+    LayoutContext,
     LocationAccuracy,
     LocationTrackOwnerId,
     Oid,
@@ -417,3 +418,34 @@ export type KmPostInfoboxExtras = {
 export function combineAlignmentPoints(points: AlignmentPoint[][]): AlignmentPoint[] {
     return deduplicateById(points.flat(), (p) => p.m).sort((p1, p2) => p1.m - p2.m);
 }
+
+export type SwitchLinkId = Brand<string, 'SwitchLinkId'>;
+export type SwitchLink = {
+    id: SwitchLinkId;
+    jointNumber: JointNumber;
+    jointRole: SwitchJointRole;
+};
+
+export type LayoutNodeType = 'SWITCH' | 'TRACK_START' | 'TRACK_END';
+export type LayoutNodeId = Brand<string, 'LayoutNodeId'>;
+export type LayoutNode = {
+    id: LayoutNodeId;
+    type: LayoutNodeType;
+    location: Point;
+    switches: SwitchLink[];
+};
+
+export type LayoutEdgeId = Brand<string, 'LayoutEdgeId'>;
+export type LayoutEdge = {
+    id: LayoutEdgeId;
+    startNode: LayoutNodeId;
+    endNode: LayoutNodeId;
+    length: number;
+    tracks: LocationTrackId[];
+};
+
+export type LayoutGraph = {
+    nodes: { [key in LayoutNodeId]: LayoutNode };
+    edges: { [key in LayoutEdgeId]: LayoutEdge };
+    context: LayoutContext;
+};

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -140,7 +140,7 @@ module.exports = (env) => {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    loader: 'swc-loader',
+                    loader: 'ts-loader',
                 },
                 {
                     test: /\.(png|jp(e*)g|gif|woff|woff2|ttf|eot|ico|otf)$/,


### PR DESCRIPTION
Täällä toteutettu hyvin alustava debug-karttataso raidegraafin visualisoinnille. Ohjeet sen käyttöön:
* Karttatasovalikossa on uusi debug-karttataso nimeltä "Raidegraafi". Sen pistäminen päälle kytkee raidegraafin päälle.
* Koska graafin piirto menee korkeammilla resoluutioilla raskaaksi, sen piirrolle on sama resoluutio-cutoff kuin sijaintiraiteillekin
* Noodit piirretään sinisillä rinkuloilla, edget toistaiseksi viivoilla joiden väri ja paksuus määräytyy sen mukaan montako sijaintiraidetta noodien välillä menee (1 sijaintiraide = sininen 2px paksu viiva, 2 sijaintiraidetta: pinkki 4px paksu viiva jne.)