### PR TITLE
GVT-2744/GVT-2717 Correctly validate name uniqueness upon merge

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -381,7 +381,17 @@ constructor(
                     listOf()
                 }
 
-            referenceIssues + geocodingIssues
+            val duplicateNumberIssues =
+                if (kmPost.trackNumberId == null || trackNumberNumber == null) listOf()
+                else
+                    validateKmPostNumberDuplication(
+                        kmPost,
+                        trackNumberNumber,
+                        context.getKmPostsByTrackNumber(kmPost.trackNumberId),
+                        context.target.type,
+                    )
+
+            referenceIssues + geocodingIssues + duplicateNumberIssues
         }
 
     private fun validateSwitch(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -103,7 +103,6 @@ class LayoutKmPostDao(
                 where (id in (:km_post_ids_to_publish)) is distinct from true
               ) km_post
             where track_number_id in (:track_number_ids)
-              and km_post.state != 'DELETED'
             order by km_post.track_number_id, km_post.km_number
         """
                 .trimIndent()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -242,7 +242,6 @@ class LayoutTrackNumberDao(
                 select id, design_id, draft, version, number
                 from layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id)
                 where number in (:numbers)
-                  and state != 'DELETED'
             """
                     .trimIndent()
             val params =

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1507,7 +1507,9 @@
                 "reference-line": {
                     "null": "Tasakilometripisteen pituusmittauslinja ei ole mukana julkaisussa"
                 },
-                "duplicate-km-number": "Ratanumerolla ei voi olla kahta tasakilometripistettä samalla tunnuksella. Tunnus on jo käytössä tällä ratanumerolla."
+                "duplicate-name-official": "Ratanumerolla {{trackNumber}} on jo kilometri tunnuksella {{kmNumber}}",
+                "duplicate-name-draft": "Muutosjoukossa on monta tasakilometripistettä tunnuksella {{kmNumber}} ratanumerolla {{trackNumber}}",
+                "duplicate-name-draft-in-main": "Ratanumerolla {{trackNumber}} on jo luotu luonnostilassa kilometri tunnuksella {{kmNumber}}."
             },
             "reference-line": {
                 "no-context": "Pituusmittauslinjalle ei voida laskea tasametripisteitä koska siltä puuttuu tietoja",


### PR DESCRIPTION
Kilometritolpilla ja ratanumeroilla on layout-konteksteittain uniikki nimi/tunnus riippumatta tilasta. Siksi niitä validoitaessa pitää ottaa mahdollisesti poistetutkin viralliset versiot mukaan.