### PR TITLE
GVT-2837 (part 2): Use BigDecimal directly as the track address meters parameter

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.logging.apiResult
 import fi.fta.geoviite.infra.util.Either
 import fi.fta.geoviite.infra.util.processRights
+import java.math.BigDecimal
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -37,8 +38,7 @@ constructor(
     fun trackAddressToCoordinateRequestSingle(
         @RequestParam(TRACK_NUMBER_NAME_PARAM, required = false) trackNumberName: FrameConverterStringV1?,
         @RequestParam(TRACK_KILOMETER_PARAM, required = false) trackKilometer: Int?,
-        @RequestParam(TRACK_METER_PARAM, required = false) trackMeter: Int?,
-        @RequestParam(TRACK_METER_DECIMALS_PARAM, required = false) trackMeterDecimals: Int?,
+        @RequestParam(TRACK_METER_PARAM, required = false) trackMeter: BigDecimal?,
         @RequestParam(LOCATION_TRACK_NAME_PARAM, required = false) locationTrackName: FrameConverterStringV1?,
         @RequestParam(LOCATION_TRACK_TYPE_PARAM, required = false)
         locationTrackType: FrameConverterLocationTrackTypeV1?,
@@ -52,7 +52,6 @@ constructor(
                 trackNumberName = trackNumberName,
                 trackKilometer = trackKilometer,
                 trackMeter = trackMeter,
-                trackMeterDecimals = trackMeterDecimals,
                 locationTrackName = locationTrackName,
                 locationTrackType = locationTrackType,
             )

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataV1.kt
@@ -20,6 +20,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.util.FreeText
+import java.math.BigDecimal
 
 typealias FrameConverterIdentifierV1 = FreeText
 
@@ -37,7 +38,6 @@ const val LOCATION_TRACK_NAME_PARAM = "sijaintiraide"
 const val LOCATION_TRACK_TYPE_PARAM = "sijaintiraide_tyyppi"
 const val TRACK_KILOMETER_PARAM = "ratakilometri"
 const val TRACK_METER_PARAM = "ratametri"
-const val TRACK_METER_DECIMALS_PARAM = "ratametri_desimaalit"
 
 data class FrameConverterStringV1 @JsonCreator(mode = DELEGATING) constructor(val value: String) {
 
@@ -237,7 +237,6 @@ data class FeatureMatchDetailsV1(
  * @property trackNumberOid User provided track number oid, one of "trackNumberName, trackNumberOid" is required.
  * @property trackKilometer User provided track kilometer, required for valid requests.
  * @property trackMeter User provided track meter on the specified track kilometer, required for valid requests.
- * @property trackMeterDecimals User provided track decimals on the specified trackMeter, optional.
  * @property locationTrackName User provided location track name filter, optional.
  * @property locationTrackOid User provided location track name filter, optional.
  * @property locationTrackType User provided location track type filter, optional.
@@ -247,8 +246,7 @@ data class TrackAddressToCoordinateRequestV1(
     @JsonProperty(TRACK_NUMBER_OID_PARAM) val trackNumberOid: FrameConverterStringV1? = null,
     @JsonProperty(TRACK_NUMBER_NAME_PARAM) val trackNumberName: FrameConverterStringV1? = null,
     @JsonProperty(TRACK_KILOMETER_PARAM) val trackKilometer: Int? = null,
-    @JsonProperty(TRACK_METER_PARAM) val trackMeter: Int? = null,
-    @JsonProperty(TRACK_METER_DECIMALS_PARAM) val trackMeterDecimals: Int? = null,
+    @JsonProperty(TRACK_METER_PARAM) val trackMeter: BigDecimal? = null,
     @JsonProperty(LOCATION_TRACK_OID_PARAM) val locationTrackOid: FrameConverterStringV1? = null,
     @JsonProperty(LOCATION_TRACK_NAME_PARAM) val locationTrackName: FrameConverterStringV1? = null,
     @JsonProperty(LOCATION_TRACK_TYPE_PARAM) val locationTrackType: FrameConverterLocationTrackTypeV1? = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterErrorV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterErrorV1.kt
@@ -21,7 +21,6 @@ enum class FrameConverterErrorV1(private val localizationSuffix: String) {
     InvalidLocationTrackOid("invalid-location-track-oid"),
     InvalidLocationTrackType("invalid-location-track-type"),
     InvalidTrackAddress("invalid-track-address"),
-    InvalidTrackAddressWithDecimals("invalid-track-address-with-decimals"),
     NoTrackNumberSearchCondition("no-track-number-search-condition"),
     BothNameAndOidForTrackNumber("both-name-and-oid-for-track-number"),
     TrackNumberNotFound("track-number-not-found"),

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterRequestDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterRequestDataV1.kt
@@ -11,24 +11,15 @@ import java.math.BigDecimal
 
 fun createValidTrackMeterOrNull(
     trackKilometer: Int?,
-    trackMeter: Int?,
-    trackDecimals: Int?,
+    trackMeter: BigDecimal?,
 ): Pair<TrackMeter?, List<FrameConverterErrorV1>> {
     return if (trackKilometer == null || trackMeter == null) {
         null to emptyList()
     } else {
-        if (trackDecimals == null) {
-            try {
-                TrackMeter(trackKilometer, trackMeter) to emptyList()
-            } catch (e: IllegalArgumentException) {
-                null to listOf(FrameConverterErrorV1.InvalidTrackAddress)
-            }
-        } else {
-            try {
-                TrackMeter(trackKilometer, BigDecimal("$trackMeter.$trackDecimals")) to emptyList()
-            } catch (e: IllegalArgumentException) {
-                null to listOf(FrameConverterErrorV1.InvalidTrackAddressWithDecimals)
-            }
+        try {
+            TrackMeter(trackKilometer, trackMeter) to emptyList()
+        } catch (e: IllegalArgumentException) {
+            null to listOf(FrameConverterErrorV1.InvalidTrackAddress)
         }
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -455,7 +455,7 @@ constructor(
             )
 
         val (validTrackMeterOrNull, trackMeterErrors) =
-            createValidTrackMeterOrNull(request.trackKilometer, request.trackMeter, request.trackMeterDecimals)
+            createValidTrackMeterOrNull(request.trackKilometer, request.trackMeter)
 
         val (mappedLocationTrackTypeOrNull, locationTrackTypeErrors) =
             mapLocationTrackTypeToDomainTypeOrNull(request.locationTrackType)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -18,7 +18,6 @@
             "invalid-location-track-oid": "Pyyntö sisälsi virheellisen sijaintiraide_oid-asetuksen.",
             "invalid-location-track-type": "Pyyntö sisälsi virheellisen sijaintiraide_tyyppi-asetuksen. Sallitut arvot ovat pääraide, sivuraide, kujaraide, turvaraide.",
             "invalid-track-address": "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen).",
-            "invalid-track-address-with-decimals": "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri.ratametri_desimaalit yhdistelmä oli virheellinen).",
             "no-track-number-search-condition": "Pyyntö ei sisältänyt hakuehtoa ratanumerolle. Sisällytä muunnospyyntöön yksi kentistä: ratanumero, ratanumero_oid.",
             "both-name-and-oid-for-track-number": "Pyyntö sisälsi useamman kuin yhden hakuehdon ratanumerolle. Sisällytä muunnospyyntöön yksi kentistä: ratanumero, ratanumero_oid.",
             "too-many-requests": "Kutsu sisälsi liian monta muunnospyyntöä. Yhdessä kutsussa saa olla korkeintaan 1000 muunnosta.",

--- a/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1-dev.yml
+++ b/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1-dev.yml
@@ -94,7 +94,6 @@ paths:
         - $ref: '#/components/parameters/ratanumero_oid-param-exactly-required'
         - $ref: '#/components/parameters/ratakilometri-param'
         - $ref: '#/components/parameters/ratametri-param'
-        - $ref: '#/components/parameters/ratametri_desimaalit-param'
         - $ref: '#/components/parameters/sijaintiraide-param'
         - $ref: '#/components/parameters/sijaintiraide_oid-param'
         - $ref: '#/components/parameters/sijaintiraide_tyyppi-param'
@@ -190,11 +189,10 @@ components:
       type: integer
       description: 'Rataosoitteen ratakilometri'
     ratametri:
-      type: integer
+      oneOf:
+        - type: number
+        - type: integer
       description: 'Rataosoitteen ratametri'
-    ratametri_desimaalit:
-      type: integer
-      description: 'Rataosoitteen ratametrin desimaaliosa'
 
     track-address-to-coordinate:
       type: object
@@ -213,8 +211,6 @@ components:
           $ref: '#/components/schemas/ratakilometri'
         ratametri:
           $ref: '#/components/schemas/ratametri'
-        ratametri_desimaalit:
-          $ref: '#/components/schemas/ratametri_desimaalit'
         sijaintiraide:
           $ref: '#/components/schemas/sijaintiraide'
         sijaintiraide_oid:
@@ -338,13 +334,6 @@ components:
       description: 'Rataosoitteen ratametri'
       schema:
         $ref: '#/components/schemas/ratametri'
-    ratametri_desimaalit-param:
-      name: ratametri_desimaalit
-      in: query
-      required: false
-      description: 'Rataosoitteen ratametrin desimaaliosa'
-      schema:
-        $ref: '#/components/schemas/ratametri_desimaalit'
     geometriatiedot-param:
       name: geometriatiedot
       in: query

--- a/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1.yml
+++ b/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1.yml
@@ -94,7 +94,6 @@ paths:
         - $ref: '#/components/parameters/ratanumero_oid-param-exactly-required'
         - $ref: '#/components/parameters/ratakilometri-param'
         - $ref: '#/components/parameters/ratametri-param'
-        - $ref: '#/components/parameters/ratametri_desimaalit-param'
         - $ref: '#/components/parameters/sijaintiraide-param'
         - $ref: '#/components/parameters/sijaintiraide_oid-param'
         - $ref: '#/components/parameters/sijaintiraide_tyyppi-param'
@@ -190,11 +189,10 @@ components:
       type: integer
       description: 'Rataosoitteen ratakilometri'
     ratametri:
-      type: integer
+      oneOf:
+        - type: number
+        - type: integer
       description: 'Rataosoitteen ratametri'
-    ratametri_desimaalit:
-      type: integer
-      description: 'Rataosoitteen ratametrin desimaaliosa'
 
     track-address-to-coordinate:
       type: object
@@ -213,8 +211,6 @@ components:
           $ref: '#/components/schemas/ratakilometri'
         ratametri:
           $ref: '#/components/schemas/ratametri'
-        ratametri_desimaalit:
-          $ref: '#/components/schemas/ratametri_desimaalit'
         sijaintiraide:
           $ref: '#/components/schemas/sijaintiraide'
         sijaintiraide_oid:
@@ -338,13 +334,6 @@ components:
       description: 'Rataosoitteen ratametri'
       schema:
         $ref: '#/components/schemas/ratametri'
-    ratametri_desimaalit-param:
-      name: ratametri_desimaalit
-      in: query
-      required: false
-      description: 'Rataosoitteen ratametrin desimaaliosa'
-      schema:
-        $ref: '#/components/schemas/ratametri_desimaalit'
     geometriatiedot-param:
       name: geometriatiedot
       in: query

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -1340,29 +1340,6 @@ constructor(
     }
 
     @Test
-    fun `Invalid track address decimals results in an error`() {
-        data class TestTrackAddressToCoordinateRequestWithStringAddress(
-            val ratanumero: String? = null,
-            val ratakilometri: Int? = null,
-            val ratametri: String? = null,
-        ) : FrameConverterTestRequest()
-
-        val request =
-            TestTrackAddressToCoordinateRequestWithStringAddress(
-                ratakilometri = 0,
-                ratametri = "500+-1",
-                ratanumero = testDBService.getUnusedTrackNumber().value,
-            )
-
-        val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
-
-        val expectedErrorMessage =
-            "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen)."
-
-        assertContainsErrorMessage(expectedErrorMessage, featureCollection.features[0].properties?.get("virheet"))
-    }
-
-    @Test
     fun `No multiple search conditions are allowed for track number`() {
         val request =
             TestTrackAddressToCoordinateRequest(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -45,7 +45,6 @@ private data class TestTrackAddressToCoordinateRequest(
     val ratanumero_oid: String? = null,
     val ratakilometri: Int? = null,
     val ratametri: Int? = null,
-    val ratametri_desimaalit: Int? = null,
     val sijaintiraide: String? = null,
     val sijaintiraide_oid: String? = null,
     val sijaintiraide_tyyppi: String? = null,
@@ -1298,6 +1297,12 @@ constructor(
 
     @Test
     fun `Track address to coordinate transformation allows decimals in search`() {
+        data class TestTrackAddressToCoordinateRequestWithDoubleAddress(
+            val ratanumero: String? = null,
+            val ratakilometri: Int? = null,
+            val ratametri: Double? = null,
+        ) : FrameConverterTestRequest()
+
         val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
@@ -1312,14 +1317,13 @@ constructor(
             segments = segments,
         )
 
-        val decimalSearchTests = listOf(0, 123, 400, 999)
+        val decimalSearchTests = listOf(0.0, 0.123, 0.400, 0.999)
 
         decimalSearchTests.forEach { testDecimals ->
             val request =
-                TestTrackAddressToCoordinateRequest(
+                TestTrackAddressToCoordinateRequestWithDoubleAddress(
                     ratakilometri = 0,
-                    ratametri = 500,
-                    ratametri_desimaalit = testDecimals,
+                    ratametri = 500.0 + testDecimals,
                     ratanumero = trackNumberName,
                 )
 
@@ -1328,24 +1332,32 @@ constructor(
             assertEquals(1, featureCollection.features.size)
             assertEquals(0, featureCollection.features[0].properties?.get("ratakilometri"))
             assertEquals(500, featureCollection.features[0].properties?.get("ratametri"))
-            assertEquals(testDecimals, featureCollection.features[0].properties?.get("ratametri_desimaalit"))
+            assertEquals(
+                (testDecimals * 1000).toInt(),
+                featureCollection.features[0].properties?.get("ratametri_desimaalit"),
+            )
         }
     }
 
     @Test
     fun `Invalid track address decimals results in an error`() {
+        data class TestTrackAddressToCoordinateRequestWithStringAddress(
+            val ratanumero: String? = null,
+            val ratakilometri: Int? = null,
+            val ratametri: String? = null,
+        ) : FrameConverterTestRequest()
+
         val request =
-            TestTrackAddressToCoordinateRequest(
+            TestTrackAddressToCoordinateRequestWithStringAddress(
                 ratakilometri = 0,
-                ratametri = 500,
-                ratametri_desimaalit = -1,
+                ratametri = "500+-1",
                 ratanumero = testDBService.getUnusedTrackNumber().value,
             )
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
         val expectedErrorMessage =
-            "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri.ratametri_desimaalit yhdistelmä oli virheellinen)."
+            "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen)."
 
         assertContainsErrorMessage(expectedErrorMessage, featureCollection.features[0].properties?.get("virheet"))
     }


### PR DESCRIPTION
This change should be backwards compatible. The earlier problem with the different field for the decimals is that the user would not be able to specify the scale of the decimal (eg. would the number 1 mean decimal 0.1, 0.001 or something else) -> BigDecimal can just be used directly instead of an int for the track address meters. The user can also choose to submit the field as an int, number or a string and all of these should parsed correctly to the BigDecimal.