### PR TITLE
GVT-3004: Increase data product geometry plan search result limit

### DIFF
--- a/ui/src/data-products/data-products-utils.ts
+++ b/ui/src/data-products/data-products-utils.ts
@@ -16,7 +16,7 @@ export const searchGeometryPlanHeaders = async (
     }
 
     const t = await getGeometryPlanHeadersBySearchTerms(
-        10,
+        100,
         undefined,
         undefined,
         [source],


### PR DESCRIPTION
Fiksaa bugin tilanteessa, jossa hakusanalla löytyy useampi kuin 10 tulosta (esim. haettaessa ratanumeron tunnuksella, kuten 001).

Rajasin tuon nyt kuitenkin sataseen, jotta jokin raja on olemassa