### PR TITLE
GVT-2939: Haetun suunnitelman nimen automaattisiirto "Lisää uusi"-dialogiin

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -2034,7 +2034,10 @@
         "license": "Lisenssi"
     },
     "dropdown": {
-        "add-new": "Lisää uusi"
+        "add-new": "Lisää uusi",
+        "unselected": "Ei valittu",
+        "no-options": "Ei vaihtoehtoja",
+        "loading": "Ladataan"
     },
     "privilege": {
         "view-basic": "Geoviitteen käyttö",

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -81,6 +81,8 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
         .map((e) => t(`workspace-dialog.${e}`))
         .concat(designNameNotUnique ? [t('workspace-dialog.name-not-unique')] : []);
 
+    React.useEffect(() => nameInputRef?.current?.focus());
+
     return (
         <Dialog
             className={styles['workspace-dialog']}

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -81,7 +81,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
         .map((e) => t(`workspace-dialog.${e}`))
         .concat(designNameNotUnique ? [t('workspace-dialog.name-not-unique')] : []);
 
-    React.useEffect(() => nameInputRef?.current?.focus());
+    React.useEffect(() => nameInputRef?.current?.focus(), []);
 
     return (
         <Dialog

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -26,6 +26,7 @@ import { isEqualIgnoreCase } from 'utils/string-utils';
 import { filterNotEmpty } from 'utils/array-utils';
 
 type WorkspaceDialogProps = {
+    nameSuggestion?: string;
     existingDesign?: LayoutDesign;
     onCancel: () => void;
     onSave: (id: LayoutDesignId | undefined, saveRequest: LayoutDesignSaveRequest) => void;
@@ -48,6 +49,7 @@ function validateDesignName(name: string, committed: boolean): string[] {
 }
 
 export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
+    nameSuggestion,
     existingDesign,
     onCancel,
     onSave,
@@ -58,8 +60,9 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
     const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(
         existingDesign ? new Date(existingDesign?.estimatedCompletion) : undefined,
     );
-    const [name, setName] = React.useState<string>(existingDesign?.name ?? '');
+    const [name, setName] = React.useState<string>(nameSuggestion ?? existingDesign?.name ?? '');
     const [nameCommitted, setNameCommitted] = React.useState<boolean>(false);
+    const nameInputRef = React.useRef<HTMLInputElement>(null);
 
     const [allDesigns, allDesignsFetchStatus] = useLoaderWithStatus(
         () => getLayoutDesigns(getChangeTimes().layoutDesign),
@@ -125,6 +128,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
                                 qa-id={'workspace-dialog-name'}
                                 hasError={allErrors.length > 0}
                                 onBlur={() => setNameCommitted(true)}
+                                ref={nameInputRef}
                             />
                         }
                         errors={allErrors}

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -54,6 +54,7 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
     const { t } = useTranslation();
     const [showCreateWorkspaceDialog, setShowCreateWorkspaceDialog] = React.useState(false);
     const [savingWorkspace, setSavingWorkspace] = React.useState(false);
+    const [workspaceNameSuggestion, setWorkspaceNameSuggestion] = React.useState<string>();
     const selectWorkspaceDropdownRef = React.useRef<HTMLInputElement>(null);
 
     React.useEffect(() => {
@@ -67,7 +68,10 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
 
     const canAddDesigns = useUserHasPrivilege(EDIT_LAYOUT);
 
-    const onAddClick = () => setShowCreateWorkspaceDialog(true);
+    const onAddClick = (nameSuggestion: string | undefined) => {
+        setWorkspaceNameSuggestion(nameSuggestion);
+        setShowCreateWorkspaceDialog(true);
+    };
 
     async function handleInsertLayoutDesign(request: LayoutDesignSaveRequest) {
         const designId = await insertLayoutDesign(request);
@@ -105,6 +109,7 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
 
             {showCreateWorkspaceDialog && (
                 <WorkspaceDialog
+                    nameSuggestion={workspaceNameSuggestion}
                     onCancel={() => setShowCreateWorkspaceDialog(false)}
                     onSave={(_, request) => {
                         setSavingWorkspace(true);

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -72,7 +72,7 @@ export type DropdownProps<TItemValue> = {
     onBlur?: () => void;
     onFocus?: () => void;
     hasError?: boolean;
-    onAddClick?: () => void;
+    onAddClick?: (searchTerm: string) => void;
     onAddClickTitle?: string;
     onAddClickIcon?: IconComponent;
     wideList?: boolean;
@@ -366,13 +366,13 @@ export const Dropdown = function <TItemValue>({
                         <li
                             className={getItemClassName(undefined, -1)}
                             onClick={unselect}
-                            title={props.unselectText || 'Ei valittu'}
+                            title={props.unselectText || t('dropdown.unselected')}
                             ref={optionFocusIndex === -1 ? focusedOptionRef : undefined}>
                             <span className={styles['dropdown__list-item-icon']}>
                                 <Icons.Selected size={IconSize.SMALL} />
                             </span>
                             <span className={styles['dropdown__list-item-text']}>
-                                {props.unselectText || 'Ei valittu'}
+                                {props.unselectText || t('dropdown.unselected')}
                             </span>
                         </li>
                     )}
@@ -401,7 +401,7 @@ export const Dropdown = function <TItemValue>({
                                 styles['dropdown__list-item'],
                                 styles['dropdown__list-item--no-options'],
                             )}>
-                            Ei vaihtoehtoja
+                            {t('dropdown.no-options')}
                         </li>
                     )}
                     {isLoading && (
@@ -411,7 +411,7 @@ export const Dropdown = function <TItemValue>({
                                 styles['dropdown__list-item'],
                                 styles['dropdown__list-item--loading'],
                             )}>
-                            Ladataan
+                            {t('dropdown.loading')}
                             <span className={styles['dropdown__loading-indicator']} />
                         </li>
                     )}
@@ -423,7 +423,7 @@ export const Dropdown = function <TItemValue>({
                             icon={props.onAddClickIcon ?? Icons.Append}
                             wide
                             onClick={() => {
-                                props.onAddClick && props.onAddClick();
+                                props.onAddClick && props.onAddClick(valueShownInInput);
                             }}>
                             {props.onAddClickTitle ?? t('dropdown.add-new')}
                         </Button>


### PR DESCRIPTION
Varsinaisen pihvin lisäksi refaktoroitu myös dropdownista pakkosuomea pois ja lisätty työtilan luontidialogin avaukseen focus nimikenttään