### PR TITLE
GVT-3038 Reimplement geometry changes summarization with getAddressPoints

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -37,6 +37,7 @@ import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import fi.fta.geoviite.infra.util.Either
 import fi.fta.geoviite.infra.util.Left
 import fi.fta.geoviite.infra.util.Right
+import fi.fta.geoviite.infra.util.getIndexRangeForRangeInOrderedList
 import fi.fta.geoviite.infra.util.processRights
 import fi.fta.geoviite.infra.util.processSortedBy
 import java.math.BigDecimal
@@ -612,22 +613,6 @@ fun splitRange(range: ClosedRange<TrackMeter>, splits: List<ClosedRange<TrackMet
         if (range.start >= allowedRange.endInclusive || range.endInclusive <= allowedRange.start) null
         else maxOf(range.start, allowedRange.start)..minOf(range.endInclusive, allowedRange.endInclusive)
     }
-
-fun <T, R : Comparable<R>> getIndexRangeForRangeInOrderedList(
-    things: List<T>,
-    rangeStart: R,
-    rangeEnd: R,
-    compare: (thing: T, rangeEnd: R) -> Int,
-): IntRange? {
-    if (rangeEnd < rangeStart) {
-        return null
-    }
-    val startInsertionPoint = things.binarySearch { t -> compare(t, rangeStart) }
-    val endInsertionPoint = things.binarySearch { t -> compare(t, rangeEnd) }
-    val start = if (startInsertionPoint < 0) -startInsertionPoint - 1 else startInsertionPoint
-    val end = if (endInsertionPoint < 0) -endInsertionPoint - 2 else endInsertionPoint
-    return start..end
-}
 
 fun <T, R : Comparable<R>> getSublistForRangeInOrderedList(
     things: List<T>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
@@ -5,8 +5,8 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingReferencePoint
-import fi.fta.geoviite.infra.geocoding.getIndexRangeForRangeInOrderedList
 import fi.fta.geoviite.infra.tracklayout.IAlignment
+import fi.fta.geoviite.infra.util.getIndexRangeForRangeInOrderedList
 import fi.fta.geoviite.infra.util.processFlattened
 import java.math.BigDecimal
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 private const val GEOMETRY_CHANGE_BATCH_SIZE = 10
-private const val MINIMUM_M_DISTANCE_SEPARATING_ALIGNMENT_CHANGE_SUMMARIES = 10.0
 
 @Component
 class PublicationGeometryChangeRemarksUpdateService(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationGeometryChangeRemarksUpdateService.kt
@@ -1,19 +1,18 @@
 package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.geocoding.AddressPoint
+import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
-import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.integration.DatabaseLock
 import fi.fta.geoviite.infra.integration.LockDao
-import fi.fta.geoviite.infra.math.IPoint
-import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
-import fi.fta.geoviite.infra.tracklayout.LayoutSegment
+import fi.fta.geoviite.infra.util.findCommonSubsequenceInCompactLists
 import fi.fta.geoviite.infra.util.rangesOfConsecutiveIndicesOf
 import java.time.Duration
-import kotlin.math.hypot
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -79,85 +78,80 @@ class PublicationGeometryChangeRemarksUpdateService(
     }
 }
 
-private data class ComparisonPoints(
-    val mOnReferenceLine: Double,
-    val oldPointIndex: Int,
-    val oldPoint: IPoint,
-    val newPoint: IPoint,
-) {
-    val roughDistance = hypot(oldPoint.x - newPoint.x, oldPoint.y - newPoint.y)
-
-    fun distance() = calculateDistance(LAYOUT_SRID, oldPoint, newPoint)
-}
-
-private fun getChangedAlignmentRanges(old: LayoutAlignment, new: LayoutAlignment): List<List<LayoutSegment>> {
-    val newIndexByGeometryId =
-        new.segments.mapIndexed { i, s -> i to s }.associate { (index, segment) -> segment.geometry.id to index }
-    val changedOldSegmentIndexRanges =
-        rangesOfConsecutiveIndicesOf(
-            false,
-            old.segments.map { segment -> newIndexByGeometryId.containsKey(segment.geometry.id) },
-        )
-    return changedOldSegmentIndexRanges.map { oldSegmentIndexRange ->
-        old.segments.subList(oldSegmentIndexRange.start, oldSegmentIndexRange.endInclusive + 1)
-    }
-}
-
 fun summarizeAlignmentChanges(
     geocodingContext: GeocodingContext,
     oldAlignment: LayoutAlignment,
     newAlignment: LayoutAlignment,
     changeThreshold: Double = 1.0,
-): List<GeometryChangeSummary> {
-    val changedRanges = getChangedAlignmentRanges(oldAlignment, newAlignment)
-    return changedRanges
-        .mapNotNull { oldSegments ->
-            val oldPoints = oldSegments.flatMap { segment -> segment.segmentPoints }
-            val changedPoints =
-                oldPoints
-                    .mapIndexed { index, oldPoint -> index to oldPoint }
-                    .parallelStream()
-                    .map { (index, oldPoint) ->
-                        geocodingContext.getAddressAndM(oldPoint)?.let { (address, mOnReferenceLine) ->
-                            geocodingContext
-                                .getTrackLocation(newAlignment, address)
-                                ?.let { newAddressPoint ->
-                                    ComparisonPoints(mOnReferenceLine, index, oldPoint, newAddressPoint.point)
-                                }
-                                ?.let { comparison ->
-                                    if (comparison.roughDistance < changeThreshold) null else comparison
-                                }
-                        }
-                    }
-                    .toList()
-                    .filterNotNull()
-            val changedPointsRangesFirstIndices =
-                changedPoints
-                    .zipWithNext { a, b ->
-                        b.mOnReferenceLine - a.mOnReferenceLine >
-                            MINIMUM_M_DISTANCE_SEPARATING_ALIGNMENT_CHANGE_SUMMARIES
-                    }
-                    .mapIndexedNotNull { index, jump -> (index + 1).takeIf { jump } }
-            val changedPointsRanges =
-                (listOf(0) + changedPointsRangesFirstIndices + changedPoints.size).zipWithNext { a, b -> a to b }
+): List<GeometryChangeSummary> =
+    if (geometriesEqual(oldAlignment, newAlignment)) listOf()
+    else
+        getCommonAddressRange(geocodingContext, oldAlignment, newAlignment)?.let { (oldPoints, newPoints) ->
+            summarizeCommonAddressRange(geocodingContext, oldPoints, newPoints, changeThreshold)
+        } ?: listOf()
 
-            if (changedPoints.isEmpty()) null
-            else
-                changedPointsRanges.mapNotNull { (from, to) ->
-                    val start = changedPoints[from]
-                    val end = changedPoints[to - 1]
-                    val startAddress = geocodingContext.getAddress(oldPoints[start.oldPointIndex])?.first
-                    val endAddress = geocodingContext.getAddress(oldPoints[end.oldPointIndex])?.first
+private fun geometriesEqual(old: LayoutAlignment, new: LayoutAlignment): Boolean =
+    old.segments.map { it.geometry.id } == new.segments.map { it.geometry.id }
 
-                    if (startAddress == null || endAddress == null) null
-                    else
-                        GeometryChangeSummary(
-                            end.mOnReferenceLine - start.mOnReferenceLine,
-                            changedPoints.subList(from, to).maxByOrNull { it.roughDistance }?.distance() ?: 0.0,
-                            startAddress,
-                            endAddress,
-                        )
-                }
-        }
+private fun getCommonAddressRange(
+    geocodingContext: GeocodingContext,
+    oldAlignment: LayoutAlignment,
+    newAlignment: LayoutAlignment,
+): Pair<List<AddressPoint>, List<AddressPoint>>? {
+    val oldAddressPoints = geocodingContext.getAddressPoints(oldAlignment)
+    val newAddressPoints = geocodingContext.getAddressPoints(newAlignment)
+    if (oldAddressPoints == null || newAddressPoints == null) return null
+
+    val (old, new) = getOldAndNewAddressPoints(oldAddressPoints, newAddressPoints)
+    return findCommonSubsequenceInCompactLists(old.map { it.address }, new.map { it.address })?.let {
+        (oldInNew, newInOld) ->
+        old.slice(newInOld) to new.slice(oldInNew)
+    }
+}
+
+private fun getOldAndNewAddressPoints(
+    oldAddressPoints: AlignmentAddresses,
+    newAddressPoints: AlignmentAddresses,
+): Pair<List<AddressPoint>, List<AddressPoint>> {
+    val takeStart = oldAddressPoints.startPoint.address == newAddressPoints.startPoint.address
+    val takeEnd = oldAddressPoints.endPoint.address == newAddressPoints.endPoint.address
+
+    return withEnds(oldAddressPoints, takeStart, takeEnd) to withEnds(newAddressPoints, takeStart, takeEnd)
+}
+
+private fun withEnds(addressPoints: AlignmentAddresses, takeStart: Boolean, takeEnd: Boolean) =
+    listOf(
+            if (takeStart) listOf(addressPoints.startPoint) else listOf(),
+            addressPoints.midPoints,
+            if (takeEnd) listOf(addressPoints.endPoint) else listOf(),
+        )
         .flatten()
+
+private fun summarizeCommonAddressRange(
+    geocodingContext: GeocodingContext,
+    oldPoints: List<AddressPoint>,
+    newPoints: List<AddressPoint>,
+    changeThreshold: Double,
+): List<GeometryChangeSummary> =
+    rangesOfConsecutiveIndicesOf(
+            true,
+            oldPoints.zip(newPoints) { old, new -> lineLength(old.point, new.point) >= changeThreshold },
+        )
+        .map { range -> summarizeChangedRange(geocodingContext, oldPoints.slice(range), newPoints.slice(range)) }
+
+private fun summarizeChangedRange(
+    geocodingContext: GeocodingContext,
+    oldPoints: List<AddressPoint>,
+    newPoints: List<AddressPoint>,
+): GeometryChangeSummary {
+    val rangeStartAddress = oldPoints.first().address
+    val rangeEndAddress = oldPoints.last().address
+    val rangeStartMOnReferenceLine = requireNotNull(geocodingContext.getProjectionLine(rangeStartAddress)).distance
+    val rangeEndMOnReferenceLine = requireNotNull(geocodingContext.getProjectionLine(rangeEndAddress)).distance
+    val changeLengthM = rangeEndMOnReferenceLine - rangeStartMOnReferenceLine
+
+    val maxDistance =
+        oldPoints.zip(newPoints) { oldPoint, newPoint -> lineLength(oldPoint.point, newPoint.point) }.max()
+
+    return GeometryChangeSummary(changeLengthM, maxDistance, rangeStartAddress, rangeEndAddress)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
@@ -7,11 +7,7 @@ fun <T : Comparable<T>> nullsLastComparator(a: T?, b: T?) =
 fun <T : Comparable<T>> nullsFirstComparator(a: T?, b: T?) =
     if (a == null && b == null) 0 else if (a == null) -1 else if (b == null) 1 else a.compareTo(b)
 
-fun rangesOfConsecutiveIndicesOf(
-    value: Boolean,
-    ts: List<Boolean>,
-    offsetRangeEndsBy: Int = 0,
-): List<ClosedRange<Int>> =
+fun rangesOfConsecutiveIndicesOf(value: Boolean, ts: List<Boolean>, offsetRangeEndsBy: Int = 0): List<IntRange> =
     sequence {
             yield(!value)
             yieldAll(ts.asSequence())
@@ -22,6 +18,21 @@ fun rangesOfConsecutiveIndicesOf(
         .chunked(2)
         .map { c -> c[0] until c[1] + offsetRangeEndsBy }
         .toList()
+
+/**
+ * "Compact list" = lists containing all values between their endpoints, in order. Generally this is meant for the
+ * address points of different alignments in the same geocoding context.
+ */
+fun <T : Comparable<T>> findCommonSubsequenceInCompactLists(a: List<T>, b: List<T>): Pair<IntRange, IntRange>? {
+    if (a.isEmpty() || b.isEmpty()) return null
+
+    val aInB = getIndexRangeForRangeInOrderedList(b, a.first(), a.last(), Comparator.naturalOrder<T>()::compare)
+    val bInA = getIndexRangeForRangeInOrderedList(a, b.first(), b.last(), Comparator.naturalOrder<T>()::compare)
+
+    return if (aInB != null && bInA != null) {
+        aInB to bInA
+    } else null
+}
 
 fun <T> chunkBySizes(list: List<T>, sizes: List<Int>): List<List<T>> {
     val starts = sizes.scan(0) { acc, size -> acc + size }
@@ -48,4 +59,20 @@ fun <T, R> processSortedBy(list: List<T>, comparator: Comparator<T>, process: (l
     withOriginalIndices.forEachIndexed { index, (originalIndex) -> rv[originalIndex] = processed[index] }
     @Suppress("UNCHECKED_CAST")
     return rv as List<R>
+}
+
+fun <T, R : Comparable<R>> getIndexRangeForRangeInOrderedList(
+    things: List<T>,
+    rangeStart: R,
+    rangeEnd: R,
+    compare: (thing: T, rangeEnd: R) -> Int,
+): IntRange? {
+    if (rangeEnd < rangeStart) {
+        return null
+    }
+    val startInsertionPoint = things.binarySearch { t -> compare(t, rangeStart) }
+    val endInsertionPoint = things.binarySearch { t -> compare(t, rangeEnd) }
+    val start = if (startInsertionPoint < 0) -startInsertionPoint - 1 else startInsertionPoint
+    val end = if (endInsertionPoint < 0) -endInsertionPoint - 2 else endInsertionPoint
+    return start..end
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/RemarksUpdaterServiceTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/RemarksUpdaterServiceTest.kt
@@ -28,7 +28,7 @@ class RemarksUpdaterServiceTest {
     }
 
     @Test
-    fun `summarizeAlignmentChanges detects multiple changes based on segment identity match`() {
+    fun `summarizeAlignmentChanges detects multiple changes on different segments`() {
         val oldAlignment =
             alignment(
                 ((0..4).map { segmentIx ->
@@ -46,10 +46,10 @@ class RemarksUpdaterServiceTest {
 
         val result = summarizeAlignmentChanges(xAxisGeocodingContext(), oldAlignment, newAlignment)
         assertEquals(2, result.size)
-        assertEquals(1.4, result[0].maxDistance, 0.1)
+        assertEquals(1.5, result[0].maxDistance, 0.1)
         assertEquals(2.0, result[0].changedLengthM)
-        assertEquals(5.0, result[1].maxDistance, 0.1)
-        assertEquals(5.0, result[1].changedLengthM)
+        assertEquals(4.0, result[1].maxDistance, 0.1)
+        assertEquals(4.0, result[1].changedLengthM)
     }
 
     @Test


### PR DESCRIPTION
Uusi geometriamuutosten laskenta tuo nyt kylläkin tuloksiin muutoksia, mutta sikäli kuin niiden vaikutusta kävin läpi prosessoimalla vaan koko julkaisuhistorian uudestaan läpi, uusi toteutus toimi kyllä vaan ainoastaan paremmin kuin entinen.

Entinen toteutus siis käveli raiteen vanhan version segmenttipisteitä, haki jokaiselle käänteisellä geokoodauksella osoitteen, geokoodasi osoitteet raiteen uudelle versiolle, ja sitten vertasi näiden sijainteja. Tämä on siis sekä erinomaisen hidas että jo ihan logiikaltaan aika änkyrä, koska geokoodaukset tehdään raiteen vanhalle ja uudelle versiolle eri suuntaan.

Uusi toteutus yksinkertaisesti hakee vaan molempien versioiden osoitepisteet ja vertaa niiden osoitteiltaan yhteistä väliä. Heitin myös tarkan etäisyyden laskennan pois, kun tässä joka tapauksessa historian pisin siirtymä on ollut 157 metriä, eli siinäpä ei maapallon pinta kerkiä paljoa kaartua.