### PR TITLE
GVT-3069 Handle inexistent track kilometers in plan loading

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -1084,11 +1084,23 @@ constructor(
                     track.id as IntId,
                     10.0,
                     KmNumber(0),
-                    KmNumber(6),
+                    KmNumber(4),
                 )
                 .map { it.id }
         assertEquals(1, overlappingEntireTrackNumber.size)
         assertContains(overlappingEntireTrackNumber, plan2IsWithinLocationTrack.id)
+
+        val endAddressPastLocationTrackAddressingEnd =
+            locationTrackService
+                .getOverlappingPlanHeaders(
+                    mainOfficialContext.context,
+                    track.id as IntId,
+                    10.0,
+                    KmNumber(0),
+                    KmNumber(6),
+                )
+                .map { it.id }
+        assertEquals(0, endAddressPastLocationTrackAddressingEnd.size)
 
         val withinPlanAreaButNotWithinTrackNumber =
             locationTrackService
@@ -1124,7 +1136,7 @@ constructor(
             locationTrackService
                 .getOverlappingPlanHeaders(mainOfficialContext.context, track.id as IntId, 10.0, null, KmNumber(5))
                 .map { it.id }
-        assertEquals(1, endIsAfterTrackNumberEndAndStartIsNull.size)
+        assertEquals(0, endIsAfterTrackNumberEndAndStartIsNull.size)
 
         val endIsBeforeLocationTrackStartButWithinTrackNumber =
             locationTrackService


### PR DESCRIPTION
Mahdollisia rajatapauksia on tässä useita, mutta onneksi niistä kaikki on sellaisia, että käyttäjän pitää tehdä jotain todella outoa, tai paikannuspohjassa olla tosi huono tuuri:

- Alkupäässä annettu kirjainpäätteellinen ratakilometri, jota ei ole raiteella, mutta joka olisi raiteen osoitevälillä, jos se olisi olemassa: Aiemmin kaaduttiin siihen, että getTrackLocation() palautti nullia, nyt palautetaan ei-oota
- Sama mutta loppupäässä: Koska koodi ei hakenut varsinaista pyydettyä ratakilometriä, vaan ainoastaan ensimmäisen KmNumber-järjestyksen mukaan sen jälkeen tulevan, loppupää löytyi, vaikka ei olisi pitänyt löytyä. Nyt palautetaan ei-oota
- Raiteelta puuttuu oudon geometrian takia siihen alku-loppu-osoitevälin mukaan kuuluva alku- tai loppu-km-tolppa: Onneksi nämä vaativat sen verran outoa geometriaa, että vaikka sellainen saattaisi teoriassa mennä meidän validaatioista läpi (en itse asiassa tiedä varmaksi), näitä ei tietääkseni ole paikannuspohjassa olemassa. Mutta on ne teoriassa mahdollisia, ainakin geokoodauslaskennan nykytoiminnalla; mutta sen verran outoja ovat, ja koko niiden mahdollisuus on toivottavasti poistumassa, että sama palauttaa tästäkin ei-oota.