### PR TITLE
General: Parempaa Reactin käyttöä

### DIFF
--- a/ui/src/geometry/geometry-model.ts
+++ b/ui/src/geometry/geometry-model.ts
@@ -344,6 +344,6 @@ export type VerticalGeometryDiagramDisplayItem = Omit<
     'layoutStartStation' | 'layoutPointStation' | 'layoutEndStation' | 'start' | 'point' | 'end'
 > & {
     start: CircularCurve | undefined;
-    point: StationPoint | undefined;
+    point: StationPoint;
     end: CircularCurve | undefined;
 };

--- a/ui/src/vertical-geometry/height-tooltip.tsx
+++ b/ui/src/vertical-geometry/height-tooltip.tsx
@@ -1,8 +1,9 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { SnappedPoint } from 'vertical-geometry/snapped-point';
 import { Coordinates } from 'vertical-geometry/coordinates';
 import { formatTrackMeter, formatTrackMeterWithoutMeters } from 'utils/geography-utils';
 import styles from './vertical-geometry-diagram.scss';
+import { useResizeObserver } from 'utils/use-resize-observer';
 
 interface HeightTooltipProps {
     point: SnappedPoint;
@@ -25,13 +26,16 @@ export const HeightTooltip: React.FC<HeightTooltipProps> = ({
     const [width, setWidth] = useState(0);
     const [height, setHeight] = useState(0);
 
-    useLayoutEffect(() => {
-        const boundingClientRect = ref.current?.getBoundingClientRect();
-        if (boundingClientRect) {
-            setWidth(boundingClientRect.width);
-            setHeight(boundingClientRect.height);
-        }
-    }, [coordinates, point, parentElementRect]);
+    useResizeObserver({
+        ref,
+        onResize: () => {
+            const boundingClientRect = ref.current?.getBoundingClientRect();
+            if (boundingClientRect) {
+                setWidth(boundingClientRect.width);
+                setHeight(boundingClientRect.height);
+            }
+        },
+    });
 
     return (
         <div

--- a/ui/src/vertical-geometry/util.ts
+++ b/ui/src/vertical-geometry/util.ts
@@ -178,31 +178,31 @@ export function sumPaddings(p1: string, p2: string) {
 
 export function substituteLayoutStationsForGeometryStations(
     geometryItem: VerticalGeometryItem,
-): VerticalGeometryDiagramDisplayItem {
-    return {
-        ...geometryItem,
+): VerticalGeometryDiagramDisplayItem | undefined {
+    return geometryItem.layoutPointStation === undefined
+        ? undefined
+        : {
+              ...geometryItem,
 
-        start: geometryItem.layoutStartStation
-            ? {
-                  ...geometryItem.start,
-                  station: geometryItem.layoutStartStation,
-              }
-            : undefined,
+              start: geometryItem.layoutStartStation
+                  ? {
+                        ...geometryItem.start,
+                        station: geometryItem.layoutStartStation,
+                    }
+                  : undefined,
 
-        point: geometryItem.layoutPointStation
-            ? {
+              point: {
                   ...geometryItem.point,
                   station: geometryItem.layoutPointStation,
-              }
-            : undefined,
+              },
 
-        end: geometryItem.layoutEndStation
-            ? {
-                  ...geometryItem.end,
-                  station: geometryItem.layoutEndStation,
-              }
-            : undefined,
-    };
+              end: geometryItem.layoutEndStation
+                  ? {
+                        ...geometryItem.end,
+                        station: geometryItem.layoutEndStation,
+                    }
+                  : undefined,
+          };
 }
 
 export function processPlanGeometries(geometry: VerticalGeometryItem[], staStart: number) {
@@ -223,6 +223,7 @@ export function processLayoutGeometries(
 
     return geometry
         .map(substituteLayoutStationsForGeometryStations)
+        .filter(filterNotEmpty)
         .filter(
             (geom) =>
                 (geom.start?.station &&


### PR DESCRIPTION
Suurimmaksi osaksi refaktoria PviGeometryssä, tosin perffi voi olla muuttunut suuntaan tai toiseen, kun nyt:

- Todnäk huonona asiana: React-komponenttirakennetta on enemmän ja varsinainen luotujen komponenttien määrä on isompi
- Hyvänä asiana: Apuviivat ja niiden kulmat piirrettiin aiemmin koko geometrialle, nyt ainoastaan näkyvälle välille
- Ehkä huonona tai hyvänä asiana: React-keyt asetetaan nyt oikeaoppisesti datan, eli niiden pystygeometriaelementtien tosi pitkien iideitten, perusteella

Koko pvi-geometry.ts on tietenkin yhäkin aikamoinen otus, mutta nyt se sentään näyttää rakenteeltaan miltei tavalliselta React-komponentilta. Tosin en ole yhäkään erityisen varma, oliko tätä koko kaaviota alkuunkaan järkeä tehdä Reactilla ja SVG:llä, vai pitäisikö vaan piirtää kaikki canvas-elementtiin käsin.