### PR TITLE
GVT-3078: Add localized error handling to ext-api

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
@@ -8,7 +8,6 @@ import fi.fta.geoviite.infra.authorization.AUTH_API_FRAME_CONVERTER
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Srid
-import fi.fta.geoviite.infra.error.ExtApiExceptionV1
 import fi.fta.geoviite.infra.logging.apiCall
 import fi.fta.geoviite.infra.logging.apiResult
 import fi.fta.geoviite.infra.util.Either
@@ -162,7 +161,7 @@ constructor(
 
     private inline fun <reified Request : FrameConverterRequestV1> assertRequestType(requests: List<*>): List<Request> {
         if (requests.any { it !is Request }) {
-            throw ExtApiExceptionV1(
+            throw FrameConverterExceptionV1(
                 message = "Unsupported request type",
                 error = FrameConverterErrorV1.UnsupportedRequestType,
             )
@@ -173,7 +172,7 @@ constructor(
 
     private fun <T : FrameConverterRequestV1> assertRequestSize(requests: List<T>) {
         if (requests.size > maxBatchRequests) {
-            throw ExtApiExceptionV1(
+            throw FrameConverterExceptionV1(
                 message = "Too many requests in batch: maxCount=$maxBatchRequests",
                 error = FrameConverterErrorV1.TooManyRequests,
             )

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterErrorV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterErrorV1.kt
@@ -1,6 +1,16 @@
 package fi.fta.geoviite.api.frameconverter.v1
 
+import fi.fta.geoviite.infra.error.ClientException
 import fi.fta.geoviite.infra.localization.LocalizationKey
+import fi.fta.geoviite.infra.localization.LocalizationParams
+import org.springframework.http.HttpStatus.BAD_REQUEST
+
+class FrameConverterExceptionV1(
+    message: String,
+    cause: Throwable? = null,
+    error: FrameConverterErrorV1,
+    localizationParams: LocalizationParams = LocalizationParams.empty,
+) : ClientException(BAD_REQUEST, "Invalid request: $message", cause, error.localizationKey, localizationParams)
 
 enum class FrameConverterErrorV1(private val localizationSuffix: String) {
     TooManyRequests("too-many-requests"),
@@ -29,6 +39,6 @@ enum class FrameConverterErrorV1(private val localizationSuffix: String) {
     val localizationKey: LocalizationKey by lazy { LocalizationKey("$BASE.$localizationSuffix") }
 
     companion object {
-        private const val BASE: String = "ext-api.error"
+        private const val BASE: String = "ext-api.frame-converter.v1.error"
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -12,6 +12,8 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 
+const val EXT_TRACK_LAYOUT_BASE_PATH = "/geoviite"
+
 @PreAuthorize(AUTH_API_GEOMETRY)
 @GeoviiteExtApiController([])
 @Tag(name = "Rataverkon paikannuspohja V1")

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutErrorHandlingV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutErrorHandlingV1.kt
@@ -1,0 +1,139 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException
+import fi.fta.geoviite.infra.error.ErrorDescription
+import fi.fta.geoviite.infra.error.ErrorPriority
+import fi.fta.geoviite.infra.error.GeoviiteErrorResponse
+import fi.fta.geoviite.infra.error.HasLocalizedMessage
+import fi.fta.geoviite.infra.localization.Translation
+import fi.fta.geoviite.infra.localization.localizationParams
+import java.time.Instant
+import org.springframework.core.convert.ConversionFailedException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.NoHandlerFoundException
+
+internal const val ERROR_KEY_BASE = "ext-api.track-layout.v1.error"
+
+data class ExtApiErrorResponseV1(
+    @JsonProperty("virheviesti") val errorMessage: String,
+    @JsonProperty("korrelaatiotunnus") val correlationId: String,
+    @JsonProperty("aikaleima") val timestamp: Instant = Instant.now(),
+) : GeoviiteErrorResponse()
+
+fun createExtApiErrorResponseV1(
+    correlationId: String,
+    status: HttpStatus,
+    causeChain: List<Exception>,
+    translation: Translation,
+): ResponseEntity<GeoviiteErrorResponse>? {
+    val headers = HttpHeaders()
+    headers.contentType = MediaType.APPLICATION_JSON
+
+    val errorMessageChain =
+        when {
+            status.is5xxServerError -> describeHttpStatus(translation, status).let(::listOf)
+
+            else -> causeChain.mapNotNull { ex -> describeException(translation, ex) }
+        }
+
+    val prioritizedErrorMessage =
+        errorMessageChain.minByOrNull { errorDescription -> errorDescription.priority }
+            ?: describeHttpStatus(translation, status)
+
+    return ResponseEntity(
+        ExtApiErrorResponseV1(errorMessage = prioritizedErrorMessage.message, correlationId = correlationId),
+        headers,
+        status,
+    )
+}
+
+private fun describeHttpStatus(translation: Translation, status: HttpStatus): ErrorDescription {
+    val errorKey =
+        if (status.is4xxClientError) {
+            "ext-api.track-layout.v1.error.client-error"
+        } else {
+            "ext-api.track-layout.v1.error.server-error"
+        }
+
+    return ErrorDescription(
+        message = translation.t(errorKey),
+        key = errorKey,
+        params = localizationParams("koodi" to status.value()),
+    )
+}
+
+private fun describeException(translation: Translation, ex: Exception): ErrorDescription? {
+    return when (ex) {
+        is HasLocalizedMessage ->
+            ErrorDescription(
+                message = ex.message ?: "${ex::class.simpleName}",
+                localizationKey = ex.localizationKey,
+                localizationParams = ex.localizationParams,
+                priority = ErrorPriority.HIGH,
+            )
+
+        is HttpRequestMethodNotSupportedException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.invalid-path"
+            val params = localizationParams("metodi" to ex.method)
+
+            ErrorDescription(translation.t(key, params), key, params)
+        }
+
+        is NoHandlerFoundException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.invalid-path"
+            val params = localizationParams("metodi" to ex.httpMethod)
+
+            ErrorDescription(translation.t(key, params), key, params)
+        }
+
+        is MissingServletRequestParameterException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.missing-parameter"
+            val params = localizationParams("parametri" to ex.parameterName, "tyyppi" to ex.parameterType)
+
+            ErrorDescription(translation.t(key, params), key, params)
+        }
+
+        is MethodArgumentTypeMismatchException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.conversion-failed-detailed"
+            val params =
+                localizationParams(
+                    "nimi" to ex.name,
+                    "parametri" to ex.parameter,
+                    "tavoitetyyppi" to (ex.requiredType?.simpleName ?: "tuntematon"),
+                )
+
+            ErrorDescription(translation.t(key, params), key, params)
+        }
+
+        is ConversionFailedException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.conversion-failed"
+            val params = localizationParams("tavoitetyyppi" to ex.targetType.type.simpleName)
+
+            ErrorDescription(translation.t(key, params), key, params, ErrorPriority.LOW)
+        }
+
+        is MismatchedInputException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.conversion-failed"
+            val params = localizationParams("tavoitetyyppi" to ex.targetType?.simpleName)
+
+            ErrorDescription(translation.t(key, params), key, params, ErrorPriority.LOW)
+        }
+
+        is ValueInstantiationException -> {
+            val key = "$ERROR_KEY_BASE.bad-request.conversion-failed"
+            val params = localizationParams("tavoitetyyppi" to ex.type?.genericSignature)
+
+            ErrorDescription(translation.t(key, params), key, params, ErrorPriority.LOW)
+        }
+
+        else -> null
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutExceptionsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutExceptionsV1.kt
@@ -1,0 +1,26 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+import fi.fta.geoviite.infra.error.ClientException
+import fi.fta.geoviite.infra.error.ServerException
+import org.springframework.http.HttpStatus
+
+class ExtOidNotFoundExceptionV1(
+    message: String,
+    cause: Throwable? = null,
+    localizedMessageKey: String = "$ERROR_KEY_BASE.oid-not-found",
+) : ClientException(HttpStatus.NOT_FOUND, "oid not found: $message", cause, localizedMessageKey)
+
+class ExtGeocodingFailedV1(message: String, cause: Throwable? = null) :
+    ServerException("geocoding failed: $message", cause)
+
+class ExtTrackNumberNotFoundV1(
+    message: String,
+    cause: Throwable? = null,
+    localizedMessageKey: String = "$ERROR_KEY_BASE.track-number-not-found",
+) : ClientException(HttpStatus.BAD_REQUEST, "track number not found: $message", cause, localizedMessageKey)
+
+class ExtTrackNetworkVersionNotFound(
+    message: String,
+    cause: Throwable? = null,
+    localizedMessageKey: String = "$ERROR_KEY_BASE.track-network-version-not-found",
+) : ClientException(HttpStatus.BAD_REQUEST, "track network version not found: $message", cause, localizedMessageKey)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
@@ -12,6 +12,7 @@ import correlationId
 import currentUser
 import currentUserRole
 import fi.fta.geoviite.api.configuration.ExtApiConfiguration
+import fi.fta.geoviite.api.tracklayout.v1.EXT_TRACK_LAYOUT_BASE_PATH
 import fi.fta.geoviite.infra.SpringContextUtility
 import fi.fta.geoviite.infra.authorization.AuthCode
 import fi.fta.geoviite.infra.authorization.AuthName
@@ -27,6 +28,8 @@ import fi.fta.geoviite.infra.environmentInfo.EnvironmentInfo
 import fi.fta.geoviite.infra.error.ApiUnauthorizedException
 import fi.fta.geoviite.infra.error.InvalidUiVersionException
 import fi.fta.geoviite.infra.error.createErrorResponse
+import fi.fta.geoviite.infra.localization.LocalizationLanguage
+import fi.fta.geoviite.infra.localization.LocalizationService
 import fi.fta.geoviite.infra.logging.apiRequest
 import fi.fta.geoviite.infra.logging.apiResponse
 import jakarta.servlet.FilterChain
@@ -51,6 +54,8 @@ import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
+import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.context.request.WebRequest
 import org.springframework.web.filter.OncePerRequestFilter
 
 const val HTTP_HEADER_REMOTE_IP = "X-FORWARDED-FOR"
@@ -80,6 +85,7 @@ constructor(
     @Value("\${geoviite.app-root:}") private val appRoot: String,
     private val extApi: ExtApiConfiguration,
     private val environmentInfo: EnvironmentInfo,
+    private val localizationService: LocalizationService,
 ) : OncePerRequestFilter() {
 
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -202,7 +208,14 @@ constructor(
                 chain.doFilter(request, response)
             }
         } catch (ex: Exception) {
-            val errorResponse = createErrorResponse(log, ex)
+            val errorResponse =
+                createErrorResponse(
+                    logger = log,
+                    exception = ex,
+                    requestType = inferRequestType(request as WebRequest),
+                    translation = localizationService.getLocalization(LocalizationLanguage.FI),
+                )
+
             response.contentType = errorResponse.headers.contentType?.toString() ?: MediaType.APPLICATION_JSON_VALUE
             response.status = errorResponse.statusCode.value()
             response.writer.write(objectMapper.writeValueAsString(errorResponse.body))
@@ -436,4 +449,23 @@ private fun parseAuthCodes(authCodeListing: String): List<AuthCode> {
         }
 
     return authCodeStrings.filter(::isValidCode).map(::AuthCode)
+}
+
+enum class GeoviiteRequestType {
+    ExtApiV1,
+    Other,
+}
+
+fun inferRequestType(request: WebRequest): GeoviiteRequestType {
+    val servletRequest = request as? ServletWebRequest
+
+    return when {
+        servletRequest != null && servletRequest.request.requestURI.startsWith(EXT_TRACK_LAYOUT_BASE_PATH) -> {
+            GeoviiteRequestType.ExtApiV1
+        }
+
+        else -> {
+            GeoviiteRequestType.Other
+        }
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/RequestFilter.kt
@@ -212,7 +212,7 @@ constructor(
                 createErrorResponse(
                     logger = log,
                     exception = ex,
-                    requestType = inferRequestType(request as WebRequest),
+                    requestType = (request as? WebRequest)?.let(::inferRequestType) ?: GeoviiteRequestType.Other,
                     translation = localizationService.getLocalization(LocalizationLanguage.FI),
                 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandler.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandler.kt
@@ -1,8 +1,15 @@
 package fi.fta.geoviite.infra.error
 
 import correlationId
+import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.configuration.GeoviiteRequestType
+import fi.fta.geoviite.infra.configuration.inferRequestType
+import fi.fta.geoviite.infra.localization.LocalizationLanguage
+import fi.fta.geoviite.infra.localization.LocalizationService
+import fi.fta.geoviite.infra.localization.Translation
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
@@ -15,37 +22,55 @@ import org.springframework.web.context.request.WebRequest
 @ConditionalOnWebApplication
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
-class ApiErrorHandler {
+@GeoviiteService
+class ApiErrorHandler
+@Autowired
+constructor(private val localizationService: LocalizationService, service: LocalizationService) {
 
-    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        log.info("Initialized error handler")
+        logger.info("Initialized error handler")
     }
 
     @ExceptionHandler(value = [(Exception::class)])
-    fun handleAnyException(ex: Exception, request: WebRequest): ResponseEntity<ApiErrorResponse> =
-        createErrorResponse(log, ex)
+    fun handleAnyException(exception: Exception, request: WebRequest): ResponseEntity<GeoviiteErrorResponse> {
+        return createErrorResponse(
+            logger,
+            exception,
+            requestType = inferRequestType(request),
+            translation = localizationService.getLocalization(LocalizationLanguage.FI),
+        )
+    }
 }
 
-fun createErrorResponse(log: Logger, ex: Exception): ResponseEntity<ApiErrorResponse> {
+fun createErrorResponse(
+    logger: Logger,
+    exception: Exception,
+    requestType: GeoviiteRequestType,
+    translation: Translation,
+): ResponseEntity<GeoviiteErrorResponse> {
     val correlationId: String = correlationId.getOrNull() ?: "N/A"
     val response =
-        createResponse(ex, correlationId)
+        handleErrorResponseCreation(exception, correlationId, requestType, translation)
             ?: run {
-                log.warn(
+                logger.warn(
                     "Error handling failed. Defaulting to \"Internal server error\": " +
-                        "correlationId=$correlationId exceptionChain=${getCauseChain(ex)}"
+                        "correlationId=$correlationId exceptionChain=${getCauseChain(exception)}"
                 )
                 createTerseErrorResponse(correlationId, INTERNAL_SERVER_ERROR)
             }
     when {
         // Log server errors with full stack
-        response.statusCode.is5xxServerError -> log.error("Server error: correlationId=$correlationId $response", ex)
+        response.statusCode.is5xxServerError ->
+            logger.error("Server error: correlationId=$correlationId $response", exception)
         // Log handled (client) errors with Exception.toString -> no stack
         response.statusCode.is4xxClientError ->
-            log.warn("Client error: correlationId=$correlationId $response exception=\"$ex\"")
-        else -> log.info("Non-error response: correlationId=$correlationId ${response.statusCode} exception=\"$ex\"")
+            logger.warn("Client error: correlationId=$correlationId $response exception=\"$exception\"")
+        else ->
+            logger.info(
+                "Non-error response: correlationId=$correlationId ${response.statusCode} exception=\"$exception\""
+            )
     }
     return response
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandler.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorHandler.kt
@@ -23,9 +23,7 @@ import org.springframework.web.context.request.WebRequest
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
 @GeoviiteService
-class ApiErrorHandler
-@Autowired
-constructor(private val localizationService: LocalizationService, service: LocalizationService) {
+class ApiErrorHandler @Autowired constructor(private val localizationService: LocalizationService) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorResponse.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ApiErrorResponse.kt
@@ -4,10 +4,12 @@ import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import java.time.Instant
 
+open class GeoviiteErrorResponse
+
 data class ApiErrorResponse(
     val messageRows: List<String>,
     val localizationKey: LocalizationKey,
     val localizationParams: LocalizationParams,
     val correlationId: String,
     val timestamp: Instant = Instant.now(),
-)
+) : GeoviiteErrorResponse()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.infra.error
 
-import fi.fta.geoviite.api.frameconverter.v1.FrameConverterErrorV1
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.RowVersion
@@ -22,7 +21,7 @@ interface HasLocalizedMessage {
     val localizationParams: LocalizationParams
 }
 
-sealed class ClientException(
+open class ClientException(
     val status: HttpStatus,
     message: String,
     cause: Throwable? = null,
@@ -214,10 +213,3 @@ class InvalidUiVersionException(cause: Throwable? = null) :
         cause = cause,
         localizedMessageKey = "error.bad-request.invalid-version",
     )
-
-class ExtApiExceptionV1(
-    message: String,
-    cause: Throwable? = null,
-    error: FrameConverterErrorV1,
-    localizationParams: LocalizationParams = LocalizationParams.empty,
-) : ClientException(BAD_REQUEST, "Invalid request: $message", cause, error.localizationKey, localizationParams)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ServerException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ServerException.kt
@@ -1,3 +1,3 @@
 package fi.fta.geoviite.infra.error
 
-class ServerException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+open class ServerException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1,28 +1,48 @@
 {
     "ext-api": {
-        "error": {
-            "features-not-found": "Annetun (alku)pisteen parametreilla ei löytynyt tietoja.",
-            "missing-x-coordinate": "Pyyntö ei sisältänyt x-koordinaattia.",
-            "missing-y-coordinate": "Pyyntö ei sisältänyt y-koordinaattia.",
-            "missing-track-kilometer": "Pyyntö ei sisältänyt ratakilometriä.",
-            "missing-track-meter": "Pyyntö ei sisältänyt ratametriä.",
-            "missing-track-number": "Pyyntö ei sisältänyt ratanumeroa.",
-            "unsupported-request-type": "Pyyntötyyppiä ei tueta.",
-            "search-radius-undefined": "Pyyntö sisälsi hakusääteen ilman arvoa (sade=null).",
-            "search-radius-under-range": "Pyyntö sisälsi pienemmän hakusäteen kuin sallittu minimiarvo (1.0).",
-            "search-radius-over-range": "Pyyntö sisälsi suuremman hakusäteen kuin sallittu maksimiarvo (1000.0).",
-            "address-geocoding-failed": "Rataosoitteen geokoodaus epäonnistui.",
-            "invalid-track-number-name": "Pyyntö sisälsi virheellisen ratanumero-asetuksen.",
-            "invalid-track-number-oid": "Pyyntö sisälsi virheellisen ratanumero_oid-asetuksen.",
-            "invalid-location-track-name": "Pyyntö sisälsi virheellisen sijaintiraide-asetuksen.",
-            "invalid-location-track-oid": "Pyyntö sisälsi virheellisen sijaintiraide_oid-asetuksen.",
-            "invalid-location-track-type": "Pyyntö sisälsi virheellisen sijaintiraide_tyyppi-asetuksen. Sallitut arvot ovat pääraide, sivuraide, kujaraide, turvaraide.",
-            "invalid-track-address": "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen).",
-            "no-track-number-search-condition": "Pyyntö ei sisältänyt hakuehtoa ratanumerolle. Sisällytä muunnospyyntöön yksi kentistä: ratanumero, ratanumero_oid.",
-            "both-name-and-oid-for-track-number": "Pyyntö sisälsi useamman kuin yhden hakuehdon ratanumerolle. Sisällytä muunnospyyntöön yksi kentistä: ratanumero, ratanumero_oid.",
-            "too-many-requests": "Kutsu sisälsi liian monta muunnospyyntöä. Yhdessä kutsussa saa olla korkeintaan 1000 muunnosta.",
-            "track-number-not-found": "Pyynnön ratanumeroa ei löydetty.",
-            "input-coordinate-transformation-failed": "Koordinaattimuunnos ei onnistunut. Onko koordinaatisto järkevä syötekoordinaatille?"
+        "frame-converter": {
+            "v1": {
+                "error": {
+                    "features-not-found": "Annetun (alku)pisteen parametreilla ei löytynyt tietoja.",
+                    "missing-x-coordinate": "Pyyntö ei sisältänyt x-koordinaattia.",
+                    "missing-y-coordinate": "Pyyntö ei sisältänyt y-koordinaattia.",
+                    "missing-track-kilometer": "Pyyntö ei sisältänyt ratakilometriä.",
+                    "missing-track-meter": "Pyyntö ei sisältänyt ratametriä.",
+                    "missing-track-number": "Pyyntö ei sisältänyt ratanumeroa.",
+                    "unsupported-request-type": "Pyyntötyyppiä ei tueta.",
+                    "search-radius-undefined": "Pyyntö sisälsi hakusääteen ilman arvoa (sade=null).",
+                    "search-radius-under-range": "Pyyntö sisälsi pienemmän hakusäteen kuin sallittu minimiarvo (1.0).",
+                    "search-radius-over-range": "Pyyntö sisälsi suuremman hakusäteen kuin sallittu maksimiarvo (1000.0).",
+                    "address-geocoding-failed": "Rataosoitteen geokoodaus epäonnistui.",
+                    "invalid-track-number-name": "Pyyntö sisälsi virheellisen ratanumero-asetuksen.",
+                    "invalid-track-number-oid": "Pyyntö sisälsi virheellisen ratanumero_oid-asetuksen.",
+                    "invalid-location-track-name": "Pyyntö sisälsi virheellisen sijaintiraide-asetuksen.",
+                    "invalid-location-track-oid": "Pyyntö sisälsi virheellisen sijaintiraide_oid-asetuksen.",
+                    "invalid-location-track-type": "Pyyntö sisälsi virheellisen sijaintiraide_tyyppi-asetuksen. Sallitut arvot ovat pääraide, sivuraide, kujaraide, turvaraide.",
+                    "invalid-track-address": "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen).",
+                    "no-track-number-search-condition": "Pyyntö ei sisältänyt hakuehtoa ratanumerolle. Sisällytä muunnospyyntöön yksi kentistä: ratanumero, ratanumero_oid.",
+                    "both-name-and-oid-for-track-number": "Pyyntö sisälsi useamman kuin yhden hakuehdon ratanumerolle. Sisällytä muunnospyyntöön yksi kentistä: ratanumero, ratanumero_oid.",
+                    "too-many-requests": "Kutsu sisälsi liian monta muunnospyyntöä. Yhdessä kutsussa saa olla korkeintaan 1000 muunnosta.",
+                    "track-number-not-found": "Pyynnön ratanumeroa ei löydetty.",
+                    "input-coordinate-transformation-failed": "Koordinaattimuunnos ei onnistunut. Onko koordinaatisto järkevä syötekoordinaatille?"
+                }
+            }
+        },
+        "track-layout": {
+            "v1": {
+                "error": {
+                    "oid-not-found": "Pyynnön OID-tunnuksen perusteella ei löydetty kohdetta.",
+                    "client-error": "Pyyntö oli tunnistamattomalla tavalla virheellinen (HTTP {{koodi}}).",
+                    "server-error": "Pyynnön käsittely epäonnistui palvelimella (HTTP {{koodi}}).",
+                    "unauthorized": "Pyyntöön ei ollut oikeutta.",
+                    "bad-request": {
+                        "invalid-path": "{{metodi}} Pyynnön polku oli virheellinen",
+                        "missing-parameter": "Pyynnöstä puuttui parametri: {{parametri}} ({{tyyppi}})",
+                        "conversion-failed": "Pyynnön argumentin tyyppi oli virheellinen (tavoitetyyppi: '{{tavoitetyyppi}}')",
+                        "conversion-failed-detailed": "Pyynnön argumentti {{nimi}} oli virheellinen: (tavoitetyyppi: '{{tavoitetyyppi}}') (tarkenne: {{parametri}})"
+                    }
+                }
+            }
         }
     },
     "error": {


### PR DESCRIPTION
Pointtina jakaa yleinen virhekäsittely siten, että aiempi geoviitteen rajapinta käyttää aiempaa, mutta virheenkäsittelijöitä voi wirettää muuallekin pyynnön polun perusteella.