### PR TITLE
GVT-3022: Fix improper dependency array for map tool useEffect hook

### DIFF
--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -739,15 +739,13 @@ const MapView: React.FC<MapViewProps> = ({
         setActiveTool(customActiveMapTool);
     }, [customActiveMapTool]);
 
-    const visibleLayerNamesKey = visibleLayers.map((l) => l.name).join();
-
     React.useEffect(() => {
         if (activeTool && olMap) {
             return activeTool.activate(olMap, visibleLayers, toolActivateOptions);
         } else {
             return () => undefined;
         }
-    }, [olMap, activeTool, visibleLayerNamesKey]);
+    }, [olMap, activeTool, visibleLayers]);
 
     React.useEffect(() => {
         if (mapTools && activeTool) {


### PR DESCRIPTION
When map layers are recreated, they may also create new searchItems closures which capture outside state. These closures need to be rebound to event handlers when the outside state of the closures has changed and the closure has been recreated.

For example, in the aligment-linking-layer, a searchItems closure is created. This closure checks if the outside drawLinkingDots state is enabled and potentially immediately returns an empty search result if the linking dots are not drawn:

```
...
return {
    name: layerName,
    layer: layer,
    searchItems: (hitArea: Rectangle, _options: SearchItemsOptions): LayerItemSearchResult => {
        if (!drawLinkingDots) {
            return emptySearchResult();
        } else {
            // Normal search
        }
    },
};
```

In the example above, the drawLinkingDots variable is not an argument to the closure and is bound from the scope above the return statement. 
        
If the drawLinkingDots in the outside state is false during the closure creation, this closure will always return the empty search result when called. 
       
A new closure will have to be created if the normal search is to be used. This also means that if this searchItems closure is used as an event handler, the event handler has to be rebound to call the new closure reference. The re-binding of the event handler did not happen when only the closure was updated for this map layer as the visibleMapLayerNamesKey of the useEffect hook was unmodified even when the searchItems closure was updated (which happens for example when the map is zoomed)

See also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures