### PR TITLE
General: Remove non-unique translation key

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -809,7 +809,6 @@
             "splitting-blocks-geometry-changes": "Raiteen geometriaa ei voi muokata koska sen jakaminen on kesken",
             "cannot-shorten-deleted-track": "Poistettua raidetta ei voi lyhentää",
             "unsupported-state-for-splitting": "Vain \"Käytössä\"-tilaisen raiteen voi jakaa",
-            "no-geometry": "Raiteella ei ole geometriaa",
             "cant-edit-while-splitting": "Raiteen tietoja ei voi muokata koska sen jakaminen on kesken",
             "cant-edit-while-linking": "Raiteen tietoja ei voi muokata linkitystilassa"
         },


### PR DESCRIPTION
Satunnaisesti huomattu editorivaroitus. Rivillä 699 on sama avain, joten tämä ei ole toiminut varmaan kovin järkevästi. Jätin tarkemman/pidemmän muodon eli `"no-geometry": "Sijaintiraiteella ei ole geometriaa"`