### PR TITLE
General: De-overload interpolate() methods + optimize call

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -17,7 +17,8 @@ import fi.fta.geoviite.infra.math.Line
 import fi.fta.geoviite.infra.math.angleAvgRads
 import fi.fta.geoviite.infra.math.angleDiffRads
 import fi.fta.geoviite.infra.math.directionBetweenPoints
-import fi.fta.geoviite.infra.math.interpolate
+import fi.fta.geoviite.infra.math.interpolateToPoint
+import fi.fta.geoviite.infra.math.interpolateToSegmentPoint
 import fi.fta.geoviite.infra.math.isSame
 import fi.fta.geoviite.infra.math.lineIntersection
 import fi.fta.geoviite.infra.math.lineLength
@@ -827,11 +828,11 @@ data class PolyLineEdge(
         }
 
     private fun interpolatePointAtM(m: Double): IPoint =
-        if (m <= startM) start else if (m >= endM) end else interpolate(start.toPoint(), end, (m - startM) / length)
+        if (m <= startM) start else if (m >= endM) end else interpolateToPoint(start, end, (m - startM) / length)
 
     fun interpolateAlignmentPointAtPortion(portion: Double): AlignmentPoint =
         interpolateSegmentPointAtPortion(portion).toAlignmentPoint(segmentStart)
 
     fun interpolateSegmentPointAtPortion(portion: Double): SegmentPoint =
-        if (portion <= 0.0) start else if (portion >= 1.0) end else interpolate(start, end, portion)
+        if (portion <= 0.0) start else if (portion >= 1.0) end else interpolateToSegmentPoint(start, end, portion)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Line.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Line.kt
@@ -32,7 +32,7 @@ fun closestPointOnLine(start: IPoint, end: IPoint, target: IPoint): Point {
     return when {
         portion < 0 -> Point(start.x, start.y)
         portion > 1 -> Point(end.x, end.y)
-        else -> interpolate(start, end, portion)
+        else -> interpolateToPoint(start, end, portion)
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Math.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Math.kt
@@ -38,10 +38,10 @@ fun interpolate(value1: Double, value2: Double, portion: Double): Double =
     if (value1.isFinite() && value2.isFinite()) value1 + (value2 - value1) * portion
     else throw IllegalArgumentException("Cannot interpolate between $value1 and $value2")
 
-fun interpolate(value1: IPoint, value2: IPoint, portion: Double): Point =
+fun interpolateToPoint(value1: IPoint, value2: IPoint, portion: Double): Point =
     Point(x = interpolate(value1.x, value2.x, portion), y = interpolate(value1.y, value2.y, portion))
 
-fun interpolate(value1: SegmentPoint, value2: SegmentPoint, portion: Double) =
+fun interpolateToSegmentPoint(value1: SegmentPoint, value2: SegmentPoint, portion: Double) =
     SegmentPoint(
         x = interpolate(value1.x, value2.x, portion),
         y = interpolate(value1.y, value2.y, portion),
@@ -50,7 +50,7 @@ fun interpolate(value1: SegmentPoint, value2: SegmentPoint, portion: Double) =
         cant = interpolate(value1.cant, value2.cant, portion),
     )
 
-fun interpolate(value1: AlignmentPoint, value2: AlignmentPoint, portion: Double) =
+fun interpolateToAlignmentPoint(value1: AlignmentPoint, value2: AlignmentPoint, portion: Double) =
     AlignmentPoint(
         x = interpolate(value1.x, value2.x, portion),
         y = interpolate(value1.y, value2.y, portion),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -32,6 +32,7 @@ import fi.fta.geoviite.infra.math.boundingBoxCombining
 import fi.fta.geoviite.infra.math.closestPointProportionOnLine
 import fi.fta.geoviite.infra.math.directionBetweenPoints
 import fi.fta.geoviite.infra.math.interpolate
+import fi.fta.geoviite.infra.math.interpolateToSegmentPoint
 import fi.fta.geoviite.infra.math.isSame
 import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.math.pointDistanceToLine
@@ -341,7 +342,7 @@ interface ISegmentGeometry {
                     PointSeekResult(pointAfter, indexAfter, true)
                 } else {
                     val portion = (segmentM - pointBefore.m) / (pointAfter.m - pointBefore.m)
-                    PointSeekResult(interpolate(pointBefore, pointAfter, portion), indexAfter, false)
+                    PointSeekResult(interpolateToSegmentPoint(pointBefore, pointAfter, portion), indexAfter, false)
                 }
             } ?: PointSeekResult(pointAfter, indexAfter, true)
         }


### PR DESCRIPTION
Nimet selkiytetty, katsoin järkevimmäksi nimetä metodit paluuarvon tyypin perusteella, koska onhan ihan mahdollista että halutaan interpoloida kahden SegmentPointin väliltä Point. Selkiytyksellä vältetään yksi SegmentPoint#toPoint()-kutsu geokoodauksessa.