### PR TITLE
GVT-2937: Muunnetun koordinaatiston näyttäminen infoboksissa linkityksessä olemassaolevaan kilometripylvääseen

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -185,6 +185,10 @@
     "design": {
         "duplicate-name": "Nimi {{name}} on jo käytössä"
     },
+    "gk-location-transform": {
+        "location-converted": "Sijainti muunnettu koordinaatistosta {{originalCrs}}",
+        "original-crs": "Alkuperäinen koordinaatisto {{originalCrs}}"
+    },
     "enum": {
         "PlanPhase": {
             "RAILWAY_PLAN": "Ratasuunnitelma, RaS",
@@ -1896,9 +1900,7 @@
             "source-manual": "Operaattorin asettama",
             "source-none": "-",
             "location-in-layout": "Sijainti paikannuspohjassa (TM35FIN)",
-            "out-of-bounds": "Sijainti ei ole laskettavissa",
-            "location-converted": "Sijainti muunnettu koordinaatistosta {{originalCrs}}",
-            "original-crs": "Alkuperäinen koordinaatisto {{originalCrs}}"
+            "out-of-bounds": "Sijainti ei ole laskettavissa"
         }
     },
     "km-post-delete-dialog": {

--- a/ui/src/geoviite-design-lib/message-box/message-box.scss
+++ b/ui/src/geoviite-design-lib/message-box/message-box.scss
@@ -2,9 +2,12 @@
 
 .message-box {
     @include vayla-design.typography-caption;
-    background-color: vayla-design.$color-lemon-light;
     color: vayla-design.$color-black-default;
     overflow: hidden;
+
+    &--warning {
+        background-color: vayla-design.$color-lemon-light;
+    }
 
     &--error {
         background-color: vayla-design.$color-red-lighter;

--- a/ui/src/geoviite-design-lib/message-box/message-box.scss
+++ b/ui/src/geoviite-design-lib/message-box/message-box.scss
@@ -5,7 +5,7 @@
     color: vayla-design.$color-black-default;
     overflow: hidden;
 
-    &--warning {
+    &--info {
         background-color: vayla-design.$color-lemon-light;
     }
 

--- a/ui/src/geoviite-design-lib/message-box/message-box.tsx
+++ b/ui/src/geoviite-design-lib/message-box/message-box.tsx
@@ -3,7 +3,7 @@ import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import styles from './message-box.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 
-type MessageBoxType = 'INFO' | 'ERROR';
+type MessageBoxType = 'INFO' | 'WARNING' | 'ERROR';
 
 type MessageBoxProps = {
     children?: React.ReactNode;
@@ -15,14 +15,16 @@ type MessageBoxProps = {
 export const MessageBox: React.FC<MessageBoxProps> = ({
     children,
     pop,
-    type = 'INFO',
+    type = 'WARNING',
 }: MessageBoxProps) => {
+    const showingWarning = type === 'WARNING';
     const showingError = type === 'ERROR';
 
     const classes = createClassName(
         styles['message-box'],
         pop !== undefined && styles['message-box--poppable'],
         pop && styles['message-box--popped'],
+        showingWarning && styles['message-box--warning'],
         showingError && styles['message-box--error'],
     );
 

--- a/ui/src/geoviite-design-lib/message-box/message-box.tsx
+++ b/ui/src/geoviite-design-lib/message-box/message-box.tsx
@@ -3,7 +3,11 @@ import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import styles from './message-box.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 
-type MessageBoxType = 'INFO' | 'WARNING' | 'ERROR';
+export enum MessageBoxType {
+    GHOST = 'GHOST',
+    INFO = 'INFO',
+    ERROR = 'ERROR',
+}
 
 type MessageBoxProps = {
     children?: React.ReactNode;
@@ -12,36 +16,38 @@ type MessageBoxProps = {
     qaId?: string;
 };
 
+const styleByType: Record<MessageBoxType, string | undefined> = {
+    [MessageBoxType.GHOST]: undefined,
+    [MessageBoxType.INFO]: styles['message-box--info'],
+    [MessageBoxType.ERROR]: styles['message-box--error'],
+};
+
+const iconByType: Record<MessageBoxType, React.ReactNode> = {
+    [MessageBoxType.GHOST]: <Icons.Info color={IconColor.INHERIT} />,
+    [MessageBoxType.INFO]: <Icons.Info color={IconColor.INHERIT} />,
+    [MessageBoxType.ERROR]: <Icons.StatusError color={IconColor.INHERIT} />,
+};
+
 export const MessageBox: React.FC<MessageBoxProps> = ({
     children,
     pop,
-    type = 'WARNING',
+    type = MessageBoxType.INFO,
 }: MessageBoxProps) => {
-    const showingWarning = type === 'WARNING';
-    const showingError = type === 'ERROR';
-
     const classes = createClassName(
         styles['message-box'],
         pop !== undefined && styles['message-box--poppable'],
         pop && styles['message-box--popped'],
-        showingWarning && styles['message-box--warning'],
-        showingError && styles['message-box--error'],
+        styleByType[type],
     );
 
     const iconClasses = createClassName(
         styles['message-box__icon'],
-        showingError && styles['message-box__icon--error'],
+        type === MessageBoxType.ERROR && styles['message-box__icon--error'],
     );
     return (
         <div className={classes}>
             <div className="message-box__inner">
-                <span className={iconClasses}>
-                    {showingError ? (
-                        <Icons.StatusError color={IconColor.INHERIT} />
-                    ) : (
-                        <Icons.Info color={IconColor.INHERIT} />
-                    )}
-                </span>
+                <span className={iconClasses}>{iconByType[type]}</span>
                 <span>{children}</span>
             </div>
         </div>

--- a/ui/src/preview/preview-view-design-drafts-exist-error.tsx
+++ b/ui/src/preview/preview-view-design-drafts-exist-error.tsx
@@ -1,4 +1,4 @@
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { MessageBox, MessageBoxType } from 'geoviite-design-lib/message-box/message-box';
 import { Trans, useTranslation } from 'react-i18next';
 import * as React from 'react';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
@@ -19,7 +19,7 @@ export const DesignDraftsExistError: React.FC<DesignDraftsExistErrorProps> = ({
     );
     return (
         <div>
-            <MessageBox type="ERROR">
+            <MessageBox type={MessageBoxType.ERROR}>
                 <Trans
                     t={t}
                     i18nKey={'preview-view.design-has-design-drafts-error'}

--- a/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
+++ b/ui/src/tool-panel/km-post/dialog/km-post-edit-store.ts
@@ -124,6 +124,10 @@ export const GK_FIN_COORDINATE_SYSTEMS: [Srid, string][] = [...Array(13)].map(
         return [srid, projection];
     },
 );
+export const isGk = (srid: Srid): boolean =>
+    GK_FIN_COORDINATE_SYSTEMS.some(([gkSrid]) => gkSrid === srid);
+export const isFromAnotherGk = (srid1: Srid, srid2: Srid): boolean =>
+    isGk(srid1) && isGk(srid2) && srid1 !== srid2;
 
 export const isWithinEastingMargin = (point: GeometryPoint): boolean => {
     const wgs84Point = pointToWgs84(point);

--- a/ui/src/tool-panel/km-post/geometry-km-post-different-gk-source-warning.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-different-gk-source-warning.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Srid } from 'common/common-model';
+import { useCoordinateSystem } from 'track-layout/track-layout-react-utils';
+import { formatWithSrid } from 'utils/geography-utils';
+
+export const GeometryKmPostDifferentGkSourceWarning: React.FC<{ originalSrid: Srid }> = ({
+    originalSrid,
+}) => {
+    const { t } = useTranslation();
+
+    const originalCoordinateSystem = useCoordinateSystem(originalSrid);
+
+    return (
+        <React.Fragment>
+            {t('gk-location-transform.location-converted', {
+                originalCrs: originalCoordinateSystem
+                    ? formatWithSrid(originalCoordinateSystem)
+                    : '',
+            })}
+        </React.Fragment>
+    );
+};

--- a/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-linking-infobox.tsx
@@ -36,7 +36,7 @@ import { compareByField } from 'utils/array-utils';
 import { isFromAnotherGk, isGk } from 'tool-panel/km-post/dialog/km-post-edit-store';
 import { GeometryKmPostNonGkSourceWarning } from 'tool-panel/km-post/geometry-km-post-non-gk-source-warning';
 import { GeometryKmPostDifferentGkSourceWarning } from 'tool-panel/km-post/geometry-km-post-different-gk-source-warning';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { MessageBox, MessageBoxType } from 'geoviite-design-lib/message-box/message-box';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 type GeometryKmPostLinkingInfoboxProps = {
@@ -90,7 +90,7 @@ const DifferingGkSourceWarning: React.FC<{ planSrid: Srid; kmPostSrid: Srid }> =
         case 'DIFFERENT':
             return (
                 <InfoboxContentSpread>
-                    <MessageBox type={'INFO'}>
+                    <MessageBox type={MessageBoxType.GHOST}>
                         <GeometryKmPostDifferentGkSourceWarning originalSrid={planSrid} />
                     </MessageBox>
                 </InfoboxContentSpread>

--- a/ui/src/tool-panel/km-post/geometry-km-post-non-gk-source-warning.tsx
+++ b/ui/src/tool-panel/km-post/geometry-km-post-non-gk-source-warning.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Srid } from 'common/common-model';
+import { useCoordinateSystem } from 'track-layout/track-layout-react-utils';
+import { formatWithSrid } from 'utils/geography-utils';
+
+export const GeometryKmPostNonGkSourceWarning: React.FC<{ originalSrid: Srid }> = ({
+    originalSrid,
+}) => {
+    const { t } = useTranslation();
+
+    const originalCoordinateSystem = useCoordinateSystem(originalSrid);
+
+    return (
+        <React.Fragment>
+            {t('gk-location-transform.location-converted', {
+                originalCrs: originalCoordinateSystem
+                    ? formatWithSrid(originalCoordinateSystem)
+                    : '',
+            })}
+        </React.Fragment>
+    );
+};

--- a/ui/src/tool-panel/location-track/splitting/location-track-split-notices.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split-notices.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { MessageBox, MessageBoxType } from 'geoviite-design-lib/message-box/message-box';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export const LocationTrackSplittingErrorNotice: React.FC<{
@@ -9,7 +9,7 @@ export const LocationTrackSplittingErrorNotice: React.FC<{
 }> = ({ msg }) => {
     return (
         <InfoboxContentSpread>
-            <MessageBox type={'ERROR'}>{msg}</MessageBox>
+            <MessageBox type={MessageBoxType.ERROR}>{msg}</MessageBox>
         </InfoboxContentSpread>
     );
 };
@@ -38,7 +38,7 @@ export const LocationTrackSplittingDuplicateTrackNotPublishedErrorNotice: React.
     const { t } = useTranslation();
     return (
         <InfoboxContentSpread>
-            <MessageBox type={'ERROR'}>
+            <MessageBox type={MessageBoxType.ERROR}>
                 <div>
                     {t('tool-panel.location-track.splitting.validation.duplicate-not-published', {
                         duplicateName: draftDuplicateName,

--- a/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { LoaderStatus } from 'utils/react-utils';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { MessageBox, MessageBoxType } from 'geoviite-design-lib/message-box/message-box';
 import styles from 'tool-panel/location-track/location-track-infobox.scss';
 import { Spinner, SpinnerSize } from 'vayla-design-lib/spinner/spinner';
 import { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
@@ -28,7 +28,8 @@ export const LocationTrackSplitRelinkingNotice: React.FC<
             {switchRelinkingLoadingState === LoaderStatus.Ready &&
                 switchRelinkingErrors &&
                 switchRelinkingErrors.length > 0 && (
-                    <MessageBox type={hasCriticalErrors ? 'ERROR' : 'WARNING'}>
+                    <MessageBox
+                        type={hasCriticalErrors ? MessageBoxType.ERROR : MessageBoxType.INFO}>
                         {hasCriticalErrors
                             ? t('tool-panel.location-track.splitting.relink-critical-errors')
                             : t('tool-panel.location-track.splitting.relink-message')}

--- a/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split-relinking-notice.tsx
@@ -28,7 +28,7 @@ export const LocationTrackSplitRelinkingNotice: React.FC<
             {switchRelinkingLoadingState === LoaderStatus.Ready &&
                 switchRelinkingErrors &&
                 switchRelinkingErrors.length > 0 && (
-                    <MessageBox type={hasCriticalErrors ? 'ERROR' : 'INFO'}>
+                    <MessageBox type={hasCriticalErrors ? 'ERROR' : 'WARNING'}>
                         {hasCriticalErrors
                             ? t('tool-panel.location-track.splitting.relink-critical-errors')
                             : t('tool-panel.location-track.splitting.relink-message')}

--- a/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-infobox.tsx
@@ -36,7 +36,7 @@ import { GeometrySwitchLinkingInfoboxVisibilities } from 'track-layout/track-lay
 import { OnSelectFunction, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { SwitchBadge, SwitchBadgeStatus } from 'geoviite-design-lib/switch/switch-badge';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { MessageBox, MessageBoxType } from 'geoviite-design-lib/message-box/message-box';
 import { useUserHasPrivilege } from 'store/hooks';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { VIEW_LAYOUT_DRAFT } from 'user/user-model';
@@ -302,7 +302,7 @@ const GeometrySwitchLinkingInfobox: React.FC<GeometrySwitchLinkingInfoboxProps> 
                             {linkingState.switchSource === 'PREDEFINED' &&
                                 layoutSwitch?.stateCategory === 'NOT_EXISTING' && (
                                     <InfoboxContentSpread>
-                                        <MessageBox type={'ERROR'}>
+                                        <MessageBox type={MessageBoxType.ERROR}>
                                             {t('tool-panel.switch.layout.cant-link-deleted')}
                                         </MessageBox>
                                     </InfoboxContentSpread>

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -33,7 +33,7 @@ import {
 import LayoutStateCategoryLabel from 'geoviite-design-lib/layout-state-category/layout-state-category-label';
 import { BoundingBox, Point } from 'model/geometry';
 import { PlacingSwitch } from 'linking/linking-model';
-import { MessageBox } from 'geoviite-design-lib/message-box/message-box';
+import { MessageBox, MessageBoxType } from 'geoviite-design-lib/message-box/message-box';
 import { translateSwitchTrapPoint } from 'utils/enum-localization-utils';
 import { filterNotEmpty } from 'utils/array-utils';
 import { SwitchInfoboxTrackMeters } from 'tool-panel/switch/switch-infobox-track-meters';
@@ -374,7 +374,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                                     {t('tool-panel.switch.layout.switch-placing-help')}
                                 </MessageBox>
                             ) : (
-                                <MessageBox type={'ERROR'}>
+                                <MessageBox type={MessageBoxType.ERROR}>
                                     {t('tool-panel.switch.layout.cant-link-deleted')}
                                 </MessageBox>
                             )}


### PR DESCRIPTION
Yllättävän paljon löytyi refaktorointitarpeita näinkin simppelin kuuloisen jutun myötä, eikä tässäkään välttämättä vielä kaikki. Täällä käytännössä siis erotettu aiemmin pelkästään kilometripylvään linkityksen luontidialogissa näytetyt GK-sijainnin muunnosvaroitukset linkitysinfoboksissa mikäli sijainti pitää muuntaa (itse varoitustekstit erotettu omiksi komponenteikseen, muu DOM on käyttöpaikkakohtaista).

Tämä poiki muutostarpeita myös `MessageBox`-komponenttiin (uusi `GHOST`-tyyppi hieman samaan tyyliin kuin meidän `GHOST`-napit). Lisäksi refaktoroin tämän myötä `MessageBox`:ia sisäisesti jonkin verran, sillä aiemman kahden tyyppiarvon sijasta nykyään pitää ottaa huomioon kolme, ja sen tekeminen fiksummin vaikutti, noh, fiksulta.