### PR TITLE
GVT-3016: Raiteiden tilojen visualisointi: Päällekkäisten raiteiden järjestäminen tilojen mukaan

### DIFF
--- a/ui/src/map/layers/alignment/location-track-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-alignment-layer.ts
@@ -35,6 +35,11 @@ export const builtAlignmentLineDash: {
     lineCap: 'butt',
 };
 
+export const builtAlignmentBackgroundLineStroke = new Stroke({
+    color: mapStyles.alignmentLineBuiltBackground,
+    width: 2,
+});
+
 const highlightedLocationTrackStyle = new Style({
     stroke: new Stroke({
         color: mapStyles.selectedAlignmentLine,
@@ -49,6 +54,10 @@ const highlightedBuiltLocationTrackStyle = new Style({
         width: 1,
         ...builtAlignmentLineDash,
     }),
+    zIndex: 3,
+});
+export const highlightedBuiltLocationTrackBackgroundStyle = new Style({
+    stroke: builtAlignmentBackgroundLineStroke,
     zIndex: 2,
 });
 
@@ -74,10 +83,37 @@ const locationTrackBuiltStyle = new Style({
         width: 1,
         ...builtAlignmentLineDash,
     }),
-    zIndex: 0,
+    zIndex: 2,
+});
+export const locationTrackBuiltBackgroundStyle = new Style({
+    stroke: builtAlignmentBackgroundLineStroke,
+    zIndex: 1,
 });
 
-export function getLocationTrackStyle(state: LocationTrackState): Style {
+export function getLocationTrackStyles(state: LocationTrackState): Style[] {
+    switch (state) {
+        case 'NOT_IN_USE':
+            return [locationTrackNotInUseStyle];
+        case 'BUILT':
+            return [locationTrackBuiltStyle, locationTrackBuiltBackgroundStyle];
+        default:
+            return [locationTrackStyle];
+    }
+}
+
+export function getLocationTrackHighlightStyles(state: LocationTrackState): Style[] {
+    switch (state) {
+        case 'BUILT':
+            return [
+                highlightedBuiltLocationTrackStyle,
+                highlightedBuiltLocationTrackBackgroundStyle,
+            ];
+        default:
+            return [highlightedLocationTrackStyle];
+    }
+}
+
+export function getLocationTrackEndTickStyle(state: LocationTrackState): Style {
     switch (state) {
         case 'NOT_IN_USE':
             return locationTrackNotInUseStyle;
@@ -88,7 +124,7 @@ export function getLocationTrackStyle(state: LocationTrackState): Style {
     }
 }
 
-export function getLocationTrackHighlightStyle(state: LocationTrackState): Style {
+export function getLocationTrackHighlightEndTickStyle(state: LocationTrackState): Style {
     switch (state) {
         case 'BUILT':
             return highlightedBuiltLocationTrackStyle;

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -15,7 +15,10 @@ import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
 import { first } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
-import { builtAlignmentLineDash } from 'map/layers/alignment/location-track-alignment-layer';
+import {
+    builtAlignmentBackgroundLineStroke,
+    builtAlignmentLineDash,
+} from 'map/layers/alignment/location-track-alignment-layer';
 
 const selectedLocationTrackStyle = new Style({
     stroke: new Stroke({
@@ -31,7 +34,11 @@ const selectedLocationTrackBuildStyle = new Style({
         width: 2,
         ...builtAlignmentLineDash,
     }),
-    zIndex: 2,
+    zIndex: 4,
+});
+const selectedLocationTrackBuildBackgroundStyle = new Style({
+    stroke: builtAlignmentBackgroundLineStroke,
+    zIndex: 3,
 });
 
 const layerName: MapLayerName = 'location-track-selected-alignment-layer';
@@ -68,12 +75,17 @@ export function createLocationTrackSelectedAlignmentLayer(
         }
 
         const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
-        return createAlignmentFeature(
-            selectedTrack,
-            showEndPointTicks,
+        const endpointTickStyle =
             selectedTrack.header.state === 'BUILT'
                 ? selectedLocationTrackBuildStyle
-                : selectedLocationTrackStyle,
+                : selectedLocationTrackStyle;
+
+        return createAlignmentFeature(
+            selectedTrack,
+            selectedTrack.header.state === 'BUILT'
+                ? [selectedLocationTrackBuildStyle, selectedLocationTrackBuildBackgroundStyle]
+                : [selectedLocationTrackStyle],
+            showEndPointTicks ? endpointTickStyle : undefined,
         );
     };
 

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -21,25 +21,25 @@ import mapStyles from 'map/map.module.scss';
 import { first } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
 
-const selectedLocationTrackStyle = new Style({
+const selectedExistingOrNotInUseLocationTrackStyle = new Style({
     stroke: new Stroke({
         color: mapStyles.selectedAlignmentLine,
         width: 2,
     }),
-    zIndex: getAlignmentZIndex('IN_USE', false),
+    zIndex: getAlignmentZIndex('IN_USE', 'NOT_HIGHLIGHTED'),
 });
 
-const selectedLocationTrackBuildStyle = new Style({
+const selectedLocationTrackBuiltStyle = new Style({
     stroke: new Stroke({
         color: mapStyles.selectedAlignmentLine,
         width: 2,
         ...builtAlignmentLineDash,
     }),
-    zIndex: getAlignmentZIndex('BUILT', false),
+    zIndex: getAlignmentZIndex('BUILT', 'NOT_HIGHLIGHTED'),
 });
-const selectedLocationTrackBuildBackgroundStyle = new Style({
+const selectedLocationTrackBuiltBackgroundStyle = new Style({
     stroke: builtAlignmentBackgroundLineStroke,
-    zIndex: getAlignmentZIndex('BUILT_BACKGROUND', false),
+    zIndex: getAlignmentZIndex('BUILT_BACKGROUND', 'NOT_HIGHLIGHTED'),
 });
 
 const layerName: MapLayerName = 'location-track-selected-alignment-layer';
@@ -78,14 +78,14 @@ export function createLocationTrackSelectedAlignmentLayer(
         const showEndPointTicks = resolution <= Limits.SHOW_LOCATION_TRACK_BADGES;
         const endpointTickStyle =
             selectedTrack.header.state === 'BUILT'
-                ? selectedLocationTrackBuildStyle
-                : selectedLocationTrackStyle;
+                ? selectedLocationTrackBuiltStyle
+                : selectedExistingOrNotInUseLocationTrackStyle;
 
         return createAlignmentFeature(
             selectedTrack,
             selectedTrack.header.state === 'BUILT'
-                ? [selectedLocationTrackBuildStyle, selectedLocationTrackBuildBackgroundStyle]
-                : [selectedLocationTrackStyle],
+                ? [selectedLocationTrackBuiltStyle, selectedLocationTrackBuiltBackgroundStyle]
+                : [selectedExistingOrNotInUseLocationTrackStyle],
             showEndPointTicks ? endpointTickStyle : undefined,
         );
     };

--- a/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-selected-alignment-layer.ts
@@ -10,22 +10,23 @@ import {
     AlignmentDataHolder,
     getSelectedLocationTrackMapAlignmentByTiles,
 } from 'track-layout/layout-map-api';
-import { createAlignmentFeature } from '../utils/alignment-layer-utils';
+import {
+    builtAlignmentBackgroundLineStroke,
+    builtAlignmentLineDash,
+    createAlignmentFeature,
+    getAlignmentZIndex,
+} from '../utils/alignment-layer-utils';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
 import { first } from 'utils/array-utils';
 import { LayoutContext } from 'common/common-model';
-import {
-    builtAlignmentBackgroundLineStroke,
-    builtAlignmentLineDash,
-} from 'map/layers/alignment/location-track-alignment-layer';
 
 const selectedLocationTrackStyle = new Style({
     stroke: new Stroke({
         color: mapStyles.selectedAlignmentLine,
         width: 2,
     }),
-    zIndex: 2,
+    zIndex: getAlignmentZIndex('IN_USE', false),
 });
 
 const selectedLocationTrackBuildStyle = new Style({
@@ -34,11 +35,11 @@ const selectedLocationTrackBuildStyle = new Style({
         width: 2,
         ...builtAlignmentLineDash,
     }),
-    zIndex: 4,
+    zIndex: getAlignmentZIndex('BUILT', false),
 });
 const selectedLocationTrackBuildBackgroundStyle = new Style({
     stroke: builtAlignmentBackgroundLineStroke,
-    zIndex: 3,
+    zIndex: getAlignmentZIndex('BUILT_BACKGROUND', false),
 });
 
 const layerName: MapLayerName = 'location-track-selected-alignment-layer';

--- a/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/location-track-split-alignment-layer.ts
@@ -89,8 +89,8 @@ function splitToParts(
 
         return createAlignmentFeature(
             alignmentPart,
-            false,
-            alignmentStyle(splittingEnabled, splitIsFocused),
+            [alignmentStyle(splittingEnabled, splitIsFocused)],
+            undefined,
         );
     });
 }
@@ -153,7 +153,7 @@ export function createLocationTrackSplitAlignmentLayer(
             return [];
         }
 
-        createAlignmentFeature(splitTrack, false, alignmentStyle(splittingEnabled, true));
+        createAlignmentFeature(splitTrack, [alignmentStyle(splittingEnabled, true)], undefined);
 
         return splitToParts(
             splitTrack,

--- a/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
@@ -42,17 +42,17 @@ const referenceLineStyle = new Style({
     zIndex: 0,
 });
 
-export function createAlignmentFeatures(
+export function createReferenceLineFeatures(
     alignments: LayoutAlignmentDataHolder[],
     selection: Selection,
     showEndTicks: boolean,
 ): Feature<LineString | OlPoint>[] {
     return alignments.flatMap((alignment) => {
         const highlighted = isHighlighted(selection, alignment.header);
-        const style = highlighted ? [highlightedReferenceLineStyle] : [referenceLineStyle];
+        const styles = highlighted ? [highlightedReferenceLineStyle] : [referenceLineStyle];
         const endTickStyle = highlighted ? highlightedReferenceLineStyle : referenceLineStyle;
 
-        return createAlignmentFeature(alignment, style, showEndTicks ? endTickStyle : undefined);
+        return createAlignmentFeature(alignment, styles, showEndTicks ? endTickStyle : undefined);
     });
 }
 
@@ -87,7 +87,7 @@ export function createReferenceLineAlignmentLayer(
         getReferenceLineMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext);
 
     const createFeatures = (referenceLines: ReferenceLineAlignmentDataHolder[]) =>
-        createAlignmentFeatures(referenceLines, selection, false);
+        createReferenceLineFeatures(referenceLines, selection, false);
 
     const onLoadingChange = (
         loading: boolean,

--- a/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-alignment-layer.ts
@@ -8,11 +8,13 @@ import { createLayer, GeoviiteMapLayer, loadLayerData } from 'map/layers/utils/l
 import { deduplicate, filterNotEmpty } from 'utils/array-utils';
 import {
     getReferenceLineMapAlignmentsByTiles,
+    LayoutAlignmentDataHolder,
     ReferenceLineAlignmentDataHolder,
 } from 'track-layout/layout-map-api';
 import {
-    createAlignmentFeatures,
+    createAlignmentFeature,
     findMatchingAlignments,
+    isHighlighted,
     NORMAL_ALIGNMENT_OPACITY,
     OTHER_ALIGNMENTS_OPACITY_WHILE_SPLITTING,
 } from 'map/layers/utils/alignment-layer-utils';
@@ -20,6 +22,7 @@ import { ReferenceLineId } from 'track-layout/track-layout-model';
 import { Rectangle } from 'model/geometry';
 import { Stroke, Style } from 'ol/style';
 import mapStyles from 'map/map.module.scss';
+import Feature from 'ol/Feature';
 
 let shownReferenceLinesCompare: string;
 
@@ -38,6 +41,20 @@ const referenceLineStyle = new Style({
     }),
     zIndex: 0,
 });
+
+export function createAlignmentFeatures(
+    alignments: LayoutAlignmentDataHolder[],
+    selection: Selection,
+    showEndTicks: boolean,
+): Feature<LineString | OlPoint>[] {
+    return alignments.flatMap((alignment) => {
+        const highlighted = isHighlighted(selection, alignment.header);
+        const style = highlighted ? [highlightedReferenceLineStyle] : [referenceLineStyle];
+        const endTickStyle = highlighted ? highlightedReferenceLineStyle : referenceLineStyle;
+
+        return createAlignmentFeature(alignment, style, showEndTicks ? endTickStyle : undefined);
+    });
+}
 
 const layerName: MapLayerName = 'reference-line-alignment-layer';
 
@@ -70,13 +87,7 @@ export function createReferenceLineAlignmentLayer(
         getReferenceLineMapAlignmentsByTiles(changeTimes, mapTiles, layoutContext);
 
     const createFeatures = (referenceLines: ReferenceLineAlignmentDataHolder[]) =>
-        createAlignmentFeatures(
-            referenceLines,
-            selection,
-            false,
-            referenceLineStyle,
-            highlightedReferenceLineStyle,
-        );
+        createAlignmentFeatures(referenceLines, selection, false);
 
     const onLoadingChange = (
         loading: boolean,

--- a/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
+++ b/ui/src/map/layers/alignment/reference-line-selected-alignment-layer.ts
@@ -50,7 +50,11 @@ export function createSelectedReferenceLineAlignmentLayer(
         const selectedReferenceLine = first(referenceLines);
         if (!selectedReferenceLine) return [];
 
-        return createAlignmentFeature(selectedReferenceLine, false, selectedReferenceLineStyle);
+        return createAlignmentFeature(
+            selectedReferenceLine,
+            [selectedReferenceLineStyle],
+            undefined,
+        );
     };
 
     loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);

--- a/ui/src/map/layers/utils/alignment-layer-utils.ts
+++ b/ui/src/map/layers/utils/alignment-layer-utils.ts
@@ -29,11 +29,15 @@ export const REFERENCE_LINE_ALIGNMENT_WIDTH = 3;
 export const LOCATION_TRACK_ALIGNMENT_WIDTH = 1;
 
 type AlignmentStyleType = 'IN_USE' | 'NOT_IN_USE' | 'BUILT_BACKGROUND' | 'BUILT';
+type AlignmentHighlightedness = 'HIGHLIGHTED' | 'NOT_HIGHLIGHTED';
 export const ALIGNMENT_DRAW_ORDER = ['IN_USE', 'NOT_IN_USE', 'BUILT_BACKGROUND', 'BUILT'];
 
-export const getAlignmentZIndex = (state: AlignmentStyleType, isHighlighted: boolean): number => {
+export const getAlignmentZIndex = (
+    state: AlignmentStyleType,
+    highlightedness: AlignmentHighlightedness,
+): number => {
     const zIndex = ALIGNMENT_DRAW_ORDER.indexOf(state);
-    return isHighlighted ? zIndex + ALIGNMENT_DRAW_ORDER.length : zIndex;
+    return highlightedness === 'HIGHLIGHTED' ? zIndex + ALIGNMENT_DRAW_ORDER.length : zIndex;
 };
 
 export const builtAlignmentLineDash: {

--- a/ui/src/map/layers/utils/publication-candidate-highlight-utils.ts
+++ b/ui/src/map/layers/utils/publication-candidate-highlight-utils.ts
@@ -338,32 +338,36 @@ const createBaseAlignmentHighlightFeatures = (
 
     return createAlignmentFeature(
         alignment,
-        false,
-        new Style({
-            stroke: new Stroke({
-                color: getHighlightColor(
+        [
+            new Style({
+                stroke: new Stroke({
+                    color: getHighlightColor(
+                        publishCandidate.stage,
+                        publishCandidate.operation === 'DELETE'
+                            ? ChangeExplicitness.EXPLICIT
+                            : ChangeExplicitness.IMPLICIT,
+                        'DELETE',
+                    ),
+                    width:
+                        publishCandidate.stage === PublicationStage.UNSTAGED
+                            ? UNSTAGED_ALIGNMENT_HIGHLIGHT_WIDTH
+                            : STAGED_ALIGNMENT_HIGHLIGHT_WIDTH,
+                    lineCap:
+                        lengthInPixels < HIGHLIGHT_ALIGNMENT_MIN_LENGTH_IN_PIXELS
+                            ? 'square'
+                            : 'butt',
+                }),
+                zIndex: getHighlightZIndex(
+                    'DELETE',
+                    publishCandidate.type,
                     publishCandidate.stage,
                     publishCandidate.operation === 'DELETE'
                         ? ChangeExplicitness.EXPLICIT
                         : ChangeExplicitness.IMPLICIT,
-                    'DELETE',
                 ),
-                width:
-                    publishCandidate.stage === PublicationStage.UNSTAGED
-                        ? UNSTAGED_ALIGNMENT_HIGHLIGHT_WIDTH
-                        : STAGED_ALIGNMENT_HIGHLIGHT_WIDTH,
-                lineCap:
-                    lengthInPixels < HIGHLIGHT_ALIGNMENT_MIN_LENGTH_IN_PIXELS ? 'square' : 'butt',
             }),
-            zIndex: getHighlightZIndex(
-                'DELETE',
-                publishCandidate.type,
-                publishCandidate.stage,
-                publishCandidate.operation === 'DELETE'
-                    ? ChangeExplicitness.EXPLICIT
-                    : ChangeExplicitness.IMPLICIT,
-            ),
-        }),
+        ],
+        undefined,
     );
 };
 
@@ -373,16 +377,17 @@ export const createBaseLocationTrackFeatures = (
     showEndPointTicks: boolean,
     metersPerPixel: number,
 ): Feature<LineString | OlPoint>[] => {
+    const style = new Style({
+        stroke: new Stroke({
+            color: mapStyles.alignmentPreviewBaseLine,
+            width: LOCATION_TRACK_ALIGNMENT_WIDTH,
+        }),
+        zIndex: DELETED_LOCATION_TRACK_Z_INDEX,
+    });
     const lineFeatures = createAlignmentFeature(
         alignment,
-        showEndPointTicks,
-        new Style({
-            stroke: new Stroke({
-                color: mapStyles.alignmentPreviewBaseLine,
-                width: LOCATION_TRACK_ALIGNMENT_WIDTH,
-            }),
-            zIndex: DELETED_LOCATION_TRACK_Z_INDEX,
-        }),
+        [style],
+        showEndPointTicks ? style : undefined,
     );
     const highlightFeatures = createBaseAlignmentHighlightFeatures(
         alignment,
@@ -401,16 +406,17 @@ export const createBaseReferenceLineFeatures = (
     showEndPointTicks: boolean,
     metersPerPixel: number,
 ): Feature<LineString | OlPoint>[] => {
+    const style = new Style({
+        stroke: new Stroke({
+            color: mapStyles.alignmentPreviewBaseLine,
+            width: REFERENCE_LINE_ALIGNMENT_WIDTH,
+        }),
+        zIndex: DELETED_REFERENCE_LINE_Z_INDEX,
+    });
     const lineFeatures = createAlignmentFeature(
         alignment,
-        showEndPointTicks,
-        new Style({
-            stroke: new Stroke({
-                color: mapStyles.alignmentPreviewBaseLine,
-                width: REFERENCE_LINE_ALIGNMENT_WIDTH,
-            }),
-            zIndex: DELETED_REFERENCE_LINE_Z_INDEX,
-        }),
+        [style],
+        showEndPointTicks ? style : undefined,
     );
     const highlightFeatures = createBaseAlignmentHighlightFeatures(
         alignment,

--- a/ui/src/map/map.module.scss
+++ b/ui/src/map/map.module.scss
@@ -45,7 +45,7 @@
     alignmentPreviewBaseLine: vayla-design.$color-red-default;
     selectedAlignmentLine: geoviite-design.$color-geoviite-blue;
     selectedAlignmentLineDisabled: geoviite-design.$color-geoviite-map-red;
-    alignmentLineBuiltBackground: rgba(vayla-design.$color-white-default, 1);
+    alignmentLineBuiltBackground: vayla-design.$color-white-default;
 
     alignmentRedHighlight: rgba(geoviite-design.$color-geoviite-map-red, 0.2);
     alignmentBlueHighlight: rgba(geoviite-design.$color-geoviite-map-blue, 0.2);

--- a/ui/src/map/map.module.scss
+++ b/ui/src/map/map.module.scss
@@ -45,6 +45,7 @@
     alignmentPreviewBaseLine: vayla-design.$color-red-default;
     selectedAlignmentLine: geoviite-design.$color-geoviite-blue;
     selectedAlignmentLineDisabled: geoviite-design.$color-geoviite-map-red;
+    alignmentLineBuiltBackground: rgba(vayla-design.$color-white-default, 1);
 
     alignmentRedHighlight: rgba(geoviite-design.$color-geoviite-map-red, 0.2);
     alignmentBlueHighlight: rgba(geoviite-design.$color-geoviite-map-blue, 0.2);


### PR DESCRIPTION
Tällä pullarilla järjestetty sijaintiraiteet kartalla tilan perusteella: Rakennettu-tilaiset päällimmäiseksi, Käytöstä poistettu -tilaiset seuraavaksi ja Käytössä-tilaiset kaiken alle. Tämän lisäksi Rakennettu-tilaisille toteutettu valkoinen pohjaviiva, jotta jos sellainen raide on päällekkäin jonkun muun raiteen kanssa, niin se erottuu sieltä alta (tällainen tilanne on hyvin mahdollinen esim. esikatselussa, jossa näytetään myös virallinen tila.)

Päädyin myös tekemään aika paljon refaktorointia kartan sijaintiraiteiden tyyleille. Tarve tälle johtui alunperin siitä, että Z-indeksilaskenta oli fiksuinta tehdä yhteisesti eri karttatasojen välillä, mutta sen siirtäminen utilsiin johti circular referenceihin. Riippuvuuksia on järkeistetty nyt siten, että enää ei pitäisi olla circular referencejä. Tämän lisäksi mahdollistettiin yksittäiselle alignmentin featurelle useamman tyylin antaminen. OpenLayers tukee sitä, että yhdelle featurelle voi antaa useamman tyylin, mutta meillä käytännössä tähän mennessä annettiin aina vain yksittäisiä. Tarve useammalle tyylille tuli Rakennettu-tilan valkoisesta pohjaviivasta (toteutettiin omana tyylinään)