### PR TITLE
GVT-2811: Selection-jumppaa (oli: Pystygeometrian kuvaaja ei mene joskus päälle)

### DIFF
--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -686,7 +686,7 @@ const MapView: React.FC<MapViewProps> = ({
             })
             .filter(filterNotEmpty);
 
-        updatedLayers.forEach((l) => l.layer.setZIndex(expectDefined(mapLayerZIndexes[l.name])));
+        updatedLayers.forEach((l) => l.layer.setZIndex(mapLayerZIndexes[l.name]));
 
         visibleLayers
             .filter((vl) => !updatedLayers.some((ul) => ul.name === vl.name))

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -686,7 +686,7 @@ const MapView: React.FC<MapViewProps> = ({
             })
             .filter(filterNotEmpty);
 
-        updatedLayers.forEach((l) => l.layer.setZIndex(mapLayerZIndexes[l.name]));
+        updatedLayers.forEach((l) => l.layer.setZIndex(expectDefined(mapLayerZIndexes[l.name])));
 
         visibleLayers
             .filter((vl) => !updatedLayers.some((ul) => ul.name === vl.name))

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -422,12 +422,6 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         verticalGeometryDiagramVisible,
     ]);
 
-    React.useEffect(() => {
-        if (selectedAsset && tabs.some((tab) => isSameAsset(tab.asset, selectedAsset))) {
-            changeTab(selectedAsset);
-        }
-    }, [tabs]);
-
     function changeTab(tab: ToolPanelAsset) {
         let lockToAsset;
 

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -76,7 +76,6 @@ export type ToolPanelAssetType =
     | 'LOCATION_TRACK'
     | 'SWITCH'
     | 'KM_POST'
-    | 'REFERENCE_LINE'
     | 'TRACK_NUMBER'
     | 'GEOMETRY_ALIGNMENT'
     | 'GEOMETRY_PLAN'

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -674,38 +674,20 @@ export const getFirstOfTypeInSelection = (
     selection: Selection,
     type: ToolPanelAssetType,
 ): ToolPanelAsset | undefined => {
-    let id: string | undefined;
-    switch (type) {
-        case 'GEOMETRY_PLAN':
-            id = first(selection.selectedItems.geometryPlans);
-            return id ? { id: id, type: 'GEOMETRY_PLAN' } : undefined;
-        case 'TRACK_NUMBER':
-            id = first(selection.selectedItems.trackNumbers);
-            return id ? { id: id, type: 'TRACK_NUMBER' } : undefined;
-        case 'KM_POST':
-            id = first(selection.selectedItems.kmPosts);
-            return id ? { id: id, type: 'KM_POST' } : undefined;
-        case 'GEOMETRY_KM_POST':
-            id = first(selection.selectedItems.geometryKmPostIds)?.geometryId;
-            return id ? { id: id, type: 'GEOMETRY_KM_POST' } : undefined;
-        case 'SWITCH':
-            id = first(selection.selectedItems.switches);
-            return id ? { id: id, type: 'SWITCH' } : undefined;
-        case 'GEOMETRY_SWITCH_SUGGESTION':
-            id = first(selection.selectedItems.suggestedSwitches)?.id;
-            return id ? { id: id, type: 'GEOMETRY_SWITCH_SUGGESTION' } : undefined;
-        case 'GEOMETRY_SWITCH':
-            id = first(selection.selectedItems.switches);
-            return id ? { id: id, type: 'GEOMETRY_SWITCH' } : undefined;
-        case 'LOCATION_TRACK':
-            id = first(selection.selectedItems.locationTracks);
-            return id ? { id: id, type: 'LOCATION_TRACK' } : undefined;
-        case 'GEOMETRY_ALIGNMENT':
-            id = first(selection.selectedItems.geometryAlignmentIds)?.geometryId;
-            return id ? { id: id, type: 'GEOMETRY_ALIGNMENT' } : undefined;
-        default:
-            return exhaustiveMatchingGuard(type);
-    }
+    const { selectedItems } = selection;
+    const assetGetters: Record<ToolPanelAssetType, () => string | undefined> = {
+        GEOMETRY_PLAN: () => first(selectedItems.geometryPlans),
+        TRACK_NUMBER: () => first(selectedItems.trackNumbers),
+        KM_POST: () => first(selectedItems.kmPosts),
+        GEOMETRY_KM_POST: () => first(selectedItems.geometryKmPostIds)?.geometryId,
+        SWITCH: () => first(selectedItems.switches),
+        GEOMETRY_SWITCH_SUGGESTION: () => first(selectedItems.suggestedSwitches)?.id,
+        GEOMETRY_SWITCH: () => first(selectedItems.switches),
+        LOCATION_TRACK: () => first(selectedItems.locationTracks),
+        GEOMETRY_ALIGNMENT: () => first(selectedItems.geometryAlignmentIds)?.geometryId,
+    };
+    const id = assetGetters[type]();
+    return id ? { id, type } : undefined;
 };
 
 export const getFirstToolPanelAsset = (selection: Selection): ToolPanelAsset | undefined => {

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -703,8 +703,6 @@ export const getFirstOfTypeInSelection = (
         case 'GEOMETRY_ALIGNMENT':
             id = first(selection.selectedItems.geometryAlignmentIds)?.geometryId;
             return id ? { id: id, type: 'GEOMETRY_ALIGNMENT' } : undefined;
-        case 'REFERENCE_LINE':
-            return undefined;
         default:
             return exhaustiveMatchingGuard(type);
     }


### PR DESCRIPTION
En saanut toistettua alkuperäistä issueta, mutta löysin kyllä muita pystygeometriakuvaajaan liittyviä issueita. Lopulta kaikki fiksit päätyivät selection-logiikkaan, ei pystygeometriakuvaajaan. Käytännössä pystygeometrian kuvaaja näytetään silloin kun kaksi ehtoa täyttyy:
1. Pystygeometrian kuvaaja on pistetty päälle infoboksin togglesta
2. Toolpanelissa valittuna tabina on joko geometria-alignment tai paikannuspohjan sijaintiraide

Valittu toolpanelin tab on meillä tallessa reduxissa (`trackLayoutSlice`:ssa oleva propsu `selectedToolPanelTab`.) Tämä ei kuitenkaan päivittynyt lähellekään joka tilanteessa joissa näytetyt tabit saattoivat vaihtua (esim. suunnitelman, tai yksittäisten suunnitelmakäsitteiden piilottamiset). Tällöin toolpanel arpoi itse ensimmäisen tabin valituksi, mutta ei päivittänyt sitä reduxiin. Tällöin esim. oli mahdollista, että toolpanelissa ja pystygeometriakuvaajassa oli valittuna jokin geometria-alignment ja ka. alignment piilotettiin selectionpanelista, jolloin toolpanel huomasi asian ja arpoi itse ensimmäisen tabin valituksi, mutta pystygeometrian kuvaaja näytti edelleen piilotetun geometria-alignmentin tietoja.

Valitun tabin arvontalogiikka on nyt poistettu ToolPanelista ja se on pyritty siirtämään parhaimpansa mukaan reduxiin. Täten a) myös pystygeometrian kuvaajan pitäisi huomata valitun assetin vaihtuminen ja b) toolpanel jää tyhjäksi. Tuo jälkimmäinen on ainakin omasta mielestäni parempi indikaatio siitä että koodissa on jotain vikaa.

Noiden lisäksi huomattu, että assettien valintalogiikka oli vähintäänkin mielenkiintoinen (oli täysin sattumanvaraista jäikö geometriapuolen asset vai samassa paikassa oleva paikannuspohjan asset valituksi). Tämä juonsi juurensa vanhasta tavasta koittaa ylläpitää valittua tabia, jonka `selectedToolPanelTab` on sittemmin (jo kauan sitten) oikeastaan syrjäyttänyt. Tämä poistettu, joka korjasi tuon ongelman.