### PR TITLE
GVT-2998: Splittauksen alkupisteen poistonapille varattu tyhjä tila näyttää pointer-kursoria

### DIFF
--- a/ui/src/tool-panel/location-track/location-track-infobox.scss
+++ b/ui/src/tool-panel/location-track/location-track-infobox.scss
@@ -113,14 +113,16 @@ $-color-warning: vayla-design.$color-lemon-dark;
     }
 }
 
-.location-track-infobox__split-close-button {
+.location-track-infobox__split-close-button-container {
     width: 22px;
     height: 20px;
     fill: vayla-design.$color-blue-dark;
     display: flex;
     justify-content: center;
     align-items: center;
+}
 
+.location-track-infobox__split-close-button {
     &--disabled {
         fill: vayla-design.$color-black-lighter;
     }

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -114,7 +114,7 @@ export const LocationTrackSplittingEndpoint: React.FC<EndpointProps> = ({
                 </span>
                 <div
                     className={createClassName(
-                        styles['location-track-infobox__split-close-button'],
+                        styles['location-track-infobox__split-close-button-container'],
                         styles['location-track-infobox__split-close-button--disabled'],
                     )}></div>
             </div>
@@ -231,6 +231,15 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
     }
 
     const [showRemovalConfirmationMenu, setShowRemovalConfirmationMenu] = React.useState(false);
+    const closeButtonClassName = () => {
+        if (!onRemove) {
+            return undefined;
+        } else {
+            return deletingDisabled
+                ? styles['location-track-infobox__split-close-button--disabled']
+                : styles['location-track-infobox__split-close-button--enabled'];
+        }
+    };
 
     return (
         <div
@@ -287,10 +296,8 @@ export const LocationTrackSplit: React.FC<SplitProps> = ({
                         <div
                             ref={closeButtonRef}
                             className={createClassName(
-                                styles['location-track-infobox__split-close-button'],
-                                deletingDisabled
-                                    ? styles['location-track-infobox__split-close-button--disabled']
-                                    : styles['location-track-infobox__split-close-button--enabled'],
+                                styles['location-track-infobox__split-close-button-container'],
+                                closeButtonClassName(),
                             )}
                             onClick={() => {
                                 setShowRemovalConfirmationMenu(!showRemovalConfirmationMenu);


### PR DESCRIPTION
Splittauksen poistonappi on (oletettavasti pienen kokonsa vuoksi) hyvin erilainen kuin meidän muut napit - se ei ole varsinaisesti nappi, vaan pelkkä ikoni jolle on bindattu `onClick`-handleri. Sille päätyi vääriä classeja, se korjattu täällä (ja muutenkin välpätty noita tyylejä ja niiden asetuksia vähän fiksummiksi)