### PR TITLE
GVT-3172 Type m-values

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -34,15 +34,16 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackSpatialCache
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.util.Either
 import fi.fta.geoviite.infra.util.Left
 import fi.fta.geoviite.infra.util.Right
 import fi.fta.geoviite.infra.util.all
 import fi.fta.geoviite.infra.util.processRights
 import fi.fta.geoviite.infra.util.produceIf
-import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.math.RoundingMode
+import org.springframework.beans.factory.annotation.Autowired
 
 @GeoviiteService
 class FrameConverterServiceV1
@@ -295,7 +296,7 @@ constructor(
         requests: List<ValidTrackAddressToCoordinateRequestV1>,
         locationTrack: LocationTrack,
         geometry: DbLocationTrackGeometry,
-        geocodingContext: GeocodingContext,
+        geocodingContext: GeocodingContext<ReferenceLineM>,
         params: FrameConverterQueryParamsV1,
         locationTrackOids: Map<DomainId<LocationTrack>, Oid<LocationTrack>>?,
         trackNumberDetails: TrackNumberDetails,
@@ -556,7 +557,7 @@ constructor(
         request: ValidTrackAddressToCoordinateRequestV1,
         params: FrameConverterQueryParamsV1,
         locationTrack: LocationTrack,
-        addressPoint: AddressPoint,
+        addressPoint: AddressPoint<*>,
         locationTrackOid: Oid<LocationTrack>?,
         trackNumberDetails: TrackNumberDetails,
     ): TrackAddressToCoordinateResponseV1 {
@@ -623,7 +624,7 @@ constructor(
 
     private data class TrackNumberDetails(
         val trackNumber: LayoutTrackNumber,
-        val geocodingContext: GeocodingContext?,
+        val geocodingContext: GeocodingContext<ReferenceLineM>?,
         val oid: Oid<LayoutTrackNumber>?,
     )
 
@@ -652,7 +653,7 @@ private fun createFeatureGeometry(params: FrameConverterQueryParamsV1, point: IP
 
 private fun createSimpleFeatureMatchOrNull(
     params: FrameConverterQueryParamsV1,
-    point: AlignmentPoint,
+    point: AlignmentPoint<*>,
     distanceToClosestPoint: Double,
 ): FeatureMatchBasicV1? {
     return if (params.featureBasic) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtCoordinateTransformsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtCoordinateTransformsV1.kt
@@ -39,7 +39,7 @@ private fun convertAlignmentEndPointCoordinateSystem(
     return alignmentEndPoint.copy(point = alignmentEndPoint.point.copy(x = convertedPoint.x, y = convertedPoint.y))
 }
 
-fun toExtAddressPoint(addressPoint: AddressPoint, targetCoordinateSystem: Srid): ExtAddressPointV1 {
+fun toExtAddressPoint(addressPoint: AddressPoint<*>, targetCoordinateSystem: Srid): ExtAddressPointV1 {
     val point =
         when (targetCoordinateSystem) {
             LAYOUT_SRID -> addressPoint.point

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/KmNumber.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DISABLED
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.math.round
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.util.StringSanitizer
 import fi.fta.geoviite.infra.util.formatForException
 import java.math.BigDecimal
@@ -119,6 +120,8 @@ constructor(override val kmNumber: KmNumber, override val meters: BigDecimal) : 
         fun isMetersValid(v: BigDecimal): Boolean {
             return -maxMeter <= v && v < maxMeter
         }
+
+        fun isMetersValid(v: LineM<*>) = isMetersValid(v.distance)
 
         fun isMetersValid(v: Double) = isMetersValid(BigDecimal.valueOf(v))
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
@@ -88,7 +88,7 @@ class CachePreloadService(
                 geocodingDao
                     .listLayoutGeocodingContextCacheKeys(MainLayoutContext.official)
                     .mapNotNull(geocodingCacheService::getGeocodingContext)
-            contexts.parallelStream().forEach(GeocodingContext::preload)
+            contexts.parallelStream().forEach(GeocodingContext<*>::preload)
             contexts.size
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -27,32 +27,39 @@ import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.math.pointInDirection
 import fi.fta.geoviite.infra.math.round
 import fi.fta.geoviite.infra.math.roundTo3Decimals
+import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
+import fi.fta.geoviite.infra.tracklayout.AnyM
+import fi.fta.geoviite.infra.tracklayout.GeocodingAlignmentM
 import fi.fta.geoviite.infra.tracklayout.GeometrySource
 import fi.fta.geoviite.infra.tracklayout.IAlignment
 import fi.fta.geoviite.infra.tracklayout.ISegment
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_M_DELTA
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
+import fi.fta.geoviite.infra.tracklayout.abs
+import fi.fta.geoviite.infra.tracklayout.segmentToAlignmentM
 import fi.fta.geoviite.infra.util.Either
 import fi.fta.geoviite.infra.util.Left
 import fi.fta.geoviite.infra.util.Right
 import fi.fta.geoviite.infra.util.getIndexRangeForRangeInOrderedList
 import fi.fta.geoviite.infra.util.processRights
 import fi.fta.geoviite.infra.util.processSortedBy
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.PI
 import kotlin.math.abs
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
-data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
-    fun isSame(other: AddressPoint) = address.isSame(other.address) && point.isSame(other.point)
+data class AddressPoint<M : AnyM<M>>(val point: AlignmentPoint<M>, val address: TrackMeter) {
+    fun isSame(other: AddressPoint<M>) = address.isSame(other.address) && point.isSame(other.point)
 
-    fun withIntegerPrecision(): AddressPoint? =
+    fun withIntegerPrecision(): AddressPoint<M>? =
         if (address.hasIntegerPrecision()) {
             this
         } else if (address.matchesIntegerValue()) {
@@ -62,19 +69,19 @@ data class AddressPoint(val point: AlignmentPoint, val address: TrackMeter) {
         }
 }
 
-data class AlignmentAddresses(
-    val startPoint: AddressPoint,
-    val endPoint: AddressPoint,
+data class AlignmentAddresses<M : AnyM<M>>(
+    val startPoint: AddressPoint<M>,
+    val endPoint: AddressPoint<M>,
     val startIntersect: IntersectType,
     val endIntersect: IntersectType,
-    val midPoints: List<AddressPoint>,
+    val midPoints: List<AddressPoint<M>>,
     val alignmentWalkFinished: Boolean,
 ) {
     @get:JsonIgnore
-    val allPoints: List<AddressPoint> by lazy { emptyList<AddressPoint>() + startPoint + midPoints + endPoint }
+    val allPoints: List<AddressPoint<M>> by lazy { emptyList<AddressPoint<M>>() + startPoint + midPoints + endPoint }
 
     @get:JsonIgnore
-    val integerPrecisionPoints: List<AddressPoint> by lazy {
+    val integerPrecisionPoints: List<AddressPoint<M>> by lazy {
         // midPoints are even anyhow, so just drop zero decimals from start/end
         val start =
             startPoint.withIntegerPrecision()?.takeIf { s ->
@@ -96,7 +103,11 @@ data class AlignmentStartAndEnd<T>(
     val staStart: Double?,
 ) {
     companion object {
-        fun <T> of(id: IntId<T>, alignment: IAlignment, geocodingContext: GeocodingContext?): AlignmentStartAndEnd<T> {
+        fun <T, M : AlignmentM<M>, G : GeocodingAlignmentM<G>> of(
+            id: IntId<T>,
+            alignment: IAlignment<M>,
+            geocodingContext: GeocodingContext<G>?,
+        ): AlignmentStartAndEnd<T> {
             val start =
                 alignment.start?.let { p ->
                     AlignmentEndPoint(p, geocodingContext?.getAddress(p)?.let(::getAddressIfIWithin))
@@ -110,27 +121,31 @@ data class AlignmentStartAndEnd<T>(
     }
 }
 
-data class AlignmentEndPoint(val point: AlignmentPoint, val address: TrackMeter?)
+data class AlignmentEndPoint(val point: AlignmentPoint<*>, val address: TrackMeter?)
 
-data class ProjectionLine(
+data class ProjectionLine<M : GeocodingAlignmentM<M>>(
     val address: TrackMeter,
     val projection: Line,
-    val distance: Double,
+    val distance: LineM<M>,
     val referenceDirection: Double,
 )
 
-data class GeocodingReferencePoint(
+data class GeocodingReferencePoint<M : GeocodingAlignmentM<M>>(
     val kmNumber: KmNumber,
     val meters: BigDecimal,
-    val distance: Double,
+    val distance: LineM<M>,
     val kmPostOffset: Double,
     val intersectType: IntersectType,
 ) {
-    val distanceRounded = roundTo3Decimals(distance)
+    val distanceRounded = roundTo3Decimals(distance.distance)
     val address = TrackMeter(kmNumber, meters)
 }
 
-data class AddressAndM(val address: TrackMeter, val m: Double, val intersectType: IntersectType)
+data class AddressAndM(
+    val address: TrackMeter,
+    val m: LineM<out GeocodingAlignmentM<*>>,
+    val intersectType: IntersectType,
+)
 
 /**
  * Don't generate a meter that is shorter than this. Prevents an extra projection being generated when the KM changes on
@@ -154,8 +169,8 @@ private val logger: Logger = LoggerFactory.getLogger(GeocodingContext::class.jav
 
 data class KmPostWithRejectedReason(val kmPost: LayoutKmPost, val rejectedReason: KmPostRejectedReason)
 
-data class GeocodingContextCreateResult(
-    val geocodingContext: GeocodingContext,
+data class GeocodingContextCreateResult<M : GeocodingAlignmentM<M>>(
+    val geocodingContext: GeocodingContext<M>,
     val rejectedKmPosts: List<KmPostWithRejectedReason>,
     val validKmPosts: List<LayoutKmPost>,
     val startPointRejectedReason: StartPointRejectedReason?,
@@ -179,10 +194,10 @@ enum class Resolution(val meters: Number) {
     QUARTER_METER(BigDecimal("0.25")),
 }
 
-data class GeocodingContext(
+data class GeocodingContext<M : GeocodingAlignmentM<M>>(
     val trackNumber: TrackNumber,
-    val referenceLineGeometry: IAlignment,
-    val referencePoints: List<GeocodingReferencePoint>,
+    val referenceLineGeometry: IAlignment<M>,
+    val referencePoints: List<GeocodingReferencePoint<M>>,
     val projectionLineDistanceDeviation: Double = PROJECTION_LINE_DISTANCE_DEVIATION,
     val projectionLineMaxAngleDelta: Double = PROJECTION_LINE_MAX_ANGLE_DELTA,
 ) {
@@ -195,18 +210,20 @@ data class GeocodingContext(
         require(referencePoints.isNotEmpty()) { "Cannot geocode without reference points, trackNumber=${trackNumber}" }
 
         require(
-            referencePoints.zipWithNext { a, b -> abs(b.distance - a.distance) }.all { TrackMeter.isMetersValid(it) }
+            referencePoints
+                .zipWithNext { a, b -> abs(b.distance.distance - a.distance.distance) }
+                .all { TrackMeter.isMetersValid(it) }
         ) {
             "Reference points are too far apart from each other, trackNumber=${trackNumber}"
         }
     }
 
-    private val polyLineEdges: List<PolyLineEdge> by lazy { getPolyLineEdges(referenceLineGeometry) }
+    private val polyLineEdges: List<PolyLineEdge<M>> by lazy { getPolyLineEdges(referenceLineGeometry) }
 
-    val projectionLines: Map<Resolution, Lazy<List<ProjectionLine>>> =
+    val projectionLines: Map<Resolution, Lazy<List<ProjectionLine<M>>>> =
         enumValues<Resolution>().associateWith { resolution -> lazy { createProjectionLines(resolution) } }
 
-    private fun createProjectionLines(resolution: Resolution): List<ProjectionLine> {
+    private fun createProjectionLines(resolution: Resolution): List<ProjectionLine<M>> {
         require(isSame(polyLineEdges.last().endM, referenceLineGeometry.length, LAYOUT_M_DELTA)) {
             "Polyline edges should cover the whole reference line geometry: " +
                 "trackNumber=$trackNumber " +
@@ -219,7 +236,7 @@ data class GeocodingContext(
         }
     }
 
-    val allKms: List<KmNumber> by lazy { referencePoints.map(GeocodingReferencePoint::kmNumber).distinct() }
+    val allKms: List<KmNumber> by lazy { referencePoints.map(GeocodingReferencePoint<M>::kmNumber).distinct() }
     val kmRange: Range<KmNumber>? by lazy {
         referencePoints.takeIf { it.isNotEmpty() }?.let { Range(it.first().kmNumber, it.last().kmNumber) }
     }
@@ -227,16 +244,17 @@ data class GeocodingContext(
     val startAddress: TrackMeter = referencePoints.first().address
 
     val endAddress: TrackMeter? =
-        (referenceLineGeometry.length - referencePoints.last().let { p -> p.distance - p.meters.toDouble() })
+        (referenceLineGeometry.length.distance -
+                referencePoints.last().let { p -> p.distance.distance - p.meters.toDouble() })
             .takeIf(TrackMeter::isMetersValid)
             ?.let { meters -> TrackMeter(referencePoints.last().kmNumber, meters, startAddress.decimalCount()) }
 
-    val startProjection: ProjectionLine? by lazy {
-        val projectionLine = polyLineEdges.first().crossSectionAt(0.0)
-        ProjectionLine(startAddress, projectionLine, 0.0, polyLineEdges.first().referenceDirection)
+    val startProjection: ProjectionLine<M>? by lazy {
+        val projectionLine = polyLineEdges.first().crossSectionAt(LineM(0.0))
+        ProjectionLine(startAddress, projectionLine, LineM(0.0), polyLineEdges.first().referenceDirection)
     }
 
-    val endProjection: ProjectionLine? by lazy {
+    val endProjection: ProjectionLine<M>? by lazy {
         endAddress?.let { address ->
             val projectionLine = polyLineEdges.last().crossSectionAt(referenceLineGeometry.length)
             ProjectionLine(
@@ -257,7 +275,7 @@ data class GeocodingContext(
         allKms
     }
 
-    fun getProjectionLine(address: TrackMeter, resolution: Resolution = Resolution.ONE_METER): ProjectionLine? {
+    fun getProjectionLine(address: TrackMeter, resolution: Resolution = Resolution.ONE_METER): ProjectionLine<M>? {
         val startProjection = startProjection
         val endProjection = endProjection
         return if (startProjection == null || endProjection == null) {
@@ -281,7 +299,7 @@ data class GeocodingContext(
         return if (startProjection != null && floor < startProjection.address) startProjection.address else floor
     }
 
-    private fun findCachedProjectionLine(address: TrackMeter, resolution: Resolution): ProjectionLine? {
+    private fun findCachedProjectionLine(address: TrackMeter, resolution: Resolution): ProjectionLine<M>? {
         val startProjection = startProjection
         val endProjection = endProjection
         return if (
@@ -302,12 +320,12 @@ data class GeocodingContext(
     }
 
     companion object {
-        fun create(
+        fun <M : GeocodingAlignmentM<M>> create(
             trackNumber: TrackNumber,
             startAddress: TrackMeter,
-            referenceLineGeometry: IAlignment,
+            referenceLineGeometry: IAlignment<M>,
             kmPosts: List<LayoutKmPost>,
-        ): GeocodingContextCreateResult {
+        ): GeocodingContextCreateResult<M> {
             val (validatedKmPosts, invalidKmPosts) = validateKmPosts(kmPosts, startAddress)
 
             val (validReferencePoints, kmPostsOutsideGeometry) =
@@ -331,10 +349,10 @@ data class GeocodingContext(
             )
         }
 
-        private fun startKmIsTooLong(
+        private fun <M : GeocodingAlignmentM<M>> startKmIsTooLong(
             startAddress: TrackMeter,
-            referenceLineGeometry: IAlignment,
-            referencePoints: List<GeocodingReferencePoint>,
+            referenceLineGeometry: IAlignment<M>,
+            referencePoints: List<GeocodingReferencePoint<M>>,
         ): Boolean =
             if (referencePoints.isEmpty()) false
             else {
@@ -344,11 +362,11 @@ data class GeocodingContext(
                 !TrackMeter.isMetersValid(startMeters + length)
             }
 
-        private fun createReferencePoints(
+        private fun <M : GeocodingAlignmentM<M>> createReferencePoints(
             startAddress: TrackMeter,
             kmPosts: List<LayoutKmPost>,
-            referenceLineGeometry: IAlignment,
-        ): Pair<List<GeocodingReferencePoint>, List<KmPostWithRejectedReason>> {
+            referenceLineGeometry: IAlignment<M>,
+        ): Pair<List<GeocodingReferencePoint<M>>, List<KmPostWithRejectedReason>> {
             val kpReferencePoints =
                 kmPosts.mapNotNull { post ->
                     post.layoutLocation?.let { location ->
@@ -356,7 +374,8 @@ data class GeocodingContext(
                     }
                 }
 
-            val firstPoint = GeocodingReferencePoint(startAddress.kmNumber, startAddress.meters, 0.0, 0.0, WITHIN)
+            val firstPoint =
+                GeocodingReferencePoint<M>(startAddress.kmNumber, startAddress.meters, LineM(0.0), 0.0, WITHIN)
             val referencePoints = listOf(firstPoint) + kpReferencePoints
 
             return validateReferencePoints(referencePoints, kmPosts)
@@ -381,10 +400,10 @@ data class GeocodingContext(
             return validKmPosts to rejectedKmPosts.map { (kp, reason) -> KmPostWithRejectedReason(kp, reason) }
         }
 
-        private fun validateReferencePoints(
-            referencePoints: List<GeocodingReferencePoint>,
+        private fun <M : GeocodingAlignmentM<M>> validateReferencePoints(
+            referencePoints: List<GeocodingReferencePoint<M>>,
             kmPosts: List<LayoutKmPost>,
-        ): Pair<List<GeocodingReferencePoint>, List<KmPostWithRejectedReason>> {
+        ): Pair<List<GeocodingReferencePoint<M>>, List<KmPostWithRejectedReason>> {
             val (withinPoints, beforePoints, afterPoints) =
                 referencePoints
                     .groupBy { it.intersectType }
@@ -420,7 +439,11 @@ data class GeocodingContext(
             return validPoints.distinctBy { it.distance } to rejectedKmPosts
         }
 
-        private fun toReferencePoint(location: IPoint, kmNumber: KmNumber, referenceLineGeometry: IAlignment) =
+        private fun <M : GeocodingAlignmentM<M>> toReferencePoint(
+            location: IPoint,
+            kmNumber: KmNumber,
+            referenceLineGeometry: IAlignment<M>,
+        ) =
             referenceLineGeometry.getClosestPointM(location)?.let { (distance, intersectType) ->
                 val pointOnLine =
                     requireNotNull(referenceLineGeometry.getPointAtM(distance)) {
@@ -447,18 +470,24 @@ data class GeocodingContext(
     fun getAddress(coordinate: IPoint, decimals: Int = DEFAULT_TRACK_METER_DECIMALS): Pair<TrackMeter, IntersectType>? =
         getAddressAndM(coordinate, decimals)?.let { (address, _, type) -> address to type }
 
-    fun getAddress(targetDistance: Double, decimals: Int = DEFAULT_TRACK_METER_DECIMALS): TrackMeter? {
+    fun getAddress(targetDistance: LineM<M>, decimals: Int = DEFAULT_TRACK_METER_DECIMALS): TrackMeter? {
         val addressPoint = findPreviousPoint(targetDistance)
-        val meters = round(addressPoint.meters.toDouble() + targetDistance - addressPoint.distance, decimals)
+        val meters =
+            round(addressPoint.meters.toDouble() + targetDistance.distance - addressPoint.distance.distance, decimals)
         return if (TrackMeter.isMetersValid(meters)) TrackMeter(addressPoint.kmNumber, meters) else null
     }
 
     val referenceLineAddresses by lazy { getAddressPoints(referenceLineGeometry) }
 
-    fun toAddressPoint(point: AlignmentPoint, decimals: Int = DEFAULT_TRACK_METER_DECIMALS) =
-        getAddress(point, decimals)?.let { (address, intersectType) -> AddressPoint(point, address) to intersectType }
+    fun <TargetM : AnyM<TargetM>> toAddressPoint(
+        point: AlignmentPoint<TargetM>,
+        decimals: Int = DEFAULT_TRACK_METER_DECIMALS,
+    ) = getAddress(point, decimals)?.let { (address, intersectType) -> AddressPoint(point, address) to intersectType }
 
-    fun getAddressPoints(alignment: IAlignment, resolution: Resolution = Resolution.ONE_METER): AlignmentAddresses? {
+    fun <TargetM : AlignmentM<TargetM>> getAddressPoints(
+        alignment: IAlignment<TargetM>,
+        resolution: Resolution = Resolution.ONE_METER,
+    ): AlignmentAddresses<TargetM>? {
         val startPoint = alignment.start?.let(::toAddressPoint)
         val endPoint = alignment.end?.let(::toAddressPoint)
         return if (startPoint != null && endPoint != null) {
@@ -480,11 +509,17 @@ data class GeocodingContext(
         } else null
     }
 
-    fun getTrackLocation(alignment: IAlignment, address: TrackMeter): AddressPoint? {
+    fun <TargetM : AlignmentM<TargetM>> getTrackLocation(
+        alignment: IAlignment<TargetM>,
+        address: TrackMeter,
+    ): AddressPoint<TargetM>? {
         return getTrackLocations(alignment, listOf(address))[0]
     }
 
-    fun getTrackLocations(alignment: IAlignment, addresses: List<TrackMeter>): List<AddressPoint?> {
+    fun <TargetM : AlignmentM<TargetM>> getTrackLocations(
+        alignment: IAlignment<TargetM>,
+        addresses: List<TrackMeter>,
+    ): List<AddressPoint<TargetM>?> {
         val alignmentStart = alignment.start
         val alignmentEnd = alignment.end
         val startAddress = alignmentStart?.let(::getAddress)?.first
@@ -493,15 +528,15 @@ data class GeocodingContext(
         else getTrackLocations(alignment, addresses, alignmentStart, startAddress, alignmentEnd, endAddress)
     }
 
-    private fun getTrackLocations(
-        alignment: IAlignment,
+    private fun <TargetM : AlignmentM<TargetM>> getTrackLocations(
+        alignment: IAlignment<TargetM>,
         addresses: List<TrackMeter>,
-        alignmentStart: AlignmentPoint,
+        alignmentStart: AlignmentPoint<TargetM>,
         startAddress: TrackMeter,
-        alignmentEnd: AlignmentPoint,
+        alignmentEnd: AlignmentPoint<TargetM>,
         endAddress: TrackMeter,
         resolution: Resolution = Resolution.ONE_METER,
-    ): List<AddressPoint?> =
+    ): List<AddressPoint<TargetM>?> =
         processRights(
             addresses,
             getProjectionLineForAddressInAlignment(alignmentStart, startAddress, alignmentEnd, endAddress),
@@ -510,12 +545,12 @@ data class GeocodingContext(
             else getManyTrackLocations(alignment, startAddress, endAddress, projectionLines, resolution)
         }
 
-    private fun getProjectionLineForAddressInAlignment(
-        alignmentStart: AlignmentPoint,
+    private fun <TargetM : AnyM<TargetM>> getProjectionLineForAddressInAlignment(
+        alignmentStart: AlignmentPoint<TargetM>,
         alignmentStartAddress: TrackMeter,
-        alignmentEnd: AlignmentPoint,
+        alignmentEnd: AlignmentPoint<TargetM>,
         alignmentEndAddress: TrackMeter,
-    ): (address: TrackMeter) -> Either<AddressPoint?, ProjectionLine> = { address ->
+    ): (address: TrackMeter) -> Either<AddressPoint<TargetM>?, ProjectionLine<M>> = { address ->
         if (address !in alignmentStartAddress..alignmentEndAddress) {
             Left(null)
         } else if (alignmentStartAddress.isSame(address)) {
@@ -527,11 +562,11 @@ data class GeocodingContext(
         }
     }
 
-    private fun getManyTrackLocations(
-        alignment: IAlignment,
+    private fun <TargetM : AlignmentM<TargetM>> getManyTrackLocations(
+        alignment: IAlignment<TargetM>,
         alignmentStartAddress: TrackMeter,
         alignmentEndAddress: TrackMeter,
-        projectionLinesWithinAlignment: List<ProjectionLine>,
+        projectionLinesWithinAlignment: List<ProjectionLine<M>>,
         resolution: Resolution,
     ) =
         processSortedBy(
@@ -543,35 +578,38 @@ data class GeocodingContext(
                             resolution,
                         )
                         .filterIndexed { index, _ -> index % 10 == 0 },
-                Comparator.comparing(ProjectionLine::distance),
+                Comparator.comparing(ProjectionLine<M>::distance),
             ) { sortedLines ->
                 getProjectedAddressPoints(sortedLines, alignment).addressPoints
             }
             .take(projectionLinesWithinAlignment.size)
 
-    fun getStartAndEnd(alignment: IAlignment): Pair<AddressPoint?, AddressPoint?> {
+    fun <TargetM : AlignmentM<TargetM>> getStartAndEnd(
+        alignment: IAlignment<TargetM>
+    ): Pair<AddressPoint<TargetM>?, AddressPoint<TargetM>?> {
         val start = alignment.start?.let(::toAddressPoint)?.first
         val end = alignment.end?.let(::toAddressPoint)?.first
         return start to end
     }
 
-    private fun getMidPoints(
-        alignment: IAlignment,
+    private fun <TargetM : AlignmentM<TargetM>> getMidPoints(
+        alignment: IAlignment<TargetM>,
         range: ClosedRange<TrackMeter>,
         resolution: Resolution = Resolution.ONE_METER,
-    ): AddressPointWalkResult = getProjectedAddressPoints(getProjectionLinesForRange(range, resolution), alignment)
+    ): AddressPointWalkResult<TargetM> =
+        getProjectedAddressPoints(getProjectionLinesForRange(range, resolution), alignment)
 
     private fun getProjectionLinesForRange(range: ClosedRange<TrackMeter>, resolution: Resolution) =
         getSublistForRangeInOrderedList(projectionLines.getValue(resolution).value, range) { p, e ->
             p.address.compareTo(e)
         }
 
-    fun getSwitchPoints(geometry: LocationTrackGeometry): List<AddressPoint> =
+    fun getSwitchPoints(geometry: LocationTrackGeometry): List<AddressPoint<LocationTrackM>> =
         geometry.trackSwitchLinks
             .mapNotNull { link -> toAddressPoint(link.location, 3)?.first }
             .distinctBy { addressPoint -> addressPoint.address }
 
-    private fun findPreviousPoint(targetDistance: Double): GeocodingReferencePoint {
+    private fun findPreviousPoint(targetDistance: LineM<M>): GeocodingReferencePoint<M> {
         val target = roundTo3Decimals(targetDistance) // Round to 1mm to work around small imprecision
         if (target < BigDecimal.ZERO) throw GeocodingFailureException("Cannot geocode with negative distance")
         return referencePoints.findLast { referencePoint -> referencePoint.distanceRounded <= target }
@@ -631,7 +669,10 @@ fun <T, R : Comparable<R>> getSublistForRangeInOrderedList(
         things.subList(indexRange.first, indexRange.last + 1)
     } ?: listOf()
 
-fun getProjectedAddressPoint(projection: ProjectionLine, alignment: IAlignment): AddressPoint? {
+fun <TargetM : AlignmentM<TargetM>, M : GeocodingAlignmentM<M>> getProjectedAddressPoint(
+    projection: ProjectionLine<M>,
+    alignment: IAlignment<TargetM>,
+): AddressPoint<TargetM>? {
     return getCollisionSegmentIndex(projection.projection, alignment)?.let { index ->
         val segment = alignment.segments[index]
         val m = alignment.segmentMValues[index].min
@@ -643,20 +684,23 @@ fun getProjectedAddressPoint(projection: ProjectionLine, alignment: IAlignment):
     }
 }
 
-private data class AddressPointWalkResult(val addressPoints: List<AddressPoint?>, val alignmentWalkFinished: Boolean)
+private data class AddressPointWalkResult<M : AnyM<M>>(
+    val addressPoints: List<AddressPoint<M>?>,
+    val alignmentWalkFinished: Boolean,
+)
 
-private data class AlignmentPointInterval(val start: AlignmentPoint, val end: AlignmentPoint) {
-    fun interpolateAlignmentPointAtPortion(proportion: Double): AlignmentPoint =
+private data class AlignmentPointInterval<M : AnyM<M>>(val start: AlignmentPoint<M>, val end: AlignmentPoint<M>) {
+    fun interpolateAlignmentPointAtPortion(proportion: Double): AlignmentPoint<M> =
         interpolateToAlignmentPoint(start, end, proportion)
 
     val referenceDirection: Double
         get() = directionBetweenPoints(start, end)
 }
 
-private fun getProjectedAddressPoints(
-    projectionLines: List<ProjectionLine>,
-    alignment: IAlignment,
-): AddressPointWalkResult {
+private fun <M : GeocodingAlignmentM<M>, TargetM : AlignmentM<TargetM>> getProjectedAddressPoints(
+    projectionLines: List<ProjectionLine<M>>,
+    alignment: IAlignment<TargetM>,
+): AddressPointWalkResult<TargetM> {
     val alignmentPoints = alignment.allAlignmentPoints.zipWithNext(::AlignmentPointInterval).toList()
     val walk = AlignmentWalk(alignmentPoints)
     val addressPoints = projectionLines.map(walk::stepWith)
@@ -676,14 +720,14 @@ private enum class StepDirection(val diff: Int) {
     Backward(-1),
 }
 
-private class AlignmentWalk(val alignmentEdges: List<AlignmentPointInterval>) {
+private class AlignmentWalk<TargetM : AnyM<TargetM>>(val alignmentEdges: List<AlignmentPointInterval<TargetM>>) {
     var alignmentLooksValid = true
     private var edgeIndex = 0
 
     private val edge
         get() = alignmentEdges[edgeIndex]
 
-    fun stepWith(projection: ProjectionLine): AddressPoint? {
+    fun <M : GeocodingAlignmentM<M>> stepWith(projection: ProjectionLine<M>): AddressPoint<TargetM>? {
         var lastStepDirection = 0
         while (true) {
             val isEdgeAligned = angleDiffRads(edge.referenceDirection, projection.referenceDirection) <= PI / 2
@@ -723,16 +767,16 @@ private class AlignmentWalk(val alignmentEdges: List<AlignmentPointInterval>) {
         }
 }
 
-private fun createProjectionLines(
-    addressPoints: List<GeocodingReferencePoint>,
-    edges: List<PolyLineEdge>,
+private fun <M : GeocodingAlignmentM<M>> createProjectionLines(
+    addressPoints: List<GeocodingReferencePoint<M>>,
+    edges: List<PolyLineEdge<M>>,
     resolution: Resolution,
-): List<ProjectionLine> {
-    val endDistance = edges.lastOrNull()?.endM ?: 0.0
-    return addressPoints.flatMapIndexed { index: Int, point: GeocodingReferencePoint ->
+): List<ProjectionLine<M>> {
+    val endDistance = edges.lastOrNull()?.endM ?: LineM(0.0)
+    return addressPoints.flatMapIndexed { index: Int, point: GeocodingReferencePoint<M> ->
         val minMeter = point.meters.setScale(0, RoundingMode.CEILING).toInt()
         val maxDistance = (addressPoints.getOrNull(index + 1)?.distance?.minus(MIN_METER_LENGTH) ?: endDistance)
-        val maxMeter = (point.meters.toDouble() + maxDistance - point.distance).toInt()
+        val maxMeter = (maxDistance + point.meters.toDouble() - point.distance).toInt()
 
         // If the km posts or reference line are sufficiently broken to cause invalid track meters
         // somewhere, it's probably bad enough that looking up track addresses is not useful, so we
@@ -755,7 +799,7 @@ private fun createProjectionLines(
             }
 
         projectionLineSteps.map { meter ->
-            val distance = point.distance + (meter.toDouble() - point.meters.toDouble())
+            val distance = point.distance + meter.toDouble() - point.meters.toDouble()
             val edge =
                 findEdge(distance, edges)
                     ?: throw GeocodingFailureException(
@@ -779,12 +823,12 @@ private fun createProjectionLines(
     }
 }
 
-private fun validateProjectionLines(
-    lines: List<ProjectionLine>,
+private fun <M : GeocodingAlignmentM<M>> validateProjectionLines(
+    lines: List<ProjectionLine<M>>,
     distanceDelta: Double,
     angleDelta: Double,
     resolution: Resolution,
-): List<ProjectionLine> {
+): List<ProjectionLine<M>> {
     val distanceRange = (resolution.meters.toDouble() - distanceDelta)..(resolution.meters.toDouble() + distanceDelta)
     return lines.filterIndexed { index, line ->
         val previous = lines.getOrNull(index - 1)
@@ -811,7 +855,7 @@ private fun validateProjectionLines(
     }
 }
 
-private fun getCollisionSegmentIndex(projection: Line, alignment: IAlignment): Int? {
+private fun getCollisionSegmentIndex(projection: Line, alignment: IAlignment<*>): Int? {
     return alignment.segments
         .mapIndexedNotNull { index, s ->
             val intersection = lineIntersection(s.segmentStart, s.segmentEnd, projection.start, projection.end)
@@ -821,7 +865,10 @@ private fun getCollisionSegmentIndex(projection: Line, alignment: IAlignment): I
         ?.second
 }
 
-fun getIntersection(projection: Line, edges: List<PolyLineEdge>): Pair<PolyLineEdge, Double>? {
+fun <M : AlignmentM<M>> getIntersection(
+    projection: Line,
+    edges: List<PolyLineEdge<M>>,
+): Pair<PolyLineEdge<M>, Double>? {
     var intersection: Intersection? = null
     val collisionEdge =
         edges.getOrNull(
@@ -844,7 +891,7 @@ fun getIntersection(projection: Line, edges: List<PolyLineEdge>): Pair<PolyLineE
     }
 }
 
-private fun getPolyLineEdges(alignment: IAlignment): List<PolyLineEdge> {
+private fun <M : AlignmentM<M>> getPolyLineEdges(alignment: IAlignment<M>): List<PolyLineEdge<M>> {
     return alignment.segmentsWithM
         .flatMapIndexed { index, (segment, m) ->
             getPolyLineEdges(
@@ -862,12 +909,12 @@ private fun getPolyLineEdges(alignment: IAlignment): List<PolyLineEdge> {
         }
 }
 
-private fun getPolyLineEdges(
+private fun <M : AlignmentM<M>> getPolyLineEdges(
     segment: ISegment,
-    startM: Double,
+    startM: LineM<M>,
     prevDir: Double?,
     nextDir: Double?,
-): List<PolyLineEdge> {
+): List<PolyLineEdge<M>> {
     return segment.segmentPoints.mapIndexedNotNull { pointIndex: Int, point: SegmentPoint ->
         if (pointIndex == 0) null
         else {
@@ -894,20 +941,24 @@ private fun getPolyLineEdges(
  * Since segment start distance and m-values are stored with a limited precision, allow finding a segment with that much
  * delta-value. Otherwise, it's possible to get a distance-value "between segments"
  */
-private fun findEdge(distance: Double, all: List<PolyLineEdge>, delta: Double = 0.000001): PolyLineEdge? =
+private fun <M : AlignmentM<M>> findEdge(
+    distance: LineM<M>,
+    all: List<PolyLineEdge<M>>,
+    delta: Double = 0.000001,
+): PolyLineEdge<M>? =
     all.getOrNull(
         all.binarySearch { edge ->
             if (edge.startM > distance + delta) 1 else if (edge.endM < distance - delta) -1 else 0
         }
     )
 
-private fun intersection(edge: PolyLineEdge, projection: Line) =
+private fun intersection(edge: PolyLineEdge<*>, projection: Line) =
     lineIntersection(edge.start, edge.end, projection.start, projection.end)
         ?: throw GeocodingFailureException(
             "Projection line parallel to segment: edge=${edge.start}-${edge.end} projection=${projection.start}-${projection.end}"
         )
 
-private fun intersection(edge: AlignmentPointInterval, projection: Line) =
+private fun intersection(edge: AlignmentPointInterval<*>, projection: Line) =
     lineIntersection(edge.start, edge.end, projection.start, projection.end)
         ?: throw GeocodingFailureException(
             "Projection line parallel to segment: edge=${edge.start}-${edge.end} projection=${projection.start}-${projection.end}"
@@ -918,34 +969,35 @@ private fun getAddressIfIWithin(address: Pair<TrackMeter, IntersectType>): Track
 
 const val PROJECTION_LINE_LENGTH = 100.0
 
-data class PolyLineEdge(
+data class PolyLineEdge<M : AlignmentM<M>>(
     val start: SegmentPoint,
     val end: SegmentPoint,
-    val segmentStart: Double,
+    val segmentStart: LineM<M>,
     val referenceDirection: Double,
 ) {
     // Direction for projection lines from the edge: 90 degrees turned from edge direction
     val projectionDirection: Double
         get() = PI / 2 + referenceDirection
 
-    val startM: Double
-        get() = start.m + segmentStart
+    val startM: LineM<M>
+        get() = start.m.segmentToAlignmentM(segmentStart)
 
-    val endM: Double
-        get() = end.m + segmentStart
+    val endM: LineM<M>
+        get() = end.m.segmentToAlignmentM(segmentStart)
 
     val length: Double
-        get() = end.m - start.m
+        get() = end.m.distance - start.m.distance
 
-    fun crossSectionAt(distance: Double) =
+    fun crossSectionAt(distance: LineM<M>) =
         interpolatePointAtM(distance).let { point ->
             Line(point, pointInDirection(point, distance = PROJECTION_LINE_LENGTH, direction = projectionDirection))
         }
 
-    private fun interpolatePointAtM(m: Double): IPoint =
-        if (m <= startM) start else if (m >= endM) end else interpolateToPoint(start, end, (m - startM) / length)
+    private fun interpolatePointAtM(m: LineM<M>): IPoint =
+        if (m <= startM) start
+        else if (m >= endM) end else interpolateToPoint(start, end, (m - startM).distance / length)
 
-    fun interpolateAlignmentPointAtPortion(portion: Double): AlignmentPoint =
+    fun interpolateAlignmentPointAtPortion(portion: Double): AlignmentPoint<M> =
         interpolateSegmentPointAtPortion(portion).toAlignmentPoint(segmentStart)
 
     fun interpolateSegmentPointAtPortion(portion: Double): SegmentPoint =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.util.toResponse
 import org.springframework.http.ResponseEntity
@@ -46,7 +47,7 @@ class GeocodingController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("locationTrackId") locationTrackId: IntId<LocationTrack>,
         @RequestParam("address") address: TrackMeter,
-    ): ResponseEntity<AddressPoint> {
+    ): ResponseEntity<AddressPoint<LocationTrackM>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return toResponse(locationTrackService.getTrackPoint(layoutContext, locationTrackId, address))
     }
@@ -57,7 +58,7 @@ class GeocodingController(
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("alignmentId") locationTrackId: IntId<LocationTrack>,
-    ): ResponseEntity<AlignmentAddresses> {
+    ): ResponseEntity<AlignmentAddresses<LocationTrackM>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return toResponse(geocodingService.getAddressPoints(layoutContext, locationTrackId))
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -13,10 +13,15 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
 import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.publication.ValidationVersions
+import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.IAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import java.time.Instant
 import java.util.*
 import kotlin.jvm.optionals.getOrNull
@@ -32,7 +37,7 @@ class GeocodingService(
         layoutContext: LayoutContext,
         locationTrackId: IntId<LocationTrack>,
         resolution: Resolution = Resolution.ONE_METER,
-    ): AlignmentAddresses? {
+    ): AlignmentAddresses<LocationTrackM>? {
         return addressPointsCache.getAddressPointCacheKey(layoutContext, locationTrackId, resolution)?.let { cacheKey ->
             addressPointsCache.getAddressPoints(cacheKey)
         }
@@ -42,7 +47,7 @@ class GeocodingService(
         contextKey: GeocodingContextCacheKey,
         trackVersion: LayoutRowVersion<LocationTrack>,
         resolution: Resolution = Resolution.ONE_METER,
-    ): AlignmentAddresses? {
+    ): AlignmentAddresses<LocationTrackM>? {
         return addressPointsCache.getAddressPoints(AddressPointCacheKey(trackVersion, contextKey, resolution))
     }
 
@@ -54,7 +59,11 @@ class GeocodingService(
         return getGeocodingContext(layoutContext, trackNumberId)?.getAddress(location)
     }
 
-    fun getAddress(layoutContext: LayoutContext, trackNumberId: IntId<LayoutTrackNumber>, meter: Double): TrackMeter? {
+    fun getAddress(
+        layoutContext: LayoutContext,
+        trackNumberId: IntId<LayoutTrackNumber>,
+        meter: LineM<ReferenceLineM>,
+    ): TrackMeter? {
         return getGeocodingContext(layoutContext, trackNumberId)?.getAddress(meter)
     }
 
@@ -68,8 +77,10 @@ class GeocodingService(
         }
     }
 
-    fun getLazyGeocodingContexts(layoutContext: LayoutContext): (IntId<LayoutTrackNumber>) -> GeocodingContext? {
-        val contexts: MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext>> = mutableMapOf()
+    fun getLazyGeocodingContexts(
+        layoutContext: LayoutContext
+    ): (IntId<LayoutTrackNumber>) -> GeocodingContext<ReferenceLineM>? {
+        val contexts: MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext<ReferenceLineM>>> = mutableMapOf()
         return { trackNumberId ->
             contexts
                 .computeIfAbsent(trackNumberId) { Optional.ofNullable(getGeocodingContext(layoutContext, it)) }
@@ -80,8 +91,8 @@ class GeocodingService(
     fun getLazyGeocodingContextsAtMoment(
         layoutContext: LayoutContext,
         moment: Instant,
-    ): (IntId<LayoutTrackNumber>) -> GeocodingContext? {
-        val contexts: MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext>> = mutableMapOf()
+    ): (IntId<LayoutTrackNumber>) -> GeocodingContext<ReferenceLineM>? {
+        val contexts: MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext<ReferenceLineM>>> = mutableMapOf()
         return { trackNumberId ->
             contexts
                 .computeIfAbsent(trackNumberId) {
@@ -91,17 +102,19 @@ class GeocodingService(
         }
     }
 
-    fun getTrackLocation(
+    fun <M : AlignmentM<M>> getTrackLocation(
         layoutContext: LayoutContext,
         locationTrack: LocationTrack,
-        alignment: IAlignment,
+        alignment: IAlignment<M>,
         address: TrackMeter,
-    ): AddressPoint? {
+    ): AddressPoint<M>? {
         return getGeocodingContext(layoutContext, locationTrack.trackNumberId)?.getTrackLocation(alignment, address)
     }
 
     @Transactional(readOnly = true)
-    fun getGeocodingContexts(layoutContext: LayoutContext): Map<IntId<LayoutTrackNumber>, GeocodingContext?> =
+    fun getGeocodingContexts(
+        layoutContext: LayoutContext
+    ): Map<IntId<LayoutTrackNumber>, GeocodingContext<ReferenceLineM>?> =
         geocodingDao.listLayoutGeocodingContextCacheKeys(layoutContext).associate { key ->
             key.trackNumberId to geocodingCacheService.getGeocodingContext(key)
         }
@@ -109,28 +122,35 @@ class GeocodingService(
     fun getGeocodingContext(
         layoutContext: LayoutContext,
         trackNumberId: DomainId<LayoutTrackNumber>?,
-    ): GeocodingContext? = if (trackNumberId is IntId) getGeocodingContext(layoutContext, trackNumberId) else null
+    ): GeocodingContext<ReferenceLineM>? =
+        if (trackNumberId is IntId) getGeocodingContext(layoutContext, trackNumberId) else null
 
     fun getGeocodingContext(geocodingContextCacheKey: GeocodingContextCacheKey) =
         geocodingCacheService.getGeocodingContext(geocodingContextCacheKey)
 
-    fun getGeocodingContext(layoutContext: LayoutContext, trackNumberId: IntId<LayoutTrackNumber>): GeocodingContext? =
+    fun getGeocodingContext(
+        layoutContext: LayoutContext,
+        trackNumberId: IntId<LayoutTrackNumber>,
+    ): GeocodingContext<ReferenceLineM>? =
         getGeocodingContextCreateResult(layoutContext, trackNumberId)?.geocodingContext
 
     fun getGeocodingContextCreateResult(
         layoutContext: LayoutContext,
         trackNumberId: IntId<LayoutTrackNumber>,
-    ): GeocodingContextCreateResult? =
+    ): GeocodingContextCreateResult<ReferenceLineM>? =
         geocodingCacheService.getGeocodingContextCreateResult(layoutContext, trackNumberId)
 
     fun getGeocodingContextAtMoment(
         branch: LayoutBranch,
         trackNumberId: IntId<LayoutTrackNumber>,
         moment: Instant,
-    ): GeocodingContext? = geocodingCacheService.getGeocodingContextAtMoment(branch, trackNumberId, moment)
+    ): GeocodingContext<ReferenceLineM>? =
+        geocodingCacheService.getGeocodingContextAtMoment(branch, trackNumberId, moment)
 
-    fun getGeocodingContext(trackNumber: TrackNumber, plan: RowVersion<GeometryPlan>): GeocodingContext? =
-        geocodingCacheService.getGeocodingContext(trackNumber, plan)
+    fun getGeocodingContext(
+        trackNumber: TrackNumber,
+        plan: RowVersion<GeometryPlan>,
+    ): GeocodingContext<PlanLayoutAlignmentM>? = geocodingCacheService.getGeocodingContext(trackNumber, plan)
 
     fun getGeocodingContextCacheKey(
         layoutContext: LayoutContext,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
@@ -7,20 +7,31 @@ import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.map.AlignmentHeader
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.LayoutState
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.util.FileName
 
-data class KmTicks(val kmNumber: KmNumber, val ticks: List<TrackMeterTick>, val endM: Double)
+data class KmTicks<M : AlignmentM<M>>(val kmNumber: KmNumber, val ticks: List<TrackMeterTick<M>>, val endM: LineM<M>)
 
-data class TrackMeterTick(val addressPoint: AddressPoint, val segmentIndex: Int?)
+data class TrackMeterTick<M : AlignmentM<M>>(val addressPoint: AddressPoint<M>, val segmentIndex: Int?)
 
-data class TrackMeterHeight(val m: Double, val meter: Double, val height: Double?, val point: Point)
+data class TrackMeterHeight<M : AlignmentM<M>>(
+    val m: LineM<M>,
+    val meter: Double,
+    val height: Double?,
+    val point: Point,
+)
 
-data class KmHeights(val kmNumber: KmNumber, val trackMeterHeights: List<TrackMeterHeight>, val endM: Double)
+data class KmHeights<M : AlignmentM<M>>(
+    val kmNumber: KmNumber,
+    val trackMeterHeights: List<TrackMeterHeight<M>>,
+    val endM: LineM<M>,
+)
 
-data class PlanLinkingSummaryItem(
-    val startM: Double,
-    val endM: Double,
+data class PlanLinkingSummaryItem<M : AlignmentM<M>>(
+    val startM: LineM<M>,
+    val endM: LineM<M>,
     val filename: FileName?,
     val alignmentHeader: AlignmentHeader<GeometryAlignment, LayoutState>?,
     val planId: DomainId<GeometryPlan>?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -27,6 +27,8 @@ import fi.fta.geoviite.infra.tracklayout.LayoutEdge
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FileName
@@ -98,7 +100,7 @@ enum class TrackGeometryElementType {
 }
 
 fun toElementListing(
-    context: GeocodingContext?,
+    context: GeocodingContext<ReferenceLineM>?,
     getTransformation: (srid: Srid) -> Transformation,
     track: LocationTrack,
     geometry: LocationTrackGeometry,
@@ -171,7 +173,7 @@ fun getEdgeSwitchName(edge: LayoutEdge, getSwitchName: (IntId<LayoutSwitch>) -> 
     (edge.startNode.switchIn ?: edge.endNode.switchIn)?.let { link -> getSwitchName(link.id) }
 
 fun toElementListing(
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     getTransformation: (srid: Srid) -> Transformation,
     plan: GeometryPlan,
     elementTypes: List<GeometryElementType>,
@@ -183,7 +185,7 @@ fun toElementListing(
     }
 
 private fun toMissingElementListing(
-    context: GeocodingContext?,
+    context: GeocodingContext<ReferenceLineM>?,
     trackNumber: TrackNumber?,
     identifier: String,
     segment: ISegment,
@@ -212,7 +214,7 @@ private fun toMissingElementListing(
     )
 
 private fun toElementListing(
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     getTransformation: (srid: Srid) -> Transformation,
     locationTrack: LocationTrack,
     planHeader: GeometryPlanHeader,
@@ -238,7 +240,7 @@ private fun toElementListing(
     )
 
 private fun toElementListing(
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     getTransformation: (srid: Srid) -> Transformation,
     plan: GeometryPlan,
     alignment: GeometryAlignment,
@@ -325,7 +327,7 @@ private fun remarks(elementListing: ElementListing, translation: Translation) =
         .joinToString(separator = ", ")
 
 private fun elementListing(
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     getTransformation: (srid: Srid) -> Transformation,
     planId: DomainId<GeometryPlan>,
     planSource: PlanSource?,
@@ -365,7 +367,7 @@ private fun elementListing(
         )
     }
 
-private fun getLocation(context: GeocodingContext?, point: SegmentPoint, directionRads: Double) =
+private fun getLocation(context: GeocodingContext<*>?, point: SegmentPoint, directionRads: Double) =
     ElementLocation(
         coordinate = point.round(COORDINATE_DECIMALS),
         address = context?.getAddress(point)?.first,
@@ -375,7 +377,7 @@ private fun getLocation(context: GeocodingContext?, point: SegmentPoint, directi
     )
 
 private fun getStartLocation(
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     transformation: Transformation?,
     alignment: GeometryAlignment,
     element: GeometryElement,
@@ -389,7 +391,7 @@ private fun getStartLocation(
     )
 
 private fun getEndLocation(
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     transformation: Transformation?,
     alignment: GeometryAlignment,
     element: GeometryElement,
@@ -402,7 +404,7 @@ private fun getEndLocation(
         cant = getEndCant(alignment, element),
     )
 
-private fun getAddress(context: GeocodingContext?, transformation: Transformation?, coordinate: Point) =
+private fun getAddress(context: GeocodingContext<*>?, transformation: Transformation?, coordinate: Point) =
     if (context == null || transformation == null) null
     else context.getAddress(transformation.transform(coordinate), ADDRESS_DECIMALS)?.first
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -22,6 +22,7 @@ import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.util.CombinedComparator
 import fi.fta.geoviite.infra.util.FreeText
@@ -315,9 +316,14 @@ constructor(private val geometryService: GeometryService, private val planLayout
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
-    ): List<KmHeights> {
-        return geometryService.getPlanAlignmentHeights(planId, planAlignmentId, startDistance, endDistance, tickLength)
-            ?: emptyList()
+    ): List<KmHeights<*>> {
+        return geometryService.getPlanAlignmentHeights(
+            planId,
+            planAlignmentId,
+            LineM(startDistance),
+            LineM(endDistance),
+            tickLength,
+        ) ?: emptyList()
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
@@ -326,7 +332,7 @@ constructor(private val geometryService: GeometryService, private val planLayout
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): List<PlanLinkingSummaryItem>? {
+    ): List<PlanLinkingSummaryItem<*>>? {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return geometryService.getLocationTrackGeometryLinkingSummary(layoutContext, id)
     }
@@ -340,13 +346,13 @@ constructor(private val geometryService: GeometryService, private val planLayout
         @RequestParam("startDistance") startDistance: Double,
         @RequestParam("endDistance") endDistance: Double,
         @RequestParam("tickLength") tickLength: Int,
-    ): List<KmHeights>? {
+    ): List<KmHeights<*>>? {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return geometryService.getLocationTrackHeights(
             layoutContext = layoutContext,
             locationTrackId = id,
-            startDistance = startDistance,
-            endDistance = endDistance,
+            startDistance = LineM(startDistance),
+            endDistance = LineM(endDistance),
             tickLength = tickLength,
         )
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfile.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfile.kt
@@ -3,6 +3,8 @@ package fi.fta.geoviite.infra.geometry
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.*
+import fi.fta.geoviite.infra.tracklayout.LineM
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
 import java.math.BigDecimal
 import kotlin.math.*
 import org.slf4j.Logger
@@ -31,21 +33,21 @@ data class VICircularCurve(
 data class GeometryProfile(val name: PlanElementName, val elements: List<VerticalIntersection>) {
     @get:JsonIgnore val segments: List<ProfileSegment> by lazy { createSegments(elements) }
 
-    fun getHeightAt(distance: Double): Double? {
+    fun getHeightAt(distance: LineM<PlanLayoutAlignmentM>): Double? {
         return when {
             segments.isEmpty() -> null
-            distance <= elements.first().point.x -> elements.first().point.y
-            distance >= elements.last().point.x -> elements.last().point.y
+            distance.distance <= elements.first().point.x -> elements.first().point.y
+            distance.distance >= elements.last().point.x -> elements.last().point.y
             else -> {
                 val segment =
-                    segments.find { s -> s.contains(distance) }
+                    segments.find { s -> s.contains(distance.distance) }
                         ?: throw IllegalArgumentException(
                             "Requested point outside profile segments: " +
                                 "$distance <> " +
                                 "[${elements.first().point.x} to ${elements.last().point.x}] => " +
                                 "${segments.map { s -> "${s.start.x}-${s.end.x}" }}"
                         )
-                segment.getYValueAt(distance)
+                segment.getYValueAt(distance.distance)
             }
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ListingCommon.kt
@@ -25,7 +25,7 @@ data class LinkedElement(
 
 fun collectLinkedElements(
     geometry: LocationTrackGeometry,
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     startAddress: TrackMeter?,
     endAddress: TrackMeter?,
 ): List<LinkedElement> =
@@ -38,7 +38,7 @@ fun collectLinkedElements(
 
 private fun overlapsAddressInterval(
     segment: ISegment,
-    context: GeocodingContext?,
+    context: GeocodingContext<*>?,
     start: TrackMeter?,
     end: TrackMeter?,
 ): Boolean =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -24,8 +24,11 @@ import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.math.round
 import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.math.roundTo6Decimals
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.printCsv
@@ -105,9 +108,9 @@ data class VerticalGeometryListing(
     val coordinateSystemSrid: Srid?,
     val coordinateSystemName: CoordinateSystemName?,
     val creationTime: Instant?,
-    val layoutStartStation: Double? = null,
-    val layoutPointStation: Double? = null,
-    val layoutEndStation: Double? = null,
+    val layoutStartStation: LineM<LocationTrackM>? = null,
+    val layoutPointStation: LineM<LocationTrackM>? = null,
+    val layoutEndStation: LineM<LocationTrackM>? = null,
     val trackNumber: TrackNumber? = null,
 )
 
@@ -115,7 +118,7 @@ fun toVerticalGeometryListing(
     planAlignments: List<GeometryAlignment>,
     getTransformation: (srid: Srid) -> Transformation,
     planHeader: GeometryPlanHeader,
-    geocodingContext: GeocodingContext?,
+    geocodingContext: GeocodingContext<*>?,
 ): List<VerticalGeometryListing> {
     return planAlignments
         .filter { it.profile != null }
@@ -153,7 +156,7 @@ fun toVerticalGeometryListing(
     geometry: LocationTrackGeometry,
     startAddress: TrackMeter?,
     endAddress: TrackMeter?,
-    geocodingContext: GeocodingContext?,
+    geocodingContext: GeocodingContext<ReferenceLineM>?,
     getTransformation: (srid: Srid) -> Transformation,
     getPlanHeaderAndAlignment: (id: IntId<GeometryAlignment>) -> Pair<GeometryPlanHeader, GeometryAlignment>,
 ): List<VerticalGeometryListing> {
@@ -223,9 +226,9 @@ fun toVerticalGeometryListing(
 
 private fun getEntryLayoutStations(
     listing: List<VerticalGeometryListing>,
-    geocodingContext: GeocodingContext,
+    geocodingContext: GeocodingContext<ReferenceLineM>,
     geometry: LocationTrackGeometry,
-): List<List<Double?>> =
+): List<List<LineM<LocationTrackM>?>> =
     processFlattened(listing.map { entry -> listOf(entry.start.address, entry.point.address, entry.end.address) }) {
         addresses ->
         processNonNulls(addresses) { nonNullAddresses ->
@@ -237,7 +240,7 @@ private fun getEntryLayoutStations(
 private fun toVerticalGeometry(
     planHeader: GeometryPlanHeader,
     getTransformation: (srid: Srid) -> Transformation,
-    geocodingContext: GeocodingContext?,
+    geocodingContext: GeocodingContext<*>?,
     geometryAlignment: GeometryAlignment,
     segment: CurvedProfileSegment,
     endAddress: TrackMeter?,
@@ -279,7 +282,7 @@ fun toVerticalGeometryListing(
     locationTrackName: AlignmentName?,
     coordinateTransform: Transformation?,
     planHeader: GeometryPlanHeader,
-    geocodingContext: GeocodingContext?,
+    geocodingContext: GeocodingContext<*>?,
     curvedSegments: List<CurvedProfileSegment>,
     linearSegments: List<LinearProfileSegment>,
     segmentStartAddress: TrackMeter?,
@@ -505,7 +508,7 @@ private fun separateCurvedAndLinearProfileSegments(segments: List<ProfileSegment
         }
 
 fun getTrackAddressAtStation(
-    geocodingContext: GeocodingContext,
+    geocodingContext: GeocodingContext<*>,
     coordinateTransform: Transformation,
     geometryAlignment: GeometryAlignment,
     station: Double,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
@@ -2,6 +2,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.error.NoSuchEntityException
+import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
@@ -12,6 +13,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import java.time.Instant
 import kotlin.reflect.KClass
 
@@ -34,10 +36,14 @@ class ChangeContext(
 ) {
 
     fun getGeocodingContextBefore(id: IntId<LayoutTrackNumber>) =
-        geocodingKeysBefore[id]?.let(geocodingService::getGeocodingContext)
+        geocodingKeysBefore[id]?.let { key ->
+            geocodingService.getGeocodingContext(key) as? GeocodingContext<ReferenceLineM>
+        }
 
     fun getGeocodingContextAfter(id: IntId<LayoutTrackNumber>) =
-        geocodingKeysAfter[id]?.let(geocodingService::getGeocodingContext)
+        geocodingKeysAfter[id]?.let { key ->
+            geocodingService.getGeocodingContext(key) as? GeocodingContext<ReferenceLineM>
+        }
 }
 
 inline fun <reified T : LayoutAsset<T>> createTypedContext(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
@@ -14,10 +14,13 @@ import fi.fta.geoviite.infra.switchLibrary.ISwitchJoint
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.tracklayout.EdgeM
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole
 
 enum class SuggestedSwitchJointMatchType {
@@ -36,7 +39,7 @@ data class EdgeId(val locationTrackId: IntId<LocationTrack>, val edgeIndex: Int)
 data class JointOnEdge(
     val jointNumber: JointNumber,
     val jointRole: SwitchJointRole,
-    val mOnEdge: Double,
+    val mOnEdge: LineM<EdgeM>,
     val direction: RelativeDirection,
     val location: Point,
 )
@@ -53,7 +56,7 @@ data class LayoutSwitchSaveRequest(
 data class FittedSwitchJointMatch(
     val locationTrackId: IntId<LocationTrack>,
     val segmentIndex: Int,
-    val mOnTrack: Double,
+    val mOnTrack: LineM<LocationTrackM>,
     val switchJoint: SwitchStructureJoint,
     val matchType: SuggestedSwitchJointMatchType,
     val distance: Double,
@@ -92,7 +95,7 @@ data class SuggestedLinks(val edgeIndex: Int, val joints: List<SwitchLinkingJoin
     }
 }
 
-data class SwitchLinkingJoint(val mvalueOnEdge: Double, val jointNumber: JointNumber, val location: Point)
+data class SwitchLinkingJoint(val mvalueOnEdge: LineM<EdgeM>, val jointNumber: JointNumber, val location: Point)
 
 data class SwitchRelinkingValidationResult(
     val id: IntId<LayoutSwitch>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchTrackRelinkingValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchTrackRelinkingValidationService.kt
@@ -141,7 +141,7 @@ private fun currentSwitchLocationsAsSwitchPlacingRequests(
 
 private fun validateChangeFromSwitchRelinking(
     track: LocationTrack,
-    geocodingContext: GeocodingContext,
+    geocodingContext: GeocodingContext<*>,
     switchId: IntId<LayoutSwitch>,
     suggestedSwitchWithOriginallyLinkedTracks: SuggestedSwitchWithOriginallyLinkedTracks?,
     originalSwitch: LayoutSwitch,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.logging.Loggable
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.MIN_POLYGON_POINTS
 import fi.fta.geoviite.infra.math.Polygon
+import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.DbLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.IAlignment
@@ -17,10 +18,15 @@ import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
+import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import fi.fta.geoviite.infra.tracklayout.segmentToAlignmentM
 import fi.fta.geoviite.infra.util.produceIf
 import kotlin.math.roundToInt
 
@@ -41,7 +47,7 @@ sealed class AlignmentHeader<AlignmentType, StateType> {
     abstract val state: StateType
     abstract val alignmentSource: MapAlignmentSource
     abstract val alignmentType: MapAlignmentType
-    abstract val length: Double
+    abstract val length: LineM<*>
     abstract val boundingBox: BoundingBox?
     abstract val segmentCount: Int
 }
@@ -52,7 +58,7 @@ data class GeometryAlignmentHeader(
     override val name: AlignmentName,
     override val state: LayoutState,
     override val alignmentType: MapAlignmentType,
-    override val length: Double,
+    override val length: LineM<PlanLayoutAlignmentM>,
     override val boundingBox: BoundingBox?,
     override val segmentCount: Int,
 ) : AlignmentHeader<GeometryAlignment, LayoutState>() {
@@ -65,7 +71,7 @@ data class ReferenceLineHeader(
     override val trackNumberId: IntId<LayoutTrackNumber>,
     override val name: AlignmentName,
     override val state: LayoutState,
-    override val length: Double,
+    override val length: LineM<ReferenceLineM>,
     override val boundingBox: BoundingBox?,
     override val segmentCount: Int,
 ) : AlignmentHeader<ReferenceLine, LayoutState>() {
@@ -81,7 +87,7 @@ data class LocationTrackHeader(
     override val name: AlignmentName,
     override val state: LocationTrackState,
     val trackType: LocationTrackType,
-    override val length: Double,
+    override val length: LineM<LocationTrackM>,
     override val boundingBox: BoundingBox?,
     override val segmentCount: Int,
 ) : AlignmentHeader<LocationTrack, LocationTrackState>() {
@@ -89,10 +95,10 @@ data class LocationTrackHeader(
     override val alignmentType = MapAlignmentType.LOCATION_TRACK
 }
 
-data class AlignmentPolyLine<T>(
+data class AlignmentPolyLine<T, M : AlignmentM<M>>(
     val id: DomainId<T>,
     val alignmentType: MapAlignmentType,
-    val points: List<AlignmentPoint>,
+    val points: List<AlignmentPoint<M>>,
 ) : Loggable {
     override fun toLog(): String = logFormat("id" to id, "type" to alignmentType, "points" to points.size)
 }
@@ -104,7 +110,7 @@ fun toAlignmentHeader(trackNumber: LayoutTrackNumber, referenceLine: ReferenceLi
         trackNumberId = referenceLine.trackNumberId,
         name = AlignmentName(trackNumber.number.toString()),
         state = trackNumber.state,
-        length = alignment?.length ?: 0.0,
+        length = alignment?.length ?: LineM(0.0),
         segmentCount = referenceLine.segmentCount,
         boundingBox = alignment?.boundingBox,
     )
@@ -123,13 +129,13 @@ fun toAlignmentHeader(locationTrack: LocationTrack, geometry: DbLocationTrackGeo
         boundingBox = geometry.boundingBox,
     )
 
-fun getSegmentBorderMValues(alignment: IAlignment): List<Double> =
+fun <M : AlignmentM<M>> getSegmentBorderMValues(alignment: IAlignment<M>): List<LineM<M>> =
     alignment.segmentMValues.map { s -> s.min } + alignment.length
 
-fun <T> toAlignmentPolyLine(
+fun <T, M : AlignmentM<M>> toAlignmentPolyLine(
     id: DomainId<T>,
     type: MapAlignmentType,
-    alignment: IAlignment,
+    alignment: IAlignment<M>,
     resolution: Int? = null,
     bbox: BoundingBox? = null,
     includeSegmentEndPoints: Boolean,
@@ -138,7 +144,10 @@ fun <T> toAlignmentPolyLine(
 const val ALIGNMENT_POLYGON_BUFFER = 10.0
 const val ALIGNMENT_POLYGON_SIMPLIFICATION_RESOLUTION = 100
 
-fun toPolygon(alignment: IAlignment, polygonBufferSize: Double = ALIGNMENT_POLYGON_BUFFER): Polygon? {
+fun <M : AlignmentM<M>> toPolygon(
+    alignment: IAlignment<M>,
+    polygonBufferSize: Double = ALIGNMENT_POLYGON_BUFFER,
+): Polygon? {
     val simplifiedAlignment =
         simplify(
             alignment = alignment,
@@ -150,15 +159,17 @@ fun toPolygon(alignment: IAlignment, polygonBufferSize: Double = ALIGNMENT_POLYG
     return produceIf(points.size >= MIN_POLYGON_POINTS) { Polygon(points) }
 }
 
-fun simplify(
-    alignment: IAlignment,
+fun <M : AlignmentM<M>> simplify(
+    alignment: IAlignment<M>,
     resolution: Int? = null,
     bbox: BoundingBox? = null,
     includeSegmentEndPoints: Boolean,
-): List<AlignmentPoint> {
+): List<AlignmentPoint<M>> {
     val segments = bbox?.let(alignment::filterSegmentsByBbox) ?: alignment.segmentsWithM
-    var previousM = Double.NEGATIVE_INFINITY
-    val isOverResolution = { mValue: Double -> resolution?.let { r -> (mValue - previousM).roundToInt() >= r } ?: true }
+    var previousM = LineM<M>(Double.NEGATIVE_INFINITY)
+    val isOverResolution = { mValue: LineM<M> ->
+        resolution?.let { r -> (mValue - previousM).distance.roundToInt() >= r } ?: true
+    }
     return segments
         .flatMapIndexed { sIndex, (s, m) ->
             if (sIndex == 0 || sIndex == segments.lastIndex || isOverResolution(m.max)) {
@@ -175,11 +186,11 @@ fun simplify(
                 }
 
                 s.segmentPoints.mapIndexedNotNull { pIndex, p ->
-                    if (isPointIncluded(pIndex, p.m + m.min, isEndPoint, isOverResolution, bboxContains)) {
+                    if (isPointIncluded(pIndex, p.m.segmentToAlignmentM(m.min), isEndPoint, isOverResolution, bboxContains)) {
                         if (!isSegmentEndPoint(pIndex)) {
                             // segment end points should be additional points,
                             // so increase m-counter only when handling middle points
-                            previousM = m.min + p.m
+                            previousM = p.m.segmentToAlignmentM(m.min)
                         }
                         p.toAlignmentPoint(m.min)
                     } else null
@@ -196,11 +207,11 @@ fun simplify(
         .let { points -> if (points.size >= 2) points else listOf() }
 }
 
-private fun isPointIncluded(
+private fun <M : AlignmentM<M>> isPointIncluded(
     index: Int,
-    m: Double,
+    m: LineM<M>,
     isEndPoint: (index: Int) -> Boolean,
-    isOverResolution: (m: Double) -> Boolean,
+    isOverResolution: (m: LineM<M>) -> Boolean,
     bboxContains: (index: Int) -> Boolean,
 ): Boolean {
     val isInsideBbox = bboxContains(index)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Math.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Math.kt
@@ -1,6 +1,8 @@
 package fi.fta.geoviite.infra.math
 
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
+import fi.fta.geoviite.infra.tracklayout.AnyM
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -21,6 +23,8 @@ fun roundTo1Decimal(value: Double): BigDecimal = round(value, 1)
 
 fun roundTo3Decimals(value: Double): BigDecimal = round(value, 3)
 
+fun roundTo3Decimals(value: LineM<*>): BigDecimal = round(value.distance, 3)
+
 fun roundTo3Decimals(value: BigDecimal): BigDecimal = round(value, 3)
 
 fun roundTo6Decimals(value: Double): BigDecimal = round(value, 6)
@@ -28,6 +32,8 @@ fun roundTo6Decimals(value: Double): BigDecimal = round(value, 6)
 fun round(value: Double, scale: Int): BigDecimal =
     if (!value.isFinite()) throw IllegalArgumentException("Cannot round $value")
     else round(BigDecimal.valueOf(value), scale)
+
+fun round(value: LineM<*>, scale: Int) = round(value.distance, scale)
 
 fun round(value: BigDecimal, scale: Int): BigDecimal = value.setScale(scale, RoundingMode.HALF_UP)
 
@@ -37,6 +43,9 @@ fun interpolate(value1: Double?, value2: Double?, portion: Double) =
 fun interpolate(value1: Double, value2: Double, portion: Double): Double =
     if (value1.isFinite() && value2.isFinite()) value1 + (value2 - value1) * portion
     else throw IllegalArgumentException("Cannot interpolate between $value1 and $value2")
+
+fun <M : AnyM<M>> interpolate(value1: LineM<M>, value2: LineM<M>, portion: Double): LineM<M> =
+    LineM(interpolate(value1.distance, value2.distance, portion))
 
 fun interpolateToPoint(value1: IPoint, value2: IPoint, portion: Double): Point =
     Point(x = interpolate(value1.x, value2.x, portion), y = interpolate(value1.y, value2.y, portion))
@@ -50,7 +59,7 @@ fun interpolateToSegmentPoint(value1: SegmentPoint, value2: SegmentPoint, portio
         cant = interpolate(value1.cant, value2.cant, portion),
     )
 
-fun interpolateToAlignmentPoint(value1: AlignmentPoint, value2: AlignmentPoint, portion: Double) =
+fun <M : AnyM<M>> interpolateToAlignmentPoint(value1: AlignmentPoint<M>, value2: AlignmentPoint<M>, portion: Double) =
     AlignmentPoint(
         x = interpolate(value1.x, value2.x, portion),
         y = interpolate(value1.y, value2.y, portion),
@@ -63,3 +72,6 @@ fun isSame(value1: Double?, value2: Double?, delta: Double) =
     (value1 == null && value2 == null) || (value1 != null && value2 != null && isSame(value1, value2, delta))
 
 fun isSame(value1: Double, value2: Double, delta: Double) = abs(value1 - value2) < delta
+
+fun <M : AnyM<M>> isSame(value1: LineM<M>?, value2: LineM<M>?, delta: Double) =
+    isSame(value1?.distance, value2?.distance, delta)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Point.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Point.kt
@@ -1,5 +1,7 @@
 package fi.fta.geoviite.infra.math
 
+import fi.fta.geoviite.infra.tracklayout.AnyM
+import fi.fta.geoviite.infra.tracklayout.LineM
 import java.math.BigDecimal
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -148,11 +150,13 @@ fun dotProduct(v1: IPoint, v2: IPoint): Double {
     return v1.x * v2.x + v1.y * v2.y
 }
 
-interface IPoint3DM : IPoint {
-    val m: Double
+interface IPoint3DM<M : AnyM<M>> : IPoint {
+    val m: LineM<M>
 }
 
-data class Point3DM(override val x: Double, override val y: Double, override val m: Double) : IPoint3DM {
+data class Point3DM<M : AnyM<M>>(override val x: Double, override val y: Double, override val m: LineM<M>) :
+    IPoint3DM<M> {
+    constructor(x: Double, y: Double, m: Double) : this(x, y, LineM(m))
     init {
         require(x.isFinite() && y.isFinite() && m.isFinite()) { "Cannot create point of: x=$x y=$y m=$m" }
     }
@@ -168,10 +172,14 @@ data class Point3DZ(override val x: Double, override val y: Double, override val
     }
 }
 
-interface IPoint4DZM : IPoint, IPoint3DZ, IPoint3DM
+interface IPoint4DZM<M : AnyM<M>> : IPoint, IPoint3DZ, IPoint3DM<M>
 
-data class Point4DZM(override val x: Double, override val y: Double, override val z: Double, override val m: Double) :
-    IPoint4DZM {
+data class Point4DZM<M : AnyM<M>>(
+    override val x: Double,
+    override val y: Double,
+    override val z: Double,
+    override val m: LineM<M>,
+) : IPoint4DZM<M> {
     init {
         require(x.isFinite() && y.isFinite() && z.isFinite() && m.isFinite()) {
             "Cannot create point of: x=$x y=$y z=$z m=$m"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Range.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/Range.kt
@@ -20,6 +20,8 @@ data class Range<T : Comparable<T>>(val min: T, val max: T) {
         val maximum = if (max > other.max) other.max else max
         return if (minimum <= maximum) Range(minimum, maximum) else null
     }
+
+    fun <R : Comparable<R>> map(f: (value: T) -> R): Range<R> = Range(f(min), f(max))
 }
 
 fun <T : Comparable<T>> combineContinuous(ranges: List<Range<T>>): List<Range<T>> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/GeometryChangeCalculation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/GeometryChangeCalculation.kt
@@ -2,25 +2,31 @@ package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
+import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.LayoutSegment
+import fi.fta.geoviite.infra.tracklayout.LineM
+import fi.fta.geoviite.infra.tracklayout.segmentToAlignmentM
 import kotlin.math.max
 import kotlin.math.min
 
-data class GeometryChangeRanges(val added: List<Range<Double>>, val removed: List<Range<Double>>)
+data class GeometryChangeRanges<M : AlignmentM<M>>(
+    val added: List<Range<LineM<M>>>,
+    val removed: List<Range<LineM<M>>>,
+)
 
-fun getChangedGeometryRanges(
-    newSegments: List<Pair<LayoutSegment, Range<Double>>>,
-    oldSegments: List<Pair<LayoutSegment, Range<Double>>>,
+fun <M : AlignmentM<M>> getChangedGeometryRanges(
+    newSegments: List<Pair<LayoutSegment, Range<LineM<M>>>>,
+    oldSegments: List<Pair<LayoutSegment, Range<LineM<M>>>>,
 ) =
     GeometryChangeRanges(
         added = getAddedSegmentMRanges(newSegments, oldSegments),
         removed = getAddedSegmentMRanges(oldSegments, newSegments),
     )
 
-fun getAddedSegmentMRanges(
-    newSegments: List<Pair<LayoutSegment, Range<Double>>>,
-    oldSegments: List<Pair<LayoutSegment, Range<Double>>>,
-): List<Range<Double>> {
+fun <M : AlignmentM<M>> getAddedSegmentMRanges(
+    newSegments: List<Pair<LayoutSegment, Range<LineM<M>>>>,
+    oldSegments: List<Pair<LayoutSegment, Range<LineM<M>>>>,
+): List<Range<LineM<M>>> {
     val addedSegmentIndices = getAddedIndexRangesExclusive(newSegments, oldSegments) { (s, _) -> s.geometry.id }
     return addedSegmentIndices.flatMap { (newRange, oldRange) ->
         val newPoints = getPointsWithMExclusive(newSegments, newRange)
@@ -36,10 +42,10 @@ fun getAddedSegmentMRanges(
     }
 }
 
-fun getPointsWithMExclusive(
-    segments: List<Pair<LayoutSegment, Range<Double>>>,
+fun <M : AlignmentM<M>> getPointsWithMExclusive(
+    segments: List<Pair<LayoutSegment, Range<LineM<M>>>>,
     indexRange: Range<Int>,
-): List<Pair<Point, Double>> =
+): List<Pair<Point, LineM<M>>> =
     indexRange
         .takeIf { r -> r.max - r.min >= 2 }
         ?.let { exclusive -> Range(exclusive.min + 1, exclusive.max - 1) }
@@ -48,7 +54,7 @@ fun getPointsWithMExclusive(
                 segments.getOrNull(i)?.let { (segment, m) ->
                     segment.segmentPoints
                         .let { if (i == inclusive.min) it else it.subList(0, it.lastIndex) }
-                        .map { p -> p.toPoint() to (p.m + m.min) }
+                        .map { p -> p.toPoint() to p.m.segmentToAlignmentM(m.min) }
                 } ?: emptyList()
             }
         } ?: emptyList()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -433,7 +433,7 @@ data class ReferenceLinePublicationCandidate(
     override val publicationGroup: PublicationGroup? = null,
     override val designAssetState: DesignAssetState?,
     val boundingBox: BoundingBox?,
-    val geometryChanges: GeometryChangeRanges?,
+    val geometryChanges: GeometryChangeRanges<ReferenceLineM>?,
 ) : PublicationCandidate<ReferenceLine> {
     override val type = DraftChangeType.REFERENCE_LINE
 }
@@ -450,7 +450,7 @@ data class LocationTrackPublicationCandidate(
     override val publicationGroup: PublicationGroup? = null,
     override val designAssetState: DesignAssetState?,
     val boundingBox: BoundingBox?,
-    val geometryChanges: GeometryChangeRanges?,
+    val geometryChanges: GeometryChangeRanges<LocationTrackM>?,
 ) : PublicationCandidate<LocationTrack> {
     override val type = DraftChangeType.LOCATION_TRACK
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -31,6 +31,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.TrackNumberAndChangeTime
 import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FreeText
@@ -109,7 +110,10 @@ constructor(
         translation: Translation,
     ): List<PublicationTableItem> {
         val geocodingContextCache =
-            ConcurrentHashMap<Instant, MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext>>>()
+            ConcurrentHashMap<
+                Instant,
+                MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext<ReferenceLineM>>>,
+            >()
         return getPublicationDetails(id).let { publication ->
             val previousPublication =
                 publicationDao
@@ -165,7 +169,10 @@ constructor(
             .sortedBy { it.publicationTime }
             .let { publications ->
                 val geocodingContextCache =
-                    ConcurrentHashMap<Instant, MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext>>>()
+                    ConcurrentHashMap<
+                        Instant,
+                        MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext<ReferenceLineM>>>,
+                    >()
                 val trackNumbersCache = trackNumberDao.fetchTrackNumberNames()
                 val getGeocodingContextOrNull = { trackNumberId: IntId<LayoutTrackNumber>, timestamp: Instant ->
                     getOrPutGeocodingContext(geocodingContextCache, layoutBranch, trackNumberId, timestamp)
@@ -308,7 +315,7 @@ constructor(
         trackNumberChanges: TrackNumberChanges,
         newTimestamp: Instant,
         oldTimestamp: Instant,
-        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
     ): List<PublicationChange<*>> {
         val oldEndAddress =
             trackNumberChanges.endPoint.old?.let { point ->
@@ -354,7 +361,7 @@ constructor(
         previousPublicationTime: Instant,
         trackNumberCache: List<TrackNumberAndChangeTime>,
         changedKmNumbers: Set<KmNumber>,
-        getGeocodingContext: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        getGeocodingContext: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
     ): List<PublicationChange<*>> {
         val oldAndTime = locationTrackChanges.duplicateOf.old to previousPublicationTime
         val newAndTime = locationTrackChanges.duplicateOf.new to publicationTime
@@ -510,7 +517,7 @@ constructor(
         newTimestamp: Instant,
         oldTimestamp: Instant,
         changedKmNumbers: Set<KmNumber>,
-        getGeocodingContext: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        getGeocodingContext: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
     ): List<PublicationChange<*>> {
         return listOfNotNull(
             compareLength(
@@ -559,7 +566,7 @@ constructor(
         newTimestamp: Instant,
         oldTimestamp: Instant,
         trackNumberCache: List<TrackNumberAndChangeTime>,
-        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
         crsNameGetter: (srid: Srid) -> String,
     ) =
         listOfNotNull(
@@ -609,7 +616,7 @@ constructor(
         timestamp: Instant,
         location: Point?,
         trackNumberId: IntId<LayoutTrackNumber>?,
-        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
     ) =
         location?.let {
             trackNumberId?.let {
@@ -626,7 +633,7 @@ constructor(
         oldTimestamp: Instant,
         operation: Operation,
         trackNumberCache: List<TrackNumberAndChangeTime>,
-        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
     ): List<PublicationChange<*>> {
         val relatedJoints = changes.joints.filterNot { it.removed }.distinctBy { it.trackNumberId }
 
@@ -715,7 +722,7 @@ constructor(
     }
 
     private fun getOrPutGeocodingContext(
-        caches: MutableMap<Instant, MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext>>>,
+        caches: MutableMap<Instant, MutableMap<IntId<LayoutTrackNumber>, Optional<GeocodingContext<ReferenceLineM>>>>,
         branch: LayoutBranch,
         trackNumberId: IntId<LayoutTrackNumber>,
         timestamp: Instant,
@@ -743,7 +750,7 @@ constructor(
         publication: PublicationDetails,
         switchLinkChanges: Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>,
         previousComparisonTime: Instant,
-        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext?,
+        geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
         trackNumberNamesCache: List<TrackNumberAndChangeTime> = trackNumberDao.fetchTrackNumberNames(),
     ): List<PublicationTableItem> {
         val publicationLocationTrackChanges = publicationDao.fetchPublicationLocationTrackChanges(publication.id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -30,9 +30,11 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import java.time.Instant
@@ -87,7 +89,7 @@ constructor(
     fun fetchChangedLocationTrackGeometryRanges(
         id: IntId<LocationTrack>,
         transition: LayoutContextTransition,
-    ): GeometryChangeRanges {
+    ): GeometryChangeRanges<LocationTrackM> {
         val trackWithGeometry1 = locationTrackService.getWithGeometry(transition.candidateContext, id)
         val trackWithGeometry2 = locationTrackService.getWithGeometry(transition.baseContext, id)
         return getChangedGeometryRanges(
@@ -99,7 +101,7 @@ constructor(
     fun fetchChangedReferenceLineGeometryRanges(
         id: IntId<ReferenceLine>,
         transition: LayoutContextTransition,
-    ): GeometryChangeRanges {
+    ): GeometryChangeRanges<ReferenceLineM> {
         val lineWithAlignment1 = referenceLineService.getWithAlignment(transition.candidateContext, id)
         val lineWithAlignment2 = referenceLineService.getWithAlignment(transition.baseContext, id)
         return getChangedGeometryRanges(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.ClientException
-import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
 import fi.fta.geoviite.infra.geocoding.GeocodingContextCreateResult
 import fi.fta.geoviite.infra.geocoding.GeocodingReferencePoint
@@ -15,6 +14,7 @@ import fi.fta.geoviite.infra.geocoding.KmPostRejectedReason
 import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.localizationParams
+import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.math.angleDiffRads
 import fi.fta.geoviite.infra.math.directionBetweenPoints
@@ -26,7 +26,7 @@ import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
-import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
+import fi.fta.geoviite.infra.tracklayout.GeocodingAlignmentM
 import fi.fta.geoviite.infra.tracklayout.IAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
@@ -34,7 +34,9 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.TopologicalConnectivityType
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLink
 import fi.fta.geoviite.infra.util.rangesOfConsecutiveIndicesOf
@@ -736,7 +738,7 @@ fun noGeocodingContext(validationTargetLocalizationPrefix: String) =
     LayoutValidationIssue(ERROR, "$validationTargetLocalizationPrefix.no-context")
 
 fun validateGeocodingContext(
-    contextCreateResult: GeocodingContextCreateResult,
+    contextCreateResult: GeocodingContextCreateResult<ReferenceLineM>,
     trackNumber: TrackNumber,
 ): List<LayoutValidationIssue> {
     val context = contextCreateResult.geocodingContext
@@ -818,14 +820,16 @@ fun validateGeocodingContext(
     return kmPostsRejected + listOfNotNull(kmPostsFarFromLine, kmPostsInWrongOrder, badStartPoint)
 }
 
-private fun isOrderOk(previous: GeocodingReferencePoint?, next: GeocodingReferencePoint?) =
-    if (previous == null || next == null) true else previous.distance < next.distance
+private fun <M : GeocodingAlignmentM<M>> isOrderOk(
+    previous: GeocodingReferencePoint<M>?,
+    next: GeocodingReferencePoint<M>?,
+) = if (previous == null || next == null) true else previous.distance < next.distance
 
 fun validateAddressPoints(
     trackNumber: LayoutTrackNumber,
     locationTrack: LocationTrack,
     validationTargetLocalizationPrefix: String,
-    geocode: () -> AlignmentAddresses?,
+    geocode: () -> AlignmentAddresses<*>?,
 ): List<LayoutValidationIssue> =
     try {
         geocode()?.let { addresses -> validateAddressPoints(trackNumber, locationTrack, addresses) }
@@ -837,11 +841,11 @@ fun validateAddressPoints(
 fun validateAddressPoints(
     trackNumber: LayoutTrackNumber,
     locationTrack: LocationTrack,
-    addresses: AlignmentAddresses,
+    addresses: AlignmentAddresses<*>,
 ): List<LayoutValidationIssue> {
     val allPoints = listOf(addresses.startPoint) + addresses.midPoints + listOf(addresses.endPoint)
-    val allCoordinates = allPoints.map(AddressPoint::point)
-    val allAddresses = allPoints.map(AddressPoint::address)
+    val allCoordinates = allPoints.map { it.point }
+    val allAddresses = allPoints.map { it.address }
     val maxRanges = 5
     fun describeAsAddressRanges(indices: List<ClosedRange<Int>>): String =
         indices
@@ -904,7 +908,7 @@ fun validateReferenceLineGeometry(alignment: LayoutAlignment) = validateGeometry
 fun validateLocationTrackGeometry(geometry: LocationTrackGeometry) =
     validateGeometry(VALIDATION_LOCATION_TRACK, geometry)
 
-private fun validateGeometry(errorParent: String, alignment: IAlignment) =
+private fun validateGeometry(errorParent: String, alignment: IAlignment<*>) =
     listOfNotNull(
         validate(alignment.segments.isNotEmpty()) { "$errorParent.empty-segments" },
         validate(getMaxDirectionDeltaRads(alignment) <= MAX_LAYOUT_POINT_ANGLE_CHANGE) {
@@ -912,7 +916,7 @@ private fun validateGeometry(errorParent: String, alignment: IAlignment) =
         },
     )
 
-fun getMaxDirectionDeltaRads(alignment: IAlignment): Double =
+fun getMaxDirectionDeltaRads(alignment: IAlignment<*>): Double =
     alignment.allSegmentPoints.zipWithNext(::directionBetweenPoints).zipWithNext(::angleDiffRads).maxOrNull() ?: 0.0
 
 private fun nodeAndJointLocationsAgree(switch: LayoutSwitch, trackLinks: List<TrackSwitchLink>): Boolean =
@@ -960,10 +964,10 @@ private fun collectJoints(structure: SwitchStructure) =
 private fun areLinksContinuous(links: List<Pair<Int, TrackSwitchLink>>): Boolean =
     links.zipWithNext().all { (prev, next) -> prev.first + 1 == next.first }
 
-private fun discontinuousDirectionRangeIndices(points: List<AlignmentPoint>) =
+private fun discontinuousDirectionRangeIndices(points: List<IPoint>) =
     rangesOfConsecutiveIndicesOf(false, points.zipWithNext(::directionBetweenPoints).zipWithNext(::isAngleDiffOk), 2)
 
-private fun stretchedMeterRangeIndices(points: List<AlignmentPoint>) =
+private fun stretchedMeterRangeIndices(points: List<IPoint>) =
     rangesOfConsecutiveIndicesOf(false, points.zipWithNext(::lineLength).map { it <= MAX_LAYOUT_METER_LENGTH }, 1)
 
 private fun discontinuousAddressRangeIndices(addresses: List<TrackMeter>): List<ClosedRange<Int>> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -24,6 +24,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -585,9 +586,10 @@ constructor(
         localizationKey: String,
         trackNumber: TrackNumber,
     ) =
-        cacheKey?.let(geocodingCacheService::getGeocodingContextWithReasons)?.let { context ->
-            validateGeocodingContext(context, trackNumber)
-        } ?: listOf(noGeocodingContext(localizationKey))
+        cacheKey
+            ?.let { key -> geocodingCacheService.getGeocodingContextWithReasons<ReferenceLineM>(key) }
+            ?.let { context -> validateGeocodingContext(context, trackNumber) }
+            ?: listOf(noGeocodingContext(localizationKey))
 
     private fun validateAddressPoints(
         trackNumber: LayoutTrackNumber,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -26,6 +26,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import java.util.concurrent.ConcurrentHashMap
@@ -214,10 +215,10 @@ class ValidationContext(
             geocodingService.getGeocodingContextCacheKey(tnId, publicationSet)
         }
 
-    fun getAddressPoints(trackId: IntId<LocationTrack>): AlignmentAddresses? =
+    fun getAddressPoints(trackId: IntId<LocationTrack>): AlignmentAddresses<LocationTrackM>? =
         getLocationTrack(trackId)?.let(::getAddressPoints)
 
-    fun getAddressPoints(track: LocationTrack): AlignmentAddresses? =
+    fun getAddressPoints(track: LocationTrack): AlignmentAddresses<LocationTrackM>? =
         getGeocodingContextCacheKey(track.trackNumberId)?.let { key ->
             geocodingService.getAddressPoints(key, track.getVersionOrThrow())
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -29,11 +29,12 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)
@@ -190,7 +191,7 @@ constructor(
 
     private fun createLocationTrackPoints(
         locationTrackOid: RatkoOid<RatkoLocationTrack>,
-        addressPoints: Collection<AddressPoint>,
+        addressPoints: Collection<AddressPoint<LocationTrackM>>,
     ) =
         toRatkoPointsGroupedByKm(addressPoints).forEach { points ->
             ratkoClient.createLocationTrackPoints(locationTrackOid, points)
@@ -200,7 +201,7 @@ constructor(
         branch: LayoutBranch,
         locationTrack: LocationTrack,
         locationTrackExternalId: FullRatkoExternalId<LocationTrack>,
-        alignmentPoints: List<AddressPoint>,
+        alignmentPoints: List<AddressPoint<LocationTrackM>>,
         trackNumberOid: Oid<LayoutTrackNumber>,
         moment: Instant,
         changedKmNumbers: Set<KmNumber>? = null,
@@ -282,10 +283,10 @@ constructor(
     }
 
     private fun findAddressPoint(
-        points: List<AddressPoint>,
+        points: List<AddressPoint<LocationTrackM>>,
         seek: TrackMeter,
         rounding: AddressRounding,
-    ): AddressPoint =
+    ): AddressPoint<LocationTrackM> =
         when (rounding) {
             AddressRounding.UP -> points.find { p -> p.address >= seek }
             AddressRounding.DOWN -> points.findLast { p -> p.address <= seek }
@@ -391,7 +392,7 @@ constructor(
 
     private fun updateLocationTrackGeometry(
         locationTrackOid: RatkoOid<RatkoLocationTrack>,
-        newPoints: Collection<AddressPoint>,
+        newPoints: Collection<AddressPoint<LocationTrackM>>,
     ) =
         toRatkoPointsGroupedByKm(newPoints).forEach { points ->
             ratkoClient.updateLocationTrackPoints(locationTrackOid, points)
@@ -425,7 +426,7 @@ constructor(
         branch: LayoutBranch,
         locationTrack: LocationTrack,
         moment: Instant,
-    ): Pair<AlignmentAddresses, List<AddressPoint>> {
+    ): Pair<AlignmentAddresses<LocationTrackM>, List<AddressPoint<LocationTrackM>>> {
         val geocodingContext =
             geocodingService
                 .getGeocodingContextCacheKey(branch, locationTrack.trackNumberId, moment)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
@@ -21,6 +21,7 @@ import fi.fta.geoviite.infra.tracklayout.DesignAssetState
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -166,7 +167,7 @@ constructor(
 
     private fun updateRouteNumberGeometry(
         routeNumberOid: RatkoOid<RatkoRouteNumber>,
-        newPoints: Collection<AddressPoint>,
+        newPoints: Collection<AddressPoint<ReferenceLineM>>,
     ) =
         toRatkoPointsGroupedByKm(newPoints).forEach { points ->
             ratkoClient.updateRouteNumberPoints(routeNumberOid, points)
@@ -201,7 +202,7 @@ constructor(
 
     private fun createRouteNumberPoints(
         routeNumberOid: RatkoOid<RatkoRouteNumber>,
-        newPoints: Collection<AddressPoint>,
+        newPoints: Collection<AddressPoint<ReferenceLineM>>,
     ) =
         toRatkoPointsGroupedByKm(newPoints).forEach { points ->
             ratkoClient.createRouteNumberPoints(routeNumberOid, points)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtils.kt
@@ -78,7 +78,7 @@ private fun <T : LayoutAsset<T>> managePlanItem(
 }
 
 fun getEndPointNodeCollection(
-    alignmentAddresses: AlignmentAddresses,
+    alignmentAddresses: AlignmentAddresses<*>,
     changedKmNumbers: Collection<KmNumber>,
     existingStartNode: RatkoNode? = null,
     existingEndNode: RatkoNode? = null,
@@ -144,7 +144,7 @@ fun sortByNullDuplicateOfFirst(duplicateOf: IntId<LocationTrack>?) = if (duplica
 fun sortByDeletedStateFirst(layoutStateCategory: LayoutStateCategory) =
     if (layoutStateCategory == LayoutStateCategory.NOT_EXISTING) 0 else 1
 
-fun toRatkoPointsGroupedByKm(addressPoints: Collection<AddressPoint>) =
+fun toRatkoPointsGroupedByKm(addressPoints: Collection<AddressPoint<*>>) =
     addressPoints
         .groupBy { point -> point.address.kmNumber }
         .map { (_, addressPointsForKm) ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
@@ -221,14 +221,14 @@ fun convertToRatkoRouteNumber(
         planItemIds = asPlanItemIdsList(trackNumberExternalId),
     )
 
-fun convertToRatkoPoint(point: AddressPoint, state: RatkoPointStates = RatkoPointStates.VALID) =
+fun convertToRatkoPoint(point: AddressPoint<*>, state: RatkoPointStates = RatkoPointStates.VALID) =
     RatkoPoint(
         state = RatkoPointState(state),
         kmM = RatkoTrackMeter(point.address),
         geometry = RatkoGeometry(point.point),
     )
 
-fun convertToRatkoNodeCollection(addresses: AlignmentAddresses) =
+fun convertToRatkoNodeCollection(addresses: AlignmentAddresses<*>) =
     convertToRatkoNodeCollection(
         listOf(
             convertToRatkoNode(addresses.startPoint, RatkoNodeType.START_POINT),
@@ -239,7 +239,7 @@ fun convertToRatkoNodeCollection(addresses: AlignmentAddresses) =
 fun convertToRatkoNodeCollection(nodes: Collection<RatkoNode>) = RatkoNodes(nodes, RatkoNodesType.START_AND_END)
 
 fun convertToRatkoNode(
-    addressPoint: AddressPoint,
+    addressPoint: AddressPoint<*>,
     nodeType: RatkoNodeType,
     state: RatkoPointStates = RatkoPointStates.VALID,
 ) = RatkoNode(nodeType, convertToRatkoPoint(addressPoint, state))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -12,9 +12,11 @@ import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionStructure
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionSuffix
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameSpecifier
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameStructure
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNamingScheme
@@ -160,6 +162,6 @@ data class SplitDuplicateTrack(
     val id: IntId<LocationTrack>,
     val nameStructure: LocationTrackNameStructure,
     val name: AlignmentName,
-    val length: Double,
+    val length: LineM<LocationTrackM>,
     val status: DuplicateStatus,
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -11,14 +11,15 @@ import fi.fta.geoviite.infra.publication.validationError
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.util.produceIf
 import kotlin.math.min
 
 const val VALIDATION_SPLIT = "$VALIDATION.split"
 
 internal fun validateSourceGeometry(
-    draftAddresses: AlignmentAddresses?,
-    officialAddressPoint: AlignmentAddresses?,
+    draftAddresses: AlignmentAddresses<LocationTrackM>?,
+    officialAddressPoint: AlignmentAddresses<LocationTrackM>?,
 ): LayoutValidationIssue? {
     return if (draftAddresses == null || officialAddressPoint == null) {
         LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.no-geometry")
@@ -74,8 +75,8 @@ const val MAX_SPLIT_POINT_OFFSET = 1.0
 
 internal fun validateTargetGeometry(
     operation: SplitTargetOperation,
-    targetPoints: List<AddressPoint>?,
-    sourcePoints: List<AddressPoint>?,
+    targetPoints: List<AddressPoint<LocationTrackM>>?,
+    sourcePoints: List<AddressPoint<LocationTrackM>>?,
 ): LayoutValidationIssue? {
     return if (targetPoints == null || sourcePoints == null) {
         LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.no-geometry")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
@@ -59,9 +59,9 @@ data class PlanLayoutAlignment(
     val header: AlignmentHeader<GeometryAlignment, LayoutState>,
     @JsonIgnore override val segments: List<PlanLayoutSegment>,
     @JsonIgnore val staStart: Double,
-    val polyLine: AlignmentPolyLine<GeometryAlignment>? = null,
-) : IAlignment {
-    override val segmentMValues: List<Range<Double>> by lazy { calculateSegmentMValues(segments) }
+    val polyLine: AlignmentPolyLine<GeometryAlignment, PlanLayoutAlignmentM>? = null,
+) : IAlignment<PlanLayoutAlignmentM> {
+    override val segmentMValues: List<Range<LineM<PlanLayoutAlignmentM>>> by lazy { calculateSegmentMValues(segments) }
 
     @get:JsonIgnore
     val id: DomainId<GeometryAlignment>

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -55,22 +55,26 @@ import fi.fta.geoviite.infra.util.produceIf
 import fi.fta.geoviite.infra.util.setNullableBigDecimal
 import fi.fta.geoviite.infra.util.setNullableInt
 import fi.fta.geoviite.infra.util.setUser
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.sql.ResultSet
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Collectors
 import kotlin.math.abs
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 const val NODE_CACHE_SIZE = 50000L
 const val EDGE_CACHE_SIZE = 100000L
 const val ALIGNMENT_CACHE_SIZE = 10000L
 const val GEOMETRY_CACHE_SIZE = 500000L
 
-data class MapSegmentProfileInfo<T>(val id: IntId<T>, val mRange: Range<Double>, val hasProfile: Boolean)
+data class MapSegmentProfileInfo<T, M : AlignmentM<M>>(
+    val id: IntId<T>,
+    val mRange: Range<LineM<M>>,
+    val hasProfile: Boolean,
+)
 
 @Component
 class LayoutAlignmentDao(
@@ -345,7 +349,7 @@ class LayoutAlignmentDao(
                 "end_node_port" to content.endNode.portConnection.name,
                 "geometry_alignment_ids" to content.segments.map { s -> s.sourceId?.parentId }.toTypedArray(),
                 "geometry_element_indices" to content.segments.map { s -> s.sourceId?.index }.toTypedArray(),
-                "start_m_values" to content.segmentMValues.map { m -> roundTo6Decimals(m.min) }.toTypedArray(),
+                "start_m_values" to content.segmentMValues.map { m -> roundTo6Decimals(m.min.distance) }.toTypedArray(),
                 "source_start_m_values" to content.segments.map { s -> s.sourceStartM }.toTypedArray(),
                 "sources" to content.segments.map { s -> s.source.name }.toTypedArray(),
                 "geometry_ids" to content.segments.map { s -> (s.geometry.id as IntId).intValue }.toTypedArray(),
@@ -455,7 +459,7 @@ class LayoutAlignmentDao(
             ps.setInt(3, trackVersion.version)
             ps.setInt(4, requireNotNull(edges[edge.contentHash]).intValue)
             ps.setInt(5, index)
-            ps.setBigDecimal(6, roundTo6Decimals(m.min))
+            ps.setBigDecimal(6, roundTo6Decimals(m.min.distance))
         }
         logger.daoAccess(AccessType.INSERT, LocationTrackGeometry::class, trackVersion)
     }
@@ -572,7 +576,7 @@ class LayoutAlignmentDao(
             mapOf(
                 "polygon_string" to alignment.boundingBox?.let { bbox -> bbox.polygonFromCorners.toWkt() },
                 "segment_count" to alignment.segments.size,
-                "length" to alignment.length,
+                "length" to alignment.length.distance,
             )
         jdbcTemplate.setUser()
         val id: RowVersion<LayoutAlignment> =
@@ -604,7 +608,7 @@ class LayoutAlignmentDao(
                 "id" to alignmentId.intValue,
                 "polygon_string" to alignment.boundingBox?.let(BoundingBox::polygonFromCorners)?.toWkt(),
                 "segment_count" to alignment.segments.size,
-                "length" to alignment.length,
+                "length" to alignment.length.distance,
             )
         jdbcTemplate.setUser()
         val result: RowVersion<LayoutAlignment> =
@@ -739,7 +743,7 @@ class LayoutAlignmentDao(
         trackVersion: LayoutRowVersion<LocationTrack>,
         metadataExternalId: Oid<*>?,
         boundingBox: BoundingBox?,
-    ): List<SegmentGeometryAndMetadata> {
+    ): List<SegmentGeometryAndMetadata<LocationTrackM>> {
         val sql =
             """
           with
@@ -884,7 +888,7 @@ class LayoutAlignmentDao(
         val result =
             jdbcTemplate.query(sql, params) { rs, _ ->
                 val rangeId = rs.getString("range_id")
-                SegmentGeometryAndMetadata(
+                SegmentGeometryAndMetadata<LocationTrackM>(
                     planId = rs.getIntIdOrNull("plan_id"),
                     fileName = rs.getFileNameOrNull("file_name"),
                     alignmentId = rs.getIntIdOrNull("geom_alignment_id"),
@@ -903,7 +907,7 @@ class LayoutAlignmentDao(
         alignmentVersion: RowVersion<LayoutAlignment>,
         metadataExternalId: Oid<*>?,
         boundingBox: BoundingBox?,
-    ): List<SegmentGeometryAndMetadata> {
+    ): List<SegmentGeometryAndMetadata<ReferenceLineM>> {
         // language=SQL
         val sql =
             """
@@ -1046,7 +1050,7 @@ class LayoutAlignmentDao(
             jdbcTemplate.query(sql, params) { rs, _ ->
                 val fromSegment = rs.getInt("from_segment")
                 val toSegment = rs.getInt("to_segment")
-                SegmentGeometryAndMetadata(
+                SegmentGeometryAndMetadata<ReferenceLineM>(
                     planId = rs.getIntIdOrNull("plan_id"),
                     fileName = rs.getFileNameOrNull("file_name"),
                     alignmentId = rs.getIntIdOrNull("geom_alignment_id"),
@@ -1113,7 +1117,7 @@ class LayoutAlignmentDao(
         layoutContext: LayoutContext,
         bbox: BoundingBox,
         hasProfileInfo: Boolean? = null,
-    ): List<MapSegmentProfileInfo<LocationTrack>> {
+    ): List<MapSegmentProfileInfo<LocationTrack, LocationTrackM>> {
         // language=SQL
         val sql =
             """
@@ -1176,7 +1180,7 @@ class LayoutAlignmentDao(
             val mRange = rs.getDouble("start_m").let { start -> Range(start, start + rs.getDouble("length")) }
             MapSegmentProfileInfo(
                 id = rs.getIntId("id"),
-                mRange = mRange,
+                mRange = mRange.map(::LineM),
                 hasProfile = rs.getBoolean("has_profile_info"),
             )
         }
@@ -1184,7 +1188,7 @@ class LayoutAlignmentDao(
 
     private fun upsertSegments(
         alignmentId: RowVersion<LayoutAlignment>,
-        segments: List<Pair<LayoutSegment, Range<Double>>>,
+        segments: List<Pair<LayoutSegment, Range<out LineM<*>>>>,
     ) {
         if (segments.isNotEmpty()) {
             val newGeometryIds =
@@ -1215,7 +1219,7 @@ class LayoutAlignmentDao(
                 ps.setInt(1, alignmentId.id.intValue)
                 ps.setInt(2, alignmentId.version)
                 ps.setInt(3, index)
-                ps.setDouble(4, m.min)
+                ps.setDouble(4, m.min.distance)
                 ps.setNullableInt(5) { if (s.sourceId is IndexedId) s.sourceId.parentId else null }
                 ps.setNullableInt(6) { if (s.sourceId is IndexedId) s.sourceId.index else null }
                 ps.setNullableBigDecimal(7, s.sourceStartM)
@@ -1236,14 +1240,14 @@ class LayoutAlignmentDao(
     private fun insertSegmentGeometries(
         geometries: List<SegmentGeometry>
     ): Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>> {
-        require(geometries.all { geom -> geom.segmentStart.m == 0.0 }) {
+        require(geometries.all { geom -> geom.segmentStart.m.distance == 0.0 }) {
             "Geometries in DB must be set to startM=0.0, so they remain valid if an earlier segment changes"
         }
         require(
             geometries.all { geom ->
                 val calculatedLength = calculateDistance(geom.segmentPoints, LAYOUT_SRID)
                 val maxDelta = calculatedLength * 0.01
-                abs(calculatedLength - geom.segmentEnd.m) <= maxDelta
+                abs(calculatedLength - geom.segmentEnd.m.distance) <= maxDelta
             }
         ) {
             "Geometries in DB should have (approximately) endM=length"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGraph.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGraph.kt
@@ -36,7 +36,7 @@ data class DbEdgeData(val edge: DbLayoutEdge, override val tracks: Set<IntId<Loc
         get() = edge.endNode
 
     override val length: Double
-        get() = edge.length
+        get() = edge.length.distance
 
     override val start: Point by lazy { edge.start.toPoint() }
     override val end: Point by lazy { edge.end.toPoint() }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -102,7 +102,7 @@ class LayoutKmPostService(
                 (_, alignment) ->
                 val kmPostM = alignment.getClosestPointM(kmPost.location)?.first
                 val kmEndM = getKmEndM(layoutContext, kmPost.trackNumberId, kmPost.kmNumber, alignment)
-                if (kmPostM == null || kmEndM == null) null else kmEndM - kmPostM
+                if (kmPostM == null || kmEndM == null) null else (kmEndM - kmPostM).distance
             }
         }
     }
@@ -112,7 +112,7 @@ class LayoutKmPostService(
         trackNumberId: IntId<LayoutTrackNumber>,
         kmNumber: KmNumber,
         referenceLineAlignment: LayoutAlignment,
-    ): Double? {
+    ): LineM<ReferenceLineM>? {
         val nextKmPost =
             dao.fetchNextWithLocationAfter(layoutContext, trackNumberId, kmNumber, LayoutState.IN_USE)
                 ?.let(dao::fetch)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
@@ -51,7 +51,7 @@ data class LayoutSwitch(
     @JsonIgnore val exists = !stateCategory.isRemoved()
     val nameParts: SwitchNameParts? by lazy { name.let(SwitchNameParts::tryParse) }
 
-    fun getJoint(location: AlignmentPoint, delta: Double): LayoutSwitchJoint? =
+    fun getJoint(location: AlignmentPoint<LocationTrackM>, delta: Double): LayoutSwitchJoint? =
         getJoint(Point(location.x, location.y), delta)
 
     fun getJoint(location: Point, delta: Double): LayoutSwitchJoint? =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -27,6 +27,9 @@ import fi.fta.geoviite.infra.publication.ValidatedAsset
 import fi.fta.geoviite.infra.publication.draftTransitionOrOfficialState
 import fi.fta.geoviite.infra.util.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.toResponse
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -36,9 +39,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 @GeoviiteController("/track-layout/track-numbers")
 class LayoutTrackNumberController(
@@ -125,7 +125,7 @@ class LayoutTrackNumberController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LayoutTrackNumber>,
         @RequestParam("bbox") boundingBox: BoundingBox? = null,
-    ): List<AlignmentPlanSection> {
+    ): List<AlignmentPlanSection<*>> {
         val context = LayoutContext.of(branch, publicationState)
         return trackNumberService.getMetadataSections(context, id, boundingBox)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LineM.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LineM.kt
@@ -1,0 +1,80 @@
+package fi.fta.geoviite.infra.tracklayout
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+import org.eclipse.emf.common.util.BasicMonitor.Delegating
+import kotlin.math.abs
+
+sealed interface AnyM<M : AnyM<M>>
+
+data object SegmentM : AnyM<SegmentM>
+
+sealed interface AlignmentM<M : AlignmentM<M>> : AnyM<M>
+
+data object EdgeM : AlignmentM<EdgeM>
+
+data object LocationTrackM : AlignmentM<LocationTrackM>
+
+sealed interface GeocodingAlignmentM<M : GeocodingAlignmentM<M>> : AlignmentM<M>
+
+data object ReferenceLineM : AlignmentM<ReferenceLineM>, GeocodingAlignmentM<ReferenceLineM>
+
+data object PlanLayoutAlignmentM : AlignmentM<PlanLayoutAlignmentM>, GeocodingAlignmentM<PlanLayoutAlignmentM>
+
+data class LineM<M : AnyM<M>> @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(
+    @JsonValue val distance: Double,
+) : Comparable<LineM<M>> {
+
+    constructor(distance: Int) : this(distance.toDouble())
+
+    override fun compareTo(other: LineM<M>): Int = distance.compareTo(other.distance)
+
+    operator fun plus(offset: Double) = LineM<M>(distance + offset)
+
+    operator fun plus(other: LineM<M>) = LineM<M>(distance + other.distance)
+
+    operator fun minus(offset: Double) = LineM<M>(distance - offset)
+
+    operator fun minus(other: LineM<M>) = LineM<M>(distance - other.distance)
+
+    operator fun times(scale: Double) = LineM<M>(distance * scale)
+    operator fun times(scale: Int) = LineM<M>(distance * scale)
+
+    operator fun div(denominator: Double) = LineM<M>(distance / denominator)
+    operator fun div(denominator: Int) = LineM<M>(distance / denominator)
+
+    fun isFinite() = distance.isFinite()
+
+    fun coerceAtLeast(min: Double) = LineM<M>(distance.coerceAtLeast(min))
+
+    fun coerceAtMost(max: Double) = LineM<M>(distance.coerceAtMost(max))
+
+    fun toInt() = distance.toInt()
+
+    fun <OtherM: AnyM<OtherM>> castToDifferentM() = LineM<OtherM>(distance)
+}
+
+fun locationTrackM(m: Double) = LineM<LocationTrackM>(m)
+
+
+fun <M : AnyM<M>> maxM(a: LineM<M>, b: LineM<M>) = if (a.distance > b.distance) a else b
+
+fun <M : AnyM<M>> minM(a: LineM<M>, b: LineM<M>) = if (a.distance < b.distance) a else b
+
+fun <M : AnyM<M>> abs(m: LineM<M>): LineM<M> = m.copy(distance = abs(m.distance))
+
+fun LineM<LocationTrackM>.toEdgeM(edgeStart: LineM<LocationTrackM>) = LineM<EdgeM>(distance - edgeStart.distance)
+
+fun <M : AlignmentM<M>> LineM<M>.toSegmentM(segmentStart: LineM<M>): LineM<SegmentM> =
+    LineM(distance - segmentStart.distance)
+
+fun LineM<EdgeM>.toLocationTrackM(edgeStart: LineM<LocationTrackM>) =
+    LineM<LocationTrackM>(distance + edgeStart.distance)
+
+fun <M : AlignmentM<M>> LineM<SegmentM>.segmentToAlignmentM(segmentStart: LineM<M>) =
+    LineM<M>(distance + segmentStart.distance)
+
+fun <M : AlignmentM<M>> LineM<EdgeM>.toAlignmentM(edgeStart: LineM<M>) = LineM<M>(distance + edgeStart.distance)
+
+fun LineM<SegmentM>.toLocationTrackM(edgeStart: LineM<LocationTrackM>, segmentStart: LineM<EdgeM>) =
+    LineM<LocationTrackM>(distance + edgeStart.distance + segmentStart.distance)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -228,7 +228,7 @@ data class LocationTrack(
     /** Comes as calculated from LocationTrackGeometry. Anything set here will be overridden on save. */
     val boundingBox: BoundingBox?,
     /** Comes as calculated from LocationTrackGeometry. Anything set here will be overridden on save. */
-    val length: Double,
+    val length: LineM<LocationTrackM>,
     /** Comes as calculated from LocationTrackGeometry. Anything set here will be overridden on save. */
     val segmentCount: Int,
     /** Comes as calculated from LocationTrackGeometry. Anything set here will be overridden on save. */
@@ -270,9 +270,9 @@ data class LocationTrackDuplicate(
     val trackNumberId: IntId<LayoutTrackNumber>,
     val nameStructure: LocationTrackNameStructure,
     val name: AlignmentName,
-    val start: AlignmentPoint?,
-    val end: AlignmentPoint?,
-    val length: Double,
+    val start: AlignmentPoint<LocationTrackM>?,
+    val end: AlignmentPoint<LocationTrackM>?,
+    val length: LineM<LocationTrackM>,
     val duplicateStatus: DuplicateStatus,
 )
 
@@ -287,7 +287,7 @@ data class SwitchOnLocationTrack(
     val name: SwitchName,
     val address: TrackMeter?,
     val location: Point?,
-    val distance: Double?,
+    val distance: LineM<LocationTrackM>?,
     val nearestOperatingPoint: RatkoOperatingPoint?,
 )
 
@@ -311,14 +311,14 @@ data class DuplicateStatus(
 )
 
 sealed class SplitPoint {
-    abstract val location: AlignmentPoint
+    abstract val location: AlignmentPoint<LocationTrackM>
     abstract val address: TrackMeter?
 
     abstract fun isSame(other: SplitPoint): Boolean
 }
 
 data class SwitchSplitPoint(
-    override val location: AlignmentPoint,
+    override val location: AlignmentPoint<LocationTrackM>,
     override val address: TrackMeter?,
     val switchId: IntId<LayoutSwitch>,
     val jointNumber: JointNumber,
@@ -331,7 +331,7 @@ data class SwitchSplitPoint(
 }
 
 data class EndpointSplitPoint(
-    override val location: AlignmentPoint,
+    override val location: AlignmentPoint<LocationTrackM>,
     override val address: TrackMeter?,
     val endPointType: DuplicateEndPointType,
 ) : SplitPoint() {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -238,7 +238,7 @@ class LocationTrackController(
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
         @RequestParam("bbox") boundingBox: BoundingBox? = null,
-    ): List<AlignmentPlanSection> {
+    ): List<AlignmentPlanSection<LocationTrackM>> {
         val context = LayoutContext.of(layoutBranch, publicationState)
         return locationTrackService.getMetadataSections(context, id, boundingBox)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -29,14 +29,14 @@ import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.sql.Timestamp
-import java.time.Instant
 
 const val LOCATIONTRACK_CACHE_SIZE = 10000L
 
@@ -256,7 +256,7 @@ class LocationTrackDao(
             type = rs.getEnum("type"),
             state = rs.getEnum("state"),
             boundingBox = rs.getBboxOrNull("bounding_box"),
-            length = rs.getDouble("length"),
+            length = LineM(rs.getDouble("length")),
             segmentCount = rs.getInt("segment_count"),
             startSwitchId = rs.getIntIdOrNull("start_switch_id"),
             endSwitchId = rs.getIntIdOrNull("end_switch_id"),
@@ -376,7 +376,7 @@ class LocationTrackDao(
                 "origin_design_id" to item.contextData.originBranch?.designId?.intValue,
                 "start_switch_id" to geometry.startSwitchLink?.id?.intValue,
                 "end_switch_id" to geometry.endSwitchLink?.id?.intValue,
-                "length" to geometry.length,
+                "length" to geometry.length.distance,
                 "edge_count" to geometry.edges.size,
                 "segment_count" to geometry.segments.size,
                 "polygon_string" to geometry.boundingBox?.let(BoundingBox::polygonFromCorners)?.toWkt(),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackSpatialCache.kt
@@ -9,9 +9,9 @@ import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.lineLength
+import java.util.concurrent.ConcurrentHashMap
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class LocationTrackSpatialCache
@@ -71,7 +71,7 @@ data class SpatialCacheEntry(
 data class LocationTrackCacheHit(
     val track: LocationTrack,
     val geometry: LocationTrackGeometry,
-    val closestPoint: AlignmentPoint,
+    val closestPoint: AlignmentPoint<LocationTrackM>,
     val distance: Double,
 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -33,7 +33,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @RequestParam("includeSegmentEndPoints") includeSegmentEndPoints: Boolean = false,
         @RequestParam("minLength") minLength: Double? = null,
         @RequestParam("locationTrackIds") locationTrackIds: List<IntId<LocationTrack>>? = null,
-    ): List<AlignmentPolyLine<*>> {
+    ): List<AlignmentPolyLine<*, *>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getAlignmentPolyLines(
             layoutContext,
@@ -54,7 +54,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable("id") locationTrackId: IntId<LocationTrack>,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("resolution") resolution: Int,
-    ): ResponseEntity<AlignmentPolyLine<LocationTrack>> {
+    ): ResponseEntity<AlignmentPolyLine<LocationTrack, LocationTrackM>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return toResponse(mapAlignmentService.getAlignmentPolyline(layoutContext, locationTrackId, bbox, resolution))
     }
@@ -87,7 +87,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): List<Double> {
+    ): List<LineM<LocationTrackM>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getLocationTrackSegmentMValues(layoutContext, id)
     }
@@ -99,7 +99,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
         @RequestParam("type") type: AlignmentFetchType,
-    ): List<MapAlignmentHighlight<*>> {
+    ): List<MapAlignmentHighlight<*, *>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getSectionsWithoutLinking(layoutContext, bbox, type)
     }
@@ -110,7 +110,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("bbox") bbox: BoundingBox,
-    ): List<MapAlignmentHighlight<LocationTrack>> {
+    ): List<MapAlignmentHighlight<LocationTrack, LocationTrackM>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getSectionsWithoutProfile(layoutContext, bbox)
     }
@@ -121,7 +121,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
-    ): List<Double> {
+    ): List<LineM<ReferenceLineM>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getReferenceLineSegmentMValues(layoutContext, id)
     }
@@ -132,7 +132,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<LocationTrack>,
-    ): MapAlignmentEndPoints {
+    ): MapAlignmentEndPoints<LocationTrackM> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getLocationTrackEnds(layoutContext, id)
     }
@@ -143,7 +143,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("id") id: IntId<ReferenceLine>,
-    ): MapAlignmentEndPoints {
+    ): MapAlignmentEndPoints<ReferenceLineM> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getReferenceLineEnds(layoutContext, id)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLine.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLine.kt
@@ -13,7 +13,7 @@ data class ReferenceLine(
     val startAddress: TrackMeter,
     val sourceId: IntId<GeometryAlignment>?,
     val boundingBox: BoundingBox? = null,
-    val length: Double = 0.0,
+    val length: LineM<ReferenceLineM> = LineM(0.0),
     val segmentCount: Int = 0,
     @JsonIgnore override val contextData: LayoutContextData<ReferenceLine>,
     @JsonIgnore val alignmentVersion: RowVersion<LayoutAlignment>? = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -112,7 +112,7 @@ class ReferenceLineDao(
             trackNumberId = rs.getIntId("track_number_id"),
             startAddress = rs.getTrackMeter("start_address"),
             boundingBox = rs.getBboxOrNull("bounding_box"),
-            length = rs.getDouble("length"),
+            length = LineM(rs.getDouble("length")),
             segmentCount = rs.getInt("segment_count"),
             contextData =
                 rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLink.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLink.kt
@@ -107,7 +107,7 @@ fun getDuplicateMatches(
                     duplicateOfId = duplicateOf,
                     startSplitPoint = start,
                     endSplitPoint = end,
-                    overlappingLength = end.location.m - start.location.m,
+                    overlappingLength = end.location.m.distance - start.location.m.distance,
                 )
         }
     }
@@ -165,7 +165,7 @@ fun collectSplitPoints(geometry: LocationTrackGeometry): List<SplitPoint> {
     // Currently the logic takes the topology link only if the inner link doesn't override it as "main link"
 
     val allSplitPoints: List<SplitPoint> =
-        geometry.edgesWithM.flatMapIndexed { index: Int, (edge: LayoutEdge, m: Range<Double>) ->
+        geometry.edgesWithM.flatMapIndexed { index: Int, (edge: LayoutEdge, m: Range<LineM<LocationTrackM>>) ->
             val edgeStart = edge.firstSegmentStart.toAlignmentPoint(m.min)
             val startSplitPoints: List<SplitPoint> =
                 if (index == 0) {
@@ -186,7 +186,7 @@ fun collectSplitPoints(geometry: LocationTrackGeometry): List<SplitPoint> {
             val endSplitPoints: List<SplitPoint> =
                 if (index == geometry.edges.lastIndex) {
                     val (lastSegment, segmentM) = edge.segmentsWithM.last()
-                    val edgeEnd = lastSegment.segmentEnd.toAlignmentPoint(m.min + segmentM.min)
+                    val edgeEnd = lastSegment.segmentEnd.toAlignmentPoint(segmentM.min.toAlignmentM(m.min))
                     // The main switch link might be a topology link or an in-track-switch link
                     val mainLink = geometry.endSwitchLink
                     // Inner links need to be included always, unless it's already the main link

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -37,6 +37,7 @@ import fi.fta.geoviite.infra.publication.PublishedInBranch
 import fi.fta.geoviite.infra.publication.PublishedInDesign
 import fi.fta.geoviite.infra.publication.PublishedInMain
 import fi.fta.geoviite.infra.ratko.model.RatkoPlanItemId
+import fi.fta.geoviite.infra.tracklayout.AnyM
 import fi.fta.geoviite.infra.tracklayout.DesignAssetState
 import fi.fta.geoviite.infra.tracklayout.DesignDraftContextData
 import fi.fta.geoviite.infra.tracklayout.DesignOfficialContextData
@@ -45,6 +46,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutContextData
 import fi.fta.geoviite.infra.tracklayout.LayoutDesign
 import fi.fta.geoviite.infra.tracklayout.LayoutRowId
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.MainDraftContextData
 import fi.fta.geoviite.infra.tracklayout.MainOfficialContextData
 import fi.fta.geoviite.infra.tracklayout.StoredAssetId
@@ -165,11 +167,11 @@ fun ResultSet.getGeometryPointOrNull(nameX: String, nameY: String, nameSrid: Str
         getSridOrNull(nameSrid)?.let { srid -> GeometryPoint(point.x, point.y, srid) }
     }
 
-fun ResultSet.getPoint3DMOrNull(nameX: String, nameY: String, nameM: String): Point3DM? {
+fun <M : AnyM<M>> ResultSet.getPoint3DMOrNull(nameX: String, nameY: String, nameM: String): Point3DM<M>? {
     val x = getDoubleOrNull(nameX)
     val y = getDoubleOrNull(nameY)
     val m = getDoubleOrNull(nameM)
-    return if (x == null || y == null || m == null) null else Point3DM(x, y, m)
+    return if (x == null || y == null || m == null) null else Point3DM(x, y, LineM(m))
 }
 
 fun ResultSet.getPointOrNull(nameX: String, nameY: String): Point? {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfileTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfileTest.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
+import fi.fta.geoviite.infra.tracklayout.LineM
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -155,22 +156,22 @@ class GeometryProfileTest {
         val profile = GeometryProfile(PlanElementName("test profile 2"), listOfVerticalIntersectionPoints2)
 
         // Exact PVI points
-        assertEquals(19.09, profile.getHeightAt(1.82))
-        assertEquals(17.92, profile.getHeightAt(505.318))
+        assertEquals(19.09, profile.getHeightAt(LineM(1.82)))
+        assertEquals(17.92, profile.getHeightAt(LineM(505.318)))
 
         // Descending line
-        assertEquals(17.99, profile.getHeightAt(492.19)!!, 0.1)
+        assertEquals(17.99, profile.getHeightAt(LineM(492.19))!!, 0.1)
         // Ascending line
-        assertEquals(19.22, profile.getHeightAt(15.81)!!, 0.1)
+        assertEquals(19.22, profile.getHeightAt(LineM(15.81))!!, 0.1)
 
         // Negative descending curve
-        assertEquals(18.11, profile.getHeightAt(301.19)!!, 0.1)
+        assertEquals(18.11, profile.getHeightAt(LineM(301.19))!!, 0.1)
         // Negative ascending curve
-        assertEquals(18.12, profile.getHeightAt(316.19)!!, 0.1)
+        assertEquals(18.12, profile.getHeightAt(LineM(316.19))!!, 0.1)
         // Positivie ascending curve
-        assertEquals(19.54, profile.getHeightAt(58.75)!!, 0.1)
+        assertEquals(19.54, profile.getHeightAt(LineM(58.75))!!, 0.1)
         // Positive descending curve
-        assertEquals(19.53, profile.getHeightAt(76.75)!!, 0.1)
+        assertEquals(19.53, profile.getHeightAt(LineM(76.75))!!, 0.1)
     }
 
     @Test
@@ -275,7 +276,7 @@ class GeometryProfileTest {
 
         for (i in 2..distance step 10) {
             val x = i.toDouble()
-            val y = profile.getHeightAt(x)
+            val y = profile.getHeightAt(LineM(x))
             println("$x; $y;")
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -16,9 +16,12 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostService
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LineM
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
 import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.assertEquals
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
@@ -115,7 +118,13 @@ constructor(
         )
 
         // tickLength = 5 => normal ticks less than 2.5 distance apart from a neighbor get dropped
-        val actual = geometryService.getLocationTrackHeights(MainLayoutContext.draft, locationTrackId, 0.0, 30.0, 5)!!
+        val actual = geometryService.getLocationTrackHeights(
+            MainLayoutContext.draft,
+            locationTrackId,
+            LineM(0.0),
+            LineM(30.0),
+            5
+        )!!
 
         // location track starts 1 m after reference line start; reference line start address is
         // 123.4; so first address
@@ -128,7 +137,7 @@ constructor(
                 "0154" to listOf(124.4 to 0.0, 125.0 to 0.6, 130.0 to 5.6, 135.0 to 10.6),
                 "0155" to listOf(0.0 to 13.5, 5.0 to 18.5, 10.0 to 23.5),
                 "0156" to listOf(0.0 to 26.6, 1.4 to 28.0),
-            )
+            ).map { (kmNumber, ms) -> kmNumber to ms.map { (meter, m) -> meter to LineM<LocationTrackM>(m) } }
 
         actual.forEachIndexed { kmIndex, actualKm ->
             val expectedKm = expectedData[kmIndex]
@@ -201,8 +210,13 @@ constructor(
                     ),
                 )
                 .id
-        val kmHeights =
-            geometryService.getLocationTrackHeights(MainLayoutContext.draft, locationTrackId, 0.0, 20.0, 5)!!
+        val kmHeights = geometryService.getLocationTrackHeights(
+            MainLayoutContext.draft,
+            locationTrackId,
+            LineM(0.0),
+            LineM(20.0),
+            5
+        )!!
         // this track is exactly straight on the reference line, so m-values and track meters
         // coincide perfectly; also,
         // the profile is at exactly 50 meters height at every point where it's linked
@@ -221,8 +235,14 @@ constructor(
                     13 to 50,
                     15 to 50,
                     17 to 50,
-                )
-                .map { (m, h) -> TrackMeterHeight(m.toDouble(), m.toDouble(), h?.toDouble(), Point(0.0, m.toDouble())) }
+                ).map { (m, h) ->
+                    TrackMeterHeight(
+                        LineM<LocationTrackM>(m.toDouble()),
+                        m.toDouble(),
+                        h?.toDouble(),
+                        Point(0.0, m.toDouble())
+                    )
+                }
         assertEquals(expected, kmHeights[0].trackMeterHeights)
         val linkingSummary =
             geometryService.getLocationTrackGeometryLinkingSummary(MainLayoutContext.draft, locationTrackId)!!
@@ -235,7 +255,7 @@ constructor(
                 Triple(13.0, 15.0, FileName("plan3.xml")),
                 Triple(15.0, 17.0, FileName("plan1.xml")),
             ),
-            linkingSummary.map { item -> Triple(item.startM, item.endM, item.filename) },
+            linkingSummary.map { item -> Triple(item.startM.distance, item.endM.distance, item.filename) },
         )
     }
 
@@ -270,7 +290,13 @@ constructor(
         val post = kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 10.00001), draft = true)
         kmPostService.saveDraft(LayoutBranch.main, post)
 
-        val actual = geometryService.getLocationTrackHeights(MainLayoutContext.draft, locationTrackId, 0.0, 20.0, 5)!!
+        val actual = geometryService.getLocationTrackHeights(
+            MainLayoutContext.draft,
+            locationTrackId,
+            LineM(0.0),
+            LineM(20.0),
+            5
+        )!!
 
         val expected =
             listOf(
@@ -315,7 +341,13 @@ constructor(
             LayoutBranch.main,
             kmPost(trackNumberId, KmNumber("0156"), Point(0.0, 9.0), draft = true),
         )
-        val actual = geometryService.getLocationTrackHeights(MainLayoutContext.draft, locationTrackId, 0.0, 20.0, 5)!!
+        val actual = geometryService.getLocationTrackHeights(
+            MainLayoutContext.draft,
+            locationTrackId,
+            LineM(0.0),
+            LineM(20.0),
+            5
+        )!!
         assertEquals(3, actual.size)
         assertEquals(2, actual[0].trackMeterHeights.size)
         assertEquals(1, actual[1].trackMeterHeights.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
@@ -24,9 +25,11 @@ import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
@@ -326,7 +329,7 @@ constructor(
         //      -------------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -336,7 +339,7 @@ constructor(
         // -----------------------
         // 0    1     2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
@@ -355,7 +358,7 @@ constructor(
         // -----------------------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
@@ -367,7 +370,7 @@ constructor(
         //      -------------
         // 0    1     2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -384,7 +387,7 @@ constructor(
         // ------------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
@@ -394,7 +397,7 @@ constructor(
         //            ------------
         // 0    1     2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
                 Point(4000.0, 0.0) to TrackMeter(4, 0),
@@ -415,7 +418,7 @@ constructor(
         //            ------------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
                 Point(4000.0, 0.0) to TrackMeter(4, 0),
@@ -425,7 +428,7 @@ constructor(
         // ------------
         // 0    1     2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
@@ -446,7 +449,7 @@ constructor(
         // -----------------------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
@@ -458,7 +461,7 @@ constructor(
         // -------/       \-------
         // 0    1     2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(1200.0, 0.0) to TrackMeter(1, 200),
@@ -481,7 +484,7 @@ constructor(
         // -------/       \-------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(1200.0, 0.0) to TrackMeter(1, 200),
@@ -497,7 +500,7 @@ constructor(
         // -----------------------
         // 0    1           3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -515,7 +518,7 @@ constructor(
         //      ------------------
         //      1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -526,7 +529,7 @@ constructor(
         // -----------------------
         // 0          2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(1000.0, 0.0) to TrackMeter(0, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -544,7 +547,7 @@ constructor(
         // -------------------------------
         // 0    1         2     3        4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
@@ -556,7 +559,7 @@ constructor(
         // -------/    \----------/    \--
         // 0    1         2     3        4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(0.0, 0.0) to TrackMeter(0, 0),
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(1300.0, 100.0) to TrackMeter(1, 300),
@@ -579,7 +582,7 @@ constructor(
         //      -------------
         // 0    1     2     3    4
         val origAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -589,7 +592,7 @@ constructor(
         //      -------------
         // 0    1     2     3    4
         val newAddresses =
-            createAddresses(
+            createAddresses<LocationTrackM>(
                 Point(1000.0, 0.0) to TrackMeter(1, 0),
                 Point(2000.0, 0.0) to TrackMeter(2, 0),
                 Point(3000.0, 0.0) to TrackMeter(3, 0),
@@ -753,12 +756,18 @@ constructor(
             .distinct()
     }
 
-    fun createEmptyAddresses(start: Pair<Point, TrackMeter>, end: Pair<Point, TrackMeter>): AlignmentAddresses =
+    fun <M : AlignmentM<M>> createEmptyAddresses(
+        start: Pair<Point, TrackMeter>,
+        end: Pair<Point, TrackMeter>,
+    ): AlignmentAddresses<M> =
         AlignmentAddresses(
-            startPoint = AddressPoint(AlignmentPoint(start.first.x, start.first.y, null, 0.0, null), start.second),
+            startPoint = AddressPoint(
+                AlignmentPoint(start.first.x, start.first.y, null, LineM<M>(0.0), null),
+                start.second
+            ),
             endPoint =
                 AddressPoint(
-                    AlignmentPoint(end.first.x, end.first.y, null, lineLength(start.first, end.first), null),
+                    AlignmentPoint(end.first.x, end.first.y, null, LineM<M>(lineLength(start.first, end.first)), null),
                     start.second,
                 ),
             startIntersect = IntersectType.WITHIN,
@@ -767,7 +776,7 @@ constructor(
             alignmentWalkFinished = true,
         )
 
-    fun createAddresses(vararg transitionPoints: Pair<Point, TrackMeter>): AlignmentAddresses {
+    fun <M : AlignmentM<M>> createAddresses(vararg transitionPoints: Pair<Point, TrackMeter>): AlignmentAddresses<M> {
         val addressPoints =
             transitionPoints.flatMapIndexed { index, transitionPoint ->
                 val from = transitionPoint.first
@@ -776,10 +785,10 @@ constructor(
                 if (nextTransitionPoint != null) {
                     val to = nextTransitionPoint.first
                     val points = createLineString(from, to)
-                    val alignmentPoints = toAlignmentPoints(points = points.toTypedArray())
+                    val alignmentPoints = toAlignmentPoints<M>(points = points.toTypedArray())
                     val addressPoints =
-                        alignmentPoints.map { alignmentPoint: AlignmentPoint ->
-                            AddressPoint(point = alignmentPoint, address = fromAddress + alignmentPoint.m)
+                        alignmentPoints.map { alignmentPoint ->
+                            AddressPoint(point = alignmentPoint, address = fromAddress + alignmentPoint.m.distance)
                         }
                     addressPoints
                 } else {
@@ -796,7 +805,8 @@ constructor(
         )
     }
 
-    fun someAddressPoint() = AddressPoint(AlignmentPoint(0.0, 0.0, null, 0.0, null), TrackMeter(0, 0))
+    fun <M : AlignmentM<M>> someAddressPoint() =
+        AddressPoint(AlignmentPoint(0.0, 0.0, null, LineM<M>(0.0), null), TrackMeter(0, 0))
 
     fun getAllKms(geocodingContextCacheKey: GeocodingContextCacheKey, start: IPoint, end: IPoint): Set<KmNumber> {
         val context = geocodingService.getGeocodingContext(geocodingContextCacheKey)!!

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -67,6 +67,11 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -76,11 +81,6 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -506,7 +506,7 @@ constructor(
         moveLocationTrackGeometryPointsAndUpdate(
             locationTrack3,
             alignment3,
-            { point -> if (point.m < 200) point + 2.0 else point.toPoint() },
+            { point -> if (point.m.distance <200) point + 2.0 else point.toPoint() },
             locationTrackService = locationTrackService,
         )
 
@@ -537,7 +537,7 @@ constructor(
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine,
             referenceLineAlignment,
-            { point -> if (point.m < 900) point - 2.0 else point.toPoint() },
+            { point -> if (point.m.distance < 900) point - 2.0 else point.toPoint() },
             referenceLineService = referenceLineService,
         )
 
@@ -581,9 +581,9 @@ constructor(
             referenceLine,
             referenceLineAlignment,
             { point ->
-                if (point.m > 1000 && point.m < 2900) {
+                if (point.m.distance > 1000 && point.m.distance < 2900) {
                     // make reference line wavy
-                    point + Point(0.0, cos((point.m - 1000) / (2900 - 1000) * PI) * 5)
+                    point + Point(0.0, cos((point.m.distance - 1000) / (2900 - 1000) * PI) * 5)
                 } else {
                     point.toPoint()
                 }
@@ -697,7 +697,7 @@ constructor(
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine = referenceLine,
             alignment = alignment,
-            moveFunc = { point -> if (point.m < 900) point - 2.0 else point.toPoint() },
+            moveFunc = { point -> if (point.m.distance < 900) point - 2.0 else point.toPoint() },
             referenceLineService = referenceLineService,
         )
 
@@ -816,7 +816,7 @@ constructor(
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine = referenceLine,
             alignment = alignment,
-            moveFunc = { point -> if (point.m < 900) point - 2.0 else point.toPoint() },
+            moveFunc = { point -> if (point.m.distance < 900) point - 2.0 else point.toPoint() },
             referenceLineService = referenceLineService,
         )
 
@@ -835,7 +835,7 @@ constructor(
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine = referenceLine,
             alignment = alignment,
-            moveFunc = { point -> if (point.m < 900) point - 2.0 else point.toPoint() },
+            moveFunc = { point -> if (point.m.distance < 900) point - 2.0 else point.toPoint() },
             referenceLineService = referenceLineService,
         )
 
@@ -927,7 +927,7 @@ constructor(
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine,
             alignment,
-            { point -> if (point.m < 900) point - 2.0 else point.toPoint() },
+            { point -> if (point.m.distance < 900.0) point - 2.0 else point.toPoint() },
             referenceLineService,
         )
 
@@ -967,7 +967,7 @@ constructor(
         moveReferenceLineGeometryPointsAndUpdate(
             referenceLine = referenceLine,
             alignment = referenceLineAlignment,
-            moveFunc = { point -> if (point.m < 900) point - 2.0 else point.toPoint() },
+            moveFunc = { point -> if (point.m.distance < 900.0) point - 2.0 else point.toPoint() },
             referenceLineService = referenceLineService,
         )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -57,6 +57,7 @@ import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.segmentToAlignmentM
 import fi.fta.geoviite.infra.tracklayout.someKmNumber
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchJoint
@@ -64,7 +65,6 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -74,6 +74,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -149,7 +150,7 @@ constructor(
         val geometryInterval =
             GeometryInterval(
                 alignmentId = geometryLayoutAlignment.id as IntId,
-                mRange = Range(geometryStartSegment.second.min, geometryEndSegment.second.max),
+                mRange = Range(geometryStartSegment.second.min, geometryEndSegment.second.max).map { it.distance },
             )
 
         // Pick layout interval to cut after first 2 point, skipping to 5th point of second interval
@@ -159,8 +160,8 @@ constructor(
                 mRange =
                     Range(
                         officialGeometry.segmentMValues[0].min,
-                        officialGeometry.segmentsWithM[1].let { (s, m) -> m.min + s.segmentPoints[4].m },
-                    ),
+                        officialGeometry.segmentsWithM[1].let { (s, m) -> s.segmentPoints[4].m.segmentToAlignmentM(m.min) },
+                    ).map { it.distance },
             )
 
         linkingService.saveLocationTrackLinking(
@@ -332,7 +333,7 @@ constructor(
         val geometryInterval =
             GeometryInterval(
                 alignmentId = geometryLayoutAlignment.id as IntId,
-                mRange = Range(geometryStartSegment.second.min, geometryEndSegment.second.max),
+                mRange = Range(geometryStartSegment.second.min, geometryEndSegment.second.max).map { it.distance },
             )
 
         val layoutInterval =
@@ -342,7 +343,7 @@ constructor(
                     Range(
                         officialAlignment.segments[0].segmentPoints.first().m,
                         officialAlignment.segments[0].segmentPoints[4].m,
-                    ),
+                    ).map { it.distance },
             )
 
         val split =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/FittedSwitchTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/FittedSwitchTest.kt
@@ -72,7 +72,7 @@ class FittedSwitchTest {
                 ?: throw Exception("Switch structure does not contain joint ${jointNumber.intValue}")
         if (
             !joint.matches.any { match ->
-                match.locationTrackId == alignmentId && (m - match.mOnTrack).absoluteValue < 0.01
+                match.locationTrackId == alignmentId && (m - match.mOnTrack.distance).absoluteValue < 0.01
             }
         ) {
             fail("Didn't found a match from joint ${jointNumber.intValue}: alignmentId $alignmentId, m $m, $endPoint")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
@@ -43,14 +43,17 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.SegmentGeometry
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole
 import fi.fta.geoviite.infra.tracklayout.SwitchLink
 import fi.fta.geoviite.infra.tracklayout.alignment
+import fi.fta.geoviite.infra.tracklayout.assertEquals
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
@@ -1457,11 +1460,11 @@ constructor(
         val fittedSwitch =
             fittedSwitch(
                 switchStructure,
-                fittedJointMatch(trackA, 1, 0.0),
-                fittedJointMatch(trackA, 5, 16.0),
-                fittedJointMatch(trackA, 2, 30.0),
-                fittedJointMatch(trackB, 1, 0.0),
-                fittedJointMatch(trackB, 3, 32.567),
+                fittedJointMatch(trackA, 1, LineM(0.0)),
+                fittedJointMatch(trackA, 5, LineM(16.0)),
+                fittedJointMatch(trackA, 2, LineM(30.0)),
+                fittedJointMatch(trackB, 1, LineM(0.0)),
+                fittedJointMatch(trackB, 3, LineM(32.567)),
             )
 
         val linkedTracks = linkFittedSwitch(context.context, switchId, fittedSwitch)
@@ -1472,9 +1475,9 @@ constructor(
             trackA.locationTrackId,
             switchId = switchId,
             listOf( //
-                1 to 0.0,
-                5 to 16.0,
-                2 to 30.0,
+                1 to LineM(0.0),
+                5 to LineM(16.0),
+                2 to LineM(30.0),
             ),
         )
         assertInnerSwitchNodeExists(
@@ -1482,8 +1485,8 @@ constructor(
             trackB.locationTrackId,
             switchId = switchId,
             listOf( //
-                1 to 0.0,
-                3 to 32.567,
+                1 to LineM(0.0),
+                3 to LineM(32.567),
             ),
         )
         assertTopologicalConnectionAtEnd(linkedTracks, trackC.locationTrackId, switchId = switchId, 1)
@@ -1568,14 +1571,14 @@ constructor(
         assertEquals(topologyStartSwitchId, geometry.outerStartSwitch?.id)
         assertEquals(topologyEndSwitchId, geometry.outerEndSwitch?.id)
         assertEquals(
-            innerSwitchesByMRange.last().first.endInclusive,
+            LineM(innerSwitchesByMRange.last().first.endInclusive),
             geometry.end!!.m,
             0.1,
             "expected given inner switches m-range to cover whole track",
         )
         innerSwitchesByMRange.forEachIndexed { rangeIndex, (range, switchId) ->
-            val edge = geometry.getEdgeAtMOrThrow(range.start)
-            val endEdge = geometry.getEdgeAtMOrThrow(range.endInclusive)
+            val edge = geometry.getEdgeAtMOrThrow(LineM(range.start))
+            val endEdge = geometry.getEdgeAtMOrThrow(LineM(range.endInclusive))
             val edgeIndexRange = geometry.edges.indexOf(edge.first)..geometry.edges.indexOf(endEdge.first)
             val edgeMRange = edgeIndexRange.joinToString { i -> "${geometry.edgeMs[i].min..geometry.edgeMs[i].max}" }
             assertEquals(
@@ -1583,8 +1586,8 @@ constructor(
                 endEdge,
                 "expected switch m range $rangeIndex ($range) to cover only one edge, but it covers $edgeIndexRange ($edgeMRange)",
             )
-            assertEquals(range.start, edge.second.min, 0.1, "edge range starts at given m-value")
-            assertEquals(range.endInclusive, edge.second.max, 0.1, "edge range ends at given m-value")
+            assertEquals(LineM(range.start), edge.second.min, 0.1, "edge range starts at given m-value")
+            assertEquals(LineM(range.endInclusive), edge.second.max, 0.1, "edge range ends at given m-value")
 
             val edgeIndex = geometry.edges.indexOf(edge.first)
 
@@ -1758,7 +1761,7 @@ constructor(
 fun suggestedSwitchJointMatch(
     locationTrackId: IntId<LocationTrack>,
     segmentIndex: Int,
-    m: Double,
+    m: LineM<LocationTrackM>,
     jointNumber: Int,
     matchDirection: RelativeDirection = RelativeDirection.Along,
 ): FittedSwitchJointMatch =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/PointTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/PointTest.kt
@@ -95,8 +95,8 @@ class PointTest {
 fun assertApproximatelyEquals(p1: IPoint, p2: IPoint, accuracy: Double = 0.0001) {
     assertEquals(p1.x, p2.x, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
     assertEquals(p1.y, p2.y, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
-    if (p1 is IPoint3DM && p2 is IPoint3DM) {
-        assertEquals(p1.m, p2.m, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
+    if (p1 is IPoint3DM<*> && p2 is IPoint3DM<*>) {
+        assertEquals(p1.m.distance, p2.m.distance, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")
     }
     if (p1 is IPoint3DZ && p2 is IPoint3DZ) {
         assertEquals(p1.z, p2.z, accuracy, "The points should be near-equal: p1=$p1 p2=$p2 accuracy=$accuracy")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
@@ -177,6 +177,6 @@ private fun assertSplitResultFields(track: LocationTrack, request: SplitRequestT
         boundingBoxCombining(result.geometry.edges.map { edge -> edge.boundingBox }),
         result.locationTrack.boundingBox,
     )
-    assertEquals(result.geometry.segments.sumOf { s -> s.length }, result.locationTrack.length)
+    assertEquals(result.geometry.segments.sumOf { s -> s.length }, result.locationTrack.length.distance)
     assertEquals(result.geometry.segments.size, result.locationTrack.segmentCount)
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.function.Supplier
 
 private const val COORDINATE_DELTA: Double = 0.000000001
 private const val LENGTH_DELTA: Double = 0.00001
@@ -110,7 +111,7 @@ fun assertMatches(expected: LayoutSegment, actual: LayoutSegment, idMatch: Boole
     expected.segmentPoints.forEachIndexed { index, point -> assertMatches(point, actual.segmentPoints[index]) }
 }
 
-fun assertMatches(expected: LayoutPoint, actual: LayoutPoint) {
+fun <M: AnyM<M>> assertMatches(expected: LayoutPoint<M>, actual: LayoutPoint<M>) {
     assertEquals(expected.x, actual.x, COORDINATE_DELTA)
     assertEquals(expected.y, actual.y, COORDINATE_DELTA)
     assertEquals(expected.m, actual.m, COORDINATE_DELTA)
@@ -146,3 +147,9 @@ fun assertMatches(expected: LayoutSwitchJoint, actual: LayoutSwitchJoint) {
     assertEquals(expected, actual.copy(location = expected.location))
     assertApproximatelyEquals(expected.location, actual.location, COORDINATE_DELTA)
 }
+
+fun <M : AnyM<M>> assertEquals(a: LineM<M>, b: LineM<M>, absoluteTolerance: Double, message: String? = null) =
+    kotlin.test.assertEquals(a.distance, b.distance, absoluteTolerance, message)
+
+fun <M : AnyM<M>> assertEquals(a: LineM<M>, b: LineM<M>, absoluteTolerance: Double, messageSupplier: Supplier<String>) =
+    assertEquals(a.distance, b.distance, absoluteTolerance, messageSupplier)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometryTest.kt
@@ -19,11 +19,11 @@ class LayoutGeometryTest {
     fun shouldReturnSegmentAsIsWhenDistanceIsOverSegmentsMValues() {
         val segment = segment(Point(0.0, 0.0), Point(10.0, 0.0), Point(20.0, 0.0))
 
-        val (startSegment, endSegment) = segment.splitAtM(30.0, 0.0)
+        val (startSegment, endSegment) = segment.splitAtM(LineM(30.0), 0.0)
         assertEquals(segment, startSegment)
         assertNull(endSegment)
 
-        val (startSegment2, endSegment2) = segment.splitAtM(0.0, 0.0)
+        val (startSegment2, endSegment2) = segment.splitAtM(LineM(0.0), 0.0)
         assertEquals(segment, startSegment2)
         assertNull(endSegment2)
     }
@@ -32,17 +32,17 @@ class LayoutGeometryTest {
     fun shouldSplitFromSegmentPoint() {
         val segment = segment(segmentPoint(0.0, 0.0, 0.0), segmentPoint(10.0, 0.0, 10.0), segmentPoint(20.0, 0.0, 20.0))
 
-        val (startSegment, endSegment) = segment.splitAtM(10.0, 0.0001)
+        val (startSegment, endSegment) = segment.splitAtM(LineM(10.0), 0.0001)
         assertEquals(2, startSegment.segmentPoints.size)
         assertEquals(0.0, startSegment.segmentPoints.first().x)
-        assertEquals(10.0, startSegment.segmentPoints.last().m)
+        assertEquals(LineM(10.0), startSegment.segmentPoints.last().m)
 
         assertNotNull(endSegment)
         assertEquals(2, endSegment!!.segmentPoints.size)
         assertEquals(10.0, endSegment.segmentPoints.first().x)
         assertEquals(20.0, endSegment.segmentPoints.last().x)
-        assertEquals(0.0, endSegment.segmentPoints.first().m)
-        assertEquals(10.0, endSegment.segmentPoints.last().m)
+        assertEquals(LineM(0.0), endSegment.segmentPoints.first().m)
+        assertEquals(LineM(10.0), endSegment.segmentPoints.last().m)
     }
 
     @Test
@@ -60,7 +60,7 @@ class LayoutGeometryTest {
                 source = GeometrySource.IMPORTED,
             )
 
-        val (startSegment, endSegment) = segment.splitAtM(10.0, 0.5)
+        val (startSegment, endSegment) = segment.splitAtM(LineM(10.0), 0.5)
         assertNotNull(endSegment)
         endSegment!!
         assertEquals(segment.sourceId, startSegment.sourceId)
@@ -77,7 +77,7 @@ class LayoutGeometryTest {
     fun shouldSplitFromPointWithinTolerance() {
         val segment = segment(segmentPoint(0.0, 0.0, 0.0), segmentPoint(10.0, 0.0, 10.0), segmentPoint(20.0, 0.0, 20.0))
 
-        val (startSegment, endSegment) = segment.splitAtM(9.9, 0.5)
+        val (startSegment, endSegment) = segment.splitAtM(LineM(9.9), 0.5)
         assertEquals(2, startSegment.segmentPoints.size)
         assertEquals(0.0, startSegment.segmentPoints.first().x)
         assertEquals(10.0, startSegment.segmentPoints.last().x)
@@ -86,50 +86,50 @@ class LayoutGeometryTest {
         assertEquals(2, endSegment!!.segmentPoints.size)
         assertEquals(10.0, endSegment.segmentPoints.first().x)
         assertEquals(20.0, endSegment.segmentPoints.last().x)
-        assertEquals(0.0, endSegment.segmentPoints.first().m)
-        assertEquals(10.0, endSegment.segmentPoints.last().m)
+        assertEquals(LineM(0.0), endSegment.segmentPoints.first().m)
+        assertEquals(LineM(10.0), endSegment.segmentPoints.last().m)
     }
 
     @Test
     fun shouldNotSplitWhenEndPointIsWithinTolerance() {
         val segment = segment(segmentPoint(0.0, 0.0, 0.0), segmentPoint(10.0, 0.0, 10.0), segmentPoint(20.0, 0.0, 20.0))
 
-        val (startSegment, endSegment) = segment.splitAtM(20.5, 1.0)
+        val (startSegment, endSegment) = segment.splitAtM(LineM(20.5), 1.0)
         assertNull(endSegment)
         assertEquals(3, startSegment.segmentPoints.size)
-        assertEquals(0.0, startSegment.segmentPoints.first().m)
-        assertEquals(20.0, startSegment.segmentPoints.last().m)
+        assertEquals(LineM(0.0), startSegment.segmentPoints.first().m)
+        assertEquals(LineM(20.0), startSegment.segmentPoints.last().m)
     }
 
     @Test
     fun shouldSplitFromANewPointWhenNonePointsWithinTolerance() {
         val segment = segment(segmentPoint(0.0, 0.0, 0.0), segmentPoint(10.0, 0.0, 10.0), segmentPoint(20.0, 0.0, 20.0))
 
-        val (startSegment1, endSegment1) = segment.splitAtM(5.0, 0.5)
+        val (startSegment1, endSegment1) = segment.splitAtM(LineM(5.0), 0.5)
         assertEquals(2, startSegment1.segmentPoints.size)
-        assertEquals(0.0, startSegment1.segmentPoints.first().m)
-        assertEquals(5.0, startSegment1.segmentPoints.last().m)
+        assertEquals(LineM(0.0), startSegment1.segmentPoints.first().m)
+        assertEquals(LineM(5.0), startSegment1.segmentPoints.last().m)
         assertEquals(0.0, startSegment1.segmentPoints.first().x)
         assertEquals(5.0, startSegment1.segmentPoints.last().x)
 
         assertNotNull(endSegment1)
         assertEquals(3, endSegment1!!.segmentPoints.size)
-        assertEquals(0.0, endSegment1.segmentPoints.first().m)
-        assertEquals(15.0, endSegment1.segmentPoints.last().m)
+        assertEquals(LineM(0.0), endSegment1.segmentPoints.first().m)
+        assertEquals(LineM(15.0), endSegment1.segmentPoints.last().m)
         assertEquals(5.0, endSegment1.segmentPoints.first().x)
         assertEquals(20.0, endSegment1.segmentPoints.last().x)
 
-        val (startSegment2, endSegment2) = segment.splitAtM(15.0, 0.5)
+        val (startSegment2, endSegment2) = segment.splitAtM(LineM(15.0), 0.5)
         assertEquals(3, startSegment2.segmentPoints.size)
-        assertEquals(0.0, startSegment2.segmentPoints.first().m)
-        assertEquals(15.0, startSegment2.segmentPoints.last().m)
+        assertEquals(LineM(0.0), startSegment2.segmentPoints.first().m)
+        assertEquals(LineM(15.0), startSegment2.segmentPoints.last().m)
         assertEquals(0.0, startSegment2.segmentPoints.first().x)
         assertEquals(15.0, startSegment2.segmentPoints.last().x)
 
         assertNotNull(endSegment2)
         assertEquals(2, endSegment2!!.segmentPoints.size)
-        assertEquals(0.0, endSegment2.segmentPoints.first().m)
-        assertEquals(5.0, endSegment2.segmentPoints.last().m)
+        assertEquals(LineM(0.0), endSegment2.segmentPoints.first().m)
+        assertEquals(LineM(5.0), endSegment2.segmentPoints.last().m)
         assertEquals(15.0, endSegment2.segmentPoints.first().x)
         assertEquals(20.0, endSegment2.segmentPoints.last().x)
     }
@@ -137,45 +137,90 @@ class LayoutGeometryTest {
     @Test
     fun seekSegmentPointAtMWorks() {
         val segment = segment(segmentPoint(0.0, 0.0, 0.0), segmentPoint(10.0, 0.0, 10.0), segmentPoint(20.0, 0.0, 20.0))
-        assertEquals(PointSeekResult(alignmentPoint(0.0, 0.0, 0.0), 0, true), segment.seekPointAtM(0.0, 0.0, 0.0))
-        assertEquals(PointSeekResult(alignmentPoint(10.0, 0.0, 10.0), 1, true), segment.seekPointAtM(0.0, 10.0, 0.0))
-        assertEquals(PointSeekResult(alignmentPoint(20.0, 0.0, 20.0), 2, true), segment.seekPointAtM(0.0, 20.0, 0.0))
+        assertEquals(
+            PointSeekResult(locationTrackPoint(0.0, 0.0, 0.0), 0, true),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(0.0), 0.0)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(10.0, 0.0, 10.0), 1, true),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(10.0), 0.0)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(20.0, 0.0, 20.0), 2, true),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(20.0), 0.0)
+        )
 
-        assertEquals(PointSeekResult(alignmentPoint(0.0, 0.0, 0.0), 0, true), segment.seekPointAtM(0.0, -5.0, 0.0))
-        assertEquals(PointSeekResult(alignmentPoint(20.0, 0.0, 20.0), 2, true), segment.seekPointAtM(0.0, 25.0, 0.0))
+        assertEquals(
+            PointSeekResult(locationTrackPoint(0.0, 0.0, 0.0), 0, true),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(-5.0), 0.0)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(20.0, 0.0, 20.0), 2, true),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(25.0), 0.0)
+        )
 
-        assertEquals(PointSeekResult(alignmentPoint(5.0, 0.0, 5.0), 1, false), segment.seekPointAtM(0.0, 5.0, 0.0))
-        assertEquals(PointSeekResult(alignmentPoint(13.0, 0.0, 13.0), 2, false), segment.seekPointAtM(0.0, 13.0, 0.0))
+        assertEquals(
+            PointSeekResult(locationTrackPoint(5.0, 0.0, 5.0), 1, false),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(5.0), 0.0)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(13.0, 0.0, 13.0), 2, false),
+            segment.seekPointAtM(LineM(0.0), locationTrackM(13.0), 0.0)
+        )
     }
 
     @Test
     fun segmentPointAtLengthSnapsCorrectly() {
         val segment = segment(segmentPoint(0.0, 0.0, 0.0), segmentPoint(10.0, 0.0, 10.0), segmentPoint(20.0, 0.0, 20.0))
-        assertEquals(PointSeekResult(alignmentPoint(0.05, 0.0, 0.05), 1, false), segment.seekPointAtM(0.0, 0.05, 0.0))
-        assertEquals(PointSeekResult(alignmentPoint(0.0, 0.0, 0.0), 0, true), segment.seekPointAtM(0.0, 0.05, 0.1))
-        assertEquals(PointSeekResult(alignmentPoint(0.15, 0.0, 0.15), 1, false), segment.seekPointAtM(0.0, 0.15, 0.1))
-
-        assertEquals(PointSeekResult(alignmentPoint(9.95, 0.0, 9.95), 1, false), segment.seekPointAtM(0.0, 9.95, 0.0))
-        assertEquals(PointSeekResult(alignmentPoint(10.0, 0.0, 10.0), 1, true), segment.seekPointAtM(0.0, 9.95, 0.1))
-        assertEquals(PointSeekResult(alignmentPoint(9.85, 0.0, 9.85), 1, false), segment.seekPointAtM(0.0, 9.85, 0.1))
         assertEquals(
-            PointSeekResult(alignmentPoint(10.05, 0.0, 10.05), 2, false),
-            segment.seekPointAtM(0.0, 10.05, 0.0),
+            PointSeekResult(locationTrackPoint(0.05, 0.0, 0.05), 1, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(0.05), 0.0)
         )
-        assertEquals(PointSeekResult(alignmentPoint(10.0, 0.0, 10.0), 1, true), segment.seekPointAtM(0.0, 10.05, 0.1))
         assertEquals(
-            PointSeekResult(alignmentPoint(10.15, 0.0, 10.15), 2, false),
-            segment.seekPointAtM(0.0, 10.15, 0.1),
+            PointSeekResult(locationTrackPoint(0.0, 0.0, 0.0), 0, true),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(0.05), 0.1)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(0.15, 0.0, 0.15), 1, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(0.15), 0.1)
         )
 
         assertEquals(
-            PointSeekResult(alignmentPoint(19.95, 0.0, 19.95), 2, false),
-            segment.seekPointAtM(0.0, 19.95, 0.0),
+            PointSeekResult(locationTrackPoint(9.95, 0.0, 9.95), 1, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(9.95), 0.0)
         )
-        assertEquals(PointSeekResult(alignmentPoint(20.0, 0.0, 20.0), 2, true), segment.seekPointAtM(0.0, 19.95, 0.1))
         assertEquals(
-            PointSeekResult(alignmentPoint(19.85, 0.0, 19.85), 2, false),
-            segment.seekPointAtM(0.0, 19.85, 0.1),
+            PointSeekResult(locationTrackPoint(10.0, 0.0, 10.0), 1, true),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(9.95), 0.1)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(9.85, 0.0, 9.85), 1, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(9.85), 0.1)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(10.05, 0.0, 10.05), 2, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(10.05), 0.0),
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(10.0, 0.0, 10.0), 1, true),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(10.05), 0.1)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(10.15, 0.0, 10.15), 2, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(10.15), 0.1),
+        )
+
+        assertEquals(
+            PointSeekResult(locationTrackPoint(19.95, 0.0, 19.95), 2, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(19.95), 0.0),
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(20.0, 0.0, 20.0), 2, true),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(19.95), 0.1)
+        )
+        assertEquals(
+            PointSeekResult(locationTrackPoint(19.85, 0.0, 19.85), 2, false),
+            segment.seekPointAtM(locationTrackM(0.0), LineM(19.85), 0.1),
         )
     }
 
@@ -188,30 +233,30 @@ class LayoutGeometryTest {
                 segment(Point(10.0, 0.0), Point(15.0, 5.0), Point(15.0, 15.0)),
             )
 
-        assertApproximatelyEquals(segmentPoint(0.0, 0.0, 0.0), alignment.getPointAtM(0.0)!!, accuracy)
-        assertApproximatelyEquals(segmentPoint(10.0, 0.0, 10.0), alignment.getPointAtM(10.0)!!, accuracy)
+        assertApproximatelyEquals(segmentPoint(0.0, 0.0, 0.0), alignment.getPointAtM(LineM(0.0))!!, accuracy)
+        assertApproximatelyEquals(segmentPoint(10.0, 0.0, 10.0), alignment.getPointAtM(LineM(10.0))!!, accuracy)
         assertApproximatelyEquals(
             segmentPoint(15.0, 5.0, 10.0 + diagonalLength),
-            alignment.getPointAtM(10.0 + diagonalLength)!!,
+            alignment.getPointAtM(LineM(10.0 + diagonalLength))!!,
             accuracy,
         )
         assertApproximatelyEquals(
             segmentPoint(15.0, 15.0, 20.0 + diagonalLength),
-            alignment.getPointAtM(20.0 + diagonalLength)!!,
+            alignment.getPointAtM(LineM(20.0 + diagonalLength))!!,
             accuracy,
         )
 
-        assertApproximatelyEquals(segmentPoint(0.0, 0.0, 0.0), alignment.getPointAtM(-5.0)!!, accuracy)
+        assertApproximatelyEquals(segmentPoint(0.0, 0.0, 0.0), alignment.getPointAtM(LineM(-5.0))!!, accuracy)
         assertApproximatelyEquals(
             segmentPoint(15.0, 15.0, 20.0 + diagonalLength),
-            alignment.getPointAtM(50.0)!!,
+            alignment.getPointAtM(LineM(50.0))!!,
             accuracy,
         )
 
-        assertApproximatelyEquals(segmentPoint(5.0, 0.0, 5.0), alignment.getPointAtM(5.0)!!, accuracy)
+        assertApproximatelyEquals(segmentPoint(5.0, 0.0, 5.0), alignment.getPointAtM(LineM(5.0))!!, accuracy)
         assertApproximatelyEquals(
             segmentPoint(13.0, 3.0, 10 + hypot(3.0, 3.0)),
-            alignment.getPointAtM(10 + hypot(3.0, 3.0))!!,
+            alignment.getPointAtM(LineM(10 + hypot(3.0, 3.0)))!!,
             accuracy,
         )
     }
@@ -237,7 +282,7 @@ class LayoutGeometryTest {
                 source = GeometrySource.IMPORTED,
             )
 
-        val (slice, sliceM) = original.slice(10.0, 1, 2)!!
+        val (slice, sliceM) = original.slice(LineM<ReferenceLineM>(10.0), 1, 2)!!
 
         assertEquals(slice.sourceId, original.sourceId)
         assertEquals(slice.sourceStartM, original.addedSourceStart(pointInterval))
@@ -246,11 +291,11 @@ class LayoutGeometryTest {
         assertEquals(2, slice.segmentPoints.size)
         assertEquals(original.segmentPoints[1].x, slice.segmentPoints[0].x)
         assertEquals(original.segmentPoints[1].y, slice.segmentPoints[0].y)
-        assertEquals(0.0, slice.segmentPoints[0].m)
+        assertEquals(LineM(0.0), slice.segmentPoints[0].m)
         assertEquals(original.segmentPoints[2].x, slice.segmentPoints[1].x)
         assertEquals(original.segmentPoints[2].y, slice.segmentPoints[1].y)
-        assertEquals(pointInterval, slice.segmentPoints[1].m, 0.00001)
-        assertEquals(Range(10.0 + pointInterval, 10.0 + 2 * pointInterval), sliceM)
+        assertEquals(LineM(pointInterval), slice.segmentPoints[1].m, 0.00001)
+        assertEquals(Range(10.0 + pointInterval, 10.0 + 2 * pointInterval).map(::LineM), sliceM)
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
@@ -558,7 +558,7 @@ class LocationTrackGeometryTest {
         assertEquals(
             listOf(
                 PlaceholderNode to alignmentPoint(0.0, 0.0, m = 0.0),
-                TmpSwitchNode(switchLinkYV(IntId(1), 1), null) to alignmentPoint(2.0, 0.0, m = 2.0),
+                TmpSwitchNode(switchLinkYV(IntId(1), 1), null) to locationTrackPoint(2.0, 0.0, m = 2.0),
                 TmpSwitchNode(switchLinkYV(IntId(2), 1), switchLinkYV(IntId(3), 1)) to
                     alignmentPoint(4.0, 0.0, m = 4.0),
                 TmpSwitchNode(switchLinkYV(IntId(4), 1), null) to alignmentPoint(6.0, 0.0, m = 6.0),
@@ -585,7 +585,7 @@ class LocationTrackGeometryTest {
     @Test
     fun `Segment m calculation works`() {
         assertEquals(
-            listOf(Range(0.0, 2.0), Range(2.0, 5.0), Range(5.0, 9.0)),
+            listOf(Range(0.0, 2.0), Range(2.0, 5.0), Range(5.0, 9.0)).map { it.map(::LineM) },
             calculateSegmentMValues(
                 listOf(
                     segment(Point(0.0, 0.0), Point(2.0, 0.0)),
@@ -599,7 +599,7 @@ class LocationTrackGeometryTest {
     @Test
     fun `Edge m calculation works`() {
         assertEquals(
-            listOf(Range(0.0, 2.0), Range(2.0, 5.0), Range(5.0, 9.0)),
+            listOf(Range(0.0, 2.0), Range(2.0, 5.0), Range(5.0, 9.0)).map { it.map(::LineM) },
             calculateEdgeMValues(
                 listOf(
                     edge(listOf(segment(Point(0.0, 0.0), Point(2.0, 0.0)))),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -753,7 +753,7 @@ constructor(
         assertEquals(1, splittingParams?.duplicates?.size)
         assertContains(splittingParams?.switches?.map { it.switchId } ?: emptyList(), switch)
         assertContains(splittingParams?.duplicates?.map { it.id } ?: emptyList(), duplicateLocationTrack.id)
-        assertEquals(50.0, splittingParams?.switches?.first()?.distance ?: 0.0, 0.01)
+        assertEquals(locationTrackM(50.0), splittingParams?.switches?.first()?.distance ?: LineM(0.0), 0.01)
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineServiceIT.kt
@@ -65,7 +65,7 @@ constructor(
         val referenceLine = referenceLineService.getByTrackNumber(MainLayoutContext.draft, trackNumberId)
         assertNotNull(referenceLine)
         assertTrue(referenceLine?.isDraft ?: false)
-        assertEquals(0.0, referenceLine?.length)
+        assertEquals(LineM(0.0), referenceLine?.length)
         assertEquals(trackNumberId, referenceLine?.trackNumberId)
         val changeTimeAfterInsert = referenceLineService.getChangeTime()
         val referenceLineId = referenceLine?.id as IntId

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLinkTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLinkTest.kt
@@ -280,14 +280,14 @@ class SwitchLocationTrackLinkTest {
     }
 }
 
-fun emptyPoint() = AlignmentPoint(0.0, 0.0, 0.0, 0.0, 0.0)
+fun emptyPoint() = AlignmentPoint(0.0, 0.0, 0.0, LineM<LocationTrackM>(0.0), 0.0)
 
 fun partialMatch(
     startSwitch: Pair<Int, Int>,
     endSwitch: Pair<Int, Int>,
     from: Int = 0,
-    startPoint: AlignmentPoint = emptyPoint(),
-    endPoint: AlignmentPoint = emptyPoint(),
+    startPoint: AlignmentPoint<LocationTrackM> = emptyPoint(),
+    endPoint: AlignmentPoint<LocationTrackM> = emptyPoint(),
 ) =
     from to
         DuplicateStatus(
@@ -303,8 +303,8 @@ fun fullMatch(
     startSwitch: Pair<Int, Int>,
     endSwitch: Pair<Int, Int>,
     from: Int = 0,
-    startPoint: AlignmentPoint = emptyPoint(),
-    endPoint: AlignmentPoint = emptyPoint(),
+    startPoint: AlignmentPoint<LocationTrackM> = emptyPoint(),
+    endPoint: AlignmentPoint<LocationTrackM> = emptyPoint(),
 ) =
     from to
         DuplicateStatus(
@@ -318,7 +318,7 @@ fun fullMatch(
 
 fun startPoint(point: IPoint): EndpointSplitPoint {
     return EndpointSplitPoint(
-        location = AlignmentPoint(point.x, point.y, null, 0.0, null),
+        location = AlignmentPoint(point.x, point.y, null, LineM(0.0), null),
         address = null,
         DuplicateEndPointType.START,
     )
@@ -326,7 +326,7 @@ fun startPoint(point: IPoint): EndpointSplitPoint {
 
 fun endPoint(point: IPoint): EndpointSplitPoint {
     return EndpointSplitPoint(
-        location = AlignmentPoint(point.x, point.y, null, 0.0, null),
+        location = AlignmentPoint(point.x, point.y, null, LineM(0.0), null),
         address = null,
         DuplicateEndPointType.END,
     )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutTest.kt
@@ -32,42 +32,53 @@ class TrackLayoutTest {
     fun slicingSegmentWorks() {
         val original = segment(10, -10.0, 10.0, -10.0, 10.0)
 
-        val originalSegmentStart = 123.111
+        val originalSegmentStart = locationTrackM(123.111)
         val (startSlice, startSliceM) = original.slice(originalSegmentStart, 0, 2)!!
         assertEquals(3, startSlice.segmentPoints.size)
         assertApproximatelyEquals(original.segmentPoints[0], startSlice.segmentPoints[0])
         assertApproximatelyEquals(original.segmentPoints[2], startSlice.segmentPoints.last())
-        assertEquals(original.segmentPoints[2].m, startSlice.length, 0.0001)
-        assertEquals(Range(originalSegmentStart, originalSegmentStart + original.segmentPoints[2].m), startSliceM)
+        assertEquals(original.segmentPoints[2].m.distance, startSlice.length, 0.0001)
+        assertEquals(
+            Range(originalSegmentStart, originalSegmentStart + original.segmentPoints[2].m.distance),
+            startSliceM
+        )
 
         val (endSlice, endSliceM) = original.slice(originalSegmentStart, 8, 9)!!
         assertEquals(2, endSlice.segmentPoints.size)
-        assertApproximatelyEquals(original.segmentPoints[8].copy(m = 0.0), endSlice.segmentPoints[0])
+        assertApproximatelyEquals(original.segmentPoints[8].copy(m = LineM(0.0)), endSlice.segmentPoints[0])
         assertApproximatelyEquals(
-            original.segmentPoints[9].copy(m = original.length - original.segmentPoints[8].m),
+            original.segmentPoints[9].copy(m = LineM(original.length - original.segmentPoints[8].m.distance)),
             endSlice.segmentPoints.last(),
         )
-        assertEquals(original.segmentPoints[9].m - original.segmentPoints[8].m, endSlice.length, 0.0001)
+        assertEquals(
+            original.segmentPoints[9].m.distance - original.segmentPoints[8].m.distance,
+            endSlice.length,
+            0.0001
+        )
         assertEquals(
             Range(
-                originalSegmentStart + original.segmentPoints[8].m,
-                originalSegmentStart + original.segmentPoints[9].m,
+                originalSegmentStart + original.segmentPoints[8].m.distance,
+                originalSegmentStart + original.segmentPoints[9].m.distance,
             ),
             endSliceM,
         )
 
         val (midSlice, midSliceM) = original.slice(originalSegmentStart, 1, 8)!!
         assertEquals(8, midSlice.segmentPoints.size)
-        assertApproximatelyEquals(original.segmentPoints[1].copy(m = 0.0), midSlice.segmentPoints[0])
+        assertApproximatelyEquals(original.segmentPoints[1].copy(m = LineM(0.0)), midSlice.segmentPoints[0])
         assertApproximatelyEquals(
             original.segmentPoints[8].copy(m = original.segmentPoints[8].m - original.segmentPoints[1].m),
             midSlice.segmentPoints.last(),
         )
-        assertEquals(original.segmentPoints[8].m - original.segmentPoints[1].m, midSlice.length, 0.0001)
+        assertEquals(
+            original.segmentPoints[8].m.distance - original.segmentPoints[1].m.distance,
+            midSlice.length,
+            0.0001
+        )
         assertEquals(
             Range(
-                originalSegmentStart + original.segmentPoints[1].m,
-                originalSegmentStart + original.segmentPoints[8].m,
+                original.segmentPoints[1].m.segmentToAlignmentM(originalSegmentStart),
+                original.segmentPoints[8].m.segmentToAlignmentM(originalSegmentStart),
             ),
             midSliceM,
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -759,7 +759,7 @@ constructor(
     private fun getGeometrySwitchFromPlan(switchName: String, geometryPlan: GeometryPlan) =
         geometryPlan.switches.find { switch -> switch.name.toString() == switchName }!!
 
-    private fun hasSegmentBetweenPoints(start: Point, end: Point, layoutAlignment: IAlignment): Boolean {
+    private fun hasSegmentBetweenPoints(start: Point, end: Point, layoutAlignment: IAlignment<*>): Boolean {
         return layoutAlignment.segments.any { segment -> segment.includes(start) && segment.includes(end) }
     }
 }


### PR DESCRIPTION
Hieman isompi kasa muutoksia kuin mitä tuli ajateltuakaan tämän olevan vielä taskia ajatellessa, mutta olipahan hyvä kesätekeminen.

Selkein teema, että onpahan meillä paljon tyyppejä, joihin piti lisätä tyyppiparametri esittämään tietoa siitä, minkä asian M-arvoja se sisältää, jos mitään: Tein näitä sillä periaatteella, että jos tyyppi itsessään näytti vähänkään geneeriseltä, niin sitten sen M-arvotkin on geneerisiä.

Tyypitin m-arvoiksi yleensä sellaiset arvot, jotka mittaavat jollain tavalla etäisyyttä raidetta pitkin. Vähän vastaavasti kuin miten meillä käytetään Point-tyyppiä joskus pisteenä ja joskus vektorina, en lähtenyt halkomaan hiuksia ihan jokaisen välitilan suhteen: Laskutoimitus, joka on tietyssä m-arvokannassa (eli esim. `LineM<EdgeM>`) pysyy siinä kannassa vaikka luvut eivät välttämättä tarkoitakaan juuri etäisyyksiä tämän kannan alkupisteestä raidetta pitkin. Funktioiden välillä menevien arvojen tyyppien pitäisi sentään olla aika tarkkoja.

LineM-tyypin parametri on rajattu F-bounded polymorphismilla, joka toivottavasti toimii oikeasti niin kuin miten se minun fiiliksen mukaan tuntuu toimivan: LineM-arvojen alatyypitys menee AnyM-hierarkian perusteella. Tällä hetkellä kyseisessä hierarkiassa on PlanLayoutAlignmentM-tyyppi edustamassa yleisesti geometriapuolelta layout-puolelle muunnettujen linjojen m-arvoja, mutta varsinaisissa geometriapuolen m-arvojen käsittelyissä on vielä kömpelöyttä tyypityksen suhteen.