### PR TITLE
GVT-3138: Add more specific success message when linking reference line geometry

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -715,6 +715,8 @@
                 "zoom-closer": "Zoomaa lähemmäksi valitaksesi yhdistymispisteet.",
                 "linking-succeeded-and-previous-unlinked": "Raide linkitetty ja vanhentuneen geometrian linkitys purettu.",
                 "linking-succeeded": "Raide linkitetty",
+                "reference-line-linking-succeeded-and-previous-unlinked": "Pituusmittauslinja linkitetty ja vanhentuneen geometrian linkitys purettu.",
+                "reference-line-linking-succeeded": "Pituusmittauslinja linkitetty",
                 "add-linking": "Lisää linkitys",
                 "show-on-map": "Kohdista kartalla",
                 "no-linkable-location-tracks": "Sopivia sijaintiraiteita ei löytynyt linkitettäväksi.",


### PR DESCRIPTION
Samalla pyritty refakkailemaan tuota varsinaista linkitysfunkkaria vähemmän syvemmäksi (ja toisteiseksi) siirtämällä tilakombinaatiot ulkopuolisiin rakenteisiin