### PR TITLE
GVT-2346: Create aliases to React router's link and anchor element to prevent confusion

### DIFF
--- a/ui/src/geoviite-design-lib/breadcrumb/breadcrumb.tsx
+++ b/ui/src/geoviite-design-lib/breadcrumb/breadcrumb.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from './breadcrumb.scss';
 import { createClassName } from 'vayla-design-lib/utils';
-import { Link } from 'vayla-design-lib/link/link';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type BreadcrumbProps = {
     some?: string;
@@ -26,7 +26,11 @@ export const BreadcrumbItem: React.FC<BreadcrumbItemProps> = (props: BreadcrumbI
     );
     return (
         <div className={className} onClick={props.onClick}>
-            {props.href ? <Link href={props.href}>{props.children}</Link> : props.children}
+            {props.href ? (
+                <AnchorLink href={props.href}>{props.children}</AnchorLink>
+            ) : (
+                props.children
+            )}
         </div>
     );
 };

--- a/ui/src/geoviite-design-lib/link/anchor-link.tsx
+++ b/ui/src/geoviite-design-lib/link/anchor-link.tsx
@@ -1,0 +1,3 @@
+import { Link } from 'vayla-design-lib/link/link';
+
+export { Link as AnchorLink };

--- a/ui/src/geoviite-design-lib/link/router-link.tsx
+++ b/ui/src/geoviite-design-lib/link/router-link.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { createClassName } from 'vayla-design-lib/utils';
+import styles from 'vayla-design-lib/link/link.scss';
+
+export const RouterLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement> & LinkProps> = ({
+    children,
+    ...props
+}) => {
+    const className = createClassName(styles.link, props.className);
+
+    return (
+        <Link className={className} {...props}>
+            {children}
+        </Link>
+    );
+};

--- a/ui/src/geoviite-design-lib/switch/switch-link.tsx
+++ b/ui/src/geoviite-design-lib/switch/switch-link.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { LayoutSwitchId } from 'track-layout/track-layout-model';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
 import { LayoutContext, TimeStamp } from 'common/common-model';
-import { Link } from 'vayla-design-lib/link/link';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
 import { createEmptyItemCollections } from 'selection/selection-store';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { getSwitch } from 'track-layout/layout-switch-api';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type SwitchLinkContainerProps = {
     switchId?: LayoutSwitchId;
@@ -59,9 +59,9 @@ export const SwitchLink: React.FC<SwitchLinkProps> = (props: SwitchLinkProps) =>
     );
     const clickAction = props.onClick || createSelectAction();
     return status === LoaderStatus.Ready ? (
-        <Link onClick={() => layoutSwitch && clickAction(layoutSwitch.id)}>
+        <AnchorLink onClick={() => layoutSwitch && clickAction(layoutSwitch.id)}>
             {layoutSwitch?.name || ''}
-        </Link>
+        </AnchorLink>
     ) : (
         <Spinner />
     );

--- a/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
+++ b/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
@@ -1,7 +1,6 @@
 import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { useTrackNumberWithStatus } from 'track-layout/track-layout-react-utils';
 import { LayoutContext, TimeStamp } from 'common/common-model';
-import { Link } from 'vayla-design-lib/link/link';
 import React from 'react';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
@@ -10,6 +9,7 @@ import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { LoaderStatus } from 'utils/react-utils';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
 import { useTranslation } from 'react-i18next';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type TrackNumberLinkContainerProps = {
     trackNumberId?: LayoutTrackNumberId;
@@ -63,7 +63,9 @@ export const TrackNumberLink: React.FC<TrackNumberLinkProps> = ({
 
     return status === LoaderStatus.Ready && trackNumber ? (
         <React.Fragment>
-            <Link onClick={() => clickAction(trackNumber.id)}>{trackNumber.number}</Link>
+            <AnchorLink onClick={() => clickAction(trackNumber.id)}>
+                {trackNumber.number}
+            </AnchorLink>
             {trackNumber.state === 'DELETED' ? (
                 <span>&nbsp;({t('enum.LayoutState.DELETED')})</span>
             ) : (

--- a/ui/src/infra-model/projektivelho/pv-redirect-link.tsx
+++ b/ui/src/infra-model/projektivelho/pv-redirect-link.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Link } from 'vayla-design-lib/link/link';
 import styles from 'infra-model/projektivelho/pv-file-list.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Oid } from 'common/common-model';
 import { getPVFilesRedirectUrl } from 'infra-model/infra-model-api';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 interface PVDocumentRedirectLinkProps {
     documentOid: Oid;
@@ -50,13 +50,16 @@ export const PVRedirectLink: React.FC<PVRedirectLinkProps> = ({
     const url = getPVFilesRedirectUrl(projectGroupOid, projectOid, assignmentOid, documentOid);
 
     return (
-        <Link className={styles['projektivelho-file-list__link']} href={url} target={'_blank'}>
+        <AnchorLink
+            className={styles['projektivelho-file-list__link']}
+            href={url}
+            target={'_blank'}>
             <span>
                 {children}{' '}
                 <span className={styles['projektivelho-file-list__link-icon']}>
                     <Icons.ExternalLink color={IconColor.INHERIT} size={IconSize.SMALL} />
                 </span>
             </span>
-        </Link>
+        </AnchorLink>
     );
 };

--- a/ui/src/preview/preview-view-design-drafts-exist-error.tsx
+++ b/ui/src/preview/preview-view-design-drafts-exist-error.tsx
@@ -1,7 +1,7 @@
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
 import { Trans, useTranslation } from 'react-i18next';
-import { Link } from 'vayla-design-lib/link/link';
 import * as React from 'react';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type DesignDraftsExistErrorProps = { goToPublishChangesMode: () => void };
 
@@ -10,7 +10,7 @@ export const DesignDraftsExistError: React.FC<DesignDraftsExistErrorProps> = ({
 }) => {
     const { t } = useTranslation();
     const actionLink = (
-        <Link
+        <AnchorLink
             onClick={(e) => {
                 goToPublishChangesMode();
                 e.preventDefault();

--- a/ui/src/publication/card/publication-card.tsx
+++ b/ui/src/publication/card/publication-card.tsx
@@ -10,7 +10,6 @@ import Card from 'geoviite-design-lib/card/card';
 import styles from './publication-card.scss';
 import { RatkoStatus } from 'ratko/ratko-api';
 import i18n from 'i18next';
-import { Link } from 'vayla-design-lib/link/link';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
@@ -24,6 +23,7 @@ import {
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { LayoutBranchType, PublicationDetails } from 'publication/publication-model';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type PublishListProps = {
     publicationChangeTime: TimeStamp;
@@ -244,19 +244,19 @@ const PublicationCard: React.FC<PublishListProps> = ({
                             )}
                         {!reachedLastPublication && (
                             <div className={styles['publication-card__show-more']}>
-                                <Link onClick={() => setPageCount(pageCount + 1)}>
+                                <AnchorLink onClick={() => setPageCount(pageCount + 1)}>
                                     {t('publication-card.show-more')}
-                                </Link>
+                                </AnchorLink>
                             </div>
                         )}
                         <br />
                         {branchType === 'MAIN' && (
                             <div>
-                                <Link
+                                <AnchorLink
                                     onClick={() => navigateToPublicationLog()}
                                     qa-id={'open-publication-log'}>
                                     {t('publication-card.log-link')}
-                                </Link>
+                                </AnchorLink>
                             </div>
                         )}
                     </ProgressIndicatorWrapper>

--- a/ui/src/publication/card/publication-list-row.tsx
+++ b/ui/src/publication/card/publication-list-row.tsx
@@ -15,7 +15,7 @@ import { putBulkTransferState } from 'publication/split/split-api';
 import { success } from 'geoviite-design-lib/snackbar/snackbar';
 import { getChangeTimes, updateSplitChangeTime } from 'common/change-time-api';
 import { useLayoutDesign } from 'track-layout/track-layout-react-utils';
-import { Link } from 'react-router-dom';
+import { RouterLink } from 'geoviite-design-lib/link/router-link';
 
 type PublicationListRowProps = {
     publication: PublicationDetails;
@@ -127,7 +127,9 @@ export const PublicationListRow: React.FC<PublicationListRowProps> = ({ publicat
                         {(() => {
                             const text = formatDateFull(publication.publicationTime);
                             return publication.layoutBranch.branch === 'MAIN' ? (
-                                <Link to={`/publications/${publication.id}`}>{text}</Link>
+                                <RouterLink to={`/publications/${publication.id}`}>
+                                    {text}
+                                </RouterLink>
                             ) : (
                                 text
                             );

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styles from './publication-log.scss';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'vayla-design-lib/link/link';
 import {
     DatePicker,
     DatePickerDateSource,
@@ -37,6 +36,7 @@ import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { debounceAsync } from 'utils/async-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { SortDirection } from 'utils/table-utils';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 const MAX_SEARCH_DAYS = 180;
 
@@ -239,13 +239,13 @@ const PublicationLog: React.FC = () => {
     return (
         <div className={styles['publication-log']}>
             <div className={styles['publication-log__title']}>
-                <Link
+                <AnchorLink
                     onClick={() => {
                         trackLayoutActionDelegates.setSelectedPublicationSearch(undefined);
                         navigate('frontpage');
                     }}>
                     {t('frontpage.frontpage-link')}
-                </Link>
+                </AnchorLink>
                 <span className={styles['publication-log__breadcrumbs']}>
                     {' > ' + t('publication-log.breadcrumbs-text')}
                 </span>

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -8,7 +8,6 @@ import {
 import styles from './publication.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'vayla-design-lib/link/link';
 import { formatDateFull } from 'utils/date-utils';
 import { ratkoPushFailed } from 'ratko/ratko-model';
 import { getPublicationAsTableItems } from 'publication/publication-api';
@@ -19,6 +18,7 @@ import {
     InitiallyUnsorted,
     PublicationDetailsTableSortInformation,
 } from 'publication/table/publication-table-utils';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type PublicationDetailsViewProps = {
     publication: PublicationDetails;
@@ -53,13 +53,13 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     return (
         <div className={styles['publication-details']}>
             <div className={styles['publication-details__title']}>
-                <Link
+                <AnchorLink
                     onClick={() => {
                         setSelectedPublicationId(undefined);
                         navigate('frontpage');
                     }}>
                     {t('frontpage.frontpage-link')}
-                </Link>
+                </AnchorLink>
                 <span className={styles['publication-details__publication-time']}>
                     {' > ' + formatDateFull(publication.publicationTime)}
                 </span>

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styles from 'tool-panel/track-number/alignment-plan-section-infobox.scss';
-import { Link } from 'vayla-design-lib/link/link';
 import { AlignmentPlanSection, PlanSectionPoint } from 'track-layout/layout-location-track-api';
 import { useTranslation } from 'react-i18next';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
@@ -13,6 +12,7 @@ import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track
 import { Eye } from 'geoviite-design-lib/eye/eye';
 import { createClassName } from 'vayla-design-lib/utils';
 import { InfoboxList, InfoboxListRow } from 'tool-panel/infobox/infobox-list';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 const ErrorFragment: React.FC<{ message?: string }> = ({ message = '' }) => (
     <span title={message} className={styles['alignment-plan-section-infobox__no-plan-icon']}>
@@ -63,12 +63,12 @@ const GeometryPlanLabel: React.FC<GeometryPlanLabelProps> = ({
         <div className={styles['alignment-plan-section-infobox__plan-name']}>
             {planName ? (
                 planId ? (
-                    <Link
+                    <AnchorLink
                         title={`${planName}, ${alignmentName}`}
                         className={styles['alignment-plan-section-infobox__plan-link-content']}
                         onClick={onGeometryClick}>
                         {planName}
-                    </Link>
+                    </AnchorLink>
                 ) : (
                     <span title={`${planName}, ${alignmentName}`}>{planName}</span>
                 )

--- a/ui/src/tool-panel/geometry-plan-link.tsx
+++ b/ui/src/tool-panel/geometry-plan-link.tsx
@@ -5,6 +5,7 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
 import { createEmptyItemCollections } from 'selection/selection-store';
 import { GeometryPlanId } from 'geometry/geometry-model';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type GeometryPlanLinkProps = {
     planId?: GeometryPlanId;
@@ -23,5 +24,9 @@ function createSelectAction() {
 export const GeometryPlanLink: React.FC<GeometryPlanLinkProps> = (props: GeometryPlanLinkProps) => {
     const header = usePlanHeader(props.planId);
     const clickAction = props.onClick || createSelectAction();
-    return <Link onClick={() => header && clickAction(header.id)}>{header?.fileName || ''}</Link>;
+    return (
+        <AnchorLink onClick={() => header && clickAction(header.id)}>
+            {header?.fileName || ''}
+        </AnchorLink>
+    );
 };

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-dialog.tsx
@@ -30,7 +30,6 @@ import { LayoutKmPost, LayoutKmPostId, LayoutTrackNumberId } from 'track-layout/
 import { useDebouncedState } from 'utils/react-utils';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import KmPostRevertConfirmationDialog from 'tool-panel/km-post/dialog/km-post-revert-confirmation-dialog';
-import { Link } from 'vayla-design-lib/link/link';
 import {
     getSaveDisabledReasons,
     useKmPost,
@@ -46,6 +45,7 @@ import { useTrackLayoutAppSelector } from 'store/hooks';
 import { KmPostEditDialogGkLocationSection } from 'tool-panel/km-post/dialog/km-post-edit-dialog-gk-location-section';
 import { GeometryPoint } from 'model/geometry';
 import { UnknownAction } from 'redux';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type KmPostEditDialogType = 'MODIFY' | 'CREATE' | 'LINKING';
 
@@ -327,13 +327,13 @@ export const KmPostEditDialog: React.FC<KmPostEditDialogProps> = (props: KmPostE
                             errors={getVisibleErrorsByProp('kmNumber')}>
                             {state.trackNumberKmPost &&
                                 state.trackNumberKmPost.id !== state.existingKmPost?.id && (
-                                    <Link
+                                    <AnchorLink
                                         className={dialogStyles['dialog__alert']}
                                         onClick={() =>
                                             props.onEditKmPost(state.trackNumberKmPost?.id)
                                         }>
                                         {moveToEditLinkText(state.trackNumberKmPost)}
-                                    </Link>
+                                    </AnchorLink>
                                 )}
                         </FieldLayout>
                         <FieldLayout

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -34,13 +34,13 @@ import { OnSelectOptions, OptionalUnselectableItemCollections } from 'selection/
 import LayoutState from 'geoviite-design-lib/layout-state/layout-state';
 import { roundToPrecision } from 'utils/rounding';
 import { ChangeTimes } from 'common/common-slice';
-import { Link } from 'vayla-design-lib/link/link';
 import { createDelegates } from 'store/store-utils';
 import { getGeometryPlan } from 'geometry/geometry-api';
 import CoordinateSystemView from 'geoviite-design-lib/coordinate-system/coordinate-system-view';
 import styles from './km-post-infobox.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 import { GK_FIN_COORDINATE_SYSTEMS } from 'tool-panel/km-post/dialog/km-post-edit-store';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type KmPostInfoboxProps = {
     layoutContext: LayoutContext;
@@ -156,8 +156,8 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
         infoboxExtras?.kmLength === undefined
             ? t('tool-panel.km-post.layout.no-kilometer-length')
             : infoboxExtras.kmLength < 0
-              ? t('tool-panel.km-post.layout.negative-kilometer-length')
-              : `${roundToPrecision(infoboxExtras.kmLength, 3)} m`;
+            ? t('tool-panel.km-post.layout.negative-kilometer-length')
+            : `${roundToPrecision(infoboxExtras.kmLength, 3)} m`;
 
     return (
         <React.Fragment>
@@ -251,7 +251,9 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                         qaId="km-post-gk-coordinates-confirmed"
                         label={t(`tool-panel.km-post.layout.gk-coordinates.confirmed-title`)}
                         value={t(
-                            `tool-panel.km-post.layout.gk-coordinates.${updatedKmPost?.gkLocation?.confirmed ? '' : 'not-'}confirmed`,
+                            `tool-panel.km-post.layout.gk-coordinates.${
+                                updatedKmPost?.gkLocation?.confirmed ? '' : 'not-'
+                            }confirmed`,
                         )}
                     />
                     <InfoboxField
@@ -263,7 +265,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                     {t(
                                         'tool-panel.km-post.layout.gk-coordinates.source-from-geometry',
                                     )}{' '}
-                                    <Link
+                                    <AnchorLink
                                         className={styles['km-post-infobox__plan-link']}
                                         onClick={() => {
                                             if (infoboxExtras?.sourceGeometryPlanId) {
@@ -279,7 +281,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                             }
                                         }}>
                                         {geometryPlan?.fileName}
-                                    </Link>
+                                    </AnchorLink>
                                 </span>
                             ) : updatedKmPost?.gkLocation?.source === 'FROM_LAYOUT' ? (
                                 t('tool-panel.km-post.layout.gk-coordinates.source-from-layout')

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -56,13 +56,13 @@ import { exhaustiveMatchingGuard, ifDefined } from 'utils/type-utils';
 import { DescriptionSuffixDropdown } from 'tool-panel/location-track/description-suffix-dropdown';
 import { getLocationTrackOwners } from 'common/common-api';
 import { useLoader } from 'utils/react-utils';
-import { Link } from 'vayla-design-lib/link/link';
 import { ChangeTimes } from 'common/common-slice';
 import { getChangeTimes } from 'common/change-time-api';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
 import { first } from 'utils/array-utils';
 import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
 import { UnknownAction } from 'redux';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type LocationTrackDialogContainerProps = {
     locationTrackId?: LocationTrackId;
@@ -456,11 +456,11 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                             ? t('location-track-dialog.name-in-use-deleted')
                                             : t('location-track-dialog.name-in-use')}
                                     </div>
-                                    <Link
+                                    <AnchorLink
                                         className={styles['location-track-edit-dialog__alert']}
                                         onClick={() => props.onEditTrack(trackWithSameName.id)}>
                                         {moveToEditLinkText(trackWithSameName)}
-                                    </Link>
+                                    </AnchorLink>
                                 </>
                             )}
                         </FieldLayout>

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -22,7 +22,6 @@ import {
     LocationTrackInfoboxVisibilities,
     trackLayoutActionCreators as TrackLayoutActions,
 } from 'track-layout/track-layout-slice';
-import { Link } from 'vayla-design-lib/link/link';
 import { getLocationTrackOwners } from 'common/common-api';
 import { createDelegates } from 'store/store-utils';
 import { OnSelectOptions } from 'selection/selection-model';
@@ -33,6 +32,7 @@ import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-u
 import { first } from 'utils/array-utils';
 import { LocationTrackState } from 'geoviite-design-lib/location-track-state/location-track-state';
 import { LocationTrackOid } from 'track-layout/oid';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type LocationTrackBasicInfoInfoboxContainerProps = {
     locationTrack: LayoutLocationTrack;
@@ -92,14 +92,14 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
         if (sw) {
             const switchId = sw.id;
             return (
-                <Link
+                <AnchorLink
                     onClick={() =>
                         onSelect({
                             switches: [switchId],
                         })
                     }>
                     {sw.name}
-                </Link>
+                </AnchorLink>
             );
         } else {
             return t('tool-panel.location-track.no-start-or-end-switch');
@@ -179,8 +179,8 @@ export const LocationTrackBasicInfoInfobox: React.FC<LocationTrackBasicInfoInfob
                         locationTrack.duplicateOf
                             ? t('tool-panel.location-track.duplicate-of')
                             : extraInfo?.duplicates?.length ?? 0 > 0
-                              ? t('tool-panel.location-track.has-duplicates')
-                              : t('tool-panel.location-track.not-a-duplicate')
+                            ? t('tool-panel.location-track.has-duplicates')
+                            : t('tool-panel.location-track.not-a-duplicate')
                     }
                     value={
                         <LocationTrackInfoboxDuplicateOf

--- a/ui/src/tool-panel/location-track/location-track-link.tsx
+++ b/ui/src/tool-panel/location-track/location-track-link.tsx
@@ -1,8 +1,8 @@
 import { LocationTrackId } from 'track-layout/track-layout-model';
-import { Link } from 'vayla-design-lib/link/link';
 import React from 'react';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type LocationTrackLinkProps = {
     locationTrackId: LocationTrackId;
@@ -15,12 +15,12 @@ export const LocationTrackLink: React.FC<LocationTrackLinkProps> = (
     const delegates = createDelegates(TrackLayoutActions);
 
     return (
-        <Link
+        <AnchorLink
             onClick={() => {
                 delegates.onSelect({ locationTracks: [props.locationTrackId] });
                 delegates.setToolPanelTab({ id: props.locationTrackId, type: 'LOCATION_TRACK' });
             }}>
             {props.locationTrackName}
-        </Link>
+        </AnchorLink>
     );
 };

--- a/ui/src/tool-panel/location-track/splitting/location-track-split-notices.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split-notices.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
-import { Link } from 'vayla-design-lib/link/link';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export const LocationTrackSplittingErrorNotice: React.FC<{
     msg: string;
@@ -65,9 +65,9 @@ export const NoticeWithNavigationLink: React.FC<NoticeWithNavigationLinkParams> 
         <InfoboxContentSpread>
             <MessageBox>
                 {t(noticeLocalizationKey)},{' '}
-                <Link onClick={onClickLink}>
+                <AnchorLink onClick={onClickLink}>
                     {t('tool-panel.location-track.splitting.validation.show')}
-                </Link>
+                </AnchorLink>
             </MessageBox>
         </InfoboxContentSpread>
     );

--- a/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { LoaderStatus } from 'utils/react-utils';
 import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
 import styles from 'tool-panel/location-track/location-track-infobox.scss';
-import { Link } from 'vayla-design-lib/link/link';
 import { Spinner, SpinnerSize } from 'vayla-design-lib/spinner/spinner';
 import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { SwitchRelinkingValidationResult } from 'linking/linking-model';
 import { hasUnrelinkableSwitches } from 'tool-panel/location-track/splitting/split-utils';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type LocationTrackSplitRelinkingNoticeProps = {
     splittingState: SplittingState;
@@ -33,11 +33,11 @@ export const LocationTrackSplitRelinkingNotice: React.FC<
                             ? t('tool-panel.location-track.splitting.relink-critical-errors')
                             : t('tool-panel.location-track.splitting.relink-message')}
                         <div className={styles['location-track-infobox__relink-link']}>
-                            <Link onClick={() => onClickRelink()}>
+                            <AnchorLink onClick={() => onClickRelink()}>
                                 {t('tool-panel.location-track.splitting.cancel-and-relink', {
                                     count: switchRelinkingErrors.length,
                                 })}
-                            </Link>
+                            </AnchorLink>
                         </div>
                     </MessageBox>
                 )}

--- a/ui/src/tool-panel/switch/dialog/switch-draft-oid-field.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-draft-oid-field.tsx
@@ -1,7 +1,6 @@
 import styles from './switch-edit-dialog.scss';
 import React, { useState } from 'react';
 import { TextField } from 'vayla-design-lib/text-field/text-field';
-import { Link } from 'vayla-design-lib/link/link';
 import { Oid, TimeStamp } from 'common/common-model';
 import { useTranslation } from 'react-i18next';
 import { LoaderStatus, useLoaderWithStatus, useRateLimitedTwoPartEffect } from 'utils/react-utils';
@@ -20,6 +19,7 @@ import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
 import { filterNotEmpty } from 'utils/array-utils';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import { Switch } from 'vayla-design-lib/switch/switch';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 const SWITCH_OID_REQUIRED_PREFIX = '1.2.246.578.3.117.';
 
@@ -38,7 +38,7 @@ const ExistingSwitchEditLink: React.FC<ExistingSwitchEditLinkProps> = ({
 }: ExistingSwitchEditLinkProps) => {
     const { t } = useTranslation();
     return (
-        <Link
+        <AnchorLink
             className={styles['switch-edit-dialog__alert']}
             onClick={() => {
                 setDraftOid('');
@@ -46,7 +46,7 @@ const ExistingSwitchEditLink: React.FC<ExistingSwitchEditLinkProps> = ({
                 onEdit(existingInGeoviite.id);
             }}>
             {moveToEditLinkText(t, existingInGeoviite)}
-        </Link>
+        </AnchorLink>
     );
 };
 

--- a/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
+++ b/ui/src/tool-panel/switch/dialog/switch-edit-dialog.tsx
@@ -40,7 +40,6 @@ import {
 } from 'track-layout/layout-switch-api';
 import styles from './switch-edit-dialog.scss';
 import { useLoader } from 'utils/react-utils';
-import { Link } from 'vayla-design-lib/link/link';
 import { getSaveDisabledReasons, useSwitch } from 'track-layout/track-layout-react-utils';
 import SwitchRevertConfirmationDialog from './switch-revert-confirmation-dialog';
 import { first } from 'utils/array-utils';
@@ -50,6 +49,7 @@ import {
     validateDraftOid,
 } from 'tool-panel/switch/dialog/switch-draft-oid-field';
 import { TFunction } from 'i18next';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 const SWITCH_NAME_REGEX = /^[A-ZÄÖÅa-zäöå0-9 \-_/]+$/g;
 
@@ -391,11 +391,11 @@ export const SwitchEditDialog = ({
                                             ? t('switch-dialog.name-in-use-deleted')
                                             : t('switch-dialog.name-in-use')}
                                     </div>
-                                    <Link
+                                    <AnchorLink
                                         className={styles['switch-edit-dialog__alert']}
                                         onClick={() => onEdit(conflictingSwitch.id)}>
                                         {moveToEditLinkText(t, conflictingSwitch)}
-                                    </Link>
+                                    </AnchorLink>
                                 </>
                             )}
                         </FieldLayout>

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-dialog.tsx
@@ -37,13 +37,13 @@ import { layoutStates } from 'utils/enum-localization-utils';
 import styles from 'geoviite-design-lib/dialog/dialog.scss';
 import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import TrackNumberRevertConfirmationDialog from 'tool-panel/track-number/dialog/track-number-revert-confirmation-dialog';
-import { Link } from 'vayla-design-lib/link/link';
 import { onRequestDeleteTrackNumber } from 'tool-panel/track-number/track-number-deletion';
 import { ChangesBeingReverted } from 'preview/preview-view';
 import { isEqualIgnoreCase } from 'utils/string-utils';
 import { useTrackLayoutAppSelector } from 'store/hooks';
 import { draftLayoutContext, LayoutContext, officialLayoutContext } from 'common/common-model';
 import { UnknownAction } from 'redux';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type TrackNumberEditDialogContainerProps = {
     editTrackNumberId?: LayoutTrackNumberId;
@@ -258,11 +258,11 @@ export const TrackNumberEditDialog: React.FC<TrackNumberEditDialogProps> = ({
                             }
                             errors={numberErrors.map(({ reason }) => t(mapError(reason)))}>
                             {otherTrackNumber && (
-                                <Link
+                                <AnchorLink
                                     className={dialogStyles['dialog__alert']}
                                     onClick={() => onEditTrackNumber(otherTrackNumber.id)}>
                                     {moveToEditLinkText(otherTrackNumber)}
-                                </Link>
+                                </AnchorLink>
                             )}
                         </FieldLayout>
                         <FieldLayout

--- a/ui/src/user/privileged-link.tsx
+++ b/ui/src/user/privileged-link.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useCommonDataAppSelector } from 'store/hooks';
 import { PrivilegeCode } from './user-model';
-import { Link } from 'vayla-design-lib/link/link';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type PrivilegedLinkProps = {
     privilege: PrivilegeCode;
@@ -14,7 +14,7 @@ export const PrivilegedLink: React.FC<PrivilegedLinkProps> = (props: PrivilegedL
     );
 
     if (userHasPrivilege) {
-        return <Link {...props}>{props.children}</Link>;
+        return <AnchorLink {...props}>{props.children}</AnchorLink>;
     } else {
         return <React.Fragment>{props.children}</React.Fragment>;
     }

--- a/ui/src/vayla-design-lib/demo/examples/table-examples.tsx
+++ b/ui/src/vayla-design-lib/demo/examples/table-examples.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Table, Td, TdVariant } from 'vayla-design-lib/table/table';
 import examplePersonsData from 'vayla-design-lib/demo/example-persons.json';
-import { Link } from 'vayla-design-lib/link/link';
 import { Button, ButtonSize } from 'vayla-design-lib/button/button';
 import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
+import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 type ExamplePerson = {
     id: number;
@@ -53,7 +53,9 @@ export const TableExamples: React.FC = () => {
                                 <td>{person.address}</td>
                                 <td>{person.email}</td>
                                 <td>
-                                    <Link href={person.website || undefined}>{person.website}</Link>
+                                    <AnchorLink href={person.website || undefined}>
+                                        {person.website}
+                                    </AnchorLink>
                                 </td>
                                 <td>{person.company}</td>
                                 <td>{person.iban}</td>


### PR DESCRIPTION
Aiemmin meillä oli eri komponenteissa kahta eri `<Link>`-elementtiä -> tehty välikomponentit eri nimillä