### PR TITLE
GVT-2918: Enable previously flaky E2E test

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -31,7 +31,6 @@ import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import java.time.Instant
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -55,7 +54,6 @@ constructor(
         testDBService.clearAllTables()
     }
 
-    @Disabled
     @Test
     fun `Retry failed publication`() {
         val originalTrackNumber = trackNumberDao.save(trackNumber(TrackNumber("original name"), draft = false))


### PR DESCRIPTION
Apparently this works now, maybe due to package updates?