### PR TITLE
GVT-3052: Suunnitelman soveltuvuus -tietoa ei voi asettaa "Ei tiedossa"-arvoon inframallilomakkeen kautta

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -240,7 +240,7 @@ constructor(
             planTime = overrideParameters?.createdDate ?: plan.planTime,
             uploadTime = plan.uploadTime,
             source = overrideParameters?.source ?: plan.source,
-            planApplicability = extraInfoParameters?.planApplicability ?: plan.planApplicability,
+            planApplicability = extraInfoParameters?.planApplicability,
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelServiceIT.kt
@@ -138,7 +138,7 @@ constructor(val infraModelService: InfraModelService, val geometryDao: GeometryD
                 elevationMeasurementMethod = ElevationMeasurementMethod.TOP_OF_SLEEPER,
                 message = FreeTextWithNewLines.of("test message 2"),
                 name = PlanName("test name 2"),
-                planApplicability = PlanApplicability.MAINTENANCE,
+                planApplicability = null,
             )
 
         val planId = infraModelService.saveInfraModel(file, overrides1, extraInfo1).id
@@ -247,5 +247,6 @@ constructor(val infraModelService: InfraModelService, val geometryDao: GeometryD
         assertEquals(extraInfo.measurementMethod, plan.measurementMethod)
         assertEquals(extraInfo.elevationMeasurementMethod, plan.elevationMeasurementMethod)
         assertEquals(extraInfo.message, plan.message)
+        assertEquals(extraInfo.planApplicability, plan.planApplicability)
     }
 }


### PR DESCRIPTION
Luulin että tämä olisi ollut isompikin työmaa, mutta menikin lopulta yllättävän kohtuuella. `PlanApplicability`-arvo lähetetään aina frontilta vaikka siihen ei olisi siellä koskettukaan -> voidaan hyvillä mielin luottaa siihen, että jos frontilta tulee `null`, niin se on haluttua.

Lisäksi korjattu testejä tarkastamaan tämä nullaustilanne muun päivityksen sijasta, ja sen lisäksi korjattu se, että applicability ylipäätään tarkastetaan (aiemmin ei tarkastettu)