### PR TITLE
GVT-3050 Use common alignment cache in locationTrackSpatialCache + redo transaction boundaries

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -17,7 +17,6 @@ import kotlin.math.abs
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 const val ALIGNMENT_CACHE_SIZE = 10000L
@@ -31,7 +30,6 @@ data class MapSegmentProfileInfo<T>(
     val hasProfile: Boolean,
 )
 
-@Transactional(readOnly = true)
 @Component
 class LayoutAlignmentDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
@@ -46,11 +44,10 @@ class LayoutAlignmentDao(
 
     fun fetchVersions() = fetchRowVersions<LayoutAlignment>(LAYOUT_ALIGNMENT)
 
-    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
     fun fetch(alignmentVersion: RowVersion<LayoutAlignment>): LayoutAlignment =
         if (cacheEnabled) alignmentsCache.get(alignmentVersion, ::fetchInternal) else fetchInternal(alignmentVersion)
 
-    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+    @Transactional(readOnly = true)
     fun fetchMany(versions: List<RowVersion<LayoutAlignment>>): Map<RowVersion<LayoutAlignment>, LayoutAlignment> =
         versions.associateWith(::fetch)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDao.kt
@@ -30,7 +30,6 @@ import fi.fta.geoviite.infra.util.setUser
 import java.sql.Timestamp
 import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 interface LayoutAssetWriter<T : LayoutAsset<T>> {
@@ -45,7 +44,6 @@ interface LayoutAssetWriter<T : LayoutAsset<T>> {
     fun deleteDrafts(branch: LayoutBranch): List<LayoutRowVersion<T>>
 }
 
-@Transactional(readOnly = true)
 interface LayoutAssetReader<T : LayoutAsset<T>> {
     fun fetch(version: LayoutRowVersion<T>): T
 
@@ -69,25 +67,29 @@ interface LayoutAssetReader<T : LayoutAsset<T>> {
 
     fun fetchOfficialVersionAtMoment(branch: LayoutBranch, id: IntId<T>, moment: Instant): LayoutRowVersion<T>?
 
+    @Transactional(readOnly = true)
     fun get(context: LayoutContext, id: IntId<T>): T? = fetchVersion(context, id)?.let(::fetch)
 
+    @Transactional(readOnly = true)
     fun getOrThrow(context: LayoutContext, id: IntId<T>): T = fetch(fetchVersionOrThrow(context, id))
 
+    @Transactional(readOnly = true)
     fun getOfficialAtMoment(branch: LayoutBranch, id: IntId<T>, moment: Instant): T? =
         fetchOfficialVersionAtMoment(branch, id, moment)?.let(::fetch)
 
+    @Transactional(readOnly = true)
     fun getMany(context: LayoutContext, ids: List<IntId<T>>): List<T> = fetchVersions(context, ids).map(::fetch)
 
+    @Transactional(readOnly = true)
     fun list(context: LayoutContext, includeDeleted: Boolean): List<T> =
         fetchVersions(context, includeDeleted).map(::fetch)
 }
 
 interface ILayoutAssetDao<T : LayoutAsset<T>> : LayoutAssetReader<T>, LayoutAssetWriter<T>
 
-@Transactional(readOnly = true)
 abstract class LayoutAssetDao<T : LayoutAsset<T>>(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
-    val table: LayoutAssetTable,
+    open val table: LayoutAssetTable,
     val cacheEnabled: Boolean,
     cacheSize: Long,
 ) : DaoBase(jdbcTemplateParam), ILayoutAssetDao<T> {
@@ -95,7 +97,6 @@ abstract class LayoutAssetDao<T : LayoutAsset<T>>(
     protected val cache: Cache<LayoutRowVersion<T>, T> =
         Caffeine.newBuilder().maximumSize(cacheSize).expireAfterAccess(layoutCacheDuration).build()
 
-    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
     override fun fetch(version: LayoutRowVersion<T>): T =
         if (cacheEnabled) {
             cache.get(version, ::fetchInternal)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -29,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional
 
 const val KM_POST_CACHE_SIZE = 10000L
 
-@Transactional(readOnly = true)
 @Component
 class LayoutKmPostDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
@@ -45,6 +44,7 @@ class LayoutKmPostDao(
     override fun fetchVersions(layoutContext: LayoutContext, includeDeleted: Boolean) =
         fetchVersions(layoutContext, includeDeleted, null, null)
 
+    @Transactional(readOnly = true)
     fun list(
         layoutContext: LayoutContext,
         includeDeleted: Boolean,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -43,7 +43,6 @@ import org.springframework.transaction.annotation.Transactional
 const val SWITCH_CACHE_SIZE = 10000L
 
 @Suppress("SameParameterValue")
-@Transactional(readOnly = true)
 @Component
 class LayoutSwitchDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -29,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional
 
 const val TRACK_NUMBER_CACHE_SIZE = 1000L
 
-@Transactional(readOnly = true)
 @Component
 class LayoutTrackNumberDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
@@ -51,6 +50,7 @@ class LayoutTrackNumberDao(
     override fun fetchVersions(layoutContext: LayoutContext, includeDeleted: Boolean) =
         fetchVersions(layoutContext, includeDeleted, null)
 
+    @Transactional(readOnly = true)
     fun list(layoutContext: LayoutContext, trackNumber: TrackNumber): List<LayoutTrackNumber> =
         fetchVersions(layoutContext, false, trackNumber).map(::fetch)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -36,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional
 
 const val LOCATIONTRACK_CACHE_SIZE = 10000L
 
-@Transactional(readOnly = true)
 @Component
 class LocationTrackDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,
@@ -397,6 +396,7 @@ class LocationTrackDao(
         }
     }
 
+    @Transactional(readOnly = true)
     fun listNear(context: LayoutContext, bbox: BoundingBox): List<LocationTrack> =
         fetchVersionsNear(context, bbox).map(::fetch)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.infra.tracklayout
 
-import LazyMap
 import com.github.davidmoten.rtree2.RTree
 import com.github.davidmoten.rtree2.geometry.Geometries
 import com.github.davidmoten.rtree2.geometry.Rectangle
@@ -55,12 +54,7 @@ constructor(
 
         val newItems = newTracks.map { (id, track) -> id to (currentTracks[id] ?: addEntry(track)) }
 
-        return ContextCache(
-            LazyMap(locationTrackDao::fetch)::get,
-            LazyMap(alignmentDao::fetch)::get,
-            newNet,
-            newItems.toMap(),
-        )
+        return ContextCache(locationTrackDao::fetch, alignmentDao::fetch, newNet, newItems.toMap())
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional
 
 const val REFERENCE_LINE_CACHE_SIZE = 1000L
 
-@Transactional(readOnly = true)
 @Component
 class ReferenceLineDao(
     jdbcTemplateParam: NamedParameterJdbcTemplate?,


### PR DESCRIPTION
Varsinainen :cut_of_meat: tässä on LazyMappien poisto LocationTrackSpatialCachesta, niistä tärkeämpänä alignmentDao#fetch()in edessä elävä: Siihen kertyi hakujen tekemisen myötä alignmenteista (ja siten niiden paljon muistia vievistä geometrioista) ne instanssit, jotka alignmentDao sattui hakuhetkellä palauttamaan, mutta alignmentDaon cachen virkistyshän sitten luo myöhemmin uudet instanssit edustamaan samoja alignmentteja, ja siten sama iso määrä tietoa on edustettuna muistissa useamman kerran.

Siinäkin tapauksessa, että näin ei olisi, niin onhan tuo LazyMap muutenkin väärä olio cachen ylläpitoon, koska siihen jää myös oikeasti vanhat versiot olioista olemaan koko softan ajoajaksi.

Mutta alkuperäinen syy, miksi tuota LazyMappia tarvittiin, oli että alignmentDao#fetch()issä hyppääminen aiheutti transaktiorajan ylittämisen, siinäkin normaalitapauksessa että olio kyllä löytyy cachesta; ja siihenkös aikaa menee. Säädin siksi transaktiorajat uusiksi niin, että kaikki layout-olioiden daojen transaktionaalisuus on asetettu vain metoditasolla, ei luokka- eikä rajapintatasolla. Tämä siis yhdenmukaisuuden nimissä kaikille LayoutAssetDaoille, ei vain LocationTrackDaolle ja AlignmentDaolle. Jätin suurimman osan sellaisista metodeista, joissa tehdään vain yksi tai kaksi hakua, transaktioimattomiksi: Niiden transaktiorajojenhan (ja kyllä muidenkin) pitäisi muutenkin olla mieluummin service-tasolla.

locationTrackSpatialCachen perffi on tämän jälkeen yhä hyvä. En mitannut hirveän tarkkaan, mutta tuhannen Ilmalan ratapihan pisteen hakuun VKM:llä meni yhä noin 0.3 sekuntia kuin ennenkin.