### PR TITLE
GVT-3012 Remove not strictly necessary fast-deep-equals dependency

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,7 +13,6 @@
                 "@jcoreio/async-throttle": "~1.6.1",
                 "@reduxjs/toolkit": "~2.5.1",
                 "date-fns": "~4.1.0",
-                "fast-deep-equal": "^3.1.3",
                 "i18next": "~24.2.2",
                 "i18next-http-backend": "~3.0.2",
                 "js-cookie": "~3.0.5",
@@ -5307,6 +5306,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,7 +55,6 @@
         "@jcoreio/async-throttle": "~1.6.1",
         "@reduxjs/toolkit": "~2.5.1",
         "date-fns": "~4.1.0",
-        "fast-deep-equal": "^3.1.3",
         "i18next": "~24.2.2",
         "i18next-http-backend": "~3.0.2",
         "js-cookie": "~3.0.5",

--- a/ui/src/utils/array-utils.ts
+++ b/ui/src/utils/array-utils.ts
@@ -1,6 +1,6 @@
 import { TimeStamp } from 'common/common-model';
 import { expectDefined } from 'utils/type-utils';
-import equal from 'fast-deep-equal';
+import { objectEquals } from 'utils/object-utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type EmptyObject = {};
@@ -320,7 +320,7 @@ export function reuseListElements<T>(
     newContent: readonly T[],
     oldElements: T[],
     extractKey: (e: T) => Primitive,
-    equals: (a: T, b: T) => boolean = equal,
+    equals: (a: T, b: T) => boolean = objectEquals,
 ): T[] {
     const oldInstances = indexIntoKeyedMapWithDuplicateCounts(oldElements, extractKey, equals);
 


### PR DESCRIPTION
Mietin review-kommenttien perusteella hieman tämän riippuvuuden tarpeellisuutta, ja niihnhän se on, että jos tätä käytetään Reactin suhteen oikeaoppisesti (ts. ei render-metodeissa vaan ainoastaan settereissä/redux-tilan päivityksissä), niin aika eipätodennäköistä on, että stringify-pohjainen yhtäsuuruustarkistus aiheuttaisi ikinä ongelmia => otetaan ylimääräinen riippuvuus pois.