### PR TITLE
GVT-3007: Soveltuvuus-tieto geometriasuunnitelmille

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryPlan.kt
@@ -58,6 +58,7 @@ data class GeometryPlanHeader(
     val hasCant: Boolean,
     val isHidden: Boolean,
     val name: PlanName,
+    val planApplicability: PlanApplicability?,
 ) : Loggable {
     @get:JsonIgnore
     val searchParams: List<String> by lazy {
@@ -97,6 +98,7 @@ data class GeometryPlan(
     val isHidden: Boolean = false,
     val id: DomainId<GeometryPlan> = StringId(),
     val dataType: DataType = DataType.TEMP,
+    val planApplicability: PlanApplicability?,
 ) : Loggable {
     @get:JsonIgnore val bounds by lazy { boundingBoxCombining(alignments.mapNotNull { a -> a.bounds }) }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -686,6 +686,10 @@ constructor(
         }
     }
 
+    @Transactional
+    fun setPlanApplicability(planId: IntId<GeometryPlan>, applicability: PlanApplicability?): RowVersion<GeometryPlan> =
+        geometryDao.setPlanApplicability(planId, applicability)
+
     fun getPlanLinkedItems(planId: IntId<GeometryPlan>): GeometryPlanLinkedItems {
         return geometryDao.getPlanLinking(planId)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanMetaData.kt
@@ -32,6 +32,12 @@ enum class PlanDecisionPhase {
     IN_USE,
 }
 
+enum class PlanApplicability {
+    PLANNING,
+    MAINTENANCE,
+    STATISTICS,
+}
+
 data class Project(val name: ProjectName, val description: FreeText?, val id: DomainId<Project> = StringId())
 
 data class Application(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
@@ -23,6 +23,7 @@ data class ExtraInfoParameters(
     val elevationMeasurementMethod: ElevationMeasurementMethod?,
     val message: FreeTextWithNewLines?,
     val name: PlanName,
+    val planApplicability: PlanApplicability?,
 )
 
 data class OverrideParameters(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelController.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.GeometryPlanLinkedItems
 import fi.fta.geoviite.infra.geometry.GeometryService
+import fi.fta.geoviite.infra.geometry.PlanApplicability
 import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.projektivelho.*
@@ -73,6 +74,15 @@ constructor(
         @RequestBody hidden: Boolean,
     ): IntId<GeometryPlan> {
         return geometryService.setPlanHidden(planId, hidden).id
+    }
+
+    @PreAuthorize(AUTH_EDIT_GEOMETRY_FILE)
+    @PutMapping("/{planId}/applicability")
+    fun setInfraModelApplicability(
+        @PathVariable("planId") planId: IntId<GeometryPlan>,
+        @RequestBody applicability: PlanApplicability?,
+    ): IntId<GeometryPlan> {
+        return geometryService.setPlanApplicability(planId, applicability).id
     }
 
     @PreAuthorize(AUTH_VIEW_GEOMETRY)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -179,6 +179,7 @@ fun toGvtPlan(
         uploadTime = null,
         isHidden = false,
         name = getPlanNameByFileName(fileName),
+        planApplicability = null,
     )
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -201,6 +201,7 @@ constructor(
             planTime = overrideParameters?.createdDate ?: plan.planTime,
             uploadTime = plan.uploadTime,
             source = overrideParameters?.source ?: plan.source,
+            planApplicability = extraInfoParameters?.planApplicability ?: plan.planApplicability,
         )
     }
 

--- a/infra/src/main/resources/db/migration/prod/V113__add_geometry_plan_applicability.sql
+++ b/infra/src/main/resources/db/migration/prod/V113__add_geometry_plan_applicability.sql
@@ -1,0 +1,17 @@
+alter table geometry.plan
+  disable trigger version_update_trigger;
+alter table geometry.plan
+  disable trigger version_row_trigger;
+
+create type geometry.plan_applicability as enum ('PLANNING', 'MAINTENANCE', 'STATISTICS');
+
+alter table geometry.plan
+  add column plan_applicability geometry.plan_applicability;
+
+alter table geometry.plan_version
+  add column plan_applicability geometry.plan_applicability;
+
+alter table geometry.plan
+  enable trigger version_update_trigger;
+alter table geometry.plan
+  enable trigger version_row_trigger;

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1106,6 +1106,7 @@
         "phase-measurement-method-formgroup-title": "Tilanne- ja laatutiedot",
         "plan-phase-field": "Suunnitteluvaihe",
         "decision-phase-field": "Vaiheen tarkennus",
+        "plan-applicability-field": "Soveltuvuus",
         "measurement-method-field": "Laatu",
         "elevation-measurement-method-field": "Korkeusasema",
         "log-formgroup-title": "Loki- ja linkitystiedot",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -308,6 +308,12 @@
             "MAIN_OFFICIAL": "Nykytila",
             "MAIN_DRAFT": "Luonnostila",
             "DESIGN": "Suunnitelmatila"
+        },
+        "PlanApplicability": {
+            "PLANNING": "Suunnitelma",
+            "MAINTENANCE": "Kunnossapito",
+            "STATISTICS": "Tilastointi",
+            "UNKNOWN": "Ei tiedossa"
         }
     },
     "environment": {
@@ -470,6 +476,7 @@
             "vertical-coordinate-system": "Korkeusjärjestelmä",
             "has-vertical-geometry": "Pystygeometria",
             "has-cant": "Kallistus",
+            "applicability": "Soveltuvuus",
             "open-inframodel": "Avaa lomakkeella",
             "download-file": "Lataa tiedosto"
         },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -465,6 +465,7 @@ fun plan(
     kmPosts: List<GeometryKmPost> = kmPosts(srid),
     project: Project = project(),
     units: GeometryUnits = geometryUnits(srid, coordinateSystemName, verticalCoordinateSystem),
+    planApplicability: PlanApplicability? = null,
 ): GeometryPlan {
     return GeometryPlan(
         source = source,
@@ -487,7 +488,7 @@ fun plan(
         message = FreeTextWithNewLines.of("test text \n description"),
         uploadTime = Instant.now(),
         name = getPlanNameByFileName(fileName),
-        planApplicability = null,
+        planApplicability = planApplicability,
     )
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDomainTestData.kt
@@ -487,6 +487,7 @@ fun plan(
         message = FreeTextWithNewLines.of("test text \n description"),
         uploadTime = Instant.now(),
         name = getPlanNameByFileName(fileName),
+        planApplicability = null,
     )
 }
 
@@ -523,6 +524,7 @@ fun planHeader(
         author = "Test Company",
         isHidden = false,
         name = getPlanNameByFileName(fileName),
+        planApplicability = null,
     )
 
 fun minimalPlan(fileName: FileName = FileName("TEST_FILE.xml")) =
@@ -552,6 +554,7 @@ fun minimalPlan(fileName: FileName = FileName("TEST_FILE.xml")) =
         trackNumber = null,
         uploadTime = null,
         name = getPlanNameByFileName(fileName),
+        planApplicability = null,
     )
 
 fun geometryLine(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -72,6 +72,21 @@ constructor(
     }
 
     @Test
+    fun `Setting Applicability works`() {
+        deletePlans()
+
+        val file = testFile()
+        val plan = plan(testDBService.getUnusedTrackNumber(), fileName = file.name, planApplicability = null)
+        val polygon = someBoundingPolygon()
+        val planId =
+            geometryDao.insertPlan(plan, file, polygon).id.let { id ->
+                geometryService.setPlanApplicability(id, PlanApplicability.PLANNING)
+            }
+
+        assertEquals(PlanApplicability.PLANNING, geometryService.getPlanHeader(planId.id).planApplicability)
+    }
+
+    @Test
     fun getLocationTrackHeightsCoversTrackStartsAndEnds() {
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = true)
         val trackNumberId = layoutTrackNumberDao.save(trackNumber).id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.error.InframodelParsingException
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryPlan
+import fi.fta.geoviite.infra.geometry.PlanApplicability
 import fi.fta.geoviite.infra.geometry.PlanDecisionPhase
 import fi.fta.geoviite.infra.geometry.PlanName
 import fi.fta.geoviite.infra.geometry.PlanPhase
@@ -100,6 +101,7 @@ constructor(val infraModelService: InfraModelService, val geometryDao: GeometryD
                 elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_RAIL,
                 message = FreeTextWithNewLines.of("test message 1"),
                 name = PlanName("test name 1"),
+                planApplicability = PlanApplicability.PLANNING,
             )
 
         val overrides2 =
@@ -121,6 +123,7 @@ constructor(val infraModelService: InfraModelService, val geometryDao: GeometryD
                 elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_SLEEPER,
                 message = FreeTextWithNewLines.of("test message 2"),
                 name = PlanName("test name 2"),
+                planApplicability = PlanApplicability.MAINTENANCE,
             )
 
         val planId = infraModelService.saveInfraModel(file, overrides1, extraInfo1).id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
@@ -12,6 +12,7 @@ import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.geometry.GeometryKmPost
 import fi.fta.geoviite.infra.geometry.GeometryPlan
+import fi.fta.geoviite.infra.geometry.PlanApplicability
 import fi.fta.geoviite.infra.geometry.PlanDecisionPhase
 import fi.fta.geoviite.infra.geometry.PlanName
 import fi.fta.geoviite.infra.geometry.PlanPhase
@@ -75,6 +76,7 @@ class HelsinkiTestData private constructor() {
                 message = null,
                 uploadTime = Instant.now(),
                 name = PlanName("ratapiha"),
+                planApplicability = PlanApplicability.PLANNING,
             )
         }
 

--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -60,6 +60,8 @@ export type KmNumberRange = {
 
 export type PlanDecisionPhase = 'APPROVED_PLAN' | 'UNDER_CONSTRUCTION' | 'IN_USE';
 
+export type PlanApplicability = 'PLANNING' | 'MAINTENANCE' | 'STATISTICS';
+
 export type PlanPhase =
     | 'RAILWAY_PLAN'
     | 'RAILWAY_CONSTRUCTION_PLAN'
@@ -90,6 +92,7 @@ export type GeometryPlanHeader = {
     hasCant: boolean;
     isHidden: boolean;
     name: string;
+    planApplicability?: PlanApplicability;
 };
 
 export type GeometryPlan = {
@@ -116,6 +119,7 @@ export type GeometryPlan = {
     uploadTime?: Date;
     isHidden: boolean;
     name: string;
+    planApplicability?: PlanApplicability;
 };
 
 export enum GeometrySortBy {

--- a/ui/src/infra-model/infra-model-api.ts
+++ b/ui/src/infra-model/infra-model-api.ts
@@ -6,7 +6,7 @@ import {
     putNonNull,
     queryParams,
 } from 'api/api-fetch';
-import { GeometryPlanId } from 'geometry/geometry-model';
+import { GeometryPlanId, PlanApplicability } from 'geometry/geometry-model';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { getChangeTimes, updatePlanChangeTime } from 'common/change-time-api';
 import {
@@ -100,6 +100,15 @@ export async function hidePlan(planId: GeometryPlanId): Promise<GeometryPlanId |
         (id) => updatePlanChangeTime().then((_) => id),
     );
 }
+
+export const updatePlanApplicability = async (
+    planId: GeometryPlanId,
+    planApplicability: PlanApplicability | undefined,
+): Promise<GeometryPlanId | undefined> =>
+    putNonNull<PlanApplicability | undefined, GeometryPlanId>(
+        `${INFRAMODEL_URI}/${planId}/applicability`,
+        planApplicability,
+    ).then((id) => updatePlanChangeTime().then((_) => id));
 
 export async function getPVDocuments(
     changeTime: TimeStamp,

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -251,6 +251,7 @@ const infraModelSlice = createSlice({
                 elevationMeasurementMethod: plan?.elevationMeasurementMethod ?? undefined,
                 message: plan?.message ?? undefined,
                 name: plan?.name ?? undefined,
+                planApplicability: plan?.planApplicability ?? undefined,
             };
             state.overrideInfraModelParameters =
                 initialInfraModelState.overrideInfraModelParameters;

--- a/ui/src/infra-model/infra-model-slice.ts
+++ b/ui/src/infra-model/infra-model-slice.ts
@@ -12,6 +12,7 @@ import { initialSelectionState, selectionReducers } from 'selection/selection-st
 import {
     AuthorId,
     GeometryPlan,
+    PlanApplicability,
     PlanDecisionPhase,
     PlanPhase,
     PlanSource,
@@ -65,6 +66,7 @@ export type ExtraInfraModelParameters = {
     elevationMeasurementMethod?: ElevationMeasurementMethod;
     message?: Message;
     name?: string;
+    planApplicability?: PlanApplicability;
 };
 
 export type XmlCharset = 'US_ASCII' | 'UTF_16LE' | 'UTF_16' | 'UTF_16BE' | 'UTF_8' | 'ISO_8859_1';

--- a/ui/src/infra-model/view/form/fields/infra-model-decision-phase-field.tsx
+++ b/ui/src/infra-model/view/form/fields/infra-model-decision-phase-field.tsx
@@ -2,31 +2,17 @@ import React from 'react';
 import FormgroupField from 'infra-model/view/formgroup/formgroup-field';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
-import { ExtraInfraModelParameters } from 'infra-model/infra-model-slice';
-import { EditablePlanField } from 'infra-model/view/form/infra-model-form';
 import { useTranslation } from 'react-i18next';
 import { planDecisionPhases } from 'utils/enum-localization-utils';
 import DecisionPhase from 'geoviite-design-lib/geometry-plan/plan-decision-phase';
+import { InfraModelExtraParameterFieldProps } from 'infra-model/view/form/fields/infra-model-field-model';
 
-export type InfraModelDecisionPhaseFieldProps = {
-    fieldInEdit: EditablePlanField;
-    setFieldInEdit: (editablePlanField: EditablePlanField | undefined) => void;
-    extraInframodelParameters: ExtraInfraModelParameters;
-    changeInExtraParametersField: <
-        TKey extends keyof ExtraInfraModelParameters,
-        TValue extends ExtraInfraModelParameters[TKey],
-    >(
-        value: TValue,
-        fieldName: TKey,
-    ) => void;
-};
-
-export const InfraModelDecisionPhaseField: React.FC<InfraModelDecisionPhaseFieldProps> = ({
+export const InfraModelDecisionPhaseField: React.FC<InfraModelExtraParameterFieldProps> = ({
     fieldInEdit,
     setFieldInEdit,
     extraInframodelParameters,
     changeInExtraParametersField,
-}: InfraModelDecisionPhaseFieldProps) => {
+}: InfraModelExtraParameterFieldProps) => {
     const { t } = useTranslation();
 
     return (

--- a/ui/src/infra-model/view/form/fields/infra-model-elevation-measurement-method-field.tsx
+++ b/ui/src/infra-model/view/form/fields/infra-model-elevation-measurement-method-field.tsx
@@ -1,34 +1,20 @@
 import React from 'react';
-import { EditablePlanField } from 'infra-model/view/form/infra-model-form';
-import { ExtraInfraModelParameters } from 'infra-model/infra-model-slice';
 import { useTranslation } from 'react-i18next';
 import FormgroupField from 'infra-model/view/formgroup/formgroup-field';
 import ElevationMeasurementMethod from 'geoviite-design-lib/elevation-measurement-method/elevation-measurement-method';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 import { elevationMeasurementMethods } from 'utils/enum-localization-utils';
-
-export type InfraModelElevationMeasurementMethodFieldProps = {
-    fieldInEdit: EditablePlanField;
-    setFieldInEdit: (editablePlanField: EditablePlanField | undefined) => void;
-    extraInframodelParameters: ExtraInfraModelParameters;
-    changeInExtraParametersField: <
-        TKey extends keyof ExtraInfraModelParameters,
-        TValue extends ExtraInfraModelParameters[TKey],
-    >(
-        value: TValue,
-        fieldName: TKey,
-    ) => void;
-};
+import { InfraModelExtraParameterFieldProps } from 'infra-model/view/form/fields/infra-model-field-model';
 
 export const InfraModelElevationMeasurementMethodField: React.FC<
-    InfraModelElevationMeasurementMethodFieldProps
+    InfraModelExtraParameterFieldProps
 > = ({
     fieldInEdit,
     setFieldInEdit,
     extraInframodelParameters,
     changeInExtraParametersField,
-}: InfraModelElevationMeasurementMethodFieldProps) => {
+}: InfraModelExtraParameterFieldProps) => {
     const { t } = useTranslation();
 
     return (

--- a/ui/src/infra-model/view/form/fields/infra-model-field-model.ts
+++ b/ui/src/infra-model/view/form/fields/infra-model-field-model.ts
@@ -1,0 +1,15 @@
+import { EditablePlanField } from 'infra-model/view/form/infra-model-form';
+import { ExtraInfraModelParameters } from 'infra-model/infra-model-slice';
+
+export type InfraModelExtraParameterFieldProps = {
+    fieldInEdit: EditablePlanField;
+    setFieldInEdit: (editablePlanField: EditablePlanField | undefined) => void;
+    extraInframodelParameters: ExtraInfraModelParameters;
+    changeInExtraParametersField: <
+        TKey extends keyof ExtraInfraModelParameters,
+        TValue extends ExtraInfraModelParameters[TKey],
+    >(
+        value: TValue,
+        fieldName: TKey,
+    ) => void;
+};

--- a/ui/src/infra-model/view/form/fields/infra-model-measurement-method-field.tsx
+++ b/ui/src/infra-model/view/form/fields/infra-model-measurement-method-field.tsx
@@ -2,31 +2,17 @@ import React from 'react';
 import FormgroupField from 'infra-model/view/formgroup/formgroup-field';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
-import { ExtraInfraModelParameters } from 'infra-model/infra-model-slice';
-import { EditablePlanField } from 'infra-model/view/form/infra-model-form';
 import { useTranslation } from 'react-i18next';
 import { measurementMethods } from 'utils/enum-localization-utils';
 import MeasurementMethod from 'geoviite-design-lib/measurement-method/measurement-method';
+import { InfraModelExtraParameterFieldProps } from 'infra-model/view/form/fields/infra-model-field-model';
 
-export type InfraModelMeasurementMethodFieldProps = {
-    fieldInEdit: EditablePlanField;
-    setFieldInEdit: (editablePlanField: EditablePlanField | undefined) => void;
-    extraInframodelParameters: ExtraInfraModelParameters;
-    changeInExtraParametersField: <
-        TKey extends keyof ExtraInfraModelParameters,
-        TValue extends ExtraInfraModelParameters[TKey],
-    >(
-        value: TValue,
-        fieldName: TKey,
-    ) => void;
-};
-
-export const InfraModelMeasurementMethodField: React.FC<InfraModelMeasurementMethodFieldProps> = ({
+export const InfraModelMeasurementMethodField: React.FC<InfraModelExtraParameterFieldProps> = ({
     fieldInEdit,
     setFieldInEdit,
     extraInframodelParameters,
     changeInExtraParametersField,
-}: InfraModelMeasurementMethodFieldProps) => {
+}: InfraModelExtraParameterFieldProps) => {
     const { t } = useTranslation();
 
     return (

--- a/ui/src/infra-model/view/form/fields/infra-model-plan-applicability.tsx
+++ b/ui/src/infra-model/view/form/fields/infra-model-plan-applicability.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import FormgroupField from 'infra-model/view/formgroup/formgroup-field';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
-import { useTranslation } from 'react-i18next';
-import { planPhases } from 'utils/enum-localization-utils';
-import PlanPhase from 'geoviite-design-lib/geometry-plan/plan-phase';
+import { planApplicabilities } from 'utils/enum-localization-utils';
 import { InfraModelExtraParameterFieldProps } from 'infra-model/view/form/fields/infra-model-field-model';
 
-export const InfraModelPhaseField: React.FC<InfraModelExtraParameterFieldProps> = ({
+export const InfraModelPlanApplicabilityField: React.FC<InfraModelExtraParameterFieldProps> = ({
     fieldInEdit,
     setFieldInEdit,
     extraInframodelParameters,
@@ -17,14 +16,14 @@ export const InfraModelPhaseField: React.FC<InfraModelExtraParameterFieldProps> 
 
     return (
         <FormgroupField
-            label={t('im-form.plan-phase-field')}
-            qaId="plan-phase-im-field"
-            inEditMode={fieldInEdit === 'planPhase'}
-            onEdit={() => setFieldInEdit('planPhase')}
+            label={t('im-form.plan-applicability-field')}
+            qaId="plan-applicability-im-field"
+            inEditMode={fieldInEdit === 'planApplicability'}
+            onEdit={() => setFieldInEdit('planApplicability')}
             onClose={() => setFieldInEdit(undefined)}>
-            {fieldInEdit !== 'planPhase' ? (
-                extraInframodelParameters.planPhase ? (
-                    <PlanPhase phase={extraInframodelParameters.planPhase} />
+            {fieldInEdit !== 'planApplicability' ? (
+                extraInframodelParameters.planApplicability ? (
+                    t(`enum.PlanApplicability.${extraInframodelParameters.planApplicability}`)
                 ) : (
                     t('im-form.information-missing')
                 )
@@ -33,13 +32,13 @@ export const InfraModelPhaseField: React.FC<InfraModelExtraParameterFieldProps> 
                     value={
                         <Dropdown
                             placeholder={t('im-form.information-missing')}
-                            wide
-                            wideList
-                            value={extraInframodelParameters.planPhase}
-                            options={planPhases}
+                            value={extraInframodelParameters.planApplicability}
+                            options={planApplicabilities}
                             unselectText={t('im-form.information-missing')}
-                            canUnselect
-                            onChange={(phase) => changeInExtraParametersField(phase, 'planPhase')}
+                            canUnselect={true}
+                            onChange={(planApplicability) =>
+                                changeInExtraParametersField(planApplicability, 'planApplicability')
+                            }
                         />
                     }
                 />

--- a/ui/src/infra-model/view/form/infra-model-form.tsx
+++ b/ui/src/infra-model/view/form/infra-model-form.tsx
@@ -59,6 +59,7 @@ import { formatWithSrid } from 'utils/geography-utils';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
 import { ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { InfraModelDownloadButton } from 'geoviite-design-lib/infra-model-download/infra-model-download-button';
+import { InfraModelPlanApplicabilityField } from 'infra-model/view/form/fields/infra-model-plan-applicability';
 
 type InframodelViewFormContainerProps = {
     changeTimes: ChangeTimes;
@@ -94,7 +95,8 @@ export type EditablePlanField =
     | 'heightSystem'
     | 'author'
     | 'createdTime'
-    | 'source';
+    | 'source'
+    | 'planApplicability';
 
 function getKmRangePresentation(kmPosts: GeometryKmPost[]): string {
     const sorted = kmPosts
@@ -599,6 +601,12 @@ const InfraModelForm: React.FC<InframodelViewFormContainerProps> = ({
                             />
                         )}
                     </FormgroupField>
+                    <InfraModelPlanApplicabilityField
+                        fieldInEdit={fieldInEdit}
+                        setFieldInEdit={setFieldInEdit}
+                        extraInframodelParameters={extraInframodelParameters}
+                        changeInExtraParametersField={changeInExtraParametersField}
+                    />
                 </FormgroupContent>
             </Formgroup>
 

--- a/ui/src/tool-panel/geometry-plan-infobox.scss
+++ b/ui/src/tool-panel/geometry-plan-infobox.scss
@@ -1,3 +1,9 @@
 .geometry-plan-tool-panel__long {
     overflow-wrap: anywhere;
 }
+
+.geometry-plan-tool-panel__applicability-value {
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+}

--- a/ui/src/tool-panel/geometry-plan-infobox.tsx
+++ b/ui/src/tool-panel/geometry-plan-infobox.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import styles from './geometry-plan-infobox.scss';
+import infoboxStyles from './infobox/infobox.module.scss';
 
 import Infobox from 'tool-panel/infobox/infobox';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
-import { GeometryPlanHeader } from 'geometry/geometry-model';
+import { GeometryPlanHeader, PlanApplicability } from 'geometry/geometry-model';
 import { useTranslation } from 'react-i18next';
 import { formatDateShort, toDateOrUndefined } from 'utils/date-utils';
 import PlanPhase from 'geoviite-design-lib/geometry-plan/plan-phase';
@@ -25,6 +26,13 @@ import { ChangeTimes } from 'common/common-slice';
 import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import { InfraModelDownloadButton } from 'geoviite-design-lib/infra-model-download/infra-model-download-button';
+import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+import { planApplicabilities } from 'utils/enum-localization-utils';
+import { updatePlanApplicability } from 'infra-model/infra-model-api';
+import { createClassName } from 'vayla-design-lib/utils';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { GeometryPlanApplicability } from 'tool-panel/geometry-plan/geometry-plan-applicability';
 
 type GeometryPlanInfoboxProps = {
     planHeader: GeometryPlanHeader;
@@ -214,6 +222,7 @@ const GeometryPlanInfobox: React.FC<GeometryPlanInfoboxProps> = ({
                             />
                         }
                     />
+                    <GeometryPlanApplicability planHeader={planHeader} />
                     <InfoboxButtons verticalLayout>
                         <Button
                             size={ButtonSize.SMALL}

--- a/ui/src/tool-panel/geometry-plan-infobox.tsx
+++ b/ui/src/tool-panel/geometry-plan-infobox.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import styles from './geometry-plan-infobox.scss';
-import infoboxStyles from './infobox/infobox.module.scss';
-
 import Infobox from 'tool-panel/infobox/infobox';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
-import { GeometryPlanHeader, PlanApplicability } from 'geometry/geometry-model';
+import { GeometryPlanHeader } from 'geometry/geometry-model';
 import { useTranslation } from 'react-i18next';
 import { formatDateShort, toDateOrUndefined } from 'utils/date-utils';
 import PlanPhase from 'geoviite-design-lib/geometry-plan/plan-phase';
@@ -26,12 +24,6 @@ import { ChangeTimes } from 'common/common-slice';
 import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import { InfraModelDownloadButton } from 'geoviite-design-lib/infra-model-download/infra-model-download-button';
-import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
-import { Icons } from 'vayla-design-lib/icon/Icon';
-import { planApplicabilities } from 'utils/enum-localization-utils';
-import { updatePlanApplicability } from 'infra-model/infra-model-api';
-import { createClassName } from 'vayla-design-lib/utils';
-import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { GeometryPlanApplicability } from 'tool-panel/geometry-plan/geometry-plan-applicability';
 
 type GeometryPlanInfoboxProps = {

--- a/ui/src/tool-panel/geometry-plan/geometry-plan-applicability.tsx
+++ b/ui/src/tool-panel/geometry-plan/geometry-plan-applicability.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { GeometryPlanHeader, PlanApplicability } from 'geometry/geometry-model';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { updatePlanApplicability } from 'infra-model/infra-model-api';
+import { createClassName } from 'vayla-design-lib/utils';
+import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
+import { planApplicabilities } from 'utils/enum-localization-utils';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import styles from 'tool-panel/geometry-plan-infobox.scss';
+import { Icons } from 'vayla-design-lib/icon/Icon';
+
+const getTranslationKey = (applicability: PlanApplicability | undefined) => {
+    let key = 'UNKNOWN';
+    switch (applicability) {
+        case 'MAINTENANCE':
+        case 'PLANNING':
+        case 'STATISTICS':
+            key = applicability;
+            break;
+        case undefined:
+            key = 'UNKNOWN';
+            break;
+        default:
+            return exhaustiveMatchingGuard(applicability);
+    }
+
+    return `enum.PlanApplicability.${key}`;
+};
+
+type GeometryPlanApplicabilityProps = {
+    planHeader: GeometryPlanHeader;
+};
+export const GeometryPlanApplicability: React.FC<GeometryPlanApplicabilityProps> = ({
+    planHeader,
+}) => {
+    const { t } = useTranslation();
+    const [editing, setEditing] = React.useState(false);
+    const [applicability, setApplicability] = React.useState<PlanApplicability | undefined>(
+        planHeader.planApplicability,
+    );
+    const [saving, setSaving] = React.useState(false);
+    const shave = () => {
+        setSaving(true);
+        updatePlanApplicability(planHeader.id, applicability).finally(() => {
+            setSaving(false);
+            setEditing(false);
+        });
+    };
+
+    const buttonContainerClasses = createClassName(
+        infoboxStyles['infobox__buttons'],
+        infoboxStyles['infobox__buttons--right'],
+    );
+
+    return (
+        <InfoboxField
+            label={t('tool-panel.geometry-plan.applicability')}
+            value={
+                <React.Fragment>
+                    {editing ? (
+                        <div>
+                            <Dropdown
+                                placeholder={t(getTranslationKey(undefined))}
+                                options={planApplicabilities}
+                                canUnselect={true}
+                                unselectText={t(getTranslationKey(undefined))}
+                                disabled={saving}
+                                value={applicability}
+                                onChange={(val) => setApplicability(val)}
+                            />
+                            <div className={buttonContainerClasses}>
+                                <Button size={ButtonSize.SMALL} variant={ButtonVariant.SECONDARY}>
+                                    {t('button.cancel')}
+                                </Button>
+                                <Button
+                                    onClick={shave}
+                                    variant={ButtonVariant.PRIMARY}
+                                    size={ButtonSize.SMALL}
+                                    disabled={saving}
+                                    isProcessing={saving}>
+                                    {t('button.save')}
+                                </Button>
+                            </div>
+                        </div>
+                    ) : (
+                        <span className={styles['geometry-plan-tool-panel__applicability-value']}>
+                            <span>{t(getTranslationKey(applicability))}</span>
+                            <Button
+                                icon={Icons.Edit}
+                                onClick={() => setEditing(true)}
+                                size={ButtonSize.X_SMALL}
+                                variant={ButtonVariant.GHOST}
+                            />
+                        </span>
+                    )}
+                </React.Fragment>
+            }
+        />
+    );
+};

--- a/ui/src/tool-panel/infobox/infobox.module.scss
+++ b/ui/src/tool-panel/infobox/infobox.module.scss
@@ -94,8 +94,13 @@
     &__buttons {
         padding: 8px 0;
 
-        .button {
+        .button:not(:last-child) {
             margin-right: 12px;
+        }
+
+        &--right {
+            display: flex;
+            justify-content: flex-end;
         }
 
         &--vertical {

--- a/ui/src/utils/enum-localization-utils.ts
+++ b/ui/src/utils/enum-localization-utils.ts
@@ -1,4 +1,9 @@
-import { PlanDecisionPhase, PlanPhase, PlanSource } from 'geometry/geometry-model';
+import {
+    PlanApplicability,
+    PlanDecisionPhase,
+    PlanPhase,
+    PlanSource,
+} from 'geometry/geometry-model';
 import {
     LayoutState,
     LayoutStateCategory,
@@ -120,6 +125,12 @@ export const elevationMeasurementMethods: LocalizedEnum<ElevationMeasurementMeth
     'ElevationMeasurementMethod',
     ['TOP_OF_SLEEPER', 'TOP_OF_RAIL'],
 );
+
+export const planApplicabilities: LocalizedEnum<PlanApplicability>[] = values('PlanApplicability', [
+    'PLANNING',
+    'MAINTENANCE',
+    'STATISTICS',
+]);
 
 export const verticalCoordinateSystems: {
     value: VerticalCoordinateSystem;


### PR DESCRIPTION
Täällä lisätty suunnitelmille soveltuvuustieto. Käytännössä tehty siis seuraavat:
* Lisätty soveltuvuustiedolle uusi enum ja kentät kantaan
* Lisätty bäkkärille uusi endpoint, jonka kautta se voidaan asettaa erillisenä tietona
* Lisätty frontille geometriasuunnitelman infoboksiin tieto suunnitelman soveltuvuudesta ja mahdollisuus editoida sitä suoraan siitä
* Lisätty frontille inframallinäkymään vastaava muokkaustoiminto suunnitelman laatutietoihin

Lisäksi vähän refaktorointia inframallinäkymän tyyppeihin, kun niissä oli päällekkäisyyttä