### PR TITLE
GVT-3017: Fix broken E2E tests

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -206,6 +206,7 @@ constructor(
         val selectionPanel = trackLayoutPage.selectionPanel
         val toolPanel = trackLayoutPage.toolPanel
 
+        trackLayoutPage.zoomToScale(E2ETrackLayoutPage.MapScale.M_200)
         selectionPanel.selectLocationTrack("lt-A")
         toolPanel.locationTrackGeneralInfo.zoomTo()
         val locationInfoBox = toolPanel.locationTrackLocation
@@ -445,6 +446,7 @@ constructor(
 
         val geometryAlignment = getGeometryAlignmentFromPlan("extending track", plan)
 
+        trackLayoutPage.zoomToScale(E2ETrackLayoutPage.MapScale.M_200)
         trackLayoutPage.selectionPanel.selectLocationTrack("lt-track to extend")
         val locationTrackLocationInfobox = toolPanel.locationTrackLocation
         val locationTrackLengthBeforeLinking = metersToDouble(locationTrackLocationInfobox.trueLength)
@@ -518,6 +520,7 @@ constructor(
         val geometryAlignmentStart = geometryAlignment.elements.first().start
         val geometryAlignmentEnd = geometryAlignment.elements.last().end
 
+        trackLayoutPage.zoomToScale(E2ETrackLayoutPage.MapScale.M_200)
         trackLayoutPage.selectionPanel.selectLocationTrack("lt-track to extend")
         val locationTrackLocationInfobox = toolPanel.locationTrackLocation
         val locationTrackLengthBeforeLinking = metersToDouble(locationTrackLocationInfobox.trueLength)
@@ -638,6 +641,7 @@ constructor(
 
         val trackLayoutPage = startGeoviiteAndGoToWork()
 
+        trackLayoutPage.zoomToScale(E2ETrackLayoutPage.MapScale.M_200)
         trackLayoutPage.selectionPanel.selectLocationTrack("lt-track to delete")
         trackLayoutPage.toolPanel.locationTrackGeneralInfo.zoomTo()
         trackLayoutPage.toolPanel.locationTrackGeneralInfo


### PR DESCRIPTION
The issue was caused by an update changing the height limit of displayed location tracks on the map. This lead to the selection panel not having the expected location track label element available at the default zoom level. This was solved by zooming close enough to the map so that the location track will be displayed on the map & selection panel before trying to select it via the E2E test.