### PR TITLE
GVT-3136: Fix broken asset tab selection

### DIFF
--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -708,16 +708,23 @@ export const TOOL_PANEL_ASSET_ORDER: ToolPanelAssetType[] = [
 
 export const getFirstOfTypeInSelection = (
     selection: Selection,
+    linkingState: LinkingState | undefined,
     type: ToolPanelAssetType,
 ): ToolPanelAsset | undefined => {
     const { selectedItems } = selection;
+
+    const switchLinkingActive =
+        linkingState?.type === LinkingType.LinkingLayoutSwitch ||
+        linkingState?.type === LinkingType.LinkingGeometrySwitch;
+
     const assetGetters: Record<ToolPanelAssetType, () => string | undefined> = {
         GEOMETRY_PLAN: () => first(selectedItems.geometryPlans),
         TRACK_NUMBER: () => first(selectedItems.trackNumbers),
         KM_POST: () => first(selectedItems.kmPosts),
         GEOMETRY_KM_POST: () => first(selectedItems.geometryKmPostIds)?.geometryId,
         SWITCH: () => first(selectedItems.switches),
-        SUGGESTED_SWITCH: () => SUGGESTED_SWITCH_TOOL_PANEL_TAB_ID,
+        SUGGESTED_SWITCH: () =>
+            switchLinkingActive ? SUGGESTED_SWITCH_TOOL_PANEL_TAB_ID : undefined,
         GEOMETRY_SWITCH: () => first(selectedItems.switches),
         LOCATION_TRACK: () => first(selectedItems.locationTracks),
         GEOMETRY_ALIGNMENT: () => first(selectedItems.geometryAlignmentIds)?.geometryId,
@@ -726,11 +733,17 @@ export const getFirstOfTypeInSelection = (
     return id ? { id, type } : undefined;
 };
 
-export const getFirstToolPanelAsset = (selection: Selection): ToolPanelAsset | undefined => {
+export const getFirstToolPanelAsset = (
+    selection: Selection,
+    linkingState: LinkingState | undefined,
+): ToolPanelAsset | undefined => {
     const firstAssetType = TOOL_PANEL_ASSET_ORDER.find(
-        (type) => getFirstOfTypeInSelection(selection, type) !== undefined,
+        (type) => getFirstOfTypeInSelection(selection, linkingState, type) !== undefined,
     );
-    return firstAssetType ? getFirstOfTypeInSelection(selection, firstAssetType) : undefined;
+
+    return firstAssetType
+        ? getFirstOfTypeInSelection(selection, linkingState, firstAssetType)
+        : undefined;
 };
 
 const updateSelectedToolPanelTab = (
@@ -742,7 +755,7 @@ const updateSelectedToolPanelTab = (
         !currentlySelectedTab ||
         !toolPanelAssetExists(selection, linkingState, currentlySelectedTab)
     ) {
-        return getFirstToolPanelAsset(selection);
+        return getFirstToolPanelAsset(selection, linkingState);
     }
 
     return currentlySelectedTab;


### PR DESCRIPTION
Context:
* The current git main-branch UI doesn't always display the vertical geometry diagram: The diagram does not always open depending on the asset selection order.
* This is tested via an E2E test, which is sometimes failing, leading to builds not always completing properly.
* Switch linking UI functionality was recently modified.
* Switch linking tab has different selection/forced selection functionality compared to other asset tabs. Only one switch linking tab should also ever exist, so it doesn't particularly make sense to duplicate the switch being active linked also to the selected tab state (although this could also be done to re-standardize tab selection).

Bug:
* The constant 'SUGGESTED_SWITCH_TOOL_PANEL_TAB_ID' is always defined, checking tab priority order based on this will always return true (compared to other checks checking asset tab arrays). Eg. when no asset tabs are selected and linking is _not_ active, the suggested switch tool tab will still always be considered "selected" and the selection is stored to redux (even though the tab itself won't exist). For example, simply refreshing Geoviite or clicking a random empty location on the map will result the 'SUGGESTED_SWITCH_TOOL_PANEL_TAB_ID' tab being stored to redux & considered selected.
* The above causes issues especially to the asset tabs that are lower in priority than the suggested switch tool tab (see TOOL_PANEL_ASSET_ORDER).

Fix (others would also be possible):
* Check if switch linking is active before prioritizing suggested switch tool tab over others.

Results:
* Fixes vertical geometry diagram display & related E2E test. The vertical geometry display uses the stored selected asset tab indirectly.