### PR TITLE
GVT-3013 Handle icon clickability more automatically

### DIFF
--- a/ui/src/vayla-design-lib/icon/Icon.tsx
+++ b/ui/src/vayla-design-lib/icon/Icon.tsx
@@ -154,7 +154,6 @@ export type IconComponent = React.ComponentType<IconProps>;
 
 export type SvgIconProps = IconProps & {
     svg: string;
-    pointerEvents?: 'NONE' | 'AUTO';
 };
 
 export type SvgIconComponent = React.FC<SvgIconProps>;
@@ -164,7 +163,6 @@ const SvgIcon: SvgIconComponent = ({
     size = IconSize.MEDIUM,
     color,
     extraClassName,
-    pointerEvents = 'NONE',
     ...props
 }: SvgIconProps) => {
     let svgContent = svg
@@ -181,7 +179,7 @@ const SvgIcon: SvgIconComponent = ({
         size && styles[size],
         props.rotation && styles[props.rotation],
         color && styles[color],
-        pointerEvents === 'NONE' && styles['icon--disable-pointer-events'],
+        props.onClick === undefined && styles['icon--disable-pointer-events'],
         extraClassName,
     );
 


### PR DESCRIPTION
Hieman heittoehdotus sen ratkaisemiseen, että saadaan SVG-ikonit olemaan syömättä napsauksia: Oletetaan tähän hätään, että jos on annettu onClick-handleri ikonille itselleen, niin sitä halutaan käytettävän, mutta jos ei ole, niin ikonin ei haluta syövän kursoritapahtumia lainkaan. Periaatteessa hieman takavasemmalta tuleva logiikka, mutta tällä pitäisi toimia suoriltaan sekä ikonin sisältävä klikattava nappi että klikattava ikoni.