### PR TITLE
GVT-2979 Save parent publication ID in inherited publications + inheritance calculation fix

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -19,6 +19,7 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.InheritanceFromPublicationInMain
 import fi.fta.geoviite.infra.publication.PreparedPublicationRequest
+import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationResult
 import fi.fta.geoviite.infra.publication.PublicationResultVersions
@@ -303,6 +304,7 @@ class CalculatedChangesService(
                     completedSwitches[branch] ?: listOf(),
                     completedKmPosts[branch] ?: listOf(),
                     mainPublication,
+                    mainPublicationResult.publicationId,
                 )
             }
     }
@@ -316,6 +318,7 @@ class CalculatedChangesService(
         completedSwitches: List<LayoutRowVersion<LayoutSwitch>>,
         completedKmPosts: List<LayoutRowVersion<LayoutKmPost>>,
         mainPublication: PreparedPublicationRequest,
+        mainPublicationId: IntId<Publication>,
     ): PreparedPublicationRequest {
         val versions =
             mergeInheritedChangeVersionsWithCompletedMergeVersions(
@@ -331,18 +334,9 @@ class CalculatedChangesService(
             DirectChanges(
                 completedKmPosts.map { it.id },
                 completedReferenceLines.map { it.id },
-                mergeTrackNumberChanges(
-                    inheritedChanges.trackNumberChanges,
-                    completedTrackNumbers.map { v -> TrackNumberChange(v.id, setOf(), false, false) },
-                ),
-                mergeLocationTrackChanges(
-                    inheritedChanges.locationTrackChanges,
-                    completedLocationTracks.map { v -> LocationTrackChange(v.id, setOf(), false, false) },
-                ),
-                mergeSwitchChanges(
-                    inheritedChanges.switchChanges,
-                    completedSwitches.map { v -> SwitchChange(v.id, listOf()) },
-                ),
+                completedTrackNumbers.map { v -> TrackNumberChange(v.id, setOf(), false, false) },
+                completedLocationTracks.map { v -> LocationTrackChange(v.id, setOf(), false, false) },
+                completedSwitches.map { v -> SwitchChange(v.id, listOf()) },
             )
         val indirectChanges =
             IndirectChanges(
@@ -363,6 +357,7 @@ class CalculatedChangesService(
             CalculatedChanges(directChanges, indirectChanges),
             mainPublication.message,
             PublicationCause.CALCULATED_CHANGE,
+            mainPublicationId,
         )
     }
 
@@ -380,16 +375,19 @@ class CalculatedChangesService(
             trackNumbers =
                 trackNumberDao
                     .getMany(inheritorBranch.official, changes.trackNumberChanges.map { it.trackNumberId })
+                    .filter { it.branch == inheritorBranch }
                     .map { requireNotNull(it.version) },
             referenceLines = listOf(),
             locationTracks =
                 locationTrackDao
                     .getMany(inheritorBranch.official, changes.locationTrackChanges.map { it.locationTrackId })
+                    .filter { it.branch == inheritorBranch }
                     .map { requireNotNull(it.version) },
             switches =
-                switchDao.getMany(inheritorBranch.official, changes.switchChanges.map { it.switchId }).map {
-                    requireNotNull(it.version)
-                },
+                switchDao
+                    .getMany(inheritorBranch.official, changes.switchChanges.map { it.switchId })
+                    .filter { it.branch == inheritorBranch }
+                    .map { requireNotNull(it.version) },
             kmPosts = listOf(),
             splits = listOf(),
         )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -87,7 +87,11 @@ data object PublishedInMain : PublishedInBranch() {
     override val branch = LayoutBranch.main
 }
 
-data class PublishedInDesign(val designBranch: DesignBranch, @JsonIgnore val designVersion: Int) : PublishedInBranch() {
+data class PublishedInDesign(
+    val designBranch: DesignBranch,
+    @JsonIgnore val designVersion: Int,
+    val parentPublicationId: IntId<Publication>?,
+) : PublishedInBranch() {
     override val branch = designBranch
 }
 
@@ -338,7 +342,7 @@ data class PublicationRequestIds(
 data class PublicationRequest(val content: PublicationRequestIds, val message: FreeTextWithNewLines)
 
 data class PublicationResult(
-    val publicationId: IntId<Publication>?,
+    val publicationId: IntId<Publication>,
     val trackNumbers: List<PublicationResultVersions<LayoutTrackNumber>>,
     val referenceLines: List<PublicationResultVersions<ReferenceLine>>,
     val locationTracks: List<PublicationResultVersions<LocationTrack>>,
@@ -704,6 +708,7 @@ data class PreparedPublicationRequest(
     val calculatedChanges: CalculatedChanges,
     val message: FreeTextWithNewLines,
     val cause: PublicationCause,
+    val parentId: IntId<Publication>?,
 )
 
 data class PublicationResultVersions<T : LayoutAsset<T>>(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -369,9 +369,14 @@ fun ResultSet.getPublicationStateOrNull(draftFlagName: String): PublicationState
 fun ResultSet.getLayoutBranch(designIdName: String): LayoutBranch =
     getIntIdOrNull<LayoutDesign>(designIdName).let { id -> if (id == null) LayoutBranch.main else DesignBranch.of(id) }
 
-fun ResultSet.getPublicationPublishedIn(designIdName: String, designVersionName: String): PublishedInBranch =
+fun ResultSet.getPublicationPublishedIn(
+    designIdName: String,
+    designVersionName: String,
+    parentIdName: String,
+): PublishedInBranch =
     getIntIdOrNull<LayoutDesign>(designIdName).let { id ->
-        if (id == null) PublishedInMain else PublishedInDesign(DesignBranch.of(id), getInt(designVersionName))
+        if (id == null) PublishedInMain
+        else PublishedInDesign(DesignBranch.of(id), getInt(designVersionName), getIntIdOrNull(parentIdName))
     }
 
 // no getLayoutBranchOrNull, as we couldn't distinguish between when to return the main branch and

--- a/infra/src/main/resources/db/migration/prod/V115__add_parent_publication_id_to_publication.sql
+++ b/infra/src/main/resources/db/migration/prod/V115__add_parent_publication_id_to_publication.sql
@@ -1,0 +1,2 @@
+alter table publication.publication
+  add column parent_publication_id int references publication.publication (id);

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -263,6 +263,7 @@ constructor(
                 layoutBranch = layoutBranch,
                 message = FreeTextWithNewLines.of(message),
                 cause = PublicationCause.MANUAL,
+                parentId = null,
             )
             .also { publicationId ->
                 val calculatedChanges =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -236,7 +236,12 @@ constructor(
                 indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
             )
         val publicationId =
-            publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of(""), PublicationCause.MANUAL)
+            publicationDao.createPublication(
+                LayoutBranch.main,
+                FreeTextWithNewLines.of(""),
+                PublicationCause.MANUAL,
+                parentId = null,
+            )
         publicationDao.insertCalculatedChanges(
             publicationId,
             changes,
@@ -269,7 +274,8 @@ constructor(
     @Test
     fun `Publication message is stored and fetched correctly`() {
         val message = FreeTextWithNewLines.of("Test")
-        val publicationId = publicationDao.createPublication(LayoutBranch.main, message, PublicationCause.MANUAL)
+        val publicationId =
+            publicationDao.createPublication(LayoutBranch.main, message, PublicationCause.MANUAL, parentId = null)
         assertEquals(message, publicationDao.getPublication(publicationId).message)
     }
 
@@ -446,17 +452,29 @@ constructor(
     fun `fetchLatestPublicationDetails lists design publications in design mode`() {
         val someDesign = DesignBranch.of(layoutDesignDao.insert(layoutDesign("one")))
         val anotherDesign = DesignBranch.of(layoutDesignDao.insert(layoutDesign("two")))
-        publicationDao.createPublication(someDesign, FreeTextWithNewLines.of("in someDesign"), PublicationCause.MANUAL)
-        publicationDao.createPublication(LayoutBranch.main, FreeTextWithNewLines.of("in main"), PublicationCause.MANUAL)
+        publicationDao.createPublication(
+            someDesign,
+            FreeTextWithNewLines.of("in someDesign"),
+            PublicationCause.MANUAL,
+            parentId = null,
+        )
+        publicationDao.createPublication(
+            LayoutBranch.main,
+            FreeTextWithNewLines.of("in main"),
+            PublicationCause.MANUAL,
+            parentId = null,
+        )
         publicationDao.createPublication(
             anotherDesign,
             FreeTextWithNewLines.of("in anotherDesign"),
             PublicationCause.MANUAL,
+            parentId = null,
         )
         publicationDao.createPublication(
             LayoutBranch.main,
             FreeTextWithNewLines.of("again in main"),
             PublicationCause.MANUAL,
+            parentId = null,
         )
         assertEquals(
             listOf("in anotherDesign", "in someDesign"),
@@ -476,6 +494,7 @@ constructor(
                 DesignBranch.of(someDesign),
                 FreeTextWithNewLines.of("pub 1"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         layoutDesignDao.update(someDesign, layoutDesign(name = "bar"))
         val pub2 =
@@ -483,6 +502,7 @@ constructor(
                 DesignBranch.of(someDesign),
                 FreeTextWithNewLines.of("pub 2"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         layoutDesignDao.update(someDesign, layoutDesign(name = "spam"))
         val pub3 =
@@ -490,18 +510,21 @@ constructor(
                 DesignBranch.of(someDesign),
                 FreeTextWithNewLines.of("pub 3"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         val pub4 =
             publicationDao.createPublication(
                 DesignBranch.of(someDesign),
                 FreeTextWithNewLines.of("pub 4"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         val pub5 =
             publicationDao.createPublication(
                 DesignBranch.of(someDesign),
                 FreeTextWithNewLines.of("pub 5"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         assertEquals(null, publicationDao.getPreviouslyPublishedDesignVersion(pub1, someDesign))
         assertEquals(1, publicationDao.getPreviouslyPublishedDesignVersion(pub2, someDesign))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -8,9 +8,11 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
@@ -1554,6 +1556,38 @@ constructor(
         assertEquals(listOf(locationTrack), candidates.locationTracks.map { it.id })
         assertEquals(listOf(switch), candidates.switches.map { it.id })
         assertEquals(listOf(kmPost), candidates.kmPosts.map { it.id })
+    }
+
+    @Test
+    fun `inherited publications gain their main publication's ID as parent ID`() {
+        val designBranch = testDBService.createDesignBranch()
+
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(0.0, 1.0)))
+        val referenceLine =
+            mainOfficialContext.insert(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment).id
+        val locationTrack = mainOfficialContext.insert(locationTrack(trackNumber), alignment).id
+        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
+
+        mainDraftContext.insert(
+            mainOfficialContext.fetch(referenceLine)!!.copy(startAddress = TrackMeter("0123+0123")),
+            alignment,
+        )
+        val mainPublicationResult =
+            publicationService.publishManualPublication(
+                LayoutBranch.main,
+                PublicationRequest(
+                    publicationRequestIds(referenceLines = listOf(referenceLine)),
+                    message = FreeTextWithNewLines.of("aoeu"),
+                ),
+            )
+        val designPublications = publicationDao.list(LayoutBranchType.DESIGN)
+        assertEquals(1, designPublications.size)
+
+        assertEquals(
+            mainPublicationResult.publicationId,
+            (designPublications[0].layoutBranch as PublishedInDesign).parentPublicationId,
+        )
     }
 
     data class PublicationGroupTestData(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -1258,6 +1258,7 @@ constructor(
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("test: bulk transfer to in progress"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         splitDao.updateSplit(splitId = splitId, publicationId = publicationId)
 
@@ -1290,6 +1291,7 @@ constructor(
                             LayoutBranch.main,
                             FreeTextWithNewLines.of("some in progress bulk transfer"),
                             PublicationCause.MANUAL,
+                            parentId = null,
                         ),
                     bulkTransferState = BulkTransferState.IN_PROGRESS,
                     bulkTransferId = someBulkTransferId,
@@ -1307,6 +1309,7 @@ constructor(
                                 LayoutBranch.main,
                                 FreeTextWithNewLines.of("pending bulk transfer"),
                                 PublicationCause.MANUAL,
+                                parentId = null,
                             ),
                     )
                     .id
@@ -1334,6 +1337,7 @@ constructor(
                                 LayoutBranch.main,
                                 FreeTextWithNewLines.of("pending bulk transfer"),
                                 PublicationCause.MANUAL,
+                                parentId = null,
                             ),
                     )
                     .id
@@ -1373,6 +1377,7 @@ constructor(
                                     LayoutBranch.main,
                                     FreeTextWithNewLines.of("pending bulk transfer $index"),
                                     PublicationCause.MANUAL,
+                                    parentId = null,
                                 ),
                         )
                         .id
@@ -1408,6 +1413,7 @@ constructor(
                                         LayoutBranch.main,
                                         FreeTextWithNewLines.of("testing $bulkTransferState"),
                                         PublicationCause.MANUAL,
+                                        parentId = null,
                                     ),
                                 bulkTransferId = testDBService.getUnusedBulkTransferId(),
                                 bulkTransferState = bulkTransferState,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -78,6 +78,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("SPLIT PUBLICATION"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         val updatedSplit =
             splitDao
@@ -209,6 +210,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("test: bulk transfer state update"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
 
         BulkTransferState.entries.forEach { newBulkTransferState ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -68,6 +68,7 @@ constructor(
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("successful"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         publicationDao.insertCalculatedChanges(
             successfulPublicationId,
@@ -86,6 +87,7 @@ constructor(
                 LayoutBranch.main,
                 FreeTextWithNewLines.of("failing test publication"),
                 PublicationCause.MANUAL,
+                parentId = null,
             )
         publicationDao.insertCalculatedChanges(
             failingPublicationId,


### PR DESCRIPTION
Pihvi: Lisätty julkaisuille parentId.

Vähän tuurilla aiemman PublicationResultSummary-luokan lisäämisen jälkeen PublicationResultissa itsessään publicationId:n ei tarvitse olla enää nullable, ja sen tekeminen ei-nullableksi oli tässä hyödyksi, siis tehty sekin.