### PR TITLE
GVT-3038 Optimize getTrackLocations() use in loading vertical geometries

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Either.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/Either.kt
@@ -88,13 +88,9 @@ fun <T, ValidInput, ErrorOrProcessedResult> processRights(
     process: (input: List<ValidInput>) -> List<ErrorOrProcessedResult>,
 ): List<ErrorOrProcessedResult> = processPartitioned(values, extractSide, { it }, process)
 
-fun <T, ProcessableInput, Result> processNonNulls(
-    values: List<T>,
-    extractProcessable: (value: T) -> ProcessableInput?,
-    process: (input: List<ProcessableInput>) -> List<Result>,
-): List<Result?> =
-    processRights(
-        values,
-        { value -> extractProcessable(value).let { if (it == null) Left(null) else Right(it) } },
-        process,
-    )
+/**
+ * Call process() only on the non-null values of the input list, but put the nulls back in their original positions
+ * afterward. process must return a list of the same length as it was passed.
+ */
+fun <T, Result> processNonNulls(values: List<T?>, process: (input: List<T>) -> List<Result>): List<Result?> =
+    processRights(values, { value -> if (value == null) Left(null) else Right(value) }, process)


### PR DESCRIPTION
getTrackLocations()in optimoinnin mahdollistamia juttuja. Ei funktionaalisia muutoksia, mutta geokoodauksen siirtäminen yhteen nopeaa algoritmia käyttämään pompsiin nopeuttaa tätä funktiota niin paljon, että rinnakkaistus ei enää käytännössä tee mitään.