### PR TITLE
GVT-3105 Re-enable linking geometry switches

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingController.kt
@@ -150,7 +150,9 @@ constructor(
     fun getSuggestedSwitchForGeometrySwitch(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @RequestParam("geometrySwitchId") geometrySwitchId: IntId<GeometrySwitch>,
-    ): GeometrySwitchSuggestionResult = switchLinkingService.getSuggestedSwitch(branch, geometrySwitchId)
+        @RequestParam("layoutSwitchId") layoutSwitchId: IntId<LayoutSwitch>?,
+    ): GeometrySwitchSuggestionResult =
+        switchLinkingService.getSuggestedSwitch(branch, geometrySwitchId, layoutSwitchId)
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping("/{$LAYOUT_BRANCH}/switches/suggested", params = ["location", "layoutSwitchId"])

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.linking.switches
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LocationAccuracy
@@ -76,10 +77,10 @@ data class FittedSwitch(val switchStructure: SwitchStructure, val joints: List<F
 data class SwitchPlacingRequest(val points: SamplingGridPoints, val layoutSwitchId: IntId<LayoutSwitch>)
 
 data class SuggestedSwitch(
+    val id: DomainId<GeometrySwitch>,
     val switchStructureId: IntId<SwitchStructure>,
     val joints: List<LayoutSwitchJoint>,
     val trackLinks: Map<IntId<LocationTrack>, SwitchLinkingTrackLinks>,
-    val geometrySwitchId: IntId<GeometrySwitch>? = null,
     val name: SwitchName,
 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -81,6 +81,7 @@ constructor(
         // fitting can move switches far enough to change how it e.g. makes topological links, so we
         // need to re-lookup nearby alignments
         val alignmentsNearFits = collectLocationTracksNearFitGrids(fitGrids, locationTrackCache)
+        val switches = switchService.getMany(branch.draft, requests.map { it.layoutSwitchId }).associateBy { it.id }
 
         return fitGrids
             .mapIndexed { i, r -> i to r }
@@ -94,7 +95,12 @@ constructor(
                         clearSwitchFromTracks(switchId, originallyLinked)
                 fitGrid.map(parallel = true) { fit ->
                     SuggestedSwitchWithOriginallyLinkedTracks(
-                        matchFittedSwitchToTracks(fit, relevantTracks, switchId),
+                        matchFittedSwitchToTracks(
+                            fit,
+                            relevantTracks,
+                            layoutSwitchId = switchId,
+                            geometrySwitchId = switches.getValue(switchId).sourceId as? IntId,
+                        ),
                         originallyLinked.keys,
                     )
                 }
@@ -148,25 +154,44 @@ constructor(
     fun getSuggestedSwitch(
         branch: LayoutBranch,
         geometrySwitchId: IntId<GeometrySwitch>,
+        layoutSwitchId: IntId<LayoutSwitch>?,
     ): GeometrySwitchSuggestionResult =
         when (val fit = switchFittingService.fitGeometrySwitch(branch, geometrySwitchId)) {
             is GeometrySwitchFittingFailure -> GeometrySwitchSuggestionFailure(fit.failure)
             is GeometrySwitchFittingSuccess ->
-                GeometrySwitchSuggestionSuccess(findRelevantTracksAndMatchFittedSwitch(branch, fit.switch).first)
+                GeometrySwitchSuggestionSuccess(
+                    findRelevantTracksAndMatchFittedSwitch(
+                            branch,
+                            fit.switch,
+                            layoutSwitchId = layoutSwitchId,
+                            geometrySwitchId = geometrySwitchId,
+                        )
+                        .first
+                )
         }
 
     private fun findRelevantTracksAndMatchFittedSwitch(
         branch: LayoutBranch,
         fit: FittedSwitch,
+        geometrySwitchId: IntId<GeometrySwitch>? = null,
         layoutSwitchId: IntId<LayoutSwitch>? = null,
-        originallyLinkedTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>>? = null,
     ): Pair<SuggestedSwitch, Map<IntId<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>>> {
         val tracksAroundFit = findLocationTracksForMatchingSwitchToTracks(branch, fit)
-        val relevantTracks = tracksAroundFit + (originallyLinkedTracks ?: mapOf())
-        // TODO GVT-3105 redo geometry switch linking so that we get a non-null layoutSwitchId here; this is because
-        // saveSwitchLinking later does get one, and hence cleans said switch from the tracks for the linking, and so
-        // this needs to clean it, too
-        val match = matchFittedSwitchToTracks(fit, relevantTracks, layoutSwitchId)
+        val originallyLinkedTracks =
+            layoutSwitchId?.let { id ->
+                clearSwitchFromTracks(
+                    id,
+                    switchService.getLocationTracksLinkedToSwitch(branch.draft, id).associateBy { it.first.id as IntId },
+                )
+            } ?: mapOf()
+        val relevantTracks = tracksAroundFit + originallyLinkedTracks
+        val match =
+            matchFittedSwitchToTracks(
+                fit,
+                relevantTracks,
+                layoutSwitchId = layoutSwitchId,
+                geometrySwitchId = geometrySwitchId,
+            )
         return match to relevantTracks.filterKeys { track -> match.trackLinks.containsKey(track) }
     }
 
@@ -177,7 +202,8 @@ constructor(
         switchId: IntId<LayoutSwitch>,
     ): LayoutRowVersion<LayoutSwitch> {
         verifySwitchExists(branch, switchId)
-        suggestedSwitch.geometrySwitchId?.let(::verifyPlanNotHidden)
+        (suggestedSwitch.id as? IntId)?.let(::verifyPlanNotHidden)
+
         val originalTracks =
             suggestedSwitch.trackLinks.keys.associateWith { id ->
                 locationTrackService.getWithGeometryOrThrow(branch.draft, id)
@@ -287,7 +313,13 @@ constructor(
                             val original = originallyLinkedLocationTracksBySwitch[switchId] ?: mapOf()
                             nearby + clearSwitchFromTracks(switchId, original + changedLocationTracks)
                         }
-                    val match = matchFittedSwitchToTracks(fittedSwitch, nearbyTracksForMatch, switchId)
+                    val match =
+                        matchFittedSwitchToTracks(
+                            fittedSwitch,
+                            nearbyTracksForMatch,
+                            geometrySwitchId = originalSwitch.sourceId as? IntId,
+                            layoutSwitchId = switchId,
+                        )
                     withChangesFromLinkingSwitch(
                             match,
                             switchLibraryService.getSwitchStructure(match.switchStructureId),
@@ -611,9 +643,7 @@ private fun linkJointToEdgeMiddle(
     isFirstJointInSequence: Boolean,
     isLastJointInSequence: Boolean,
 ): List<TmpLayoutEdge> {
-    require(!(isFirstJointInSequence && isLastJointInSequence)) {
-        "can't link joint topologically mid-track"
-    }
+    require(!(isFirstJointInSequence && isLastJointInSequence)) { "can't link joint topologically mid-track" }
     val middleOuterNodeConnection = NodeConnection.switch(inner = null, outer = switchLink)
     val middleInnerNodeConnection = NodeConnection.switch(inner = switchLink, outer = null)
     return listOf(
@@ -654,7 +684,7 @@ fun clearSwitchFromTracks(
 ) = tracks.mapValues { (_, track) -> track.first to track.second.withoutSwitch(switchId) }
 
 fun createModifiedLayoutSwitchLinking(suggestedSwitch: SuggestedSwitch, layoutSwitch: LayoutSwitch): LayoutSwitch {
-    val newGeometrySwitchId = suggestedSwitch.geometrySwitchId ?: layoutSwitch.sourceId
+    val newGeometrySwitchId = suggestedSwitch.id as? IntId
 
     return layoutSwitch.copy(
         sourceId = newGeometrySwitchId,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchMatching.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchMatching.kt
@@ -2,7 +2,9 @@ package fi.fta.geoviite.infra.linking.switches
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.geometry.GeometrySwitch
 import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
@@ -23,10 +25,11 @@ import kotlin.math.absoluteValue
 fun matchFittedSwitchToTracks(
     fittedSwitch: FittedSwitch,
     clearedTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>>,
-    switchId: IntId<LayoutSwitch>?,
+    layoutSwitchId: IntId<LayoutSwitch>?,
+    geometrySwitchId: IntId<GeometrySwitch>? = null,
     name: SwitchName? = null,
 ): SuggestedSwitch {
-    require(switchId == null || clearedTracks.values.none { it.second.containsSwitch(switchId) }) {
+    require(layoutSwitchId == null || clearedTracks.values.none { it.second.containsSwitch(layoutSwitchId) }) {
         "Must clear switch from tracks before calling matchFittedSwitchToTracks on it"
     }
     val jointsOnEdges = mapFittedSwitchToEdges(fittedSwitch, clearedTracks)
@@ -37,6 +40,7 @@ fun matchFittedSwitchToTracks(
     val linkedTracks = suggestDelinking(clearedTracks) + suggestLinking(bestLinks, clearedTracks)
 
     return SuggestedSwitch(
+        id = geometrySwitchId ?: StringId(),
         fittedSwitch.switchStructure.id,
         fittedSwitch.joints.map {
             LayoutSwitchJoint(
@@ -47,7 +51,6 @@ fun matchFittedSwitchToTracks(
             )
         },
         linkedTracks,
-        null,
         name ?: SwitchName(fittedSwitch.switchStructure.baseType.name),
     )
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -1577,7 +1577,8 @@ constructor(
                     suggestedFitting,
                     switch.id as IntId,
                 ),
-                switch.id as IntId,
+                layoutSwitchId = switch.id as IntId,
+                geometrySwitchId = null,
             ),
             switch.id as IntId,
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
@@ -138,7 +138,7 @@ constructor(
     fun linkingExistingGeometrySwitchGetsSwitchAccuracyForJoints() {
         val geometrySwitchId = setupJointLocationAccuracyTest()
         val suggestedSwitch =
-            (switchLinkingService.getSuggestedSwitch(LayoutBranch.main, geometrySwitchId)
+            (switchLinkingService.getSuggestedSwitch(LayoutBranch.main, geometrySwitchId, layoutSwitchId = null)
                     as GeometrySwitchSuggestionSuccess)
                 .switch
         for (joint in suggestedSwitch.joints.map { j -> j.number }) {

--- a/ui/src/linking/linking-api.ts
+++ b/ui/src/linking/linking-api.ts
@@ -228,8 +228,9 @@ export async function getSuggestedSwitchForLayoutSwitchPlacing(
 export async function getSuggestedSwitchForGeometrySwitch(
     layoutBranch: LayoutBranch,
     geometrySwitchId: GeometrySwitchId,
+    layoutSwitchId: LayoutSwitchId | undefined,
 ): Promise<GeometrySwitchSuggestionResult | undefined> {
-    return getSuggestedSwitch(layoutBranch, queryParams({ geometrySwitchId }));
+    return getSuggestedSwitch(layoutBranch, queryParams({ geometrySwitchId, layoutSwitchId }));
 }
 
 function getSuggestedSwitch<SuggestedSwitchType>(

--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -283,12 +283,10 @@ export type SwitchLinkingJoint = {
 };
 
 export type SuggestedSwitch = {
-    id: SuggestedSwitchId;
+    id: GeometrySwitchId;
     switchStructureId: SwitchStructureId;
     joints: LayoutSwitchJoint[];
     trackLinks: Record<LocationTrackId, SwitchLinkingTrackLinks>;
-    geometryPlanId?: GeometryPlanId;
-    geometrySwitchId?: GeometrySwitchId;
     name: string;
 };
 

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -234,7 +234,7 @@ export const linkingReducers = {
         // operator needs to take an action to select a switch
         state.selection.selectedItems.switches = [];
     },
-    lockSwitchSelection: (
+    selectLayoutSwitchForLinking: (
         state: TrackLayoutState,
         { payload: switchId }: PayloadAction<LayoutSwitchId | undefined>,
     ) => {

--- a/ui/src/tool-panel/switch/dialog/suggested-switch-infobox-container.tsx
+++ b/ui/src/tool-panel/switch/dialog/suggested-switch-infobox-container.tsx
@@ -35,11 +35,11 @@ export const SuggestedSwitchInfoboxContainer: React.FC<SuggestedSwitchInfoboxCon
         <GeometrySwitchInfobox
             visibilities={visibilities}
             onVisibilityChange={onVisibilityChange}
-            switchId={suggestedSwitch.geometrySwitchId ?? undefined}
+            switchId={suggestedSwitch.id}
             layoutSwitch={layoutSwitch}
             suggestedSwitch={suggestedSwitch}
             linkingState={trackLayoutState.linkingState}
-            planId={suggestedSwitch.geometryPlanId ?? undefined}
+            planId={undefined}
             changeTimes={changeTimes}
             locationTrackChangeTime={changeTimes.layoutLocationTrack}
             onShowOnMap={onShowMapLocation}

--- a/ui/src/tool-panel/switch/geometry-switch-linking-container.tsx
+++ b/ui/src/tool-panel/switch/geometry-switch-linking-container.tsx
@@ -48,6 +48,7 @@ const GeometrySwitchLinkingContainer: React.FC<GeometrySwitchLinkingContainerPro
                 delegates.startSwitchLinking({ suggestedSwitch, source: 'USER_SELECTED' });
             }}
             selectedSuggestedSwitch={suggestedSwitch}
+            selectLayoutSwitchForLinking={delegates.selectLayoutSwitchForLinking}
             onSelect={delegates.onSelect}
             onUnselect={delegates.onUnselect}
             switchChangeTime={switchChangeTime}

--- a/ui/src/tool-panel/tool-panel.tsx
+++ b/ui/src/tool-panel/tool-panel.tsx
@@ -315,7 +315,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
             };
         });
         const geometrySwitchTabs: ToolPanelTab[] = geometrySwitchIds
-            .filter((s) => !suggestedSwitches.some((ss) => ss.geometrySwitchId === s.geometryId))
+            .filter((s) => !suggestedSwitches.some((ss) => ss.id === s.geometryId))
             .map((s) => {
                 const geomSwitch = getPlan(s.planId)?.switches?.find(
                     (gs) => gs.sourceId === s.geometryId,
@@ -441,7 +441,7 @@ const ToolPanel: React.FC<ToolPanelProps> = ({
                 return (
                     ((t.asset.type === 'GEOMETRY_SWITCH' ||
                         t.asset.type === 'GEOMETRY_SWITCH_SUGGESTION') &&
-                        t.asset.id === linkingState.suggestedSwitch.geometrySwitchId) ||
+                        t.asset.id === linkingState.suggestedSwitch.id) ||
                     suggestedSwitches.some((s) => t.asset.id === s.id)
                 );
             })?.asset;

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -412,7 +412,7 @@ const trackLayoutSlice = createSlice({
                     break;
                 case LinkingType.LinkingSwitch: {
                     const selectedSwitch = first(state.selection.selectedItems.switches);
-                    linkingReducers.lockSwitchSelection(state, {
+                    linkingReducers.selectLayoutSwitchForLinking(state, {
                         type: '',
                         payload: selectedSwitch,
                     });


### PR DESCRIPTION
En ole ihan varma, olisiko tässä tapahtuvat asiat mahdollista tehdä suoraviivaisemminkin: Vaihdelinkityksen frontissa on sen verran sudenkuoppia, etten enää luottanut olemassaolevaan koodiin vaan tein uutta. Jäljessä tulee refakkia, tämä kommitti kun kaivaa vielä lisää sudenkuoppia.

Mutta perusajatus nyt on siis:

- Geometriavaihteen vaihde-ehdotus on yhä mahdollista tehdä ilman tietoa siitä, mille paikannuspohjan vaihteelle se linkitetään. Tämä siksi, että pystytään näyttämään vaihde-ehdotus heti, kun on aloitettu linkitys, ilman että käyttäjä valitsee kohdevaihteen, ja ilman että ehdokkaita lähistöllä on edes olemassa.
- ... mutta toisin kuin ennen, nyt vaihde-ehdotus haetaan uusiksi joka kerta, kun käyttäjä valitsee valikosta, mille paikannuspohjan vaihteelle tehdään linkitystä. Tällöin näkyy suoraan linjoittain, onnistuuko linkitys vai ei. Tosin uuden vaihdelinkityskoodin snäppäys on sen verran innokas, että uudenkin vaihteen linkittäminen vaan suoraan olemassaolevan linkitetyn vaihteen päälle voi onnistua ainakin osittain, mutta se on oma ongelmansa.

