### PR TITLE
GVT-2923 Banish has_official from existence

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -121,7 +121,11 @@ constructor(
         val revertTrackNumberIds = trackNumbers.filter(LayoutTrackNumber::isDraft).map { it.id as IntId }
         // If revert breaks other draft row references, they should be reverted too
         val draftOnlyTrackNumberIds =
-            trackNumbers.filter { tn -> tn.isDraft && !tn.contextData.hasOfficial }.map { it.id as IntId }
+            trackNumbers
+                .filter { tn ->
+                    tn.isDraft && trackNumberDao.fetchVersion(tn.layoutContext.branch.official, tn.id as IntId) == null
+                }
+                .map { it.id as IntId }
 
         val revertLocationTrackIds =
             requestIds.locationTracks +

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -71,7 +71,6 @@ data class StoredAssetId<T : LayoutAsset<T>>(override val version: LayoutRowVers
 }
 
 sealed class LayoutContextData<T : LayoutAsset<T>> : LayoutContextAware<T> {
-    @get:JsonIgnore abstract val hasOfficial: Boolean
     @get:JsonIgnore abstract val layoutAssetId: LayoutAssetId<T>
 
     override val version: LayoutRowVersion<T>?
@@ -115,7 +114,6 @@ sealed class LayoutContextData<T : LayoutAsset<T>> : LayoutContextAware<T> {
                 is MainBranch ->
                     MainDraftContextData(
                         layoutAssetId = id?.let(::IdentifiedAssetId) ?: TemporaryAssetId(),
-                        hasOfficial = false,
                         originBranch = LayoutBranch.main,
                     )
                 is DesignBranch ->
@@ -123,7 +121,6 @@ sealed class LayoutContextData<T : LayoutAsset<T>> : LayoutContextAware<T> {
                         layoutAssetId = id?.let(::IdentifiedAssetId) ?: TemporaryAssetId(),
                         designId = branch.designId,
                         designAssetState = DesignAssetState.OPEN,
-                        hasOfficial = false,
                     )
             }
 
@@ -150,19 +147,12 @@ sealed class DesignContextData<T : LayoutAsset<T>> : LayoutContextData<T>() {
 
 data class MainOfficialContextData<T : LayoutAsset<T>>(override val layoutAssetId: LayoutAssetId<T>) :
     MainContextData<T>() {
-    override val hasOfficial: Boolean
-        get() = true
-
     override val isOfficial: Boolean
         get() = true
 
     fun asMainDraft(): MainDraftContextData<T> {
         val ownRowVersion = requireStoredRowVersion()
-        return MainDraftContextData(
-            layoutAssetId = EditedAssetId(ownRowVersion),
-            hasOfficial = true,
-            originBranch = LayoutBranch.main,
-        )
+        return MainDraftContextData(layoutAssetId = EditedAssetId(ownRowVersion), originBranch = LayoutBranch.main)
     }
 
     fun asDesignDraft(designId: IntId<LayoutDesign>): DesignDraftContextData<T> {
@@ -171,7 +161,6 @@ data class MainOfficialContextData<T : LayoutAsset<T>>(override val layoutAssetI
             layoutAssetId = EditedAssetId(ownRowVersion),
             designId = designId,
             designAssetState = DesignAssetState.OPEN,
-            hasOfficial = true,
         )
     }
 
@@ -181,7 +170,6 @@ data class MainOfficialContextData<T : LayoutAsset<T>>(override val layoutAssetI
 
 data class MainDraftContextData<T : LayoutAsset<T>>(
     override val layoutAssetId: LayoutAssetId<T>,
-    override val hasOfficial: Boolean,
     override val originBranch: LayoutBranch,
 ) : MainContextData<T>() {
     override val isDraft: Boolean
@@ -198,9 +186,6 @@ data class DesignOfficialContextData<T : LayoutAsset<T>>(
     override val designId: IntId<LayoutDesign>,
     override val designAssetState: DesignAssetState,
 ) : DesignContextData<T>() {
-    override val hasOfficial: Boolean
-        get() = true
-
     override val isOfficial: Boolean
         get() = true
 
@@ -214,7 +199,6 @@ data class DesignOfficialContextData<T : LayoutAsset<T>>(
         val ownRowVersion = requireStoredRowVersion()
         return MainDraftContextData(
             layoutAssetId = EditedAssetId(sourceRowVersion = ownRowVersion),
-            hasOfficial = true,
             originBranch = DesignBranch.of(designId),
         )
     }
@@ -225,7 +209,6 @@ data class DesignOfficialContextData<T : LayoutAsset<T>>(
             layoutAssetId = EditedAssetId(ownRowVersion),
             designId = designId,
             designAssetState = designAssetState,
-            hasOfficial = true,
         )
     }
 
@@ -238,7 +221,6 @@ data class DesignDraftContextData<T : LayoutAsset<T>>(
     override val layoutAssetId: LayoutAssetId<T>,
     override val designId: IntId<LayoutDesign>,
     override val designAssetState: DesignAssetState,
-    override val hasOfficial: Boolean,
 ) : DesignContextData<T>() {
 
     override val isDraft: Boolean

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -174,11 +174,7 @@ class LayoutKmPostDao(
               gk_location_source,
               gk_location_confirmed,
               state,
-              origin_design_id,
-              exists(select * from layout.km_post official_kp
-                     where kpv.id = official_kp.id
-                       and (official_kp.design_id is null or official_kp.design_id = kpv.design_id)
-                       and not official_kp.draft) as has_official
+              origin_design_id
             from layout.km_post_version kpv
             where id = :id 
               and version = :version
@@ -225,10 +221,6 @@ class LayoutKmPostDao(
               kp.gk_location_source,
               kp.gk_location_confirmed,
               kp.state,
-              exists(select * from layout.km_post official_kp
-                     where kp.id = official_kp.id
-                       and (official_kp.design_id is null or official_kp.design_id = kp.design_id)
-                       and not official_kp.draft) as has_official,
               kp.origin_design_id
             from layout.km_post kp
         """
@@ -254,15 +246,7 @@ class LayoutKmPostDao(
             state = rs.getEnum("state"),
             sourceId = rs.getIntIdOrNull("geometry_km_post_id"),
             contextData =
-                rs.getLayoutContextData(
-                    "id",
-                    "design_id",
-                    "draft",
-                    "version",
-                    "design_asset_state",
-                    "has_official",
-                    "origin_design_id",
-                ),
+                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -295,10 +295,6 @@ class LayoutSwitchDao(
               sv.source,
               origin_design_id,
               sv.draft_oid,
-              exists(select * from layout.switch official_sv
-                     where official_sv.id = sv.id
-                       and (official_sv.design_id is null or official_sv.design_id = sv.design_id)
-                       and not official_sv.draft) as has_official,
               coalesce(joint_numbers, '{}') as joint_numbers,
               coalesce(joint_roles, '{}') as joint_roles,
               coalesce(joint_x_values, '{}') as joint_x_values,
@@ -354,10 +350,6 @@ class LayoutSwitchDao(
               joint_y_values,
               joint_location_accuracies,
               s.draft_oid,
-              exists(select * from layout.switch official_sv
-                     where official_sv.id = s.id
-                       and (official_sv.design_id is null or official_sv.design_id = s.design_id)
-                       and not official_sv.draft) as has_official,
               s.origin_design_id
             from layout.switch s
               left join lateral
@@ -405,15 +397,7 @@ class LayoutSwitchDao(
             source = rs.getEnum("source"),
             draftOid = rs.getOidOrNull("draft_oid"),
             contextData =
-                rs.getLayoutContextData(
-                    "id",
-                    "design_id",
-                    "draft",
-                    "version",
-                    "design_asset_state",
-                    "has_official",
-                    "origin_design_id",
-                ),
+                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -86,7 +86,7 @@ constructor(
         // main-official or null
         val draft = dao.get(branch.draft, id)
         // If removal also breaks references, clear them out first
-        if (draft?.contextData?.hasOfficial != true) {
+        if (dao.fetchVersion(branch.official, id) != null) {
             clearSwitchInformationFromSegments(branch, id)
         }
         return super.deleteDraft(branch, id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -93,10 +93,6 @@ class LayoutTrackNumberDao(
               tn.state,
               -- Track number reference line identity never changes, so any instance whatsoever is fine
               (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
-              exists (select * from layout.track_number official_tn
-                      where official_tn.id = tn.id
-                        and (official_tn.design_id is null or official_tn.design_id = tn.design_id)
-                        and not official_tn.draft) has_official,
               tn.origin_design_id
             from layout.track_number_version tn
             where tn.id = :id
@@ -131,10 +127,6 @@ class LayoutTrackNumberDao(
               tn.design_asset_state,
               -- Track number reference line identity never changes, so any instance whatsoever is fine
               (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
-              exists (select * from layout.track_number official_tn
-                      where official_tn.id = tn.id
-                        and (official_tn.design_id is null or official_tn.design_id = tn.design_id)
-                        and not official_tn.draft) has_official,
               tn.origin_design_id
             from layout.track_number tn
             order by tn.id
@@ -161,15 +153,7 @@ class LayoutTrackNumberDao(
             // data
             referenceLineId = rs.getIntIdOrNull("reference_line_id"),
             contextData =
-                rs.getLayoutContextData(
-                    "id",
-                    "design_id",
-                    "draft",
-                    "version",
-                    "design_asset_state",
-                    "has_official",
-                    "origin_design_id",
-                ),
+                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
         )
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -149,10 +149,6 @@ class LocationTrackDao(
                     and sv.alignment_version = ltv.alignment_version
                     and sv.switch_id is not null
               ) as segment_switch_ids,
-              exists(select * from layout.location_track official_lt
-                     where official_lt.id = ltv.id
-                       and (official_lt.design_id is null or official_lt.design_id = ltv.design_id)
-                       and not official_lt.draft) as has_official,
               ltv.origin_design_id
             from layout.location_track_version ltv
               left join layout.alignment_version av on ltv.alignment_id = av.id and ltv.alignment_version = av.version
@@ -209,10 +205,6 @@ class LocationTrackDao(
                     and sv.alignment_version = lt.alignment_version
                     and sv.switch_id is not null
               ) as segment_switch_ids,
-              exists(select * from layout.location_track official_lt
-                     where official_lt.id = lt.id
-                       and (official_lt.design_id is null or official_lt.design_id = lt.design_id)
-                       and not official_lt.draft) as has_official,
               lt.origin_design_id
             from layout.location_track lt
               left join layout.alignment_version av on lt.alignment_id = av.id and lt.alignment_version = av.version
@@ -256,15 +248,7 @@ class LocationTrackDao(
                 },
             segmentSwitchIds = rs.getIntIdArray("segment_switch_ids"),
             contextData =
-                rs.getLayoutContextData(
-                    "id",
-                    "design_id",
-                    "draft",
-                    "version",
-                    "design_asset_state",
-                    "has_official",
-                    "origin_design_id",
-                ),
+                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
         )
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -222,7 +222,7 @@ class LocationTrackService(
         // main-official or null
         val draft = dao.get(branch.draft, id)
         // If removal also breaks references, clear them out first
-        if (draft?.contextData?.hasOfficial != true) {
+        if (dao.fetchVersion(branch.official, id) != null) {
             clearDuplicateReferences(branch, id)
         }
         val deletedVersion = super.deleteDraft(branch, id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -51,10 +51,6 @@ class ReferenceLineDao(
               av.length,
               av.segment_count,
               rlv.start_address,
-              exists(select * from layout.reference_line official_rl
-                     where rlv.id = official_rl.id
-                       and (official_rl.design_id is null or official_rl.design_id = rlv.design_id)
-                       and not official_rl.draft) as has_official,
               origin_design_id
             from layout.reference_line_version rlv
               left join layout.alignment_version av on rlv.alignment_id = av.id and rlv.alignment_version = av.version
@@ -91,10 +87,6 @@ class ReferenceLineDao(
               av.length,
               av.segment_count,
               rl.start_address,
-              exists(select * from layout.reference_line official_rl
-                     where rl.id = official_rl.id
-                       and (official_rl.design_id is null or official_rl.design_id = rl.design_id)
-                       and not official_rl.draft) as has_official,
               rl.origin_design_id
             from layout.reference_line rl
               left join layout.alignment_version av on rl.alignment_id = av.id and rl.alignment_version = av.version
@@ -122,15 +114,7 @@ class ReferenceLineDao(
             length = rs.getDouble("length"),
             segmentCount = rs.getInt("segment_count"),
             contextData =
-                rs.getLayoutContextData(
-                    "id",
-                    "design_id",
-                    "draft",
-                    "version",
-                    "design_asset_state",
-                    "has_official",
-                    "origin_design_id",
-                ),
+                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
         )
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -37,9 +37,6 @@ sealed class LayoutAsset<T : LayoutAsset<T>>(contextData: LayoutContextData<T>) 
     LayoutContextAware<T> by contextData, Loggable {
     @get:JsonIgnore abstract val contextData: LayoutContextData<T>
 
-    val hasOfficial: Boolean
-        get() = contextData.hasOfficial
-
     abstract fun withContext(contextData: LayoutContextData<T>): T
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -409,14 +409,12 @@ fun <T : LayoutAsset<T>> ResultSet.getLayoutContextData(
     draftFlagName: String,
     versionName: String,
     designAssetStateName: String,
-    hasOfficialName: String,
     originDesignIdName: String,
 ): LayoutContextData<T> {
     val designId = getIntIdOrNull<LayoutDesign>(designIdName)
     val isDraft = getBoolean(draftFlagName)
     val rowVersion = getLayoutRowVersion<T>(idName, designIdName, draftFlagName, versionName)
     val designAssetState = getEnumOrNull<DesignAssetState>(designAssetStateName)
-    val hasOfficial = getBoolean(hasOfficialName)
     val originBranch = getLayoutBranch(originDesignIdName)
     return if (designId != null) {
         requireNotNull(designAssetState) { "Expected design asset state for $idName in design" }
@@ -425,7 +423,6 @@ fun <T : LayoutAsset<T>> ResultSet.getLayoutContextData(
                 layoutAssetId = StoredAssetId(rowVersion),
                 designId = designId,
                 designAssetState = designAssetState,
-                hasOfficial = hasOfficial,
             )
         } else {
             DesignOfficialContextData(
@@ -435,11 +432,7 @@ fun <T : LayoutAsset<T>> ResultSet.getLayoutContextData(
             )
         }
     } else if (isDraft) {
-        MainDraftContextData(
-            layoutAssetId = StoredAssetId(rowVersion),
-            hasOfficial = hasOfficial,
-            originBranch = originBranch,
-        )
+        MainDraftContextData(layoutAssetId = StoredAssetId(rowVersion), originBranch = originBranch)
     } else {
         MainOfficialContextData(layoutAssetId = StoredAssetId(rowVersion))
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -547,9 +547,8 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
                     }
                 DRAFT ->
                     when (branch) {
-                        is MainBranch -> MainDraftContextData(rowContextId, false, LayoutBranch.main)
-                        is DesignBranch ->
-                            DesignDraftContextData(rowContextId, branch.designId, DesignAssetState.OPEN, false)
+                        is MainBranch -> MainDraftContextData(rowContextId, LayoutBranch.main)
+                        is DesignBranch -> DesignDraftContextData(rowContextId, branch.designId, DesignAssetState.OPEN)
                     }
             }
         }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -1,9 +1,7 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.TestLayoutContext
 import fi.fta.geoviite.infra.common.AlignmentName
-import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.PublicationState
@@ -12,9 +10,7 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -295,74 +291,5 @@ constructor(
         assertEquals(locationTrack, designDraftContext.fetchVersion(locationTrack.id))
         assertEquals(switch, designDraftContext.fetchVersion(switch.id))
         assertEquals(kmPost, designDraftContext.fetchVersion(kmPost.id))
-    }
-
-    @Test
-    fun `hasOfficial indicates having any official row above`() {
-        val someDesignBranch = testDBService.createDesignBranch()
-        val designOfficialContext = testDBService.testContext(someDesignBranch, PublicationState.OFFICIAL)
-        val designDraftContext = testDBService.testContext(someDesignBranch, PublicationState.DRAFT)
-
-        val assets = AllAssetTypes.createIn(mainDraftContext)
-
-        assets.fetchAllAndRun(mainDraftContext) { asset -> assertFalse(asset.hasOfficial) }
-        assets.copyFromTo(mainDraftContext, designDraftContext)
-
-        assets.fetchAllAndRun(mainDraftContext) { asset -> assertFalse(asset.hasOfficial) }
-        assets.fetchAllAndRun(designDraftContext) { asset -> assertFalse(asset.hasOfficial) }
-
-        assets.copyFromTo(designDraftContext, designOfficialContext)
-        // normally publication would delete drafts and hence force version increments, we'll just
-        // do it by hand here
-        assets.incrementVersionsInContext(designDraftContext)
-
-        assets.fetchAllAndRun(mainDraftContext) { asset -> assertFalse(asset.hasOfficial) }
-        assets.fetchAllAndRun(designDraftContext) { asset -> assertTrue(asset.hasOfficial) }
-
-        assets.copyFromTo(mainDraftContext, mainOfficialContext)
-        assets.incrementVersionsInContext(designDraftContext)
-        assets.incrementVersionsInContext(mainDraftContext)
-
-        assets.fetchAllAndRun(mainDraftContext) { asset -> assertTrue(asset.hasOfficial) }
-        assets.fetchAllAndRun(designDraftContext) { asset -> assertTrue(asset.hasOfficial) }
-    }
-
-    private data class AllAssetTypes(
-        val trackNumber: IntId<LayoutTrackNumber>,
-        val referenceLine: IntId<ReferenceLine>,
-        val locationTrack: IntId<LocationTrack>,
-        val switch: IntId<LayoutSwitch>,
-        val kmPost: IntId<LayoutKmPost>,
-    ) {
-        companion object {
-            fun createIn(context: TestLayoutContext): AllAssetTypes {
-                val trackNumber = context.insert(trackNumber()).id
-                return AllAssetTypes(
-                    trackNumber = trackNumber,
-                    referenceLine = context.insert(referenceLineAndAlignment(trackNumber)).id,
-                    locationTrack = context.insert(locationTrackAndAlignment(trackNumber)).id,
-                    switch = context.insert(switch()).id,
-                    kmPost = context.insert(kmPost(trackNumber, KmNumber(123))).id,
-                )
-            }
-        }
-
-        fun copyFromTo(fromContext: TestLayoutContext, toContext: TestLayoutContext) {
-            toContext.insert(fromContext.fetch(trackNumber)!!)
-            toContext.insert(fromContext.fetch(referenceLine)!!)
-            toContext.insert(fromContext.fetch(locationTrack)!!)
-            toContext.insert(fromContext.fetch(switch)!!)
-            toContext.insert(fromContext.fetch(kmPost)!!)
-        }
-
-        fun fetchAllAndRun(context: TestLayoutContext, callback: (asset: LayoutAsset<*>) -> Unit) {
-            callback(context.fetch(trackNumber)!!)
-            callback(context.fetch(referenceLine)!!)
-            callback(context.fetch(locationTrack)!!)
-            callback(context.fetch(switch)!!)
-            callback(context.fetch(kmPost)!!)
-        }
-
-        fun incrementVersionsInContext(context: TestLayoutContext) = copyFromTo(context, context)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
@@ -197,34 +197,6 @@ constructor(
         assertEquals(draft2, trackNumberDao.fetchVersion(MainLayoutContext.draft, draft1.id))
     }
 
-    @Test
-    fun `hasOfficial is calculated to be false for unpublished drafts`() {
-        val draft = kmPost(null, someKmNumber(), draft = true)
-        assertFalse(draft.hasOfficial)
-        assertFalse(draft.isOfficial)
-        assertTrue(draft.isDraft)
-    }
-
-    @Test
-    fun `hasOfficial is calculated to be true for unedited officials`() {
-        val official =
-            insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false))
-        assertTrue(official.hasOfficial)
-        assertTrue(official.isOfficial)
-        assertFalse(official.isDraft)
-    }
-
-    @Test
-    fun `hasOfficial is calculated to be true for drafts with an official version`() {
-        val edited =
-            asMainDraft(
-                insertAndVerify(kmPost(mainOfficialContext.createLayoutTrackNumber().id, someKmNumber(), draft = false))
-            )
-        assertTrue(edited.hasOfficial)
-        assertFalse(edited.isOfficial)
-        assertTrue(edited.isDraft)
-    }
-
     private fun createReferenceLineAndAlignment(draft: Boolean): Pair<ReferenceLine, LayoutAlignment> =
         referenceLineAndAlignment(
             mainOfficialContext.createLayoutTrackNumber().id,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -964,7 +964,6 @@ fun <T : LayoutAsset<T>> createMainContext(id: IntId<T>?, draft: Boolean): Layou
     if (draft) {
         MainDraftContextData(
             if (id != null) IdentifiedAssetId(id) else TemporaryAssetId(),
-            hasOfficial = false,
             originBranch = LayoutBranch.main,
         )
     } else {

--- a/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
+++ b/ui/src/geoviite-design-lib/demo/examples/badge-examples.tsx
@@ -18,7 +18,6 @@ const layoutAssetFields: LayoutAssetFields = {
     version: 'version',
     dataType: 'TEMP',
     isDraft: true,
-    hasOfficial: false,
 };
 
 const layoutLocationTrack: LayoutLocationTrack = {

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-candidates.tsx
@@ -192,7 +192,7 @@ export const GeometryAlignmentLinkingReferenceLineCandidates: React.FC<
             .includes(referenceLineSearchInput);
 
         const trackNumberWithEmptyGeometryIsAlreadyPublished =
-            !line.foundWithBoundingBox && line.hasOfficial && !line.isDraft;
+            !line.foundWithBoundingBox && !line.isDraft;
 
         const displayTrackNumberOption =
             (hasSearchInput && trackNumberMatchesSearchInput) ||

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -33,9 +33,15 @@ import KmPostRevertConfirmationDialog from 'tool-panel/km-post/dialog/km-post-re
 import { Link } from 'vayla-design-lib/link/link';
 import {
     getSaveDisabledReasons,
+    useKmPost,
     useTrackNumbersIncludingDeleted,
 } from 'track-layout/track-layout-react-utils';
-import { draftLayoutContext, LayoutContext, Srid } from 'common/common-model';
+import {
+    draftLayoutContext,
+    LayoutContext,
+    officialLayoutContext,
+    Srid,
+} from 'common/common-model';
 import { useTrackLayoutAppSelector } from 'store/hooks';
 import { KmPostEditDialogGkLocationSection } from 'tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section';
 import { GeometryPoint } from 'model/geometry';
@@ -98,7 +104,9 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
         },
     );
     const stateActions = createDelegatesWithDispatcher(dispatcher, actions);
-    const canSetDeleted = state.existingKmPost?.hasOfficial;
+    const canSetDeleted =
+        useKmPost(state.existingKmPost?.id, officialLayoutContext(props.layoutContext)) !==
+        undefined;
     const kmPostStateOptions = layoutStates
         .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -61,7 +61,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { getChangeTimes } from 'common/change-time-api';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
 import { first } from 'utils/array-utils';
-import { draftLayoutContext, LayoutContext } from 'common/common-model';
+import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
 import { UnknownAction } from 'redux';
 
 type LocationTrackDialogContainerProps = {
@@ -144,7 +144,14 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         props.changeTimes,
     );
 
-    const canSetDeleted = !state.isNewLocationTrack && state.existingLocationTrack?.hasOfficial;
+    const hasOfficialLocationTrack =
+        useLocationTrack(
+            state.existingLocationTrack?.id,
+            officialLayoutContext(props.layoutContext),
+            props.changeTimes.layoutLocationTrack,
+        ) !== undefined;
+
+    const canSetDeleted = !state.isNewLocationTrack && hasOfficialLocationTrack;
     const stateOptions = locationTrackStates
         .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));

--- a/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-splitting-infobox.tsx
@@ -62,7 +62,7 @@ import {
     ValidatedSplit,
     validateSplit,
 } from 'tool-panel/location-track/splitting/split-utils';
-import { draftLayoutContext, LayoutContext } from 'common/common-model';
+import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
 import { BoundingBox, boundingBoxAroundPoints, multiplyBoundingBox, Point } from 'model/geometry';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { validateLocationTrackSwitchRelinking } from 'linking/linking-api';
@@ -167,15 +167,23 @@ export const LocationTrackSplittingInfoboxContainer: React.FC<
         [changeTimes.layoutLocationTrack, changeTimes.layoutSwitch],
     );
 
+    const hasOfficialLocationTrack =
+        useLocationTrack(
+            splittingState?.originLocationTrack.id,
+            officialLayoutContext(layoutContext),
+            changeTimes.layoutLocationTrack,
+        ) !== undefined;
+
     React.useEffect(() => {
         locationTrack &&
             delegates.setDisabled(
                 !locationTrack ||
-                    (locationTrack.isDraft && !locationTrack.hasOfficial) ||
+                    (locationTrack.isDraft && !hasOfficialLocationTrack) ||
                     hasUnrelinkableSwitches(switchRelinkingErrors || []),
             );
     }, [
         locationTrack,
+        hasOfficialLocationTrack,
         switchRelinkingErrors,
         changeTimes.layoutLocationTrack,
         changeTimes.layoutSwitch,

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -22,6 +22,7 @@ import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import {
     draftLayoutContext,
     LayoutContext,
+    officialLayoutContext,
     SwitchOwner,
     SwitchOwnerId,
     SwitchStructure,
@@ -40,7 +41,7 @@ import {
 import styles from './switch-edit-dialog.scss';
 import { useLoader } from 'utils/react-utils';
 import { Link } from 'vayla-design-lib/link/link';
-import { getSaveDisabledReasons } from 'track-layout/track-layout-react-utils';
+import { getSaveDisabledReasons, useSwitch } from 'track-layout/track-layout-react-utils';
 import SwitchRevertConfirmationDialog from './switch-revert-confirmation-dialog';
 import { first } from 'utils/array-utils';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
@@ -129,7 +130,10 @@ export const SwitchEditDialog = ({
     const switchStructureChanged =
         isExistingSwitch && switchStructureId !== existingSwitch?.switchStructureId;
 
-    const canSetDeleted = isExistingSwitch && !!existingSwitch?.hasOfficial;
+    const hasExistingOfficial =
+        useSwitch(existingSwitch?.id, officialLayoutContext(layoutContext), changeTime) !==
+        undefined;
+    const canSetDeleted = isExistingSwitch && hasExistingOfficial;
     const stateCategoryOptions = layoutStateCategories
         .map((s) => (s.value !== 'NOT_EXISTING' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((sc) => ({ ...sc, qaId: sc.value }));

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -200,10 +200,6 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         });
     };
 
-    // Draft-only entities should be hidden when viewing in official mode. Show everything in draft mode
-    const visibleByContextAndState = ({ hasOfficial }: { hasOfficial: boolean }) =>
-        layoutContext.publicationState === 'DRAFT' || hasOfficial;
-
     React.useEffect(() => {
         if (tracksSwitchesKmPostsPlans === undefined) {
             return;
@@ -228,7 +224,6 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
         const trackNumberTabs = trackNumberIds
             .map((tnId) => trackNumbers?.find((tn) => tn.id === tnId))
             .filter(filterNotEmpty)
-            .filter(visibleByContextAndState)
             .map((t) => {
                 return {
                     asset: { type: 'TRACK_NUMBER', id: t.id },
@@ -246,7 +241,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                 } as ToolPanelTab;
             });
 
-        const layoutKmPostTabs = kmPosts.filter(visibleByContextAndState).map((k) => {
+        const layoutKmPostTabs = kmPosts.map((k) => {
             return {
                 asset: { type: 'KM_POST', id: k.id },
                 title: k.kmNumber,
@@ -285,7 +280,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             },
         );
 
-        const switchTabs = switches.filter(visibleByContextAndState).map((s) => {
+        const switchTabs = switches.map((s) => {
             return {
                 asset: { type: 'SWITCH', id: s.id },
                 title: s.name,
@@ -341,25 +336,23 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                 };
             });
 
-        const locationTrackTabs = locationTracks
-            .filter(visibleByContextAndState)
-            .map((track: LayoutLocationTrack): ToolPanelTab => {
-                return {
-                    asset: { type: 'LOCATION_TRACK', id: track.id },
-                    title: track.name,
-                    element: (
-                        <LocationTrackInfoboxLinkingContainer
-                            visibilities={infoboxVisibilities.locationTrack}
-                            onVisibilityChange={(visibilities) =>
-                                infoboxVisibilityChange('locationTrack', visibilities)
-                            }
-                            locationTrackId={track.id}
-                            onDataChange={onDataChange}
-                            onHoverOverPlanSection={onHoverOverPlanSection}
-                        />
-                    ),
-                };
-            });
+        const locationTrackTabs = locationTracks.map((track: LayoutLocationTrack): ToolPanelTab => {
+            return {
+                asset: { type: 'LOCATION_TRACK', id: track.id },
+                title: track.name,
+                element: (
+                    <LocationTrackInfoboxLinkingContainer
+                        visibilities={infoboxVisibilities.locationTrack}
+                        onVisibilityChange={(visibilities) =>
+                            infoboxVisibilityChange('locationTrack', visibilities)
+                        }
+                        locationTrackId={track.id}
+                        onDataChange={onDataChange}
+                        onHoverOverPlanSection={onHoverOverPlanSection}
+                    />
+                ),
+            };
+        });
 
         const geometryAlignmentTabs = geometryAlignmentIds.map(
             (item: SelectedGeometryItem<GeometryAlignmentId>): ToolPanelTab => {

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -10,6 +10,7 @@ import { createTrackNumber, updateTrackNumber } from 'track-layout/layout-track-
 import {
     getSaveDisabledReasons,
     useReferenceLineStartAndEnd,
+    useTrackNumber,
     useTrackNumberReferenceLine,
     useTrackNumbersIncludingDeleted,
 } from 'track-layout/track-layout-react-utils';
@@ -41,7 +42,7 @@ import { onRequestDeleteTrackNumber } from 'tool-panel/track-number/track-number
 import { ChangesBeingReverted } from 'preview/preview-view';
 import { isEqualIgnoreCase } from 'utils/string-utils';
 import { useTrackLayoutAppSelector } from 'store/hooks';
-import { draftLayoutContext, LayoutContext } from 'common/common-model';
+import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
 import { UnknownAction } from 'redux';
 
 type TrackNumberEditDialogContainerProps = {
@@ -74,7 +75,11 @@ export const TrackNumberEditDialogContainer: React.FC<TrackNumberEditDialogConta
         editTrackNumberId,
     );
     const editReferenceLine = useTrackNumberReferenceLine(trackNumberId, layoutContext);
-    const isNewDraft = !!editReferenceLine && !editReferenceLine.hasOfficial;
+    const hasOfficialTrackNumber = useTrackNumber(
+        trackNumberId,
+        officialLayoutContext(layoutContext),
+    );
+    const isNewDraft = !!editReferenceLine && !hasOfficialTrackNumber;
 
     if (trackNumbers !== undefined && trackNumberId === editReferenceLine?.trackNumberId) {
         return (

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -92,7 +92,6 @@ export type LayoutAssetFields = {
     version?: RowVersion;
     dataType: DataType;
     isDraft: boolean;
-    hasOfficial: boolean;
 };
 
 export type LayoutAsset =


### PR DESCRIPTION
Pitkälti triviaaleja muutoksia. Parikin käyttöpaikkaa oli sellaisia, että eipä siellä oikeasti ole voitu tehdä mitään hyödyllistä hasOfficial-tiedolla alkuunkaan, joten heitin ne vaan pois. Taustana siis se, että ID-remontin myötä tieto siitä, onko oliosta olemassa virallista versiota, ei pitäisi olla enää liitettynä olioon itseensä.