### PR TITLE
GVT-2989/GVT-3085 Remove automatic reference line cancellation special case

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -1,7 +1,6 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
@@ -94,15 +93,6 @@ class LayoutTrackNumberService(
         referenceLineService.deleteDraftByTrackNumberId(branch, id)
         return deleteDraft(branch, id).id
     }
-
-    @Transactional
-    override fun cancel(branch: DesignBranch, id: IntId<LayoutTrackNumber>): LayoutRowVersion<LayoutTrackNumber>? =
-        dao.get(branch.official, id)?.let { trackNumber ->
-            referenceLineService.getByTrackNumber(branch.official, trackNumber.id as IntId)?.let {
-                referenceLineService.cancel(branch, it.id as IntId)
-            }
-            super.cancel(branch, id)
-        }
 
     fun idMatches(
         layoutContext: LayoutContext,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineController.kt
@@ -1,10 +1,12 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteController
+import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
 import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
@@ -16,6 +18,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestParam
 
 @GeoviiteController("/track-layout/reference-lines")
@@ -92,4 +95,11 @@ class ReferenceLineController(private val referenceLineService: ReferenceLineSer
         val layoutContext = LayoutContext.of(branch, publicationState)
         return toResponse(referenceLineService.getLayoutAssetChangeInfo(layoutContext, id))
     }
+
+    @PreAuthorize(AUTH_EDIT_LAYOUT)
+    @PostMapping("/{$LAYOUT_BRANCH}/{id}/cancel")
+    fun cancelReferenceLine(
+        @PathVariable(LAYOUT_BRANCH) branch: DesignBranch,
+        @PathVariable("id") id: IntId<ReferenceLine>,
+    ): ResponseEntity<IntId<ReferenceLine>> = toResponse(referenceLineService.cancel(branch, id)?.id)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -1786,7 +1786,7 @@ constructor(
             designOfficialContext
                 .insert(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
-        trackNumberService.cancel(designBranch, trackNumber)
+        referenceLineService.cancel(designBranch, referenceLine)
         designDraftContext.insert(designOfficialContext.fetch(trackNumber)!!)
         val validateBoth =
             publicationValidationService.validatePublicationCandidates(
@@ -1877,6 +1877,7 @@ constructor(
         val kmPost = designOfficialContext.insert(kmPost(trackNumber, KmNumber(1), Point(1.0, 0.0))).id
         designDraftContext.insert(designOfficialContext.fetch(kmPost)!!)
         trackNumberService.cancel(designBranch, trackNumber)
+        referenceLineService.cancel(designBranch, referenceLine)
         val validateTrackNumber =
             publicationValidationService.validatePublicationCandidates(
                 publicationService.collectPublicationCandidates(PublicationInDesign(designBranch)),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -1605,6 +1605,7 @@ constructor(
             PublicationRequest(publishAll, FreeTextWithNewLines.of("")),
         )
         trackNumberService.cancel(designBranch, trackNumber.id)
+        referenceLineService.cancel(designBranch, referenceLine.id)
         locationTrackService.cancel(designBranch, locationTrack.id)
         switchService.cancel(designBranch, switch.id)
         publicationService.publishManualPublication(
@@ -1690,6 +1691,7 @@ constructor(
         fakeRatko.hostPushedRouteNumber("1.1.1.1.2")
 
         trackNumberService.cancel(designBranch, trackNumber.id)
+        referenceLineService.cancel(designBranch, referenceLine.id)
         locationTrackService.cancel(designBranch, locationTrack.id)
         switchService.cancel(designBranch, switch.id)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -372,33 +372,6 @@ constructor(
     }
 
     @Test
-    fun `cancelling a track number cancels its reference line as well`() {
-        val designBranch = testDBService.createDesignBranch()
-        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
-
-        val trackNumber = mainOfficialContext.insert(trackNumber())
-        val referenceLine = mainOfficialContext.insert(referenceLineAndAlignment(trackNumber.id))
-
-        val firstTrackNumberDraft =
-            trackNumberService.saveDraft(designBranch, mainOfficialContext.fetch(trackNumber.id)!!)
-        val firstReferenceLineDraft =
-            referenceLineService.saveDraft(designBranch, mainOfficialContext.fetch(referenceLine.id)!!)
-        val designOfficialTrackNumber = trackNumberService.publish(designBranch, firstTrackNumberDraft).published
-        val designOfficialReferenceLine = referenceLineService.publish(designBranch, firstReferenceLineDraft).published
-
-        // before cancelling the design change: design-official version is visible in draft context
-        assertEquals(designOfficialTrackNumber, designDraftContext.fetchVersion(trackNumber.id))
-        assertEquals(designOfficialReferenceLine, designDraftContext.fetchVersion(referenceLine.id))
-
-        trackNumberService.cancel(designBranch, trackNumber.id)
-
-        // after cancelling the design change: cancellation hides design-official version in draft
-        // context, leaving main-official version visible
-        assertEquals(trackNumber, designDraftContext.fetchVersion(trackNumber.id))
-        assertEquals(referenceLine, designDraftContext.fetchVersion(referenceLine.id))
-    }
-
-    @Test
     fun `draft track number can find reference line in any above context`() {
         val designBranch = testDBService.createDesignBranch()
         val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)


### PR DESCRIPTION
Päädyin MVP-mielessä siihen, että vaikka periaatteessa onkin niin, että ratanumeron luomisen perumisen yhteydessä pitää aina perua myös sen pituusmittauslinjan luominen, ei yritetä tehdä sitä automaattisesti. Tämä automatisointi nimittäin aiheuttaa monta muuta nysvättävää asiaa: Julkaisun esikatselunäkymä ei osaa hoksata pituusmittauslinjan muutoksen peruutuneen kuin vasta muutosajan päivittymisen jälkeen, pituusmittauslinjan perumisen pitäisi oikeasti tarkistaa, onko nyt kysessä suunnitelmassa luotu linja, ja ehkä testauksen jälkeen löytyisi muitakin juttuja.