### PR TITLE
GVT-2885: Refactor alignment geometry listing to smaller components & fix eye positioning

### DIFF
--- a/ui/src/geoviite-design-lib/eye/eye.scss
+++ b/ui/src/geoviite-design-lib/eye/eye.scss
@@ -3,7 +3,6 @@
 .eye-container {
     cursor: pointer;
     margin-left: auto;
-    padding-left: 4px;
 }
 
 .eye-container button:disabled {

--- a/ui/src/geoviite-design-lib/eye/eye.tsx
+++ b/ui/src/geoviite-design-lib/eye/eye.tsx
@@ -9,13 +9,17 @@ type EyeProps = {
     fetchingContent?: boolean;
     onVisibilityToggle: React.MouseEventHandler;
     disabled?: boolean;
+    extraClassName?: string;
 };
 export const Eye: React.FC<EyeProps> = ({
     visibility,
     fetchingContent,
     onVisibilityToggle,
     disabled = false,
+    extraClassName,
 }) => {
+    const containerClassName = createClassName(styles['eye-container'], extraClassName);
+
     const iconClassName = createClassName(
         styles['eye-icon'],
         visibility && styles['eye--visible'],
@@ -23,7 +27,7 @@ export const Eye: React.FC<EyeProps> = ({
     );
 
     return (
-        <span className={styles['eye-container']}>
+        <span className={containerClassName}>
             <Button
                 size={ButtonSize.SMALL}
                 onClick={onVisibilityToggle}

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from 'tool-panel/track-number/alignment-plan-section-infobox.scss';
 import { Link } from 'vayla-design-lib/link/link';
-import { AlignmentPlanSection } from 'track-layout/layout-location-track-api';
+import { AlignmentPlanSection, PlanSectionPoint } from 'track-layout/layout-location-track-api';
 import { useTranslation } from 'react-i18next';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { createDelegates } from 'store/store-utils';
@@ -10,6 +10,15 @@ import { LayoutTrackNumberId, LocationTrackId } from 'track-layout/track-layout-
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { useTrackLayoutAppSelector } from 'store/hooks';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
+import { Eye } from 'geoviite-design-lib/eye/eye';
+import { createClassName } from 'vayla-design-lib/utils';
+import { InfoboxList, InfoboxListRow } from 'tool-panel/infobox/infobox-list';
+
+const ErrorFragment: React.FC<{ message?: string }> = ({ message = '' }) => (
+    <span title={message} className={styles['alignment-plan-section-infobox__no-plan-icon']}>
+        <Icons.StatusError size={IconSize.SMALL} color={IconColor.INHERIT} />
+    </span>
+);
 
 type HighlightedItemBase = {
     startM: number;
@@ -35,11 +44,80 @@ type AlignmentPlanSectionInfoboxContentProps = {
     onHighlightSection: OnHighlightSection;
 };
 
+type GeometryPlanLabelProps = {
+    planId: GeometryPlanId | undefined;
+    planName: string | undefined;
+    alignmentName: string | undefined;
+    onGeometryClick: () => void;
+};
+
+const GeometryPlanLabel: React.FC<GeometryPlanLabelProps> = ({
+    planId,
+    planName,
+    alignmentName,
+    onGeometryClick,
+}) => {
+    const { t } = useTranslation();
+
+    return (
+        <div className={styles['alignment-plan-section-infobox__plan-name']}>
+            {planName ? (
+                planId ? (
+                    <Link onClick={onGeometryClick} title={`${planName}, ${alignmentName}`}>
+                        <span
+                            className={styles['alignment-plan-section-infobox__plan-link-content']}>
+                            {planName}
+                        </span>
+                    </Link>
+                ) : (
+                    <span title={`${planName}, ${alignmentName}`}>{planName}</span>
+                )
+            ) : (
+                t('tool-panel.alignment-plan-sections.no-plan')
+            )}
+        </div>
+    );
+};
+
+type TrackMeterRangeProps = {
+    start: PlanSectionPoint | undefined;
+    end: PlanSectionPoint | undefined;
+};
+
+const TrackMeterRange: React.FC<TrackMeterRangeProps> = ({ start, end }) => {
+    const { t } = useTranslation();
+
+    const TrackMeterOrError: React.FC<{
+        point: PlanSectionPoint | undefined;
+    }> = ({ point }) => {
+        return (
+            <span>
+                {point ? (
+                    <NavigableTrackMeter
+                        trackMeter={point.address}
+                        location={point.location}
+                        displayDecimals={false}
+                    />
+                ) : (
+                    <ErrorFragment
+                        message={t('tool-panel.alignment-plan-sections.geocoding-failed')}
+                    />
+                )}
+            </span>
+        );
+    };
+
+    return (
+        <div className={styles['alignment-plan-section-infobox__meters']}>
+            <TrackMeterOrError point={start} />
+            <TrackMeterOrError point={end} />
+        </div>
+    );
+};
+
 export const AlignmentPlanSectionInfoboxContent: React.FC<
     AlignmentPlanSectionInfoboxContentProps
 > = ({ sections, onHighlightSection }) => {
-    const { t } = useTranslation();
-
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
     const visiblePlans = useTrackLayoutAppSelector((state) => state.selection.visiblePlans);
 
@@ -59,128 +137,84 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
         });
     }
 
-    const errorFragment = (errorMessage = '') => (
-        <span
-            title={errorMessage}
-            className={styles['alignment-plan-section-infobox__no-plan-icon']}>
-            <Icons.StatusError size={IconSize.SMALL} color={IconColor.INHERIT} />
-        </span>
+    const startSectionHighlight = (section: AlignmentPlanSection) => {
+        section.start &&
+            section.end &&
+            onHighlightSection({
+                startM: section.start.m,
+                endM: section.end.m,
+            });
+    };
+
+    const endSectionHighlight = () => onHighlightSection(undefined);
+
+    const selectGeometry = (planId: GeometryPlanId | undefined) => {
+        if (planId) {
+            delegates.onSelect({
+                geometryPlans: [planId],
+            });
+            delegates.setToolPanelTab({
+                id: planId,
+                type: 'GEOMETRY_PLAN',
+            });
+        }
+    };
+
+    const PlanVisibilityToggle: React.FC<{
+        planId: GeometryPlanId;
+        alignmentId: GeometryAlignmentId | undefined;
+    }> = ({ planId, alignmentId }) => (
+        <Eye
+            extraClassName={styles['alignment-plan-section-infobox__navigation-eye']}
+            visibility={isVisible(planId)}
+            onVisibilityToggle={() => {
+                togglePlanVisibility(planId, alignmentId);
+            }}
+        />
     );
 
     return (
         <React.Fragment>
-            <div className="infobox__list">
+            <InfoboxList>
                 {sections.map((section: AlignmentPlanSection) => (
-                    <div
-                        className="infobox__list-row"
+                    <InfoboxListRow
                         key={section.id}
-                        onMouseOver={() => {
-                            section.start &&
-                                section.end &&
-                                onHighlightSection({
-                                    startM: section.start.m,
-                                    endM: section.end.m,
-                                });
-                        }}
-                        onMouseOut={() => {
-                            onHighlightSection(undefined);
-                        }}>
-                        {section.planName && !section.isLinked && (
-                            <div className="infobox__list-cell">{errorFragment()}</div>
-                        )}
-                        <div className="infobox__list-cell infobox__list-cell--stretch infobox__list-cell--label">
-                            <div className={styles['alignment-plan-section-infobox__plan-name']}>
-                                {section.planName ? (
-                                    section.planId ? (
-                                        <React.Fragment>
-                                            <Link
-                                                onClick={() => {
-                                                    if (section.planId) {
-                                                        delegates.onSelect({
-                                                            geometryPlans: [section.planId],
-                                                        });
-                                                        delegates.setToolPanelTab({
-                                                            id: section.planId,
-                                                            type: 'GEOMETRY_PLAN',
-                                                        });
-                                                    }
-                                                }}
-                                                title={`${section.planName}, ${section.alignmentName}`}>
-                                                <span
-                                                    className={
-                                                        styles[
-                                                            'alignment-plan-section-infobox__plan-link-content'
-                                                        ]
-                                                    }>
-                                                    {section.planName}
-                                                </span>
-                                            </Link>
-                                        </React.Fragment>
-                                    ) : (
-                                        <span
-                                            title={`${section.planName}, ${section.alignmentName}`}>
-                                            {section.planName}
-                                        </span>
-                                    )
-                                ) : (
-                                    t('tool-panel.alignment-plan-sections.no-plan')
+                        onMouseOver={() => startSectionHighlight(section)}
+                        onMouseOut={() => endSectionHighlight()}
+                        label={
+                            <React.Fragment>
+                                {section.planName && !section.isLinked && (
+                                    <div className="infobox__list-cell">
+                                        <ErrorFragment />
+                                    </div>
                                 )}
+                                <GeometryPlanLabel
+                                    planId={section.planId}
+                                    planName={section.planName}
+                                    alignmentName={section.alignmentName}
+                                    onGeometryClick={() => selectGeometry(section.planId)}
+                                />
+                            </React.Fragment>
+                        }
+                        content={
+                            <div
+                                className={createClassName(
+                                    'infobox__list-cell',
+                                    styles['alignment-plan-section-infobox__navigation'],
+                                )}>
+                                {section.planId && section.isLinked && (
+                                    <PlanVisibilityToggle
+                                        planId={section.planId}
+                                        alignmentId={section.alignmentId}
+                                    />
+                                )}
+
+                                <TrackMeterRange start={section.start} end={section.end} />
                             </div>
-                        </div>
-                        <div className="infobox__list-cell">
-                            {section.planId && section.isLinked && (
-                                <div
-                                    onClick={() =>
-                                        section.planId &&
-                                        togglePlanVisibility(section.planId, section.alignmentId)
-                                    }
-                                    className="alignment-plan-section-infobox__show-plan-icon"
-                                    title={`${section.planName}, ${section.alignmentName}`}>
-                                    {isVisible(section.planId) ? (
-                                        <Icons.Eye />
-                                    ) : (
-                                        <Icons.Eye color={IconColor.INHERIT} />
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                        <div className="infobox__list-cell">
-                            <div className={styles['alignment-plan-section-infobox__meters']}>
-                                <span>
-                                    {section.start ? (
-                                        <NavigableTrackMeter
-                                            trackMeter={section?.start?.address}
-                                            location={section?.start?.location}
-                                            displayDecimals={false}
-                                        />
-                                    ) : (
-                                        errorFragment(
-                                            t(
-                                                'tool-panel.alignment-plan-sections.geocoding-failed',
-                                            ),
-                                        )
-                                    )}
-                                </span>{' '}
-                                <span>
-                                    {section.end ? (
-                                        <NavigableTrackMeter
-                                            trackMeter={section?.end?.address}
-                                            location={section?.end?.location}
-                                            displayDecimals={false}
-                                        />
-                                    ) : (
-                                        errorFragment(
-                                            t(
-                                                'tool-panel.alignment-plan-sections.geocoding-failed',
-                                            ),
-                                        )
-                                    )}
-                                </span>
-                            </div>
-                        </div>
-                    </div>
+                        }
+                    />
                 ))}
-            </div>
+            </InfoboxList>
         </React.Fragment>
     );
 };

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -63,11 +63,11 @@ const GeometryPlanLabel: React.FC<GeometryPlanLabelProps> = ({
         <div className={styles['alignment-plan-section-infobox__plan-name']}>
             {planName ? (
                 planId ? (
-                    <Link onClick={onGeometryClick} title={`${planName}, ${alignmentName}`}>
-                        <span
-                            className={styles['alignment-plan-section-infobox__plan-link-content']}>
-                            {planName}
-                        </span>
+                    <Link
+                        title={`${planName}, ${alignmentName}`}
+                        className={styles['alignment-plan-section-infobox__plan-link-content']}
+                        onClick={onGeometryClick}>
+                        {planName}
                     </Link>
                 ) : (
                     <span title={`${planName}, ${alignmentName}`}>{planName}</span>

--- a/ui/src/tool-panel/infobox/infobox-list.tsx
+++ b/ui/src/tool-panel/infobox/infobox-list.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styles from 'tool-panel/infobox/infobox.module.scss';
+import { createClassName } from 'vayla-design-lib/utils';
+
+type InfoboxListProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+export const InfoboxList: React.FC<InfoboxListProps> = ({ className, children }) => {
+    const containerClassName = createClassName(styles['infobox__list'], className);
+
+    return <div className={containerClassName}>{children}</div>;
+};
+
+type InfoboxListRowProps = {
+    label: React.ReactNode;
+    content: React.ReactNode;
+} & Pick<React.HTMLProps<HTMLDivElement>, 'key' | 'onMouseOver' | 'onMouseOut'>;
+
+export const InfoboxListRow: React.FC<InfoboxListRowProps> = ({ label, content, ...props }) => {
+    return (
+        <div className={styles['infobox__list-row']} {...props}>
+            <div className="infobox__list-cell infobox__list-cell--label">{label}</div>
+            <div className="infobox__list-cell infobox__list-cell--stretch">{content}</div>
+        </div>
+    );
+};

--- a/ui/src/tool-panel/infobox/infobox.module.scss
+++ b/ui/src/tool-panel/infobox/infobox.module.scss
@@ -136,6 +136,8 @@
 }
 
 .infobox__list-cell {
+    display: flex;
+
     @include vayla-design.typography-caption-strong;
 
     &:not(:last-child) {
@@ -144,6 +146,7 @@
 }
 
 .infobox__list-cell--label {
+    width: 120px;
     font-weight: 400;
     @include vayla-design.typography-caption;
     color: vayla-design.$color-black-light;

--- a/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
@@ -3,7 +3,6 @@ import Infobox from 'tool-panel/infobox/infobox';
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { LoaderStatus, useRateLimitedLoaderWithStatus } from 'utils/react-utils';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
-import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
 import { getLocationTrackSectionsByPlan } from 'track-layout/layout-location-track-api';
 import { MapViewport } from 'map/map-model';
@@ -18,6 +17,7 @@ import {
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { LayoutContext } from 'common/common-model';
+import { InfoboxList, InfoboxListRow } from 'tool-panel/infobox/infobox-list';
 
 type LocationTrackGeometryInfoboxProps = {
     layoutContext: LayoutContext;
@@ -66,15 +66,18 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
             contentVisible={contentVisible}
             onContentVisibilityChange={onContentVisibilityChange}>
             <InfoboxContent>
-                <InfoboxField
-                    label={t('tool-panel.alignment-plan-sections.bounding-box-geometries')}
-                    value={
-                        <Checkbox
-                            checked={useBoundingBox}
-                            onChange={(e) => setUseBoundingBox(e.target.checked)}
-                        />
-                    }
-                />
+                <InfoboxList>
+                    <InfoboxListRow
+                        label={t('tool-panel.alignment-plan-sections.bounding-box-geometries')}
+                        content={
+                            <Checkbox
+                                extraClassName="alignment-plan-section-infobox__navigation-checkbox"
+                                checked={useBoundingBox}
+                                onChange={(e) => setUseBoundingBox(e.target.checked)}
+                            />
+                        }
+                    />
+                </InfoboxList>
                 <ProgressIndicatorWrapper
                     indicator={ProgressIndicatorType.Area}
                     inProgress={elementFetchStatus !== LoaderStatus.Ready}

--- a/ui/src/tool-panel/track-number/alignment-plan-section-infobox.scss
+++ b/ui/src/tool-panel/track-number/alignment-plan-section-infobox.scss
@@ -24,9 +24,24 @@
     line-height: 0;
 }
 
+.alignment-plan-section-infobox__navigation {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-direction: row;
+}
+
+.alignment-plan-section-infobox__navigation-checkbox {
+    padding-left: 4px;
+}
+
+.alignment-plan-section-infobox__navigation-eye {
+    padding-right: 8px;
+}
+
 .alignment-plan-section-infobox__meters {
     display: inline-grid;
     grid-template-columns: repeat(2, 50%);
     grid-column-gap: 6px;
-    width: 100%;
 }

--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -3,7 +3,6 @@ import Infobox from 'tool-panel/infobox/infobox';
 import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { LoaderStatus, useRateLimitedLoaderWithStatus } from 'utils/react-utils';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
-import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
 import { LayoutContext, TimeStamp } from 'common/common-model';
 import { MapViewport } from 'map/map-model';
@@ -18,6 +17,7 @@ import {
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { getTrackNumberReferenceLineSectionsByPlan } from 'track-layout/layout-track-number-api';
+import { InfoboxList, InfoboxListRow } from 'tool-panel/infobox/infobox-list';
 
 type TrackNumberGeometryInfoboxProps = {
     layoutContext: LayoutContext;
@@ -73,15 +73,18 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
             contentVisible={contentVisible}
             onContentVisibilityChange={onContentVisibilityChange}>
             <InfoboxContent>
-                <InfoboxField
-                    label={t('tool-panel.alignment-plan-sections.bounding-box-geometries')}
-                    value={
-                        <Checkbox
-                            checked={useBoundingBox}
-                            onChange={(e) => setUseBoundingBox(e.target.checked)}
-                        />
-                    }
-                />
+                <InfoboxList>
+                    <InfoboxListRow
+                        label={t('tool-panel.alignment-plan-sections.bounding-box-geometries')}
+                        content={
+                            <Checkbox
+                                extraClassName="alignment-plan-section-infobox__navigation-checkbox"
+                                checked={useBoundingBox}
+                                onChange={(e) => setUseBoundingBox(e.target.checked)}
+                            />
+                        }
+                    />
+                </InfoboxList>
                 <ProgressIndicatorWrapper
                     indicator={ProgressIndicatorType.Area}
                     inProgress={elementFetchStatus !== LoaderStatus.Ready}

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -57,7 +57,7 @@ const locationTrackOidsCache = asyncCache<
     { [key in LayoutBranch]?: Oid } | undefined
 >();
 
-type PlanSectionPoint = {
+export type PlanSectionPoint = {
     address: TrackMeter;
     location: AlignmentPoint;
     m: number;

--- a/ui/src/vayla-design-lib/checkbox/checkbox.tsx
+++ b/ui/src/vayla-design-lib/checkbox/checkbox.tsx
@@ -6,12 +6,22 @@ import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 export type CheckboxProps = {
     foo?: string;
     qaId?: string;
+    extraClassName?: string;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Checkbox: React.FC<CheckboxProps> = ({ children, qaId, ...props }: CheckboxProps) => {
+export const Checkbox: React.FC<CheckboxProps> = ({
+    children,
+    qaId,
+    extraClassName,
+    ...props
+}: CheckboxProps) => {
     const [touched, setTouched] = React.useState(false);
 
-    const className = createClassName(styles.checkbox, touched && styles['checkbox--touched']);
+    const className = createClassName(
+        styles.checkbox,
+        touched && styles['checkbox--touched'],
+        extraClassName,
+    );
     return (
         <label
             className={className}


### PR DESCRIPTION
Tämähän lähti siitä, että raiteen ja pituusmittauslinjojen silmä ja "vain kartalle osuvat geometriat"-checkboxi olivat eri kohtiin tasattuna. Tuo geometrialistauskomponentti vaikutti keränneen sen verran monimutkaisuutta, että pilkoin hallittavimmiksi blokeiksi samalla.

* Muutettu myös geometrialistauksen silmä napiksi, eli sillekin päätyy esimerkiksi nyt tausta selectionpanelin silmien tavoin.
* Checkboksi ja silmä ovat nyt visuaalisesti päällekkäin riippumatta layoutcontextista. Checkboxi on tätä nappikokoa hiukan pienempi, mutta silmäikoni on normaalisti ghostina eli sillä ei ole taustaa, joten eroa on vaikea huomata. Checkboxin keskilinjan pitäisi kuitenkin olla tasattuna silmäikoninkin keskilinjaan pystysuunnassa.
* Luotu myös uusi yleiskäyttöisempi `<InfoboxList>`-komponentti. Tällainen oikeastaan olikin jo aiemmin, mutta sen käyttö perustui suoriin css-luokkien käyttöön React-komponentin sijaan.