### PR TITLE
GVT-2981 Move design Ratko ID to separate table

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -457,11 +457,9 @@ constructor(
         val lastPublicationDesign =
             layoutDesignDao.fetchVersion(RowVersion(designBranch.designId, lastPublicationDesignVersion))
 
-        // An interrupted push can leave the design itself knowing its Ratko ID, but the most recent
-        // publication pointing at a version before it was saved; so always look up the current ID
-        val presentRatkoId = layoutDesignDao.fetch(designBranch.designId).ratkoId
+        val existingRatkoId = layoutDesignDao.fetchRatkoId(designBranch.designId)
         val ratkoId =
-            if (presentRatkoId == null) {
+            if (existingRatkoId == null) {
                 createPlanInRatko(lastPublicationDesign, designBranch.designId)
             } else {
                 updatePlanInRatkoIfNeeded(
@@ -469,9 +467,9 @@ constructor(
                     designBranch,
                     lastPublicationDesignVersion,
                     lastPublicationDesign,
-                    presentRatkoId,
+                    existingRatkoId,
                 )
-                presentRatkoId
+                existingRatkoId
             }
         return PushableDesignBranch(designBranch, ratkoId)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesign.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.DomainId
-import fi.fta.geoviite.infra.ratko.model.RatkoPlanId
 import fi.fta.geoviite.infra.util.StringSanitizer
 import java.time.LocalDate
 
@@ -34,7 +33,6 @@ data class LayoutDesignName @JsonCreator(mode = DELEGATING) constructor(private 
 
 data class LayoutDesign(
     val id: DomainId<LayoutDesign>,
-    val ratkoId: RatkoPlanId?,
     val name: LayoutDesignName,
     val estimatedCompletion: LocalDate,
     val designState: DesignState,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignDao.kt
@@ -16,6 +16,7 @@ import fi.fta.geoviite.infra.util.getIntOrNull
 import fi.fta.geoviite.infra.util.getLocalDate
 import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.queryOne
+import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
 import java.sql.ResultSet
@@ -33,7 +34,7 @@ class LayoutDesignDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(
     fun fetch(id: IntId<LayoutDesign>): LayoutDesign {
         val sql =
             """
-            select id, ratko_id, name, estimated_completion, design_state
+            select id, name, estimated_completion, design_state
             from layout.design
             where id = :id
         """
@@ -44,7 +45,7 @@ class LayoutDesignDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(
     fun fetchVersion(rowVersion: RowVersion<LayoutDesign>): LayoutDesign {
         val sql =
             """
-            select id, ratko_id, name, estimated_completion, design_state
+            select id, name, estimated_completion, design_state
             from layout.design_version
             where id = :id and version = :version
         """
@@ -59,7 +60,7 @@ class LayoutDesignDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(
     fun list(includeCompleted: Boolean = false, includeDeleted: Boolean = false): List<LayoutDesign> {
         val sql =
             """
-            select id, ratko_id, name, estimated_completion, design_state
+            select id, name, estimated_completion, design_state
             from layout.design
             where design_state = 'ACTIVE'::layout.design_state 
               or :include_completed is true and design_state = 'COMPLETED'::layout.design_state
@@ -79,14 +80,20 @@ class LayoutDesignDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(
         jdbcTemplate.setUser()
         val sql =
             """
-            update layout.design
-            set ratko_id = :ratko_id
-            where id = :id and ratko_id is null
+            insert into integrations.ratko_design values (:design_id, :ratko_id)
         """
                 .trimIndent()
-        val updated = jdbcTemplate.update(sql, mapOf("id" to toDbId(id).intValue, "ratko_id" to ratkoId.intValue))
+        val updated =
+            jdbcTemplate.update(sql, mapOf("design_id" to toDbId(id).intValue, "ratko_id" to ratkoId.intValue))
         require(updated == 1) {
             "Expected initializing Ratko ID for design $id to update exactly one row, but updated count was $updated"
+        }
+    }
+
+    fun fetchRatkoId(id: IntId<LayoutDesign>): RatkoPlanId? {
+        val sql = """select ratko_plan_id from integrations.ratko_design where design_id = :id"""
+        return jdbcTemplate.queryOptional(sql, mapOf("id" to id.intValue)) { rs, _ ->
+            rs.getIntOrNull("ratko_plan_id")?.let(::RatkoPlanId)
         }
     }
 
@@ -185,7 +192,6 @@ fun asDuplicateNameException(e: DataIntegrityViolationException): DuplicateDesig
 private fun getLayoutDesign(rs: ResultSet) =
     LayoutDesign(
         rs.getIntId("id"),
-        rs.getIntOrNull("ratko_id")?.let(::RatkoPlanId),
         LayoutDesignName(rs.getString("name")),
         rs.getLocalDate("estimated_completion"),
         rs.getEnum("design_state"),

--- a/infra/src/main/resources/db/migration/prod/V111__move_design_ratko_id_to_separate_table.sql
+++ b/infra/src/main/resources/db/migration/prod/V111__move_design_ratko_id_to_separate_table.sql
@@ -1,0 +1,14 @@
+create table integrations.ratko_design
+(
+  design_id     int primary key,
+  ratko_plan_id int not null
+);
+insert into integrations.ratko_design (
+  select id, ratko_id
+    from layout.design
+    where ratko_id is not null
+);
+alter table layout.design
+  drop column ratko_id;
+alter table layout.design_version
+  drop column ratko_id;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -1438,7 +1438,7 @@ constructor(
             PublicationRequest(publicationRequestIds(), message = FreeTextWithNewLines.of("aoeu")),
         )
         ratkoService.pushChangesToRatko(design)
-        assertEquals(123, layoutDesignDao.fetch(design.designId).ratkoId?.intValue)
+        assertEquals(123, layoutDesignDao.fetchRatkoId(design.designId)?.intValue)
     }
 
     @Test


### PR DESCRIPTION
Pienenpieni rakenteenselkiytysjuttu. Jyrki oli jo alkuaan suunnitellut että tämänhän pitäisi mennä omaan tauluunsa, ja niinhän sen pitäisi, kun kyseessä ei ole tieto, joka voi muuttua ajan kanssa suunnitelmissa, vaan oikeastaan vain Ratko-integraation tieto.