### PR TITLE
GVT-3074 Various React performance bugfixes

### DIFF
--- a/ui/src/store/hooks.ts
+++ b/ui/src/store/hooks.ts
@@ -10,32 +10,26 @@ export const useAppDispatch = () => useDispatch<AppDispatch>();
 export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector;
 
 export function useTrackLayoutAppSelector<T>(fn: (state: TrackLayoutState) => T) {
-    const trackLayoutState = useSelector(
-        (state: AppState) => state.trackLayout as TrackLayoutState,
-    );
-    return fn(trackLayoutState);
+    return useAppSelector((state) => fn(state.trackLayout));
 }
 
 export function useInfraModelAppSelector<T>(fn: (state: InfraModelState) => T) {
-    const infraModelState = useSelector((state: AppState) => state.infraModel as InfraModelState);
-    return fn(infraModelState);
+    return useAppSelector((state) => fn(state.infraModel));
 }
 
 export function useDataProductsAppSelector<T>(fn: (state: DataProductsState) => T) {
-    const dataProductsState = useSelector(
-        (state: AppState) => state.dataProducts as DataProductsState,
-    );
-    return fn(dataProductsState);
+    return useAppSelector((state) => fn(state.dataProducts));
 }
 
 export function useCommonDataAppSelector<T>(fn: (state: CommonState) => T) {
-    const commonState = useSelector((state: AppState) => state.common as CommonState);
-    return fn(commonState);
+    return useAppSelector((state) => fn(state.common));
 }
 
 export function useUserHasPrivilege(code: PrivilegeCode): boolean {
-    const privileges = useCommonDataAppSelector((state) => state.user?.role.privileges ?? []).map(
-        (p) => p.code,
+    return useCommonDataAppSelector((state) =>
+        userHasPrivilege(
+            (state.user?.role.privileges ?? []).map((p) => p.code),
+            code,
+        ),
     );
-    return userHasPrivilege(privileges, code);
 }

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -115,15 +115,37 @@ const TrackMeterRange: React.FC<TrackMeterRangeProps> = ({ start, end }) => {
     );
 };
 
-export const AlignmentPlanSectionInfoboxContent: React.FC<
-    AlignmentPlanSectionInfoboxContentProps
-> = ({ sections, onHighlightSection }) => {
+const PlanVisibilityToggle: React.FC<{
+    section: AlignmentPlanSection;
+    isVisible: boolean;
+    togglePlanVisibility: (
+        planId: GeometryPlanId,
+        alignmentId: GeometryAlignmentId | undefined,
+    ) => void;
+}> = ({ section, isVisible, togglePlanVisibility }) => {
+    const planId = section.planId;
+
+    return (
+        <div
+            className={styles['alignment-plan-section-infobox__navigation-plan-visibility-toggle']}>
+            {planId && section.isLinked && (
+                <Eye
+                    visibility={isVisible}
+                    onVisibilityToggle={() => {
+                        togglePlanVisibility(planId, section.alignmentId);
+                    }}
+                />
+            )}
+        </div>
+    );
+};
+
+const AlignmentPlanSectionInfoboxContentM: React.FC<AlignmentPlanSectionInfoboxContentProps> = ({
+    sections,
+    onHighlightSection,
+}) => {
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
     const visiblePlans = useTrackLayoutAppSelector((state) => state.selection.visiblePlans);
-
-    function isVisible(planId: GeometryPlanId) {
-        return visiblePlans.some((plan) => plan.id === planId);
-    }
 
     function togglePlanVisibility(
         planId: GeometryPlanId,
@@ -160,28 +182,6 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
         }
     };
 
-    const PlanVisibilityToggle: React.FC<{
-        section: AlignmentPlanSection;
-    }> = ({ section }) => {
-        const planId = section.planId;
-
-        return (
-            <div
-                className={
-                    styles['alignment-plan-section-infobox__navigation-plan-visibility-toggle']
-                }>
-                {planId && section.isLinked && (
-                    <Eye
-                        visibility={isVisible(planId)}
-                        onVisibilityToggle={() => {
-                            togglePlanVisibility(planId, section.alignmentId);
-                        }}
-                    />
-                )}
-            </div>
-        );
-    };
-
     return (
         <React.Fragment>
             <InfoboxList>
@@ -208,7 +208,13 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
                                     'infobox__list-cell--strong',
                                     styles['alignment-plan-section-infobox__navigation'],
                                 )}>
-                                <PlanVisibilityToggle section={section} />
+                                <PlanVisibilityToggle
+                                    section={section}
+                                    togglePlanVisibility={togglePlanVisibility}
+                                    isVisible={visiblePlans.some(
+                                        (plan) => plan.id === section.planId,
+                                    )}
+                                />
                                 <TrackMeterRange start={section.start} end={section.end} />
                             </div>
                         }
@@ -218,3 +224,5 @@ export const AlignmentPlanSectionInfoboxContent: React.FC<
         </React.Fragment>
     );
 };
+
+export const AlignmentPlanSectionInfoboxContent = React.memo(AlignmentPlanSectionInfoboxContentM);

--- a/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-geometry-infobox.tsx
@@ -49,16 +49,19 @@ export const LocationTrackGeometryInfobox: React.FC<LocationTrackGeometryInfobox
         1000,
         [locationTrackId, layoutContext.publicationState, layoutContext.branch, viewportDep],
     );
-    const onHighlightSection: OnHighlightSection = (section) =>
-        onHighlightItem(
-            section === undefined
-                ? undefined
-                : {
-                      ...section,
-                      id: locationTrackId,
-                      type: 'LOCATION_TRACK',
-                  },
-        );
+    const onHighlightSection: OnHighlightSection = React.useCallback(
+        (section) =>
+            onHighlightItem(
+                section === undefined
+                    ? undefined
+                    : {
+                          ...section,
+                          id: locationTrackId,
+                          type: 'LOCATION_TRACK',
+                      },
+            ),
+        [onHighlightItem, locationTrackId],
+    );
 
     return (
         <Infobox

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -209,4 +209,4 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
     );
 };
 
-export default LocationTrackInfobox;
+export default React.memo(LocationTrackInfobox);


### PR DESCRIPTION
useSelector()in käyttöjen korjaamiset on ehkä oleellisin osa, ja niissä on aika paljonkin potentiaalia saada hyötyä aikaan. useSelector()han siis toimii niin, että se muistaa palautusarvonsa (olion identiteetin), ja jos palautusarvo ei ole muuttunut, ei itsessään triggaa uudelleenrenderöintiä, ja tämän takia siitä kannattaa palauttaa aina mahdollisimman harvoin muuttuva tieto. Tai en itse asiassa edes tiedä, mitä kaikkea magiaa se tekeekään, mutta tämä nyt on oleellisin osa sen oikeaoppisesta käytöstä.

Komponenttien määrittely render-funktioissa aiheuttaa ongelmia, siksi PlanVisibilityToggle siirretty ylätasolle: https://www.developerway.com/posts/react-re-renders-guide#part3.1

Näiden muutosten jälkeen jäljellä vain selkeää memottelua ja useCallback-veivausta.