### PR TITLE
GVT-2992: Fix dialog close icon capturing pointer events, disable icon pointer events by default

### DIFF
--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -154,6 +154,7 @@ export type IconComponent = React.ComponentType<IconProps>;
 
 export type SvgIconProps = IconProps & {
     svg: string;
+    pointerEvents?: 'NONE' | 'AUTO';
 };
 
 export type SvgIconComponent = React.FC<SvgIconProps>;
@@ -163,6 +164,7 @@ const SvgIcon: SvgIconComponent = ({
     size = IconSize.MEDIUM,
     color,
     extraClassName,
+    pointerEvents = 'NONE',
     ...props
 }: SvgIconProps) => {
     let svgContent = svg
@@ -179,6 +181,7 @@ const SvgIcon: SvgIconComponent = ({
         size && styles[size],
         props.rotation && styles[props.rotation],
         color && styles[color],
+        pointerEvents === 'NONE' && styles['icon--disable-pointer-events'],
         extraClassName,
     );
 

--- a/ui/src/vayla-design-lib/icon/icon.scss
+++ b/ui/src/vayla-design-lib/icon/icon.scss
@@ -60,3 +60,7 @@ $icon-size-large: 30px;
     margin-bottom: -2px;
     opacity: 0.4;
 }
+
+.icon--disable-pointer-events {
+    pointer-events: none;
+}


### PR DESCRIPTION
En huomannut paikkaa, jossa oikeasti olisi hyödynnyttä ikonin pointer eventtejä 🤔 
=> Selvempää vaan disabloida defaulttina