### PR TITLE
GVT-2995 Handle merged objects being cancelled before merger completion

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetService.kt
@@ -116,23 +116,23 @@ abstract class LayoutAssetService<ObjectType : LayoutAsset<ObjectType>, DaoType 
 
         val completedVersion =
             (draft.contextData as? MainDraftContextData)?.originBranch?.let { originBranch ->
-                if (originBranch is DesignBranch) {
-                    val designOfficial = dao.fetchVersion(originBranch.official, draftVersion.id)
-                    // TODO these are not currently actually guaranteed! User could merge and then
-                    // cancel an object.
-                    requireNotNull(designOfficial) {
-                        "Expected published object $draftVersion's to find an object looking for its origin in $originBranch"
-                    }
-                    require(designOfficial.context == originBranch.official) {
-                        "Expected published object $draftVersion's origin object to be in $originBranch"
-                    }
-                    val completedVersion = dao.save(completed(dao.fetch(designOfficial)))
-                    originBranch to completedVersion
-                } else null
+                completeMergeToMain(draftVersion.id, originBranch)
             }
 
         return PublicationResultVersions(published = publicationVersion, completed = completedVersion)
     }
+
+    private fun completeMergeToMain(
+        id: IntId<ObjectType>,
+        originBranch: LayoutBranch,
+    ): Pair<DesignBranch, LayoutRowVersion<ObjectType>>? =
+        if (originBranch is DesignBranch) {
+            val designOfficial = dao.fetchVersion(originBranch.official, id)
+            if (designOfficial != null && designOfficial.context == originBranch.official) {
+                val completedVersion = dao.save(completed(dao.fetch(designOfficial)))
+                originBranch to completedVersion
+            } else null
+        } else null
 
     protected fun fetchAndCheckForMerging(fromBranch: DesignBranch, id: IntId<ObjectType>): ObjectType {
         val branchOfficialVersion = dao.fetchVersion(fromBranch.official, id)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1573,14 +1573,7 @@ constructor(
             mainOfficialContext.fetch(referenceLine)!!.copy(startAddress = TrackMeter("0123+0123")),
             alignment,
         )
-        val mainPublicationResult =
-            publicationService.publishManualPublication(
-                LayoutBranch.main,
-                PublicationRequest(
-                    publicationRequestIds(referenceLines = listOf(referenceLine)),
-                    message = FreeTextWithNewLines.of("aoeu"),
-                ),
-            )
+        val mainPublicationResult = publishManualPublication(referenceLines = listOf(referenceLine))
         val designPublications = publicationDao.list(LayoutBranchType.DESIGN)
         assertEquals(1, designPublications.size)
 
@@ -1589,6 +1582,129 @@ constructor(
             (designPublications[0].layoutBranch as PublishedInDesign).parentPublicationId,
         )
     }
+
+    @Test
+    fun `publication in main cleans up origin object from live table`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designDraftContext = testDBService.testContext(designBranch, DRAFT)
+
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(0.0, 1.0)))
+        mainOfficialContext.insert(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment).id
+        val locationTrack = mainOfficialContext.insert(locationTrack(trackNumber), alignment)
+        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
+        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        designDraftContext.copyFrom(locationTrack)
+
+        publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
+        locationTrackService.mergeToMainBranch(designBranch, locationTrack.id)
+        publishManualPublication(MainBranch.instance, locationTracks = listOf(locationTrack.id))
+
+        assertEquals(MainLayoutContext.official, designDraftContext.fetch(locationTrack.id)!!.layoutContext)
+        jdbc.query(
+            "select count(*) count_in_design from layout.location_track where design_id = :design_id",
+            mapOf("design_id" to designBranch.designId.intValue),
+        ) { rs, _ ->
+            assertEquals(0, rs.getInt("count_in_design"), "design objects are fully cleaned up from live table")
+        }
+    }
+
+    @Test
+    fun `publication in main succeeds even if origin object has been cancelled`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designDraftContext = testDBService.testContext(designBranch, DRAFT)
+
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(0.0, 1.0)))
+        mainOfficialContext.insert(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment).id
+        val locationTrack = mainOfficialContext.insert(locationTrack(trackNumber), alignment)
+        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
+        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        designDraftContext.copyFrom(locationTrack)
+
+        publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
+        locationTrackService.mergeToMainBranch(designBranch, locationTrack.id)
+        locationTrackService.cancel(designBranch, locationTrack.id)
+        publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
+        publishManualPublication(MainBranch.instance, locationTracks = listOf(locationTrack.id))
+        assertEquals(MainLayoutContext.official, designDraftContext.fetch(locationTrack.id)!!.layoutContext)
+        jdbc.query(
+            "select count(*) count_in_design from layout.location_track where design_id = :design_id",
+            mapOf("design_id" to designBranch.designId.intValue),
+        ) { rs, _ ->
+            assertEquals(0, rs.getInt("count_in_design"), "design objects are fully cleaned up from live table")
+        }
+    }
+
+    @Test
+    fun `publication in main succeeds even if origin object has been partially cancelled`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designDraftContext = testDBService.testContext(designBranch, DRAFT)
+
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(0.0, 1.0)))
+        mainOfficialContext.insert(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment).id
+        val locationTrack = mainOfficialContext.insert(locationTrack(trackNumber), alignment)
+        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
+        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        designDraftContext.copyFrom(locationTrack)
+
+        publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
+        locationTrackService.mergeToMainBranch(designBranch, locationTrack.id)
+        locationTrackService.cancel(designBranch, locationTrack.id)
+        // cancellation started but not finished
+        publishManualPublication(MainBranch.instance, locationTracks = listOf(locationTrack.id))
+        assertEquals(MainLayoutContext.official, designDraftContext.fetch(locationTrack.id)!!.layoutContext)
+        jdbc.query(
+            "select count(*) count_in_design from layout.location_track where design_id = :design_id",
+            mapOf("design_id" to designBranch.designId.intValue),
+        ) { rs, _ ->
+            assertEquals(0, rs.getInt("count_in_design"), "design objects are fully cleaned up from live table")
+        }
+    }
+
+    @Test
+    fun `publication in main of object created in design succeeds even if origin object has been cancelled`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designDraftContext = testDBService.testContext(designBranch, DRAFT)
+
+        val trackNumber = mainOfficialContext.insert(trackNumber()).id
+        val alignment = alignment(segment(Point(0.0, 0.0), Point(0.0, 1.0)))
+        mainOfficialContext.insert(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment).id
+        val locationTrack = designDraftContext.insert(locationTrack(trackNumber), alignment)
+        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
+        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+
+        publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
+        locationTrackService.mergeToMainBranch(designBranch, locationTrack.id)
+        locationTrackService.cancel(designBranch, locationTrack.id)
+        publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
+        publishManualPublication(MainBranch.instance, locationTracks = listOf(locationTrack.id))
+        assertEquals(MainLayoutContext.official, designDraftContext.fetch(locationTrack.id)!!.layoutContext)
+        jdbc.query(
+            "select count(*) count_in_design from layout.location_track where design_id = :design_id",
+            mapOf("design_id" to designBranch.designId.intValue),
+        ) { rs, _ ->
+            assertEquals(0, rs.getInt("count_in_design"), "design objects are fully cleaned up from live table")
+        }
+    }
+
+    private fun publishManualPublication(
+        layoutBranch: LayoutBranch = MainBranch.instance,
+        message: FreeTextWithNewLines = FreeTextWithNewLines.of("in $layoutBranch"),
+        trackNumbers: List<IntId<LayoutTrackNumber>> = listOf(),
+        referenceLines: List<IntId<ReferenceLine>> = listOf(),
+        locationTracks: List<IntId<LocationTrack>> = listOf(),
+        switches: List<IntId<LayoutSwitch>> = listOf(),
+        kmPosts: List<IntId<LayoutKmPost>> = listOf(),
+    ) =
+        publicationService.publishManualPublication(
+            layoutBranch,
+            PublicationRequest(
+                publicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts),
+                message,
+            ),
+        )
 
     data class PublicationGroupTestData(
         val sourceLocationTrackId: IntId<LocationTrack>,


### PR DESCRIPTION
"Completion"/toteutuminen tarkoittaa siis, että kirjataan suunnitelma puolelle tieto siitä, että sieltä mainiin tuotu olio on nyt julkaistu viralliseen paikannuspohjaan. Tämä ei ole mitenkään täydellinen prosessi, koska olioitahan pystyy ihan vapaasti muokkaamaan luonnostilassa suunnitelmasta tuomisen jälkeen, eli koko originBranch-tiedon merkitys ei ole erityisen suuri: Mutta on siinä nyt se, että jos toteutuminen menee normaaliprosessin mukaisesti, niin ainakin saadaan suunnitelman versio lopuksi pois paikannuspohjan live-tilan tauluista.