### PR TITLE
GVT-3075: Radan/raiteen automaattinen valinta siirryttyessä suunnitelmien latausikkunaan luonnostilasta ++

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -209,8 +209,12 @@ class LayoutTrackNumberService(
         startKmNumber: KmNumber?,
         endKmNumber: KmNumber?,
     ): List<GeometryPlanHeader> {
-        val alignmentVersion =
-            requireNotNull(referenceLineService.getByTrackNumberOrThrow(layoutContext, trackNumberId).alignmentVersion)
+        val referenceLine = referenceLineService.getByTrackNumber(layoutContext, trackNumberId)
+        if (referenceLine == null) {
+            return emptyList()
+        }
+
+        val alignmentVersion = requireNotNull(referenceLine.alignmentVersion)
         val geocodingContext = requireNotNull(geocodingService.getGeocodingContext(layoutContext, trackNumberId))
 
         if (!cropIsWithinReferenceLine(startKmNumber, endKmNumber, geocodingContext)) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -396,7 +396,11 @@ class LocationTrackService(
         cropStart: KmNumber?,
         cropEnd: KmNumber?,
     ): List<GeometryPlanHeader> {
-        val locationTrack = getOrThrow(layoutContext, locationTrackId)
+        val locationTrack = get(layoutContext, locationTrackId)
+        if (locationTrack == null) {
+            return emptyList()
+        }
+
         val context = requireNotNull(geocodingService.getGeocodingContext(layoutContext, locationTrack.trackNumberId))
         val alignment = alignmentDao.fetch(requireNotNull(locationTrack.alignmentVersion))
 

--- a/ui/src/map/map-view-container.tsx
+++ b/ui/src/map/map-view-container.tsx
@@ -46,6 +46,8 @@ const getTrackLayoutProps = (): MapViewProps => {
         mapLayerMenuGroups: store.map.layerMenu,
         onMapLayerChange: delegates.onLayerMenuItemChange,
         onStopPlanDownload: delegates.onStopPlanDownload,
+        selectedDesignId: store.designId,
+        layoutContextMode: store.layoutContextMode,
     };
 };
 

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -29,7 +29,7 @@ import { LinkingState, LinkingSwitch, LinkPoint } from 'linking/linking-model';
 import { pointLocationTool } from 'map/tools/point-location-tool';
 import { LocationHolderView } from 'map/location-holder/location-holder-view';
 import { GeometryPlanLayout, LAYOUT_SRID } from 'track-layout/track-layout-model';
-import { LayoutContext } from 'common/common-model';
+import { LayoutContext, LayoutContextMode, LayoutDesignId } from 'common/common-model';
 import Overlay from 'ol/Overlay';
 import { useTranslation } from 'react-i18next';
 import { createDebugLayer } from 'map/layers/debug/debug-layer';
@@ -126,6 +126,8 @@ export type MapViewProps = {
     customActiveMapTool?: MapTool;
     designPublicationMode?: DesignPublicationMode;
     mapTools?: MapToolWithButton[];
+    layoutContextMode?: LayoutContextMode;
+    selectedDesignId?: LayoutDesignId;
 };
 
 export type ClickType = 'all' | 'geometryPoint' | 'layoutPoint' | 'remove';
@@ -208,6 +210,8 @@ const MapView: React.FC<MapViewProps> = ({
     customActiveMapTool,
     designPublicationMode,
     mapTools,
+    layoutContextMode,
+    selectedDesignId,
 }: MapViewProps) => {
     const { t } = useTranslation();
     // State to store OpenLayers map object between renders
@@ -233,6 +237,7 @@ const MapView: React.FC<MapViewProps> = ({
     };
     const isLoading = () => [...map.visibleLayers].some((l) => layersLoadingData.includes(l));
     const inPreviewView = !!designPublicationMode;
+    const isSelectingDesign = layoutContextMode === 'DESIGN' && !selectedDesignId;
 
     const mapLayers = [...map.visibleLayers].sort().join();
 
@@ -831,7 +836,7 @@ const MapView: React.FC<MapViewProps> = ({
                     <Spinner />
                 </div>
             )}
-            {!inPreviewView && planDownloadState && (
+            {!inPreviewView && !isSelectingDesign && planDownloadState && (
                 <PlanDownloadPopup
                     onClose={() => onStopPlanDownload()}
                     layoutContext={layoutContext}

--- a/ui/src/map/plan-download/confirm-move-to-main-official-dialog.tsx
+++ b/ui/src/map/plan-download/confirm-move-to-main-official-dialog.tsx
@@ -5,6 +5,8 @@ import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
+import { useTrackLayoutAppSelector } from 'store/hooks';
+import { initialSelectionForPlanDownload } from 'map/plan-download/plan-download-store';
 
 type ConfirmMoveToMainOfficialDialogContainerProps = {
     onClose: () => void;
@@ -14,11 +16,16 @@ export const ConfirmMoveToMainOfficialDialogContainer: React.FC<
     ConfirmMoveToMainOfficialDialogContainerProps
 > = ({ onClose }) => {
     const delegates = createDelegates(TrackLayoutActions);
+    const state = useTrackLayoutAppSelector((state) => state);
 
     return (
         <ConfirmMoveToMainOfficialDialog
             moveToMainOfficial={() => delegates.onLayoutContextModeChange('MAIN_OFFICIAL')}
-            openPlanDownloadDialog={delegates.onStartPlanDownload}
+            openPlanDownloadDialog={() =>
+                delegates.onStartPlanDownload(
+                    initialSelectionForPlanDownload(state?.selectedToolPanelTab),
+                )
+            }
             onClose={onClose}
         />
     );

--- a/ui/src/map/plan-download/confirm-move-to-main-official-dialog.tsx
+++ b/ui/src/map/plan-download/confirm-move-to-main-official-dialog.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
 import { useTrackLayoutAppSelector } from 'store/hooks';
-import { initialSelectionForPlanDownload } from 'map/plan-download/plan-download-store';
+import { planDownloadAssetIdFromToolPanelAsset } from 'map/plan-download/plan-download-store';
 
 type ConfirmMoveToMainOfficialDialogContainerProps = {
     onClose: () => void;
@@ -17,15 +17,14 @@ export const ConfirmMoveToMainOfficialDialogContainer: React.FC<
 > = ({ onClose }) => {
     const delegates = createDelegates(TrackLayoutActions);
     const state = useTrackLayoutAppSelector((state) => state);
+    const initialAsset = state.selectedToolPanelTab
+        ? planDownloadAssetIdFromToolPanelAsset(state.selectedToolPanelTab)
+        : undefined;
 
     return (
         <ConfirmMoveToMainOfficialDialog
             moveToMainOfficial={() => delegates.onLayoutContextModeChange('MAIN_OFFICIAL')}
-            openPlanDownloadDialog={() =>
-                delegates.onStartPlanDownload(
-                    initialSelectionForPlanDownload(state?.selectedToolPanelTab),
-                )
-            }
+            openPlanDownloadDialog={() => delegates.onStartPlanDownload(initialAsset)}
             onClose={onClose}
         />
     );

--- a/ui/src/map/plan-download/plan-download-area-section.tsx
+++ b/ui/src/map/plan-download/plan-download-area-section.tsx
@@ -108,7 +108,10 @@ export const PlanDownloadAreaSection: React.FC<{
     ).includes('end-before-start');
 
     const labelClasses = (hasErrors: boolean) =>
-        createClassName(hasErrors && styles['plan-download-popup__field-label--error']);
+        createClassName(
+            hasErrors && styles['plan-download-popup__field-label--error'],
+            disabled && styles['plan-download-popup__field-label--disabled'],
+        );
 
     const selectedDropdownValue = inferDropdownItemValue(selectedAsset);
 

--- a/ui/src/map/plan-download/plan-download-popup.scss
+++ b/ui/src/map/plan-download/plan-download-popup.scss
@@ -28,6 +28,10 @@
         color: vayla-design.$color-red-dark;
     }
 
+    &__field-label--disabled {
+        color: vayla-design.$color-black-lighter;
+    }
+
     &__area-grid {
         display: grid;
         grid-template-columns: 2fr 3fr;

--- a/ui/src/map/plan-download/plan-download-store.ts
+++ b/ui/src/map/plan-download/plan-download-store.ts
@@ -28,6 +28,7 @@ import {
 import { isValidKmNumber } from 'tool-panel/km-post/dialog/km-post-edit-store';
 import { brand } from 'common/brand';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
+import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 export type AreaSelection = {
     asset: PlanDownloadAssetId | undefined;
@@ -59,6 +60,7 @@ export enum PlanDownloadAssetType {
     TRACK_NUMBER = 'TRACK_NUMBER',
     LOCATION_TRACK = 'LOCATION_TRACK',
 }
+
 export type PlanDownloadAssetId =
     | {
           id: LayoutTrackNumberId;
@@ -98,21 +100,31 @@ export const initialPlanDownloadStateFromSelection = (
     };
 };
 
-export const initialSelectionForPlanDownload = (
-    selectedAsset: ToolPanelAsset | undefined,
+export const planDownloadAssetIdFromToolPanelAsset = (
+    selectedAsset: ToolPanelAsset,
 ): PlanDownloadAssetId | undefined => {
-    if (selectedAsset?.type === 'TRACK_NUMBER') {
-        return {
-            type: PlanDownloadAssetType.TRACK_NUMBER,
-            id: brand(selectedAsset.id),
-        };
-    } else if (selectedAsset?.type === 'LOCATION_TRACK') {
-        return {
-            type: PlanDownloadAssetType.LOCATION_TRACK,
-            id: brand(selectedAsset.id),
-        };
+    switch (selectedAsset.type) {
+        case 'TRACK_NUMBER':
+            return {
+                type: PlanDownloadAssetType.TRACK_NUMBER,
+                id: brand(selectedAsset.id),
+            };
+        case 'LOCATION_TRACK':
+            return {
+                type: PlanDownloadAssetType.LOCATION_TRACK,
+                id: brand(selectedAsset.id),
+            };
+        case 'GEOMETRY_PLAN':
+        case 'GEOMETRY_ALIGNMENT':
+        case 'GEOMETRY_KM_POST':
+        case 'GEOMETRY_SWITCH':
+        case 'GEOMETRY_SWITCH_SUGGESTION':
+        case 'KM_POST':
+        case 'SWITCH':
+            return undefined;
+        default:
+            return exhaustiveMatchingGuard(selectedAsset.type);
     }
-    return undefined;
 };
 
 export const initialPlanDownloadState: PlanDownloadState = {

--- a/ui/src/map/plan-download/plan-download-store.ts
+++ b/ui/src/map/plan-download/plan-download-store.ts
@@ -26,6 +26,8 @@ import {
     PlanSource,
 } from 'geometry/geometry-model';
 import { isValidKmNumber } from 'tool-panel/km-post/dialog/km-post-edit-store';
+import { brand } from 'common/brand';
+import { ToolPanelAsset } from 'tool-panel/tool-panel';
 
 export type AreaSelection = {
     asset: PlanDownloadAssetId | undefined;
@@ -94,6 +96,23 @@ export const initialPlanDownloadStateFromSelection = (
             asset: selectedAsset,
         },
     };
+};
+
+export const initialSelectionForPlanDownload = (
+    selectedAsset: ToolPanelAsset | undefined,
+): PlanDownloadAssetId | undefined => {
+    if (selectedAsset?.type === 'TRACK_NUMBER') {
+        return {
+            type: PlanDownloadAssetType.TRACK_NUMBER,
+            id: brand(selectedAsset.id),
+        };
+    } else if (selectedAsset?.type === 'LOCATION_TRACK') {
+        return {
+            type: PlanDownloadAssetType.LOCATION_TRACK,
+            id: brand(selectedAsset.id),
+        };
+    }
+    return undefined;
 };
 
 export const initialPlanDownloadState: PlanDownloadState = {

--- a/ui/src/selection-panel/selection-panel-container.tsx
+++ b/ui/src/selection-panel/selection-panel-container.tsx
@@ -9,8 +9,7 @@ import {
     useReferenceLines,
     useSwitches,
 } from 'track-layout/track-layout-react-utils';
-import { PlanDownloadAssetId, PlanDownloadAssetType } from 'map/plan-download/plan-download-store';
-import { brand } from 'common/brand';
+import { initialSelectionForPlanDownload } from 'map/plan-download/plan-download-store';
 
 type SelectionPanelContainerProps = {
     setSwitchToOfficialDialogOpen: (open: boolean) => void;
@@ -48,28 +47,15 @@ export const SelectionPanelContainer: React.FC<SelectionPanelContainerProps> = (
         changeTimes.layoutKmPost,
     );
 
-    const initialSelectionForPlanDownload: () => PlanDownloadAssetId | undefined = () => {
-        if (state.selectedToolPanelTab?.type === 'TRACK_NUMBER') {
-            return {
-                type: PlanDownloadAssetType.TRACK_NUMBER,
-                id: brand(state.selectedToolPanelTab.id),
-            };
-        } else if (state.selectedToolPanelTab?.type === 'LOCATION_TRACK') {
-            return {
-                type: PlanDownloadAssetType.LOCATION_TRACK,
-                id: brand(state.selectedToolPanelTab.id),
-            };
-        }
-        return undefined;
-    };
-
     const togglePlanDownload = () => {
         if (state.planDownloadState) {
             delegates.onStopPlanDownload();
         } else if (state.layoutContext.publicationState === 'DRAFT') {
             setSwitchToOfficialDialogOpen(true);
         } else {
-            delegates.onStartPlanDownload(initialSelectionForPlanDownload());
+            delegates.onStartPlanDownload(
+                initialSelectionForPlanDownload(state?.selectedToolPanelTab),
+            );
         }
     };
 

--- a/ui/src/selection-panel/selection-panel-container.tsx
+++ b/ui/src/selection-panel/selection-panel-container.tsx
@@ -9,7 +9,7 @@ import {
     useReferenceLines,
     useSwitches,
 } from 'track-layout/track-layout-react-utils';
-import { initialSelectionForPlanDownload } from 'map/plan-download/plan-download-store';
+import { planDownloadAssetIdFromToolPanelAsset } from 'map/plan-download/plan-download-store';
 
 type SelectionPanelContainerProps = {
     setSwitchToOfficialDialogOpen: (open: boolean) => void;
@@ -53,9 +53,10 @@ export const SelectionPanelContainer: React.FC<SelectionPanelContainerProps> = (
         } else if (state.layoutContext.publicationState === 'DRAFT') {
             setSwitchToOfficialDialogOpen(true);
         } else {
-            delegates.onStartPlanDownload(
-                initialSelectionForPlanDownload(state?.selectedToolPanelTab),
-            );
+            const initialAsset = state.selectedToolPanelTab
+                ? planDownloadAssetIdFromToolPanelAsset(state.selectedToolPanelTab)
+                : undefined;
+            delegates.onStartPlanDownload(initialAsset);
         }
     };
 


### PR DESCRIPTION
Varsinainen pihvi oli aika simppeli korjaus: Popupin avaamislogiikka ei dialogin kautta tullessa katsonut ollenkaan valittua toolpanelin tabia. Logiikka yleistetty ja otettu käyttöön sielläkin. Tämän myötä myös huomattu, että overlappaavien sunnitelmien haku heitti poikkeusta mikäli sitä kutsuttiin olemattoman ratanumeron tai sijaintiraiteen id:llä (esim. tämän korjauksen myötä tilanne, jossa ratanumero/sijaintiraide oltiin luotu draftissa mutta sitä ei oltu julkaistu vielä ollenkaan.) Bäkkäri pistetty palauttamaan näissä tilanteissa tyhjän listan suunnitelmia. 

Näiden lisäksi tehty seuraavanlaista kevyttä refaktorointia sekä korjauksia pikkubugeihin:
* Edellämainittu toolpanelissa valitun assetin perusteella popupin alkuassetin valitseva logiikka muutettu if-elsestä switch-caseksi
* Lisätty disabled-väritys popupin aluevalinnan kenttien labeleille
* Piilotetaan suunnitelmien lataus-popup kun ollaan klikattu Suunnitelmatila-tab päälle mutta mitään työtilaa ei ole vielä valittuna (popup piirtyi aiemmin maitolasin päälle)
  * Ideaalinen korjaus tähän olisi ollut laittaa popup piirtymään maitolasin alle. Tämä ei kuitenkaan ole niin simppeliä kuin miltä se alustavasti kuulostaa: Maitolasi piirretään tarkoituksella vain karttanäkymän päälle (yläpalkkeja pitää pystyä operoimaan sen ollessa näkyvissä), mutta popup on portaloitu suoraan `<body>`:yn. Siten jos popup haluttaisiin näyttää maitolasin alla, niin se pitäisi siirtää DOM:issa `<MapView>`:in alle. Tämä käyttötilanne on oletettavasti hyvin harvinainen, eikä popupin kanssa pystyisi interactaamaan silloin muutenkaan maitolasin alta, niin katsoin kustannustehokkaimmaksi korjaukseksi vain piilottaa popup maitolasin ollessa esillä. Popup tulee takaisin esiin kun työtila on saatu valittua/luotua 