### PR TITLE
GVT-3147: Modify location track response codes in certain states, add openapi documentation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -99,6 +99,11 @@ class ExtLocationTrackControllerV1(
                         "Sijaintiraidetta ei löytynyt OID-tunnuksella tai annettua rataverkon versiota ei ole olemassa.",
                     content = [Content(schema = Schema(hidden = true))],
                 ),
+                ApiResponse(
+                    responseCode = "500",
+                    description = EXT_OPENAPI_SERVER_ERROR,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
             ]
     )
     fun extGetLocationTrack(
@@ -157,6 +162,11 @@ class ExtLocationTrackControllerV1(
                     responseCode = "404",
                     description =
                         "Sijaintiraidetta ei löytynyt OID-tunnuksella tai annettua rataverkon versiota ei ole olemassa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "500",
+                    description = EXT_OPENAPI_SERVER_ERROR,
                     content = [Content(schema = Schema(hidden = true))],
                 ),
             ]

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -85,13 +85,18 @@ class ExtLocationTrackControllerV1(
                 ApiResponse(
                     responseCode = "204",
                     description =
-                        "Sijaintiraiteen OID-tunnus löytyi, muttei se ollut olemassa annetussa rataverkon versiossa.",
+                        "Sijaintiraiteen OID-tunnus löytyi, muttei se ole olemassa annetussa rataverkon versiossa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = EXT_OPENAPI_INVALID_ARGUMENTS,
                     content = [Content(schema = Schema(hidden = true))],
                 ),
                 ApiResponse(
                     responseCode = "404",
                     description =
-                        "Sijaintiraidetta ei löytynyt annetulla OID-tunnuksella tai annettua rataverkon versiota ei ollut olemassa.",
+                        "Sijaintiraidetta ei löytynyt OID-tunnuksella tai annettua rataverkon versiota ei ole olemassa.",
                     content = [Content(schema = Schema(hidden = true))],
                 ),
             ]
@@ -128,6 +133,34 @@ class ExtLocationTrackControllerV1(
 
     @GetMapping("/sijaintiraiteet/{$LOCATION_TRACK_OID_PARAM}/geometria")
     @Tag(name = EXT_LOCATION_TRACK_TAG_V1)
+    @Operation(summary = "Yksittäisen sijaintiraiteen geometrian haku OID-tunnuksella")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description =
+                        "Sijaintiraiteen geometria löytyi onnistuneesti uusimmasta tai annetusta rataverkon versiosta.",
+                ),
+                ApiResponse(
+                    responseCode = "204",
+                    description =
+                        "Sijaintiraiteen OID-tunnus löytyi, muttei sille ole olemassa geometriaa annetussa rataverkon versiossa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = EXT_OPENAPI_INVALID_ARGUMENTS,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description =
+                        "Sijaintiraidetta ei löytynyt OID-tunnuksella tai annettua rataverkon versiota ei ole olemassa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+            ]
+    )
     fun extGetLocationTrackGeometry(
         @PathVariable(LOCATION_TRACK_OID_PARAM) oid: Oid<LocationTrack>,
         @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>? = null,
@@ -135,13 +168,15 @@ class ExtLocationTrackControllerV1(
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid? = null,
         @RequestParam(TRACK_KILOMETER_START_PARAM, required = false) trackKmStart: KmNumber? = null,
         @RequestParam(TRACK_KILOMETER_END_PARAM, required = false) trackKmEnd: KmNumber? = null,
-    ): ExtLocationTrackGeometryResponseV1 {
-        return extLocationTrackGeometryService.createGeometryResponse(
-            oid,
-            trackLayoutVersion,
-            extResolution?.toResolution() ?: Resolution.ONE_METER,
-            coordinateSystem ?: LAYOUT_SRID,
-            ExtTrackKilometerIntervalV1(trackKmStart, trackKmEnd),
-        )
+    ): ResponseEntity<ExtLocationTrackGeometryResponseV1> {
+        return extLocationTrackGeometryService
+            .createGeometryResponse(
+                oid,
+                trackLayoutVersion,
+                extResolution?.toResolution() ?: Resolution.ONE_METER,
+                coordinateSystem ?: LAYOUT_SRID,
+                ExtTrackKilometerIntervalV1(trackKmStart, trackKmEnd),
+            )
+            .let(::toResponse)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -11,7 +11,13 @@ import fi.fta.geoviite.infra.geocoding.Resolution
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.util.toResponse
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -68,18 +74,38 @@ class ExtLocationTrackControllerV1(
 
     @GetMapping("/sijaintiraiteet/{$LOCATION_TRACK_OID_PARAM}")
     @Tag(name = EXT_LOCATION_TRACK_TAG_V1)
+    @Operation(summary = "Yksittäisen sijaintiraiteen haku OID-tunnuksella")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description = "Sijaintiraide löytyi onnistuneesti uusimmasta tai annetusta rataverkon versiosta.",
+                ),
+                ApiResponse(
+                    responseCode = "204",
+                    description =
+                        "Sijaintiraiteen OID-tunnus löytyi, muttei se ollut olemassa annetussa rataverkon versiossa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description =
+                        "Sijaintiraidetta ei löytynyt annetulla OID-tunnuksella tai annettua rataverkon versiota ei ollut olemassa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+            ]
+    )
     fun extGetLocationTrack(
         @Parameter(description = LOCATION_TRACK_OID_DESCRIPTION)
         @PathVariable(LOCATION_TRACK_OID_PARAM)
         oid: Oid<LocationTrack>,
         @RequestParam(TRACK_LAYOUT_VERSION, required = false) trackLayoutVersion: Uuid<Publication>?,
         @RequestParam(COORDINATE_SYSTEM_PARAM, required = false) coordinateSystem: Srid?,
-    ): ExtLocationTrackResponseV1 {
-        return extLocationTrackService.createLocationTrackResponse(
-            oid,
-            trackLayoutVersion,
-            coordinateSystem ?: LAYOUT_SRID,
-        )
+    ): ResponseEntity<ExtLocationTrackResponseV1> {
+        return extLocationTrackService
+            .createLocationTrackResponse(oid, trackLayoutVersion, coordinateSystem ?: LAYOUT_SRID)
+            .let(::toResponse)
     }
 
     @GetMapping("/sijaintiraiteet/{$LOCATION_TRACK_OID_PARAM}/muutokset", params = [MODIFICATIONS_FROM_VERSION])

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -11,3 +11,5 @@ const val COORDINATE_SYSTEM_PARAM = "koordinaatisto"
 const val ADDRESS_POINT_RESOLUTION = "osoitepistevali"
 
 const val LOCATION_TRACK_OID_DESCRIPTION = "Sijaintiraiteen OID-tunnus"
+
+const val EXT_OPENAPI_INVALID_ARGUMENTS = "Yhden tai useamman hakuargumentin muoto oli virheellinen."

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -13,3 +13,4 @@ const val ADDRESS_POINT_RESOLUTION = "osoitepistevali"
 const val LOCATION_TRACK_OID_DESCRIPTION = "Sijaintiraiteen OID-tunnus"
 
 const val EXT_OPENAPI_INVALID_ARGUMENTS = "Yhden tai useamman hakuargumentin muoto oli virheellinen."
+const val EXT_OPENAPI_SERVER_ERROR = "Palvelussa tapahtui sisäinen virhe. Ota tarvittaessa yhteyttä ylläpitoon."


### PR DESCRIPTION
Noille /muutokset-pinnoille tulee vastaavat dokuilut/muutetut vastauskoodit toisen tiksun yhteydessä.

Kommentteja voi heittää varsinkin vastausdokuilun ymmärrettävyydestä. Annotaatiodokut toki päätyvät aika monirivisiksi, ja niiden pitää olla staattisesti muodostettavissa käännösvaiheessa, eli esimerkiksi noita ApiResponse-instansseja ei voi jakaa eri rajapintojen kesken, vaikka ne ovatkin identtistä muotoa.