### PR TITLE
GVT-2992 (part 2): Fix E2E tests

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EAccordion.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/common/E2EAccordion.kt
@@ -32,7 +32,7 @@ open class E2EAccordion(accordionBy: By) : E2EViewFragment(accordionBy) {
     fun open(): E2EAccordion = apply {
         logger.info("Open accordion")
         if (!childExists(By.className("accordion__body"))) {
-            clickChild(By.cssSelector(".accordion-toggle svg"))
+            clickChild(By.cssSelector(".accordion-toggle"))
             waitUntilChildVisible(By.className("accordion__body"))
         }
     }
@@ -40,7 +40,7 @@ open class E2EAccordion(accordionBy: By) : E2EViewFragment(accordionBy) {
     fun close(): E2EAccordion = apply {
         logger.info("Close accordion")
         if (childExists(By.className("accordion__body"))) {
-            clickChild(By.cssSelector(".accordion-toggle svg"))
+            clickChild(By.cssSelector(".accordion-toggle"))
             waitUntilChildInvisible(By.className("accordion__body"))
         }
     }


### PR DESCRIPTION
Näistä tuli tämmösiä:
```
org.openqa.selenium.ElementClickInterceptedException: element click intercepted: 
Element <svg class="icon icon--size-small icon--color-original icon--disable-pointer-events" viewBox="0 0 6 10">...</svg> is not clickable at point (30, 285). 
Other element would receive the click: <span class="accordion-toggle">...</span>
```

Testi siis yritti klikata tarkalleen svg-ikonia (eikä itse accordion-toggle nappia), joka ei toki nyt onnistu kun noilta lähti pointer-eventit oletuksena veks.