### PR TITLE
GVT-2986 Map between zero-based and staStart-based m-values for vertical geometry diagram

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -31,6 +31,7 @@ import fi.fta.geoviite.infra.tracklayout.ISegment
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_M_DELTA
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -78,7 +79,12 @@ data class AlignmentAddresses(
     }
 }
 
-data class AlignmentStartAndEnd<T>(val id: IntId<T>, val start: AlignmentEndPoint?, val end: AlignmentEndPoint?) {
+data class AlignmentStartAndEnd<T>(
+    val id: IntId<T>,
+    val start: AlignmentEndPoint?,
+    val end: AlignmentEndPoint?,
+    val staStart: Double?,
+) {
     companion object {
         fun <T> of(id: IntId<T>, alignment: IAlignment, geocodingContext: GeocodingContext?): AlignmentStartAndEnd<T> {
             val start =
@@ -89,7 +95,7 @@ data class AlignmentStartAndEnd<T>(val id: IntId<T>, val start: AlignmentEndPoin
                 alignment.end?.let { p ->
                     AlignmentEndPoint(p, geocodingContext?.getAddress(p)?.let(::getAddressIfIWithin))
                 }
-            return AlignmentStartAndEnd(id, start, end)
+            return AlignmentStartAndEnd(id, start, end, (alignment as? PlanLayoutAlignment)?.staStart)
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -665,9 +665,10 @@ constructor(
         val heightTriangles = heightTriangleDao.fetchTriangles(boundingBox.polygonFromCorners)
         val verticalCoordinateSystem = plan.units.verticalCoordinateSystem ?: return null
 
+        val startStation = geometryAlignment.staStart.toDouble()
         return collectTrackMeterHeights(startDistance, endDistance, geocodingContext, alignment, tickLength) { point, _
             ->
-            profile?.getHeightAt(point.m)?.let { height ->
+            profile?.getHeightAt(point.m + startStation)?.let { height ->
                 transformHeightValue(height, point, heightTriangles, verticalCoordinateSystem)
             }
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
@@ -58,6 +58,7 @@ data class GeometryPlanLayout(
 data class PlanLayoutAlignment(
     val header: AlignmentHeader<GeometryAlignment, LayoutState>,
     @JsonIgnore override val segments: List<PlanLayoutSegment>,
+    @JsonIgnore val staStart: Double,
     val polyLine: AlignmentPolyLine<GeometryAlignment>? = null,
     val segmentMValues: List<Double> = listOf(),
 ) : IAlignment {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -171,6 +171,7 @@ fun toMapAlignments(
 
         PlanLayoutAlignment(
             header = toAlignmentHeader(trackNumberId, alignment, boundingBoxInLayoutSpace),
+            staStart = alignment.staStart.toDouble(),
             segments = mapSegments,
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -522,6 +522,7 @@ fun mapAlignment(segments: List<PlanLayoutSegment>) =
                 length = segments.map(PlanLayoutSegment::length).sum(),
                 boundingBox = boundingBoxCombining(segments.mapNotNull(PlanLayoutSegment::boundingBox)),
             ),
+        staStart = 0.0,
         segments = segments,
     )
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -368,6 +368,7 @@ export type AlignmentStartAndEnd = {
     id: AlignmentId;
     start?: AlignmentEndPoint;
     end?: AlignmentEndPoint;
+    staStart?: number;
 };
 
 export function getSwitchPresentationJoint(

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -205,6 +205,15 @@ export function substituteLayoutStationsForGeometryStations(
     };
 }
 
+export function processPlanGeometries(geometry: VerticalGeometryItem[], staStart: number) {
+    return geometry.map((item) => ({
+        ...item,
+        start: { ...item.start, station: item.start.station - staStart },
+        point: { ...item.point, station: item.point.station - staStart },
+        end: { ...item.end, station: item.end.station - staStart },
+    }));
+}
+
 export function processLayoutGeometries(
     geometry: VerticalGeometryItem[],
     linkingSummary: PlanLinkingSummaryItem[],

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -19,7 +19,7 @@ import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { OnSelectOptions } from 'selection/selection-model';
 import { BoundingBox } from 'model/geometry';
-import { processLayoutGeometries } from 'vertical-geometry/util';
+import { processLayoutGeometries, processPlanGeometries } from 'vertical-geometry/util';
 import { useTranslation } from 'react-i18next';
 import {
     planAlignmentKey,
@@ -51,7 +51,6 @@ type AlignmentAndExtents = {
     endM: number;
 };
 
-// we don't really need the station values in the plan geometry for anything in this entire diagram
 async function getStartAndEnd(
     changeTimes: ChangeTimes,
     alignmentId: VerticalGeometryDiagramAlignmentId,
@@ -165,7 +164,7 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
                     setProcessedGeometry(
                         (linkingSummary
                             ? processLayoutGeometries(geometry, linkingSummary)
-                            : geometry
+                            : processPlanGeometries(geometry, startEnd?.staStart ?? 0)
                         ).sort((a, b) =>
                             !a.point || !b.point ? 0 : a.point.station - b.point.station,
                         ),


### PR DESCRIPTION
Tässä on vielä aika hyvänkin refaktorin varaa, koska tällä hetkellä koko pystygeometriakuvaajan koodin geometriapuoli asuu yksi jalka PlanLayoutAlignment-maailmassa (missä m-arvot alkavat aina nollasta) ja toinen GeometryAlignment-maailmassa (missä alignmentin sisältö alkaa vasta staStart-arvon kohdalta), ja staStart-arvo salakuljetetaan frontille vähän epämääräistä kautta.

Paremmassa maailmassa olisi niin, että nämä maailmat olisivat kunnolla erillään, eikä pystygeometrian kuvaajan koodi tekisi näitä mäppäyksiä lainkaan... mutta sinne pääseminen vaatisi vähän omaa miettimistään.