### PR TITLE
GVT-3038/GVT-3064 Adapt KmHeights to getTrackLocations()s behavior better

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
@@ -4,10 +4,15 @@ import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.ElevationMeasurementMethod
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
+import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.map.AlignmentHeader
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.util.FileName
+
+data class KmTicks(val kmNumber: KmNumber, val ticks: List<TrackMeterTick>, val endM: Double)
+
+data class TrackMeterTick(val addressPoint: AddressPoint, val segmentIndex: Int?)
 
 data class TrackMeterHeight(val m: Double, val meter: Double, val height: Double?, val point: Point)
 


### PR DESCRIPTION
Kaksi oleellista muutosta:

- collectTrackMeterHeights()in rajapintaa on yksinkertaistettu, periaatteessa aika huomattavasti. Voisi yksinkertaistaa vielä pitemmällekin, nimittäin tämä koodihan ei lopulta oikeastaan liity millään tavalla suoraan noihin pystygeometrioihin, vaan ainoastaan geokoodaukseen, siis niin, että se se hakkaa raiteen sopivan näppärän tasaisena kaaviolla näkyviin pisteisiin tasametripisteiden kohdalla (ja geometrioiden muutoskohdilla). Varsinainen korkeuksien hakeminen on sitten täysin asia erikseen.
- Se oletus, että kyllä kaikki raiteen alku- ja loppuosoitteen väliset osoitteet löytyy raiteelta, on poistettu, koska sehän tosiaan ei nykyisellä geokoodauksen toimintaperiaatteella ole totta. Tämä oli bugi GVT-3064.

Rajapinnan yksinkertaistaminen on sitten mahdollistanut sen, että varsinainen kallis asia eli tuo korkeuksien hakeminen saadaan rinnakkaistettua. Tosin siinäkin kallein osa on oikean kolmion löytäminen kolmioverkosta, missä https://github.com/finnishtransportagency/geoviite/pull/1720 auttaa jonkin verran, mutta ei niin paljoa, ettei se näkyisi profiilissa yhä isoimpana toimena.