### PR TITLE
General: Optimize height transformation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTransformation.kt
@@ -21,7 +21,7 @@ fun transformHeightValue(
     return when (verticalCoordinateSystem) {
         VerticalCoordinateSystem.N2000 -> height
         VerticalCoordinateSystem.N60 -> {
-            val triangle = heightTriangles.find { t -> t.contains(point) }
+            val triangle = findHeightTriangleContainingPoint(heightTriangles, point)
             if (triangle != null) interpolateHeightAtGivenPoint(triangle, point, height)
             else {
                 fi.fta.geoviite.infra.inframodel.logger.error("triangles=$heightTriangles point=$point")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTriangle.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/HeightTriangle.kt
@@ -12,10 +12,15 @@ data class HeightTriangle(
     val corner2Diff: Double,
     val corner3Diff: Double,
 ) {
-    private val polygon by lazy { toJtsGeoPolygon(listOf(corner1, corner2, corner3, corner1), LAYOUT_SRID) }
+    internal val polygon by lazy { toJtsGeoPolygon(listOf(corner1, corner2, corner3, corner1), LAYOUT_SRID) }
     val corner1XZ: Point by lazy { Point(corner1.x, corner1Diff) }
     val corner2XZ: Point by lazy { Point(corner2.x, corner2Diff) }
     val corner3XZ: Point by lazy { Point(corner3.x, corner3Diff) }
 
     fun contains(point: IPoint) = polygon.intersects(toJtsGeoPoint(point, LAYOUT_SRID))
+}
+
+fun findHeightTriangleContainingPoint(triangles: List<HeightTriangle>, point: IPoint): HeightTriangle? {
+    val jtsPoint = toJtsGeoPoint(point, LAYOUT_SRID)
+    return triangles.find { triangle -> triangle.polygon.intersects(jtsPoint) }
 }


### PR DESCRIPTION
Pikkuoptimointi tähän hommaan, muiden optimointien jälkeen kun alkoi tuo toJtsGeoPoint näkymään yllättävän paljon profiileissa. Enemmänkin voisi optimoinnin vuoksi tehdä, mutta itse asiassa ihan äkkiseltään ei ollut näkyvää hyötyä esim. kolmioverkon työntämisestä R-puuhun (ehkä käytin sitä jollain tavalla väärin). 