### PR TITLE
GVT-3070 Write segment geometry preload query as semijoin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -732,11 +732,13 @@ class LayoutAlignmentDao(
               when geom.cant_values is null then null 
               else array_to_string(geom.cant_values, ',', 'null') 
             end as cant_values
-          from layout.alignment a
-            left join layout.segment_version sv on a.id = sv.alignment_id and a.version = sv.alignment_version
-            left join layout.segment_geometry geom on geom.id = sv.geometry_id
-          where geom.id is not null
-          group by geom.id
+          from layout.segment_geometry geom
+          where exists(
+            select *
+            from layout.alignment a
+              join layout.segment_version sv on a.id = sv.alignment_id and a.version = sv.alignment_version
+            where geom.id = sv.geometry_id
+          )
         """
                 .trimIndent()
 


### PR DESCRIPTION
Yllätyin, että postgres ajoi haun alkuperäistä muotoa huonosti, koska eipä se erityisen monimutkainen monsteri ole, mutta kyllä tämä vaan nopeuttaa hakua minun koneella noin kuudesta ja puolesta sekunnista alle neljään sekuntiin. Se alkuperäisen erikoisuus, että postgressin rinnakkaistus hidastaa hakua, katoaa myös: Uusi haku toimii nopeammin meidän kontin oletusarvoilla, joissa rinnakkaistus on päällä.

Mutta lähinnä kai hyvä ottaa sitten myös graafihaarassa huomioon, että tämä tosi iso preloadi on ihan oikeasti iso.