### PR TITLE
GVT-3009 Esivalmistelu: Assettihaun erottaminen omaksi komponentikseen

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -22,6 +22,13 @@ data class TrackLayoutSearchResult(
     val operatingPoints: List<RatkoOperatingPoint>,
 )
 
+enum class TrackLayoutSearchedAssetType {
+    LOCATION_TRACK,
+    SWITCH,
+    TRACK_NUMBER,
+    OPERATING_POINT,
+}
+
 @GeoviiteController("/track-layout/search")
 class LayoutSearchController(private val searchService: LayoutSearchService) {
 
@@ -33,8 +40,15 @@ class LayoutSearchController(private val searchService: LayoutSearchService) {
         @RequestParam("searchTerm", required = true) searchTerm: FreeText,
         @RequestParam("limitPerResultType", required = true) limitPerResultType: Int,
         @RequestParam("locationTrackSearchScope", required = false) locationTrackSearchScope: IntId<LocationTrack>?,
+        @RequestParam("types", required = true) types: List<TrackLayoutSearchedAssetType>,
     ): TrackLayoutSearchResult {
         val layoutContext = LayoutContext.of(branch, publicationState)
-        return searchService.searchAssets(layoutContext, searchTerm, limitPerResultType, locationTrackSearchScope)
+        return searchService.searchAssets(
+            layoutContext,
+            searchTerm,
+            limitPerResultType,
+            locationTrackSearchScope,
+            types,
+        )
     }
 }

--- a/ui/src/tool-bar/search-dropdown.tsx
+++ b/ui/src/tool-bar/search-dropdown.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dropdown, dropdownOption, DropdownSize, Item } from 'vayla-design-lib/dropdown/dropdown';
+import {
+    LayoutLocationTrack,
+    LayoutSwitch,
+    LayoutTrackNumber,
+    LocationTrackId,
+    OperatingPoint,
+} from 'track-layout/track-layout-model';
+import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
+import { getBySearchTerm } from 'track-layout/track-layout-search-api';
+import { isNilOrBlank } from 'utils/string-utils';
+import { ALIGNMENT_DESCRIPTION_REGEX } from 'tool-panel/location-track/dialog/location-track-validation';
+import { LayoutContext } from 'common/common-model';
+import { debounceAsync } from 'utils/async-utils';
+import { SplittingState } from 'tool-panel/location-track/split-store';
+
+type LocationTrackItemValue = {
+    locationTrack: LayoutLocationTrack;
+    type: 'locationTrackSearchItem';
+};
+
+function createLocationTrackOptionItem(
+    locationTrack: LayoutLocationTrack,
+    description: string,
+): Item<LocationTrackItemValue> {
+    return dropdownOption(
+        {
+            type: 'locationTrackSearchItem',
+            locationTrack: locationTrack,
+        } as const,
+        `${locationTrack.name}, ${description}`,
+        `location-track-${locationTrack.id}`,
+    );
+}
+
+type SwitchItemValue = {
+    layoutSwitch: LayoutSwitch;
+    type: 'switchSearchItem';
+};
+
+function createSwitchOptionItem(layoutSwitch: LayoutSwitch): Item<SwitchItemValue> {
+    return dropdownOption(
+        {
+            type: 'switchSearchItem',
+            layoutSwitch: layoutSwitch,
+        } as const,
+        layoutSwitch.name,
+        `switch-${layoutSwitch.id}`,
+    );
+}
+
+type TrackNumberItemValue = {
+    trackNumber: LayoutTrackNumber;
+    type: 'trackNumberSearchItem';
+};
+
+function createTrackNumberOptionItem(
+    layoutTrackNumber: LayoutTrackNumber,
+): Item<TrackNumberItemValue> {
+    return dropdownOption(
+        {
+            type: 'trackNumberSearchItem',
+            trackNumber: layoutTrackNumber,
+        } as const,
+        layoutTrackNumber.number,
+        `track-number-${layoutTrackNumber.id}`,
+    );
+}
+
+type OperatingPointItemValue = {
+    operatingPoint: OperatingPoint;
+    type: 'operatingPointSearchItem';
+};
+
+function createOperatingPointOptionItem(
+    operatingPoint: OperatingPoint,
+): Item<OperatingPointItemValue> {
+    return dropdownOption(
+        {
+            operatingPoint: operatingPoint,
+            type: 'operatingPointSearchItem',
+        } as const,
+        `${operatingPoint.name}, ${operatingPoint.abbreviation}`,
+        `operating-point-${operatingPoint.name}`,
+    );
+}
+
+// The characters that alignment descriptions can contain is a superset of the characters that can be used in search,
+// and it's considered quite likely to stay that way even if allowed character sets for names etc. are changed.
+const SEARCH_REGEX = ALIGNMENT_DESCRIPTION_REGEX;
+
+async function getOptions(
+    layoutContext: LayoutContext,
+    searchTerm: string,
+    locationTrackSearchScope: LocationTrackId | undefined,
+    searchTypes: SearchType[],
+): Promise<Item<SearchItemValue>[]> {
+    if (isNilOrBlank(searchTerm) || !searchTerm.match(SEARCH_REGEX)) {
+        return Promise.resolve([]);
+    }
+
+    const searchResult = await getBySearchTerm(
+        searchTerm,
+        layoutContext,
+        searchTypes,
+        locationTrackSearchScope,
+    );
+
+    const locationTrackDescriptions = await getLocationTrackDescriptions(
+        searchResult.locationTracks.map((lt) => lt.id),
+        layoutContext,
+    );
+
+    const locationTrackOptions = searchResult.locationTracks.map((locationTrack) => {
+        const description =
+            locationTrackDescriptions?.find((d) => d.id === locationTrack.id)?.description ?? '';
+
+        return createLocationTrackOptionItem(locationTrack, description);
+    });
+
+    return [
+        searchResult.operatingPoints.map(createOperatingPointOptionItem),
+        locationTrackOptions,
+        searchResult.switches.map(createSwitchOptionItem),
+        searchResult.trackNumbers.map(createTrackNumberOptionItem),
+    ].flat();
+}
+
+// Use debounced function to collect keystrokes before triggering a search
+const debouncedGetOptions = debounceAsync(getOptions, 250);
+
+export type SearchItemValue =
+    | LocationTrackItemValue
+    | SwitchItemValue
+    | TrackNumberItemValue
+    | OperatingPointItemValue;
+
+type SearchDropdownProps = {
+    layoutContext: LayoutContext;
+    splittingState?: SplittingState;
+    placeholder: string;
+    disabled?: boolean;
+    onItemSelected: (item: SearchItemValue | undefined) => void;
+    searchTypes: SearchType[];
+};
+
+export enum SearchType {
+    LOCATION_TRACK = 'LOCATION_TRACK',
+    SWITCH = 'SWITCH',
+    TRACK_NUMBER = 'TRACK_NUMBER',
+    OPERATING_POINT = 'OPERATING_POINT',
+}
+
+export const SearchDropdown: React.FC<SearchDropdownProps> = ({
+    layoutContext,
+    placeholder,
+    disabled = false,
+    onItemSelected,
+    splittingState,
+    searchTypes,
+}) => {
+    const { t } = useTranslation();
+
+    // Use memoized function to make debouncing functionality to work when re-rendering
+    const memoizedDebouncedGetOptions = React.useCallback(
+        (searchTerm: string) =>
+            debouncedGetOptions(
+                layoutContext,
+                searchTerm,
+                splittingState?.originLocationTrack?.id,
+                searchTypes,
+            ),
+        [layoutContext, splittingState],
+    );
+
+    return (
+        <Dropdown
+            placeholder={placeholder}
+            disabled={disabled}
+            options={memoizedDebouncedGetOptions}
+            searchable
+            onChange={onItemSelected}
+            size={DropdownSize.STRETCH}
+            wideList
+            wide
+            qa-id="search-box"
+        />
+    );
+};

--- a/ui/src/tool-bar/search-dropdown.tsx
+++ b/ui/src/tool-bar/search-dropdown.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Dropdown, dropdownOption, DropdownSize, Item } from 'vayla-design-lib/dropdown/dropdown';
 import {
     LayoutLocationTrack,
@@ -161,8 +160,6 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({
     splittingState,
     searchTypes,
 }) => {
-    const { t } = useTranslation();
-
     // Use memoized function to make debouncing functionality to work when re-rendering
     const memoizedDebouncedGetOptions = React.useCallback(
         (searchTerm: string) =>

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -6,17 +6,6 @@ import {
     ButtonSize,
     ButtonVariant,
 } from 'vayla-design-lib/button/button';
-import { Dropdown, dropdownOption, DropdownSize, Item } from 'vayla-design-lib/dropdown/dropdown';
-import { getLocationTrackDescriptions } from 'track-layout/layout-location-track-api';
-import {
-    LayoutLocationTrack,
-    LayoutSwitch,
-    LayoutTrackNumber,
-    LocationTrackId,
-    OperatingPoint,
-} from 'track-layout/track-layout-model';
-import { debounceAsync } from 'utils/async-utils';
-import { isNilOrBlank } from 'utils/string-utils';
 import {
     BoundingBox,
     boundingBoxAroundPoints,
@@ -40,7 +29,6 @@ import {
     refreshSwitchSelection,
     refreshTrackNumberSelection,
 } from 'track-layout/track-layout-react-utils';
-import { getBySearchTerm } from 'track-layout/track-layout-search-api';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import { PrivilegeRequired } from 'user/privilege-required';
@@ -65,7 +53,6 @@ import { getLayoutDesign, updateLayoutDesign } from 'track-layout/layout-design-
 import { getChangeTimes, updateLayoutDesignChangeTime } from 'common/change-time-api';
 import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-dialog';
-import { ALIGNMENT_DESCRIPTION_REGEX } from 'tool-panel/location-track/dialog/location-track-validation';
 import { SearchDropdown, SearchItemValue, SearchType } from 'tool-bar/search-dropdown';
 
 const DESIGN_SELECT_POPUP_MARGIN_WHEN_SELECTED = 6;

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -66,6 +66,7 @@ import { getChangeTimes, updateLayoutDesignChangeTime } from 'common/change-time
 import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-dialog';
 import { ALIGNMENT_DESCRIPTION_REGEX } from 'tool-panel/location-track/dialog/location-track-validation';
+import { SearchDropdown, SearchItemValue, SearchType } from 'tool-bar/search-dropdown';
 
 const DESIGN_SELECT_POPUP_MARGIN_WHEN_SELECTED = 6;
 const DESIGN_SELECT_POPUP_MARGIN_WHEN_NOT_SELECTED = 3;
@@ -87,118 +88,6 @@ export type ToolbarParams = {
     designId: LayoutDesignId | undefined;
     onDesignIdChange: (value: LayoutDesignId | undefined) => void;
 };
-
-type LocationTrackItemValue = {
-    locationTrack: LayoutLocationTrack;
-    type: 'locationTrackSearchItem';
-};
-
-function createLocationTrackOptionItem(
-    locationTrack: LayoutLocationTrack,
-    description: string,
-): Item<LocationTrackItemValue> {
-    return dropdownOption(
-        {
-            type: 'locationTrackSearchItem',
-            locationTrack: locationTrack,
-        } as const,
-        `${locationTrack.name}, ${description}`,
-        `location-track-${locationTrack.id}`,
-    );
-}
-
-type SwitchItemValue = {
-    layoutSwitch: LayoutSwitch;
-    type: 'switchSearchItem';
-};
-
-function createSwitchOptionItem(layoutSwitch: LayoutSwitch): Item<SwitchItemValue> {
-    return dropdownOption(
-        {
-            type: 'switchSearchItem',
-            layoutSwitch: layoutSwitch,
-        } as const,
-        layoutSwitch.name,
-        `switch-${layoutSwitch.id}`,
-    );
-}
-
-type TrackNumberItemValue = {
-    trackNumber: LayoutTrackNumber;
-    type: 'trackNumberSearchItem';
-};
-
-function createTrackNumberOptionItem(
-    layoutTrackNumber: LayoutTrackNumber,
-): Item<TrackNumberItemValue> {
-    return dropdownOption(
-        {
-            type: 'trackNumberSearchItem',
-            trackNumber: layoutTrackNumber,
-        } as const,
-        layoutTrackNumber.number,
-        `track-number-${layoutTrackNumber.id}`,
-    );
-}
-
-type OperatingPointItemValue = {
-    operatingPoint: OperatingPoint;
-    type: 'operatingPointSearchItem';
-};
-
-function createOperatingPointOptionItem(
-    operatingPoint: OperatingPoint,
-): Item<OperatingPointItemValue> {
-    return dropdownOption(
-        {
-            operatingPoint: operatingPoint,
-            type: 'operatingPointSearchItem',
-        } as const,
-        `${operatingPoint.name}, ${operatingPoint.abbreviation}`,
-        `operating-point-${operatingPoint.name}`,
-    );
-}
-
-type SearchItemValue =
-    | LocationTrackItemValue
-    | SwitchItemValue
-    | TrackNumberItemValue
-    | OperatingPointItemValue;
-
-// The characters that alignment descriptions can contain is a superset of the characters that can be used in search,
-// and it's considered quite likely to stay that way even if allowed character sets for names etc. are changed.
-const SEARCH_REGEX = ALIGNMENT_DESCRIPTION_REGEX;
-
-async function getOptions(
-    layoutContext: LayoutContext,
-    searchTerm: string,
-    locationTrackSearchScope: LocationTrackId | undefined,
-): Promise<Item<SearchItemValue>[]> {
-    if (isNilOrBlank(searchTerm) || !searchTerm.match(SEARCH_REGEX)) {
-        return Promise.resolve([]);
-    }
-
-    const searchResult = await getBySearchTerm(searchTerm, layoutContext, locationTrackSearchScope);
-
-    const locationTrackDescriptions = await getLocationTrackDescriptions(
-        searchResult.locationTracks.map((lt) => lt.id),
-        layoutContext,
-    );
-
-    const locationTrackOptions = searchResult.locationTracks.map((locationTrack) => {
-        const description =
-            locationTrackDescriptions?.find((d) => d.id === locationTrack.id)?.description ?? '';
-
-        return createLocationTrackOptionItem(locationTrack, description);
-    });
-
-    return [
-        searchResult.operatingPoints.map(createOperatingPointOptionItem),
-        locationTrackOptions,
-        searchResult.switches.map(createSwitchOptionItem),
-        searchResult.trackNumbers.map(createTrackNumberOptionItem),
-    ].flat();
-}
 
 export const ToolBar: React.FC<ToolbarParams> = ({
     onSelect,
@@ -283,15 +172,6 @@ export const ToolBar: React.FC<ToolbarParams> = ({
             'tool-bar.new-km-post',
         ),
     ];
-
-    // Use debounced function to collect keystrokes before triggering a search
-    const debouncedGetOptions = debounceAsync(getOptions, 250);
-    // Use memoized function to make debouncing functionality to work when re-rendering
-    const memoizedDebouncedGetOptions = React.useCallback(
-        (searchTerm: string) =>
-            debouncedGetOptions(layoutContext, searchTerm, splittingState?.originLocationTrack?.id),
-        [layoutContext, splittingState],
-    );
 
     function onItemSelected(item: SearchItemValue | undefined) {
         if (!item) {
@@ -580,7 +460,9 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     </PrivilegeRequired>
                 )}
                 <div className={styles['tool-bar__search-container']}>
-                    <Dropdown
+                    <SearchDropdown
+                        layoutContext={layoutContext}
+                        splittingState={splittingState}
                         placeholder={
                             splittingState
                                 ? t('tool-bar.search-from-track', {
@@ -588,14 +470,14 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                                   })
                                 : t('tool-bar.search-from-whole-network')
                         }
+                        onItemSelected={onItemSelected}
                         disabled={!canSearch}
-                        options={memoizedDebouncedGetOptions}
-                        searchable
-                        onChange={onItemSelected}
-                        size={DropdownSize.STRETCH}
-                        wideList
-                        wide
-                        qa-id="search-box"
+                        searchTypes={[
+                            SearchType.LOCATION_TRACK,
+                            SearchType.SWITCH,
+                            SearchType.TRACK_NUMBER,
+                            SearchType.OPERATING_POINT,
+                        ]}
                     />
                 </div>
             </div>

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -8,6 +8,7 @@ import {
 import { getNonNull, queryParams } from 'api/api-fetch';
 import { TRACK_LAYOUT_URI, contextInUri } from 'track-layout/track-layout-api';
 import { LayoutContext } from 'common/common-model';
+import { SearchType } from 'tool-bar/search-dropdown';
 
 export interface LayoutSearchResult {
     switches: LayoutSwitch[];
@@ -19,6 +20,7 @@ export interface LayoutSearchResult {
 export async function getBySearchTerm(
     searchTerm: string,
     layoutContext: LayoutContext,
+    types: SearchType[],
     locationTrackSearchScope?: LocationTrackId,
     limitPerResultType: number = 10,
 ): Promise<LayoutSearchResult> {
@@ -28,6 +30,7 @@ export async function getBySearchTerm(
         searchTerm: searchTerm,
         locationTrackSearchScope: locationTrackSearchScope,
         limitPerResultType: limitPerResultType,
+        types: types,
     });
 
     return await getNonNull<LayoutSearchResult>(`${uri}${params}`);


### PR DESCRIPTION
Suunnitelmien latausnäkymässä on tarve hakea samalla hakuboksilla sekä ratanumeroita että sijaintiraiteita. Meillähän on tuollainen hakuboksi jo ennestään, se oli vaan kiinteä osa `<ToolBar>`:ia. Tällä tiketillä erotettu se omakseen sekä mahdollistettu hakutulosten rajaaminen assettityypin mukaan.

P.S. Huomasin tarpeen tälle ihan kesken matkan toteuttaessani latausnäkymää. Tämä on irrotettu omakseen siitä isommasta kokonaisuudesta, jota olen jo koodannut lokaalisti mutta en vielä puskenut, joten jos tällä pullarilla näkyy jotain outoutta tai jänniä viittauksia, niin tuo saattaa olla syynä siihen. Tätä ei ole tarkoitus mergata mainiin sellaisenaan.