### PR TITLE
GVT-3145: Change response code from HTTP 400 to HTTP 404 when track layout version is not found

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -41,11 +41,11 @@ class ExtLocationTrackControllerV1(
     @GetMapping("/sijaintiraiteet")
     @Tag(name = EXT_LOCATION_TRACK_COLLECTION_TAG_V1)
     fun extGetLocationTrackCollection(
-        @RequestParam(TRACK_NETWORK_VERSION, required = false) trackNetworkVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>?,
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid?,
     ): ExtLocationTrackCollectionResponseV1 {
         return extLocationTrackCollectionService.createLocationTrackCollectionResponse(
-            trackNetworkVersion = trackNetworkVersion,
+            trackLayoutVersion = trackLayoutVersion,
             coordinateSystem = coordinateSystem ?: LAYOUT_SRID,
         )
     }
@@ -54,13 +54,13 @@ class ExtLocationTrackControllerV1(
     @Tag(name = EXT_LOCATION_TRACK_COLLECTION_TAG_V1)
     fun extGetLocationTrackCollectionModifications(
         @RequestParam(MODIFICATIONS_FROM_VERSION, required = true) modificationsFromVersion: Uuid<Publication>,
-        @RequestParam(TRACK_NETWORK_VERSION, required = false) trackNetworkVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>?,
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid?,
     ): ResponseEntity<ExtModifiedLocationTrackCollectionResponseV1> {
         return extLocationTrackCollectionService
             .createLocationTrackCollectionModificationResponse(
                 modificationsFromVersion = modificationsFromVersion,
-                trackNetworkVersion = trackNetworkVersion,
+                trackLayoutVersion = trackLayoutVersion,
                 coordinateSystem = coordinateSystem ?: LAYOUT_SRID,
             )
             ?.let { modifiedResponse -> ResponseEntity.ok(modifiedResponse) } ?: ResponseEntity.noContent().build()
@@ -72,12 +72,12 @@ class ExtLocationTrackControllerV1(
         @Parameter(description = LOCATION_TRACK_OID_DESCRIPTION)
         @PathVariable(LOCATION_TRACK_OID_PARAM)
         oid: Oid<LocationTrack>,
-        @RequestParam(TRACK_NETWORK_VERSION, required = false) trackNetworkVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>?,
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid?,
     ): ExtLocationTrackResponseV1 {
         return extLocationTrackService.createLocationTrackResponse(
             oid,
-            trackNetworkVersion,
+            trackLayoutVersion,
             coordinateSystem ?: LAYOUT_SRID,
         )
     }
@@ -87,14 +87,14 @@ class ExtLocationTrackControllerV1(
     fun extGetLocationTrackModifications(
         @PathVariable(LOCATION_TRACK_OID_PARAM) locationTrackOid: Oid<LocationTrack>,
         @RequestParam(MODIFICATIONS_FROM_VERSION, required = true) modificationsFromVersion: Uuid<Publication>,
-        @RequestParam(TRACK_NETWORK_VERSION, required = false) trackNetworkVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>?,
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid?,
     ): ResponseEntity<ExtModifiedLocationTrackResponseV1> {
         return extLocationTrackService
             .createLocationTrackModificationResponse(
                 locationTrackOid,
                 modificationsFromVersion,
-                trackNetworkVersion,
+                trackLayoutVersion,
                 coordinateSystem ?: LAYOUT_SRID,
             )
             ?.let { modifiedResponse -> ResponseEntity.ok(modifiedResponse) } ?: ResponseEntity.noContent().build()
@@ -104,7 +104,7 @@ class ExtLocationTrackControllerV1(
     @Tag(name = EXT_LOCATION_TRACK_TAG_V1)
     fun extGetLocationTrackGeometry(
         @PathVariable(LOCATION_TRACK_OID_PARAM) oid: Oid<LocationTrack>,
-        @RequestParam(TRACK_NETWORK_VERSION, required = false) trackNetworkVersion: Uuid<Publication>? = null,
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>? = null,
         @RequestParam(ADDRESS_POINT_RESOLUTION, required = false) extResolution: ExtResolutionV1? = null,
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid? = null,
         @RequestParam(TRACK_KILOMETER_START_PARAM, required = false) trackKmStart: KmNumber? = null,
@@ -112,7 +112,7 @@ class ExtLocationTrackControllerV1(
     ): ExtLocationTrackGeometryResponseV1 {
         return extLocationTrackGeometryService.createGeometryResponse(
             oid,
-            trackNetworkVersion,
+            trackLayoutVersion,
             extResolution?.toResolution() ?: Resolution.ONE_METER,
             coordinateSystem ?: LAYOUT_SRID,
             ExtTrackKilometerIntervalV1(trackKmStart, trackKmEnd),

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
@@ -26,14 +26,14 @@ import org.springframework.beans.factory.annotation.Autowired
 
 @Schema(name = "Vastaus: Sijaintiraidegeometria")
 data class ExtLocationTrackGeometryResponseV1(
-    @JsonProperty(TRACK_NETWORK_VERSION) val trackNetworkVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
     @JsonProperty(LOCATION_TRACK_OID_PARAM) val locationTrackOid: Oid<LocationTrack>,
     @JsonProperty("osoitevalit") val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
 )
 
 @Schema(name = "Vastaus: Muutettu sijaintiraidegeometria")
 data class ExtLocationTrackModifiedGeometryResponseV1(
-    @JsonProperty(TRACK_NETWORK_VERSION) val trackNetworkVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
     @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
     @JsonProperty(LOCATION_TRACK_OID_PARAM) val locationTrackOid: Oid<LocationTrack>,
     @JsonProperty("osoitevalit") val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
@@ -76,7 +76,7 @@ constructor(
 
     fun createGeometryResponse(
         oid: Oid<LocationTrack>,
-        trackNetworkVersion: Uuid<Publication>?,
+        trackLayoutVersion: Uuid<Publication>?,
         resolution: Resolution,
         coordinateSystem: Srid,
         trackIntervalFilter: ExtTrackKilometerIntervalV1,
@@ -84,9 +84,9 @@ constructor(
         val layoutContext = MainLayoutContext.official
 
         val publication =
-            trackNetworkVersion?.let { uuid ->
+            trackLayoutVersion?.let { uuid ->
                 publicationDao.fetchPublicationByUuid(uuid)
-                    ?: throw ExtTrackNetworkVersionNotFound("fetch failed, uuid=$uuid")
+                    ?: throw ExtTrackLayoutVersionNotFound("fetch failed, uuid=$uuid")
             } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
 
         val locationTrack =
@@ -101,7 +101,7 @@ constructor(
             ) ?: throw ExtGeocodingFailedV1("could not get geocoding context cache key")
 
         return ExtLocationTrackGeometryResponseV1(
-            trackNetworkVersion = publication.uuid,
+            trackLayoutVersion = publication.uuid,
             locationTrackOid = oid,
             trackIntervals =
                 getExtLocationTrackGeometry(

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -28,14 +28,14 @@ import java.time.Instant
 
 @Schema(name = "Vastaus: Sijaintiraide")
 data class ExtLocationTrackResponseV1(
-    @JsonProperty(TRACK_NETWORK_VERSION) val trackNetworkVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
     @JsonProperty(COORDINATE_SYSTEM_PARAM) val coordinateSystem: Srid,
     @JsonProperty(LOCATION_TRACK_PARAM) val locationTrack: ExtLocationTrackV1,
 )
 
 @Schema(name = "Vastaus: Muutettu sijaintiraide")
 data class ExtModifiedLocationTrackResponseV1(
-    @JsonProperty(TRACK_NETWORK_VERSION) val trackNetworkVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
     @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
     @JsonProperty(COORDINATE_SYSTEM_PARAM) val coordinateSystem: Srid,
     @JsonProperty(LOCATION_TRACK_PARAM) val locationTrack: ExtLocationTrackV1,
@@ -68,13 +68,13 @@ constructor(
 
     fun createLocationTrackResponse(
         oid: Oid<LocationTrack>,
-        trackNetworkVersion: Uuid<Publication>?,
+        trackLayoutVersion: Uuid<Publication>?,
         coordinateSystem: Srid,
     ): ExtLocationTrackResponseV1 {
         val layoutContext = MainLayoutContext.official
 
         val publication =
-            trackNetworkVersion?.let { uuid -> publicationDao.fetchPublicationByUuid(uuid).let(::requireNotNull) }
+            trackLayoutVersion?.let { uuid -> publicationDao.fetchPublicationByUuid(uuid).let(::requireNotNull) }
                 ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
 
         val locationTrack =
@@ -84,7 +84,7 @@ constructor(
                 )
 
         return ExtLocationTrackResponseV1(
-            trackNetworkVersion = publication.uuid,
+            trackLayoutVersion = publication.uuid,
             coordinateSystem = coordinateSystem,
             locationTrack =
                 getExtLocationTrack(oid, locationTrack, layoutContext, publication.publicationTime, coordinateSystem),
@@ -94,19 +94,19 @@ constructor(
     fun createLocationTrackModificationResponse(
         oid: Oid<LocationTrack>,
         modificationsFromVersion: Uuid<Publication>,
-        trackNetworkVersion: Uuid<Publication>?,
+        trackLayoutVersion: Uuid<Publication>?,
         coordinateSystem: Srid,
     ): ExtModifiedLocationTrackResponseV1? {
         val layoutContext = MainLayoutContext.official
 
         val fromPublication =
             publicationDao.fetchPublicationByUuid(modificationsFromVersion)
-                ?: throw ExtTrackNetworkVersionNotFound("modificationsFromVersion=${modificationsFromVersion}")
+                ?: throw ExtTrackLayoutVersionNotFound("modificationsFromVersion=${modificationsFromVersion}")
 
         val toPublication =
-            trackNetworkVersion?.let { uuid ->
+            trackLayoutVersion?.let { uuid ->
                 publicationDao.fetchPublicationByUuid(uuid)
-                    ?: throw ExtTrackNetworkVersionNotFound("trackNetworkVersion=${uuid}")
+                    ?: throw ExtTrackLayoutVersionNotFound("trackLayoutVersion=${uuid}")
             } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
 
         return if (fromPublication == toPublication) {
@@ -147,7 +147,7 @@ constructor(
             } else {
                 ExtModifiedLocationTrackResponseV1(
                     modificationsFromVersion = modificationsFromVersion,
-                    trackNetworkVersion = toPublication.uuid,
+                    trackLayoutVersion = toPublication.uuid,
                     coordinateSystem = coordinateSystem,
                     locationTrack =
                         getExtLocationTrack(

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
 const val MODIFICATIONS_FROM_VERSION = "muutokset_versiosta"
-const val TRACK_NETWORK_VERSION = "rataverkon_versio"
+const val TRACK_LAYOUT_VERSION = "rataverkon_versio"
 const val LOCATION_TRACK_OID_PARAM = "sijaintiraide_oid"
 const val LOCATION_TRACK_PARAM = "sijaintiraide"
 const val LOCATION_TRACK_COLLECTION = "sijaintiraiteet"

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutExceptionsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutExceptionsV1.kt
@@ -25,8 +25,8 @@ class ExtTrackNumberNotFoundV1(
     localizedMessageKey: String = "$ERROR_KEY_BASE.track-number-not-found",
 ) : ClientException(HttpStatus.BAD_REQUEST, "track number not found: $message", cause, localizedMessageKey)
 
-class ExtTrackNetworkVersionNotFound(
+class ExtTrackLayoutVersionNotFound(
     message: String,
     cause: Throwable? = null,
-    localizedMessageKey: String = "$ERROR_KEY_BASE.track-network-version-not-found",
-) : ClientException(HttpStatus.BAD_REQUEST, "track network version not found: $message", cause, localizedMessageKey)
+    localizedMessageKey: String = "$ERROR_KEY_BASE.track-layout-version-not-found",
+) : ClientException(HttpStatus.NOT_FOUND, "track layout version not found: $message", cause, localizedMessageKey)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -33,6 +33,8 @@
                 "error": {
                     "oid-not-found": "Pyynnön OID-tunnuksen perusteella ei löydetty kohdetta.",
                     "location-track-not-found": "Sijaintiraidetta ei löydetty.",
+                    "track-number-not-found": "Ratanumeroa ei löydetty.",
+                    "track-layout-version-not-found": "Rataverkon versiota ei löydetty.",
                     "client-error": "Pyyntö oli tunnistamattomalla tavalla virheellinen (HTTP {{koodi}}).",
                     "server-error": "Pyynnön käsittely epäonnistui palvelimella (HTTP {{koodi}}).",
                     "unauthorized": "Pyyntöön ei ollut oikeutta.",


### PR DESCRIPTION
* This API is not in use yet so these kinds of changes can still be easily made.

* The naming of trackNetworkVersion was also changed to trackLayoutVersion as the network term is unusual in this codebase in this context.

* Some missing translations were also added.