### PR TITLE
GVT-3050 Remove memory-leak-inducing duplicate object reference

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
@@ -123,17 +123,13 @@ data class ContextCache(
         location: IPoint,
         thresholdMeters: Double,
     ): LocationTrackCacheHit? {
-        val layoutSegment = getAlignment(segment.alignmentVersion).segments[segment.segmentIndex]
+        val alignment = getAlignment(segment.alignmentVersion)
+        val layoutSegment = alignment.segments[segment.segmentIndex]
         val closestPointM = layoutSegment.getClosestPointM(location).first
         val closestPoint = layoutSegment.seekPointAtM(closestPointM).point
         val distance = lineLength(location, closestPoint)
         return if (distance < thresholdMeters) {
-            LocationTrackCacheHit(
-                getTrack(segment.locationTrackVersion),
-                getAlignment(segment.alignmentVersion),
-                closestPoint,
-                distance,
-            )
+            LocationTrackCacheHit(getTrack(segment.locationTrackVersion), alignment, closestPoint, distance)
         } else {
             null
         }


### PR DESCRIPTION
LocationTrackSpatialCache virkistetään laiskasti sen perusteella, onko versiotiedon perusteella tietoja muuttunut; mutta segmentGeometryCachen virkistyksessä luodaan aina kaikki oliot uusiksi. Kun molemmissa on suorat olioviittaukset segmenttien geometriatietoihin, kakkujen ensimmäisen virkistyksen jälkeen tällöin jälkimmäiseen tulee uudet instanssit olioista, mutta edelliseen jää elämään alkuperäiset, ja tällöin segmenttigeometrioiden muistinkäyttö käytännössä kaksinkertaistuu.

Korjausmahdollisuuksia on useampi, mutta eihän konseptitasolla tätä tietoa haluta duplikoida lainkaan, kun tietoon voidaan viitata tunnisteella. Kai tästä jokin pari epäsuoraa muistiviittausta tulee lisää, mutta perffin suhteen näkee myöt heti, että olemmissa paikoissa, joihin on lisätty getAlignment-kutsu, tehdään muutenkin myös selvästi huomattavasti kalliimpiakin operaatioita.