### PR TITLE
GVT-3161 Make publication log queryable by item

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -29,9 +29,6 @@ const val CACHE_PLAN_GEOCODING_CONTEXTS = "plan-geocoding-contexts"
 
 const val CACHE_RATKO_HEALTH_STATUS = "ratko-health-status"
 
-const val CACHE_PUBLISHED_LOCATION_TRACKS = "published-location-tracks"
-const val CACHE_PUBLISHED_SWITCHES = "published-switches"
-
 val planCacheDuration: Duration = Duration.ofMinutes(60)
 val layoutCacheDuration: Duration = Duration.ofMinutes(60)
 val staticDataCacheDuration: Duration = Duration.ofHours(24)
@@ -64,9 +61,6 @@ constructor(@Value("\${geoviite.cache.enabled}") private val cacheEnabled: Boole
             manager.registerCustomCache(CACHE_PLAN_GEOCODING_CONTEXTS, cache(50, planCacheDuration))
 
             manager.registerCustomCache(CACHE_RATKO_HEALTH_STATUS, ephemeralCache(1, healthCheckLifetime))
-
-            manager.registerCustomCache(CACHE_PUBLISHED_LOCATION_TRACKS, cache(500, staticDataCacheDuration))
-            manager.registerCustomCache(CACHE_PUBLISHED_SWITCHES, cache(500, staticDataCacheDuration))
 
             manager
         } else {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -188,12 +188,63 @@ data class PublicationDetails(
     val allPublishedSwitches = switches + indirectChanges.switches
 }
 
-enum class DraftChangeType {
+enum class PublishableObjectType {
     TRACK_NUMBER,
     LOCATION_TRACK,
     REFERENCE_LINE,
     SWITCH,
     KM_POST,
+}
+
+sealed class PublishableObjectIdAndType {
+    abstract val id: IntId<*>
+    abstract val type: PublishableObjectType
+
+    open fun isTrackNumber(other: IntId<LayoutTrackNumber>) = false
+    open fun isLocationTrack(other: IntId<LocationTrack>) = false
+    open fun isReferenceLine(other: IntId<ReferenceLine>) = false
+    open fun isSwitch(other: IntId<LayoutSwitch>) = false
+    open fun isKmPost(other: IntId<LayoutKmPost>) = false
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun byType(id: IntId<*>, type: PublishableObjectType) = when(type) {
+            PublishableObjectType.TRACK_NUMBER -> TrackNumberIdAndType(id as IntId<LayoutTrackNumber>)
+            PublishableObjectType.LOCATION_TRACK -> LocationTrackIdAndType(id as IntId<LocationTrack>)
+            PublishableObjectType.REFERENCE_LINE -> ReferenceLineIdAndType(id as IntId<ReferenceLine>)
+            PublishableObjectType.SWITCH -> SwitchIdAndType(id as IntId<LayoutSwitch>)
+            PublishableObjectType.KM_POST -> KmPostIdAndType(id as IntId<LayoutKmPost>)
+        }
+    }
+}
+data class TrackNumberIdAndType(override val id: IntId<LayoutTrackNumber>) : PublishableObjectIdAndType() {
+
+    override val type = PublishableObjectType.TRACK_NUMBER
+    override fun isTrackNumber(other: IntId<LayoutTrackNumber>) = id == other
+}
+
+data class LocationTrackIdAndType(override val id: IntId<LocationTrack>) : PublishableObjectIdAndType() {
+
+    override val type = PublishableObjectType.LOCATION_TRACK
+    override fun isLocationTrack(other: IntId<LocationTrack>) = id == other
+}
+
+data class ReferenceLineIdAndType(override val id: IntId<ReferenceLine>) : PublishableObjectIdAndType() {
+
+    override val type = PublishableObjectType.REFERENCE_LINE
+    override fun isReferenceLine(other: IntId<ReferenceLine>) = id == other
+}
+
+data class SwitchIdAndType(override val id: IntId<LayoutSwitch>) : PublishableObjectIdAndType() {
+
+    override val type = PublishableObjectType.SWITCH
+    override fun isSwitch(other: IntId<LayoutSwitch>) = id == other
+}
+
+data class KmPostIdAndType(override val id: IntId<LayoutKmPost>) : PublishableObjectIdAndType() {
+
+    override val type = PublishableObjectType.KM_POST
+    override fun isKmPost(other: IntId<LayoutKmPost>) = id == other
 }
 
 enum class Operation(val priority: Int) {
@@ -390,7 +441,7 @@ data class LayoutValidationIssue(
 }
 
 interface PublicationCandidate<T : LayoutAsset<T>> {
-    val type: DraftChangeType
+    val type: PublishableObjectType
     val rowVersion: LayoutRowVersion<T>
     val draftChangeTime: Instant
     val userName: UserName
@@ -419,7 +470,7 @@ data class TrackNumberPublicationCandidate(
     override val designAssetState: DesignAssetState?,
     val boundingBox: BoundingBox?,
 ) : PublicationCandidate<LayoutTrackNumber> {
-    override val type = DraftChangeType.TRACK_NUMBER
+    override val type = PublishableObjectType.TRACK_NUMBER
 }
 
 data class ReferenceLinePublicationCandidate(
@@ -435,7 +486,7 @@ data class ReferenceLinePublicationCandidate(
     val boundingBox: BoundingBox?,
     val geometryChanges: GeometryChangeRanges<ReferenceLineM>?,
 ) : PublicationCandidate<ReferenceLine> {
-    override val type = DraftChangeType.REFERENCE_LINE
+    override val type = PublishableObjectType.REFERENCE_LINE
 }
 
 data class LocationTrackPublicationCandidate(
@@ -452,7 +503,7 @@ data class LocationTrackPublicationCandidate(
     val boundingBox: BoundingBox?,
     val geometryChanges: GeometryChangeRanges<LocationTrackM>?,
 ) : PublicationCandidate<LocationTrack> {
-    override val type = DraftChangeType.LOCATION_TRACK
+    override val type = PublishableObjectType.LOCATION_TRACK
 }
 
 data class SwitchPublicationCandidate(
@@ -467,7 +518,7 @@ data class SwitchPublicationCandidate(
     override val designAssetState: DesignAssetState?,
     val location: Point?,
 ) : PublicationCandidate<LayoutSwitch> {
-    override val type = DraftChangeType.SWITCH
+    override val type = PublishableObjectType.SWITCH
 }
 
 data class KmPostPublicationCandidate(
@@ -482,7 +533,7 @@ data class KmPostPublicationCandidate(
     override val designAssetState: DesignAssetState?,
     val location: Point?,
 ) : PublicationCandidate<LayoutKmPost> {
-    override val type = DraftChangeType.KM_POST
+    override val type = PublishableObjectType.KM_POST
 }
 
 data class SwitchLocationTrack(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -201,15 +201,21 @@ constructor(
         @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam("to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
+        @RequestParam("type", required = false) type: PublishableObjectType?,
+        @RequestParam("id", required = false) id: IntId<*>?,
         @RequestParam("sortBy", required = false) sortBy: PublicationTableColumn?,
         @RequestParam("order", required = false) order: SortOrder?,
         @RequestParam("lang") lang: LocalizationLanguage,
     ): Page<PublicationTableItem> {
+        require((type == null) == (id == null)) { "Must provide either both or neither of id and type"}
+        val specificId = if (type != null) PublishableObjectIdAndType.byType(requireNotNull(id), type) else null
+
         val publications =
             publicationLogService.fetchPublicationDetails(
                 layoutBranch = layoutBranch ?: LayoutBranch.main,
                 from = from,
                 to = to,
+                specificId = specificId,
                 sortBy = sortBy,
                 order = order,
                 translation = localizationService.getLocalization(lang),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -1,19 +1,94 @@
 package fi.fta.geoviite.infra.publication
 
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.*
-import fi.fta.geoviite.infra.configuration.CACHE_PUBLISHED_LOCATION_TRACKS
-import fi.fta.geoviite.infra.configuration.CACHE_PUBLISHED_SWITCHES
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.MeasurementMethod
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumberDescription
+import fi.fta.geoviite.infra.common.Uuid
+import fi.fta.geoviite.infra.common.assertMainBranch
+import fi.fta.geoviite.infra.configuration.staticDataCacheDuration
 import fi.fta.geoviite.infra.geometry.MetaDataName
-import fi.fta.geoviite.infra.integration.*
-import fi.fta.geoviite.infra.logging.AccessType.*
+import fi.fta.geoviite.infra.integration.CalculatedChanges
+import fi.fta.geoviite.infra.integration.LocationTrackChange
+import fi.fta.geoviite.infra.integration.SwitchChange
+import fi.fta.geoviite.infra.integration.SwitchJointChange
+import fi.fta.geoviite.infra.integration.TrackNumberChange
+import fi.fta.geoviite.infra.logging.AccessType.FETCH
+import fi.fta.geoviite.infra.logging.AccessType.INSERT
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
-import fi.fta.geoviite.infra.tracklayout.*
-import fi.fta.geoviite.infra.util.*
-import org.springframework.cache.annotation.Cacheable
+import fi.fta.geoviite.infra.tracklayout.DesignAssetState
+import fi.fta.geoviite.infra.tracklayout.KmPostGkLocationSource
+import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
+import fi.fta.geoviite.infra.tracklayout.LayoutAsset
+import fi.fta.geoviite.infra.tracklayout.LayoutDesign
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.LayoutRowId
+import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
+import fi.fta.geoviite.infra.tracklayout.LayoutState
+import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionSuffix
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import fi.fta.geoviite.infra.tracklayout.LocationTrackType
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
+import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.FreeTextWithNewLines
+import fi.fta.geoviite.infra.util.getBboxOrNull
+import fi.fta.geoviite.infra.util.getBooleanOrNull
+import fi.fta.geoviite.infra.util.getChange
+import fi.fta.geoviite.infra.util.getChangeGeometryPoint
+import fi.fta.geoviite.infra.util.getChangePoint
+import fi.fta.geoviite.infra.util.getChangeRowVersion
+import fi.fta.geoviite.infra.util.getDoubleOrNull
+import fi.fta.geoviite.infra.util.getEnum
+import fi.fta.geoviite.infra.util.getEnumOrNull
+import fi.fta.geoviite.infra.util.getFreeTextWithNewLines
+import fi.fta.geoviite.infra.util.getInstant
+import fi.fta.geoviite.infra.util.getInstantOrNull
+import fi.fta.geoviite.infra.util.getIntId
+import fi.fta.geoviite.infra.util.getIntIdArray
+import fi.fta.geoviite.infra.util.getIntIdOrNull
+import fi.fta.geoviite.infra.util.getJointNumber
+import fi.fta.geoviite.infra.util.getKmNumber
+import fi.fta.geoviite.infra.util.getKmNumberOrNull
+import fi.fta.geoviite.infra.util.getLayoutBranch
+import fi.fta.geoviite.infra.util.getLayoutBranchArrayOrNull
+import fi.fta.geoviite.infra.util.getLayoutRowVersion
+import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
+import fi.fta.geoviite.infra.util.getList
+import fi.fta.geoviite.infra.util.getListOrNull
+import fi.fta.geoviite.infra.util.getOidOrNull
+import fi.fta.geoviite.infra.util.getPoint
+import fi.fta.geoviite.infra.util.getPointOrNull
+import fi.fta.geoviite.infra.util.getPublicationPublishedIn
+import fi.fta.geoviite.infra.util.getSridOrNull
+import fi.fta.geoviite.infra.util.getStringArray
+import fi.fta.geoviite.infra.util.getStringArrayOrNull
+import fi.fta.geoviite.infra.util.getTrackMeter
+import fi.fta.geoviite.infra.util.getTrackMeterOrNull
+import fi.fta.geoviite.infra.util.getTrackNumber
+import fi.fta.geoviite.infra.util.getTrackNumberOrNull
+import fi.fta.geoviite.infra.util.getUuid
+import fi.fta.geoviite.infra.util.queryOptional
+import fi.fta.geoviite.infra.util.setUser
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -501,7 +576,10 @@ class PublicationDao(
             .also { logger.daoAccess(FETCH, "Duplicate track versions", ids) }
     }
 
-    fun getPublication(publicationId: IntId<Publication>): Publication {
+    fun getPublication(publicationId: IntId<Publication>) =
+        getPublications(setOf(publicationId)).getValue(publicationId)
+
+    fun getPublications(publicationIds: Set<IntId<Publication>>): Map<IntId<Publication>, Publication> {
         val sql =
             """
             select
@@ -515,15 +593,16 @@ class PublicationDao(
               cause,
               parent_publication_id
             from publication.publication
-            where publication.id = :id
+            where publication.id = any(array[:ids]::int[])
         """
                 .trimIndent()
 
-        return getOne(
-                publicationId,
-                jdbcTemplate.query(sql, mapOf("id" to publicationId.intValue)) { rs, _ ->
+        return jdbcTemplate
+            .query(sql, mapOf("ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                val id = rs.getIntId<Publication>("id")
+                id to
                     Publication(
-                        id = rs.getIntId("id"),
+                        id = id,
                         uuid = rs.getUuid<Publication>("publication_uuid"),
                         publicationUser = rs.getString("publication_user").let(UserName::of),
                         publicationTime = rs.getInstant("publication_time"),
@@ -532,9 +611,9 @@ class PublicationDao(
                             rs.getPublicationPublishedIn("design_id", "design_version", "parent_publication_id"),
                         cause = rs.getEnum("cause"),
                     )
-                },
-            )
-            .also { logger.daoAccess(FETCH, Publication::class, publicationId) }
+            }
+            .associate { it }
+            .also { logger.daoAccess(FETCH, Publication::class, publicationIds) }
     }
 
     @Transactional
@@ -786,13 +865,14 @@ class PublicationDao(
     fun fetchPublicationLocationTrackSwitchLinkChanges(
         publicationId: IntId<Publication>
     ): Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges> =
-        fetchPublicationLocationTrackSwitchLinkChanges(publicationId, null, null, null)[publicationId] ?: mapOf()
+        fetchPublicationLocationTrackSwitchLinkChanges(publicationId, null, null, null, null)[publicationId] ?: mapOf()
 
     fun fetchPublicationLocationTrackSwitchLinkChanges(
         publicationId: IntId<Publication>?,
         layoutBranch: LayoutBranch?,
         from: Instant?,
         to: Instant?,
+        specificObjectId: PublishableObjectIdAndType?,
     ): Map<IntId<Publication>, Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>> {
         require((layoutBranch != null) != (publicationId != null)) {
             """"Must provide exactly one of layoutBranch or publicationId, but provided:
@@ -853,8 +933,9 @@ class PublicationDao(
                       else :design_id is not distinct from publication.design_id end
                 and (:from::timestamptz is null or :from <= publication_time)
                 and (:to::timestamptz is null or :to >= publication_time)
-        """
-                .trimIndent()
+                and (:specific_location_track_id::int is null or :specific_location_track_id = location_track_id)
+              order by change_side, switch_id;
+        """.trimIndent()
 
         data class ResultRow(
             val changeSide: String,
@@ -873,6 +954,7 @@ class PublicationDao(
                     "from" to from?.let { Timestamp.from(it) },
                     "to" to to?.let { Timestamp.from(it) },
                     "design_id" to layoutBranch?.designId?.intValue,
+                    "specific_location_track_id" to (specificObjectId as? LocationTrackIdAndType)?.id?.intValue,
                 ),
             ) { rs, _ ->
                 ResultRow(
@@ -1824,11 +1906,21 @@ class PublicationDao(
         )
     }
 
-    @Cacheable(CACHE_PUBLISHED_LOCATION_TRACKS, sync = true)
-    fun fetchPublishedLocationTracks(publicationId: IntId<Publication>): PublishedItemListing<PublishedLocationTrack> {
+    private val publishedLocationTracksCache: Cache<IntId<Publication>, PublishedItemListing<PublishedLocationTrack>> =
+        Caffeine.newBuilder().maximumSize(500).expireAfterAccess(staticDataCacheDuration).build()
+
+    fun fetchPublishedLocationTracks(
+        publicationIds: Set<IntId<Publication>>
+    ): Map<IntId<Publication>, PublishedItemListing<PublishedLocationTrack>> =
+        publishedLocationTracksCache.getAll(publicationIds, ::fetchPublishedLocationTracksInternal)
+
+    fun fetchPublishedLocationTracksInternal(
+        publicationIds: Set<IntId<Publication>>
+    ): Map<IntId<Publication>, PublishedItemListing<PublishedLocationTrack>> {
         val sql =
             """
             select
+              plt.publication_id,
               ltv.id,
               ltv.design_id,
               ltv.draft,
@@ -1848,13 +1940,13 @@ class PublicationDao(
                 from publication.location_track_km pltk
                 where pltk.location_track_id = plt.location_track_id and pltk.publication_id = plt.publication_id
               ) pltk on (true)
-            where plt.publication_id = :publication_id
+            where plt.publication_id = any(array[:publication_ids]::int[])
         """
                 .trimIndent()
 
         return jdbcTemplate
-            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-                rs.getBoolean("direct_change") to
+            .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                (rs.getIntId<Publication>("publication_id") to rs.getBoolean("direct_change")) to
                     PublishedLocationTrack(
                         version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
                         name = AlignmentName(rs.getString("name")),
@@ -1865,20 +1957,17 @@ class PublicationDao(
             }
             .let { locationTrackRows ->
                 logger.daoAccess(FETCH, PublishedLocationTrack::class, locationTrackRows.map { it.second.version })
-                partitionDirectIndirectChanges(locationTrackRows)
+                partitionByPublicationIdAndDirectOrIndirect(locationTrackRows)
             }
     }
 
-    fun fetchPublishedReferenceLines(publicationId: IntId<Publication>): List<PublishedReferenceLine> {
+    fun fetchPublishedReferenceLines(
+        publicationIds: Set<IntId<Publication>>
+    ): Map<IntId<Publication>, List<PublishedReferenceLine>> {
         val sql =
             """
-            with prev_pub 
-              as (select max(publication_time) as prev_publication_time 
-              from publication.publication
-              where id < :publication_id
-                and design_id is not distinct from (select design_id from publication.publication where id = :publication_id)
-            )
             select
+              prl.publication_id,
               rl.id,
               rl.design_id,
               rl.draft,
@@ -1894,7 +1983,6 @@ class PublicationDao(
               from publication.reference_line prl
                 inner join layout.reference_line_version rl
                           on rl.id = prl.reference_line_id and rl.layout_context_id = prl.layout_context_id and rl.version = prl.reference_line_version
-                left join prev_pub on true
                 left join publication.publication p
                           on p.id = prl.publication_id
                 left join publication.track_number ptn
@@ -1905,27 +1993,30 @@ class PublicationDao(
                           on tn_old.id = ptn.track_number_id
                             and tn_old.layout_context_id = 'main_official'
                             and tn_old.version = tn.version - case when ptn.direct_change then 1 else 0 end
-              where prl.publication_id = :publication_id
+              where prl.publication_id = any(array[:publication_ids]::int[])
         """
                 .trimIndent()
         return jdbcTemplate
-            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-                PublishedReferenceLine(
-                    version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
-                    trackNumberId = rs.getIntId("track_number_id"),
-                    operation = rs.getEnumOrNull<Operation>("operation") ?: Operation.MODIFY,
-                    changedKmNumbers = rs.getStringArray("changed_km").map(::KmNumber).toSet(),
-                )
+            .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                rs.getIntId<Publication>("publication_id") to
+                    PublishedReferenceLine(
+                        version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
+                        trackNumberId = rs.getIntId("track_number_id"),
+                        operation = rs.getEnumOrNull<Operation>("operation") ?: Operation.MODIFY,
+                        changedKmNumbers = rs.getStringArray("changed_km").map(::KmNumber).toSet(),
+                    )
             }
             .also { referenceLines ->
-                logger.daoAccess(FETCH, PublishedReferenceLine::class, referenceLines.map { it.version })
+                logger.daoAccess(FETCH, PublishedReferenceLine::class, referenceLines.map { it.second.version })
             }
+            .groupBy({ it.first }, { it.second })
     }
 
-    fun fetchPublishedKmPosts(publicationId: IntId<Publication>): List<PublishedKmPost> {
+    fun fetchPublishedKmPosts(publicationIds: Set<IntId<Publication>>): Map<IntId<Publication>, List<PublishedKmPost>> {
         val sql =
             """
             select
+              pkp.publication_id,
               kmp.id,
               kmp.design_id,
               kmp.draft,
@@ -1938,28 +2029,32 @@ class PublicationDao(
                 on pkp.km_post_id = kmp.id and pkp.layout_context_id = kmp.layout_context_id and pkp.km_post_version = kmp.version
               inner join layout.km_post_change_view kpc
                 on kpc.id = pkp.km_post_id and kpc.layout_context_id = pkp.layout_context_id and kpc.version = pkp.km_post_version
-            where publication_id = :publication_id
+            where publication_id = any(array[:publication_ids]::int[])
         """
                 .trimIndent()
 
         return jdbcTemplate
-            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-                PublishedKmPost(
-                    version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
-                    trackNumberId = rs.getIntId("track_number_id"),
-                    kmNumber = rs.getKmNumber("km_number"),
-                    operation = rs.getEnum("operation"),
-                )
+            .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                rs.getIntId<Publication>("publication_id") to
+                    PublishedKmPost(
+                        version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
+                        trackNumberId = rs.getIntId("track_number_id"),
+                        kmNumber = rs.getKmNumber("km_number"),
+                        operation = rs.getEnum("operation"),
+                    )
             }
-            .also { kmPosts -> logger.daoAccess(FETCH, PublishedKmPost::class, kmPosts.map { it.version }) }
+            .also { kmPosts -> logger.daoAccess(FETCH, PublishedKmPost::class, kmPosts.map { it.second.version }) }
+            .groupBy({ it.first }, { it.second })
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(CACHE_PUBLISHED_SWITCHES, sync = true)
-    fun fetchPublishedSwitches(publicationId: IntId<Publication>): PublishedItemListing<PublishedSwitch> {
+    fun fetchPublishedSwitches(
+        publicationIds: Set<IntId<Publication>>
+    ): Map<IntId<Publication>, PublishedItemListing<PublishedSwitch>> {
         val sql =
             """
             select
+              ps.publication_id,
               sv.id,
               sv.design_id,
               sv.draft,
@@ -1979,38 +2074,41 @@ class PublicationDao(
                 on ps.switch_id = sv.id and ps.layout_context_id = sv.layout_context_id and ps.switch_version = sv.version
               inner join layout.switch_change_view sc
                 on sc.id = ps.switch_id and sc.layout_context_id = ps.layout_context_id and sc.version = ps.switch_version
-            where ps.publication_id = :publication_id
+            where ps.publication_id = any(array[:publication_ids]::int[])
         """
                 .trimIndent()
 
-        val publishedSwitchJoints = publishedSwitchJoints(publicationId)
+        val publishedSwitchJoints = publishedSwitchJoints(publicationIds)
 
         return jdbcTemplate
-            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-                rs.getBoolean("direct_change") to
+            .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                val publicationId = rs.getIntId<Publication>("publication_id")
+                val switchVersion = rs.getLayoutRowVersion<LayoutSwitch>("id", "design_id", "draft", "version")
+                (publicationId to rs.getBoolean("direct_change")) to
                     PublishedSwitch(
-                        version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
+                        version = switchVersion,
                         name = SwitchName(rs.getString("name")),
                         trackNumberIds = rs.getIntIdArray<LayoutTrackNumber>("track_number_ids").toSet(),
                         operation = rs.getEnum("operation"),
                         changedJoints =
                             publishedSwitchJoints
-                                .filter { it.first == rs.getIntId<LayoutSwitch>("id") }
-                                .flatMap { it.second },
+                                .getOrDefault(publicationId, mapOf())
+                                .getOrDefault(switchVersion.id, listOf()),
                     )
             }
             .let { switchRows ->
                 logger.daoAccess(FETCH, PublishedSwitch::class, switchRows.map { it.second.version })
-                partitionDirectIndirectChanges(switchRows)
+                partitionByPublicationIdAndDirectOrIndirect(switchRows)
             }
     }
 
     private fun publishedSwitchJoints(
-        publicationId: IntId<Publication>
-    ): List<Pair<IntId<LayoutSwitch>, List<SwitchJointChange>>> {
+        publicationIds: Set<IntId<Publication>>
+    ): Map<IntId<Publication>, Map<IntId<LayoutSwitch>, List<SwitchJointChange>>> {
         val sql =
             """
             select
+              publication_id,
               switch_id as id,
               joint_number,
               removed,
@@ -2022,13 +2120,13 @@ class PublicationDao(
               track_number_id,
               track_number_external_id
             from publication.switch_joint
-            where publication_id = :publication_id
+            where publication_id = any(array[:publication_ids]::int[])
         """
                 .trimIndent()
 
         return jdbcTemplate
-            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-                rs.getIntId<LayoutSwitch>("id") to
+            .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                (rs.getIntId<Publication>("publication_id") to rs.getIntId<LayoutSwitch>("id")) to
                     SwitchJointChange(
                         number = rs.getJointNumber("joint_number"),
                         isRemoved = rs.getBoolean("removed"),
@@ -2040,14 +2138,19 @@ class PublicationDao(
                         trackNumberExternalId = rs.getOidOrNull("track_number_external_id"),
                     )
             }
-            .groupBy { it.first }
-            .map { (switchId, switchJoints) -> switchId to switchJoints.map { it.second } }
+            .groupBy({ it.first.first }, { it.first.second to it.second })
+            .mapValues { (_, idsAndJoints) ->
+                idsAndJoints.groupBy({ it.first }).mapValues { (_, js) -> js.map { it.second } }
+            }
     }
 
-    fun fetchPublishedTrackNumbers(publicationId: IntId<Publication>): PublishedItemListing<PublishedTrackNumber> {
+    fun fetchPublishedTrackNumbers(
+        publicationIds: Set<IntId<Publication>>
+    ): Map<IntId<Publication>, PublishedItemListing<PublishedTrackNumber>> {
         val sql =
             """
           select
+            publication.id as publication_id,
             ptn.track_number_id as id,
             publication.design_id,
             track_number_version as version,
@@ -2066,13 +2169,13 @@ class PublicationDao(
               on tn.id = ptn.track_number_id and tn.layout_context_id = ptn.layout_context_id and tn.version = ptn.track_number_version
             join publication.publication
               on ptn.publication_id = publication.id
-          where ptn.publication_id = :publication_id
+          where ptn.publication_id = any(array[:publication_ids]::int[])
         """
                 .trimIndent()
 
         return jdbcTemplate
-            .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
-                rs.getBoolean("direct_change") to
+            .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
+                (rs.getIntId<Publication>("publication_id") to rs.getBoolean("direct_change")) to
                     PublishedTrackNumber(
                         version =
                             LayoutRowVersion(
@@ -2087,7 +2190,7 @@ class PublicationDao(
             }
             .let { trackNumberRows ->
                 logger.daoAccess(FETCH, PublishedTrackNumber::class, trackNumberRows.map { it.second.version })
-                partitionDirectIndirectChanges(trackNumberRows)
+                partitionByPublicationIdAndDirectOrIndirect(trackNumberRows)
             }
     }
 
@@ -2151,6 +2254,13 @@ class PublicationDao(
         return jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId("location_track_id") }
     }
 }
+
+private fun <T> partitionByPublicationIdAndDirectOrIndirect(
+    rows: List<Pair<Pair<IntId<Publication>, Boolean>, T>>
+): Map<IntId<Publication>, PublishedItemListing<T>> =
+    rows.groupBy({ it.first.first }, { it.first.second to it.second }).mapValues { (_, publicationRows) ->
+        partitionDirectIndirectChanges(publicationRows)
+    }
 
 private fun <T> partitionDirectIndirectChanges(rows: List<Pair<Boolean, T>>) =
     rows

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -68,41 +68,61 @@ constructor(
     }
 
     @Transactional(readOnly = true)
-    fun getPublicationDetails(id: IntId<Publication>): PublicationDetails {
-        val publication = publicationDao.getPublication(id)
-        val ratkoStatus = ratkoPushDao.getRatkoStatus(id).sortedByDescending { it.endTime }.firstOrNull()
+    fun getPublicationDetails(ids: Set<IntId<Publication>>): Map<IntId<Publication>, PublicationDetails> {
+        val publications = publicationDao.getPublications(ids)
+        val ratkoStatuses =
+            ratkoPushDao.getRatkoStatuses(ids).mapValues { (_, statuses) ->
+                statuses.sortedByDescending { it.endTime }.firstOrNull()
+            }
 
-        val publishedReferenceLines = publicationDao.fetchPublishedReferenceLines(id)
-        val publishedKmPosts = publicationDao.fetchPublishedKmPosts(id)
-        val (publishedDirectTrackNumbers, publishedIndirectTrackNumbers) = publicationDao.fetchPublishedTrackNumbers(id)
-        val (publishedDirectTracks, publishedIndirectTracks) = publicationDao.fetchPublishedLocationTracks(id)
-        val (publishedDirectSwitches, publishedIndirectSwitches) = publicationDao.fetchPublishedSwitches(id)
-        val split = splitService.getSplitIdByPublicationId(id)?.let(splitService::get)
+        val publishedReferenceLines = publicationDao.fetchPublishedReferenceLines(ids)
+        val publishedKmPosts = publicationDao.fetchPublishedKmPosts(ids)
+        val publishedTrackNumbers = publicationDao.fetchPublishedTrackNumbers(ids)
+        val publishedLocationTracks = publicationDao.fetchPublishedLocationTracks(ids)
+        val publishedSwitches = publicationDao.fetchPublishedSwitches(ids)
+        val splits = splitService.getSplitIdsByPublication(ids).mapValues { (_, splitId) -> splitService.get(splitId) }
 
-        return PublicationDetails(
-            id = publication.id,
-            uuid = publication.uuid,
-            publicationTime = publication.publicationTime,
-            publicationUser = publication.publicationUser,
-            message = publication.message,
-            trackNumbers = publishedDirectTrackNumbers,
-            referenceLines = publishedReferenceLines,
-            locationTracks = publishedDirectTracks,
-            switches = publishedDirectSwitches,
-            kmPosts = publishedKmPosts,
-            ratkoPushStatus = ratkoStatus?.status,
-            ratkoPushTime = ratkoStatus?.endTime,
-            indirectChanges =
-                PublishedIndirectChanges(
-                    trackNumbers = publishedIndirectTrackNumbers,
-                    locationTracks = publishedIndirectTracks,
-                    switches = publishedIndirectSwitches,
-                ),
-            split = split?.let(::SplitHeader),
-            layoutBranch = publication.layoutBranch,
-            cause = publication.cause,
-        )
+        return ids.associateWith { id ->
+            val publication = publications.getValue(id)
+            val referenceLines = publishedReferenceLines[id] ?: listOf()
+            val kmPosts = publishedKmPosts[id] ?: listOf()
+            val (directTrackNumbers, indirectTrackNumbers) =
+                publishedTrackNumbers[id] ?: PublishedItemListing(listOf(), listOf())
+            val (directLocationTracks, indirectLocationTracks) =
+                publishedLocationTracks[id] ?: PublishedItemListing(listOf(), listOf())
+            val (directSwitches, indirectSwitches) = publishedSwitches[id] ?: PublishedItemListing(listOf(), listOf())
+            val ratkoStatus = ratkoStatuses[id]
+            val split = splits[id]
+
+            PublicationDetails(
+                id = publication.id,
+                uuid = publication.uuid,
+                publicationTime = publication.publicationTime,
+                publicationUser = publication.publicationUser,
+                message = publication.message,
+                trackNumbers = directTrackNumbers,
+                referenceLines = referenceLines,
+                locationTracks = directLocationTracks,
+                switches = directSwitches,
+                kmPosts = kmPosts,
+                ratkoPushStatus = ratkoStatus?.status,
+                ratkoPushTime = ratkoStatus?.endTime,
+                indirectChanges =
+                    PublishedIndirectChanges(
+                        trackNumbers = indirectTrackNumbers,
+                        locationTracks = indirectLocationTracks,
+                        switches = indirectSwitches,
+                    ),
+                split = split?.let(::SplitHeader),
+                layoutBranch = publication.layoutBranch,
+                cause = publication.cause,
+            )
+        }
     }
+
+    @Transactional(readOnly = true)
+    fun getPublicationDetails(id: IntId<Publication>): PublicationDetails =
+        getPublicationDetails(setOf(id)).getValue(id)
 
     @Transactional(readOnly = true)
     fun getPublicationDetailsAsTableItems(
@@ -124,6 +144,7 @@ constructor(
             mapToPublicationTableItems(
                 translation,
                 publication,
+                specificObjectId = null,
                 publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(publication.id),
                 previousPublication?.key ?: publication.publicationTime.minusMillis(1),
                 { trackNumberId: IntId<LayoutTrackNumber>, timestamp: Instant ->
@@ -144,7 +165,10 @@ constructor(
         from: Instant? = null,
         to: Instant? = null,
     ): List<PublicationDetails> {
-        return publicationDao.fetchPublicationsBetween(layoutBranch, from, to).map { getPublicationDetails(it.id) }
+        val publications = publicationDao.fetchPublicationsBetween(layoutBranch, from, to)
+        val ids = publications.map { it.id }
+        val details = getPublicationDetails(ids.toSet())
+        return ids.map(details::getValue)
     }
 
     @Transactional(readOnly = true)
@@ -158,12 +182,14 @@ constructor(
         layoutBranch: LayoutBranch,
         from: Instant? = null,
         to: Instant? = null,
+        specificId: PublishableObjectIdAndType? = null,
         sortBy: PublicationTableColumn? = null,
         order: SortOrder? = null,
         translation: Translation,
     ): List<PublicationTableItem> {
         val switchLinkChanges =
-            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(null, layoutBranch, from, to)
+            if (specificId != null && specificId !is LocationTrackIdAndType) mapOf() else
+            publicationDao.fetchPublicationLocationTrackSwitchLinkChanges(null, layoutBranch, from, to, specificId)
 
         return fetchPublicationDetailsBetweenInstants(layoutBranch, from, to)
             .sortedBy { it.publicationTime }
@@ -188,6 +214,7 @@ constructor(
                         mapToPublicationTableItems(
                             translation,
                             publicationDetails,
+                            specificObjectId = specificId,
                             switchLinkChanges[publicationDetails.id] ?: mapOf(),
                             timeDiff,
                             getGeocodingContextOrNull,
@@ -217,7 +244,8 @@ constructor(
                     }
                 val targetLocationTracks =
                     publicationDao
-                        .fetchPublishedLocationTracks(id)
+                        .fetchPublishedLocationTracks(setOf(id))
+                        .getOrDefault(id, PublishedItemListing(listOf(), listOf()))
                         .let { changes -> (changes.indirectChanges + changes.directChanges).map { c -> c.version } }
                         .distinct()
                         .mapNotNull { v ->
@@ -748,201 +776,260 @@ constructor(
     private fun mapToPublicationTableItems(
         translation: Translation,
         publication: PublicationDetails,
+        specificObjectId: PublishableObjectIdAndType?,
         switchLinkChanges: Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>,
         previousComparisonTime: Instant,
         geocodingContextGetter: (IntId<LayoutTrackNumber>, Instant) -> GeocodingContext<ReferenceLineM>?,
         trackNumberNamesCache: List<TrackNumberAndChangeTime> = trackNumberDao.fetchTrackNumberNames(),
     ): List<PublicationTableItem> {
-        val publicationLocationTrackChanges = publicationDao.fetchPublicationLocationTrackChanges(publication.id)
+        publication.locationTracks
+        val publicationLocationTrackChanges =
+            if (
+                specificObjectId != null &&
+                    (specificObjectId !is LocationTrackIdAndType ||
+                        publication.allPublishedLocationTracks.none { it.id == specificObjectId.id })
+            ) {
+                mapOf()
+            } else publicationDao.fetchPublicationLocationTrackChanges(publication.id)
         val publicationTrackNumberChanges =
-            publicationDao.fetchPublicationTrackNumberChanges(
-                publication.layoutBranch.branch,
-                publication.id,
-                previousComparisonTime,
+            if (
+                specificObjectId != null &&
+                    (specificObjectId !is TrackNumberIdAndType ||
+                        (publication.allPublishedTrackNumbers.none { it.id == specificObjectId.id }))
+            ) {
+                mapOf()
+            } else
+                publicationDao.fetchPublicationTrackNumberChanges(
+                    publication.layoutBranch.branch,
+                    publication.id,
+                    previousComparisonTime,
+                )
+        val publicationKmPostChanges =
+            if (
+                specificObjectId != null &&
+                    (specificObjectId !is KmPostIdAndType || publication.kmPosts.none { it.id == specificObjectId.id })
             )
-        val publicationKmPostChanges = publicationDao.fetchPublicationKmPostChanges(publication.id)
-        val publicationReferenceLineChanges = publicationDao.fetchPublicationReferenceLineChanges(publication.id)
-        val publicationSwitchChanges = publicationDao.fetchPublicationSwitchChanges(publication.id)
+                mapOf()
+            else publicationDao.fetchPublicationKmPostChanges(publication.id)
+
+        val publicationReferenceLineChanges =
+            if (
+                specificObjectId != null &&
+                    (specificObjectId !is ReferenceLineIdAndType ||
+                        publication.referenceLines.none { it.id == specificObjectId.id })
+            )
+                mapOf()
+            else publicationDao.fetchPublicationReferenceLineChanges(publication.id)
+        val publicationSwitchChanges =
+            if (
+                specificObjectId != null &&
+                    (specificObjectId !is SwitchIdAndType ||
+                        publication.allPublishedSwitches.none { it.id == specificObjectId.id })
+            )
+                mapOf()
+            else publicationDao.fetchPublicationSwitchChanges(publication.id)
 
         val trackNumbers =
-            publication.trackNumbers.map { tn ->
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.track-number-long")} ${tn.number}",
-                    trackNumbers = setOf(tn.number),
-                    changedKmNumbers = tn.changedKmNumbers,
-                    operation = tn.operation,
-                    publication = publication,
-                    propChanges =
-                        diffTrackNumber(
-                            translation,
-                            publicationTrackNumberChanges.getOrElse(tn.id) {
-                                error("Track number changes not found: id=${tn.id} version=${tn.version}")
-                            },
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            geocodingContextGetter,
-                        ),
-                )
-            }
+            publication.trackNumbers
+                .filter { tn -> specificObjectId == null || specificObjectId.isTrackNumber(tn.id) }
+                .map { tn ->
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.track-number-long")} ${tn.number}",
+                        trackNumbers = setOf(tn.number),
+                        changedKmNumbers = tn.changedKmNumbers,
+                        operation = tn.operation,
+                        publication = publication,
+                        propChanges =
+                            diffTrackNumber(
+                                translation,
+                                publicationTrackNumberChanges.getOrElse(tn.id) {
+                                    error("Track number changes not found: id=${tn.id} version=${tn.version}")
+                                },
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                geocodingContextGetter,
+                            ),
+                    )
+                }
 
         val referenceLines =
-            publication.referenceLines.map { rl ->
-                val tn =
-                    trackNumberNamesCache
-                        .findLast { it.id == rl.trackNumberId && it.changeTime <= publication.publicationTime }
-                        ?.number
+            publication.referenceLines
+                .filter { rl -> specificObjectId == null || specificObjectId.isReferenceLine(rl.id) }
+                .map { rl ->
+                    val tn =
+                        trackNumberNamesCache
+                            .findLast { it.id == rl.trackNumberId && it.changeTime <= publication.publicationTime }
+                            ?.number
 
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.reference-line")} $tn",
-                    trackNumbers = setOfNotNull(tn),
-                    changedKmNumbers = rl.changedKmNumbers,
-                    operation = rl.operation,
-                    publication = publication,
-                    propChanges =
-                        diffReferenceLine(
-                            translation,
-                            publicationReferenceLineChanges.getOrElse(rl.id) {
-                                error("Reference line changes not found: id=${rl.id} version=${rl.version}")
-                            },
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            rl.changedKmNumbers,
-                            geocodingContextGetter,
-                        ),
-                )
-            }
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.reference-line")} $tn",
+                        trackNumbers = setOfNotNull(tn),
+                        changedKmNumbers = rl.changedKmNumbers,
+                        operation = rl.operation,
+                        publication = publication,
+                        propChanges =
+                            diffReferenceLine(
+                                translation,
+                                publicationReferenceLineChanges.getOrElse(rl.id) {
+                                    error("Reference line changes not found: id=${rl.id} version=${rl.version}")
+                                },
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                rl.changedKmNumbers,
+                                geocodingContextGetter,
+                            ),
+                    )
+                }
 
         val locationTracks =
-            publication.locationTracks.map { lt ->
-                val trackNumber =
-                    trackNumberNamesCache
-                        .findLast { it.id == lt.trackNumberId && it.changeTime <= publication.publicationTime }
-                        ?.number
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.location-track")} ${lt.name}",
-                    trackNumbers = setOfNotNull(trackNumber),
-                    changedKmNumbers = lt.changedKmNumbers,
-                    operation = lt.operation,
-                    publication = publication,
-                    propChanges =
-                        diffLocationTrack(
-                            translation,
-                            publicationLocationTrackChanges.getOrElse(lt.id) {
-                                error("Location track changes not found: id=${lt.id} version=${lt.version}")
-                            },
-                            switchLinkChanges[lt.id],
-                            publication.layoutBranch.branch,
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            trackNumberNamesCache,
-                            lt.changedKmNumbers,
-                            geocodingContextGetter,
-                        ),
-                )
-            }
+            publication.locationTracks
+                .filter { lt -> specificObjectId == null || specificObjectId.isLocationTrack(lt.id) }
+                .map { lt ->
+                    val trackNumber =
+                        trackNumberNamesCache
+                            .findLast { it.id == lt.trackNumberId && it.changeTime <= publication.publicationTime }
+                            ?.number
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.location-track")} ${lt.name}",
+                        trackNumbers = setOfNotNull(trackNumber),
+                        changedKmNumbers = lt.changedKmNumbers,
+                        operation = lt.operation,
+                        publication = publication,
+                        propChanges =
+                            diffLocationTrack(
+                                translation,
+                                publicationLocationTrackChanges.getOrElse(lt.id) {
+                                    error("Location track changes not found: id=${lt.id} version=${lt.version}")
+                                },
+                                switchLinkChanges[lt.id],
+                                publication.layoutBranch.branch,
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                trackNumberNamesCache,
+                                lt.changedKmNumbers,
+                                geocodingContextGetter,
+                            ),
+                    )
+                }
 
         val switches =
-            publication.switches.map { s ->
-                val tns =
-                    latestTrackNumberNamesAtMoment(trackNumberNamesCache, s.trackNumberIds, publication.publicationTime)
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.switch")} ${s.name}",
-                    trackNumbers = tns,
-                    operation = s.operation,
-                    publication = publication,
-                    propChanges =
-                        diffSwitch(
-                            translation,
-                            publicationSwitchChanges.getOrElse(s.id) {
-                                error("Switch changes not found: id=${s.id} version=${s.version}")
-                            },
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            s.operation,
+            publication.switches
+                .filter { sw -> specificObjectId == null || specificObjectId.isSwitch(sw.id) }
+                .map { s ->
+                    val tns =
+                        latestTrackNumberNamesAtMoment(
                             trackNumberNamesCache,
-                            geocodingContextGetter,
-                        ),
-                )
-            }
+                            s.trackNumberIds,
+                            publication.publicationTime,
+                        )
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.switch")} ${s.name}",
+                        trackNumbers = tns,
+                        operation = s.operation,
+                        publication = publication,
+                        propChanges =
+                            diffSwitch(
+                                translation,
+                                publicationSwitchChanges.getOrElse(s.id) {
+                                    error("Switch changes not found: id=${s.id} version=${s.version}")
+                                },
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                s.operation,
+                                trackNumberNamesCache,
+                                geocodingContextGetter,
+                            ),
+                    )
+                }
 
         val kmPosts =
-            publication.kmPosts.map { kp ->
-                val tn =
-                    trackNumberNamesCache
-                        .findLast { it.id == kp.trackNumberId && it.changeTime <= publication.publicationTime }
-                        ?.number
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.km-post")} ${kp.kmNumber}",
-                    trackNumbers = setOfNotNull(tn),
-                    operation = kp.operation,
-                    publication = publication,
-                    propChanges =
-                        diffKmPost(
-                            translation,
-                            publicationKmPostChanges.getOrElse(kp.id) {
-                                error("KM Post changes not found: id=${kp.id} version=${kp.version}")
-                            },
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            trackNumberNamesCache,
-                            geocodingContextGetter,
-                            crsNameGetter = { srid -> geographyService.getCoordinateSystem(srid).name.toString() },
-                        ),
-                )
-            }
+            publication.kmPosts
+                .filter { kp -> specificObjectId == null || specificObjectId.isKmPost(kp.id) }
+                .map { kp ->
+                    val tn =
+                        trackNumberNamesCache
+                            .findLast { it.id == kp.trackNumberId && it.changeTime <= publication.publicationTime }
+                            ?.number
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.km-post")} ${kp.kmNumber}",
+                        trackNumbers = setOfNotNull(tn),
+                        operation = kp.operation,
+                        publication = publication,
+                        propChanges =
+                            diffKmPost(
+                                translation,
+                                publicationKmPostChanges.getOrElse(kp.id) {
+                                    error("KM Post changes not found: id=${kp.id} version=${kp.version}")
+                                },
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                trackNumberNamesCache,
+                                geocodingContextGetter,
+                                crsNameGetter = { srid -> geographyService.getCoordinateSystem(srid).name.toString() },
+                            ),
+                    )
+                }
 
         val calculatedLocationTracks =
-            publication.indirectChanges.locationTracks.map { lt ->
-                val tn =
-                    trackNumberNamesCache
-                        .findLast { it.id == lt.trackNumberId && it.changeTime <= publication.publicationTime }
-                        ?.number
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.location-track")} ${lt.name}",
-                    trackNumbers = setOfNotNull(tn),
-                    changedKmNumbers = lt.changedKmNumbers,
-                    operation = Operation.CALCULATED,
-                    publication = publication,
-                    propChanges =
-                        diffLocationTrack(
-                            translation,
-                            publicationLocationTrackChanges.getOrElse(lt.id) {
-                                error("Location track changes not found: id=${lt.id} version=${lt.version}")
-                            },
-                            switchLinkChanges[lt.id],
-                            publication.layoutBranch.branch,
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            trackNumberNamesCache,
-                            lt.changedKmNumbers,
-                            geocodingContextGetter,
-                        ),
-                )
-            }
+            publication.indirectChanges.locationTracks
+                .filter { lt -> specificObjectId == null || specificObjectId.isLocationTrack(lt.id) }
+                .map { lt ->
+                    val tn =
+                        trackNumberNamesCache
+                            .findLast { it.id == lt.trackNumberId && it.changeTime <= publication.publicationTime }
+                            ?.number
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.location-track")} ${lt.name}",
+                        trackNumbers = setOfNotNull(tn),
+                        changedKmNumbers = lt.changedKmNumbers,
+                        operation = Operation.CALCULATED,
+                        publication = publication,
+                        propChanges =
+                            diffLocationTrack(
+                                translation,
+                                publicationLocationTrackChanges.getOrElse(lt.id) {
+                                    error("Location track changes not found: id=${lt.id} version=${lt.version}")
+                                },
+                                switchLinkChanges[lt.id],
+                                publication.layoutBranch.branch,
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                trackNumberNamesCache,
+                                lt.changedKmNumbers,
+                                geocodingContextGetter,
+                            ),
+                    )
+                }
 
         val calculatedSwitches =
-            publication.indirectChanges.switches.map { s ->
-                val tns =
-                    latestTrackNumberNamesAtMoment(trackNumberNamesCache, s.trackNumberIds, publication.publicationTime)
-                mapToPublicationTableItem(
-                    name = "${translation.t("publication-table.switch")} ${s.name}",
-                    trackNumbers = tns,
-                    operation = Operation.CALCULATED,
-                    publication = publication,
-                    propChanges =
-                        diffSwitch(
-                            translation,
-                            publicationSwitchChanges.getOrElse(s.id) {
-                                error("Switch changes not found: id=${s.id} version=${s.version}")
-                            },
-                            publication.publicationTime,
-                            previousComparisonTime,
-                            Operation.CALCULATED,
+            publication.indirectChanges.switches
+                .filter { s -> specificObjectId == null || specificObjectId.isSwitch(s.id) }
+                .map { s ->
+                    val tns =
+                        latestTrackNumberNamesAtMoment(
                             trackNumberNamesCache,
-                            geocodingContextGetter,
-                        ),
-                )
-            }
+                            s.trackNumberIds,
+                            publication.publicationTime,
+                        )
+                    mapToPublicationTableItem(
+                        name = "${translation.t("publication-table.switch")} ${s.name}",
+                        trackNumbers = tns,
+                        operation = Operation.CALCULATED,
+                        publication = publication,
+                        propChanges =
+                            diffSwitch(
+                                translation,
+                                publicationSwitchChanges.getOrElse(s.id) {
+                                    error("Switch changes not found: id=${s.id} version=${s.version}")
+                                },
+                                publication.publicationTime,
+                                previousComparisonTime,
+                                Operation.CALCULATED,
+                                trackNumberNamesCache,
+                                geocodingContextGetter,
+                            ),
+                    )
+                }
 
         return listOf(
                 trackNumbers,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -203,7 +203,11 @@ class SplitService(
     }
 
     fun getSplitIdByPublicationId(publicationId: IntId<Publication>): IntId<Split>? {
-        return splitDao.fetchSplitIdByPublication(publicationId)
+        return splitDao.fetchSplitIdsByPublication(setOf(publicationId))[publicationId]
+    }
+
+    fun getSplitIdsByPublication(publicationIds: Set<IntId<Publication>>): Map<IntId<Publication>, IntId<Split>> {
+        return splitDao.fetchSplitIdsByPublication(publicationIds)
     }
 
     fun get(splitId: IntId<Split>): Split? {

--- a/infra/src/main/resources/db/migration/repeatable/R__03.08_layout_switch_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.08_layout_switch_change_view.sql
@@ -10,8 +10,16 @@ select
   switch_version.state_category,
   switch_version.version,
   switch_version.change_user,
-  lag(switch_version.state_category)
-      over (partition by switch_version.id, design_id order by switch_version.version) as old_state_category
+  old.state_category as old_state_category
   from layout.switch_version
+    left join lateral (
+    select state_category
+      from layout.switch_version old
+      where old.id = switch_version.id
+        and old.layout_context_id = switch_version.layout_context_id
+        and old.version < switch_version.version
+      order by old.version desc
+      limit 1
+    ) old on (true)
   where not draft
 );

--- a/infra/src/main/resources/db/migration/repeatable/R__03.09_layout_km_post_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.09_layout_km_post_change_view.sql
@@ -11,8 +11,16 @@ select
   km_post_version.state,
   km_post_version.version,
   km_number,
-  lag(km_post_version.state)
-      over (partition by km_post_version.id, design_id order by km_post_version.version) as old_state
+  old.state as old_state
   from layout.km_post_version
+    left join lateral (
+    select state
+      from layout.km_post_version old
+      where old.id = km_post_version.id
+        and old.layout_context_id = km_post_version.layout_context_id
+        and old.version < km_post_version.version
+      order by old.version desc
+      limit 1
+    ) old on (true)
   where not draft
 );

--- a/infra/src/main/resources/db/migration/repeatable/R__03.10_layout_track_number_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.10_layout_track_number_change_view.sql
@@ -10,8 +10,16 @@ select
   track_number_version.change_user,
   track_number_version.state,
   track_number_version.version,
-  lag(track_number_version.state)
-      over (partition by track_number_version.id, design_id order by track_number_version.version) old_state
+  old.state as old_state
   from layout.track_number_version
+    left join lateral (
+      select state
+      from layout.track_number_version old
+      where old.id = track_number_version.id
+        and old.layout_context_id = track_number_version.layout_context_id
+        and old.version < track_number_version.version
+      order by old.version desc
+      limit 1
+    ) old on (true)
   where not draft
 );

--- a/infra/src/main/resources/db/migration/repeatable/R__03.11_layout_location_track_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.11_layout_location_track_change_view.sql
@@ -12,8 +12,16 @@ select
   location_track_version.state,
   location_track_version.change_user,
   location_track_version.version,
-  lag(location_track_version.state)
-      over (partition by location_track_version.id, design_id order by location_track_version.version) old_state
+  old.state as old_state
   from layout.location_track_version
+    left join lateral (
+      select state
+      from layout.location_track_version old
+      where old.id = location_track_version.id
+        and old.layout_context_id = location_track_version.layout_context_id
+        and old.version < location_track_version.version
+      order by old.version desc
+      limit 1
+      ) old on (true)
   where not draft
 );

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -925,7 +925,8 @@
         "oid": {
             "copy-success": "OID {{oid}} kopioitu leikepöydälle",
             "copy-failed": "OID:n kopiointi leikepöydälle epäonnistui"
-        }
+        },
+        "show-in-publication-log": "Avaa julkaisuloki"
     },
     "data-products": {
         "search": {
@@ -1814,6 +1815,8 @@
         "breadcrumbs-text": "Julkaisuloki",
         "start-date": "Alkupvm.",
         "end-date": "Loppupvm.",
+        "specific-object": "Muutoskohde",
+        "search-specific-object": "Hae...",
         "export-csv": "Lataa CSV",
         "end-before-start": "Loppupäivämäärä on ennen alkupäivämäärää",
         "search-range-too-long": "Hakuaikaväli on liian pitkä. Lyhennä hakuaikaväliä alle {{maxDays}} päivän mittaiseksi."

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -147,7 +147,8 @@ constructor(
         assertTrue(lastPush < publicationMoment)
 
         val publications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, lastPush, null)
-        val (publishedLocationTracks, _) = publicationDao.fetchPublishedLocationTracks(publications[1].id)
+        val (publishedLocationTracks, _) =
+            publicationDao.fetchPublishedLocationTracks(setOf(publications[1].id)).getValue(publications[1].id)
 
         assertEquals(publicationId, publications[1].id)
         assertEquals(locationTrackId, publishedLocationTracks[0].id)
@@ -172,7 +173,8 @@ constructor(
         val latestPushedPublish = ratkoPushDao.getLatestPushedPublicationMoment(LayoutBranch.main)
         assertTrue(latestPushedPublish < publicationMoment)
         val publications = publicationDao.fetchPublicationsBetween(LayoutBranch.main, latestPushedPublish, null)
-        val (publishedLocationTracks, _) = publicationDao.fetchPublishedLocationTracks(publications[1].id)
+        val (publishedLocationTracks, _) =
+            publicationDao.fetchPublishedLocationTracks(setOf(publications[1].id)).getValue(publications[1].id)
 
         assertEquals(2, publications.size)
         assertEquals(publicationId, publications[1].id)
@@ -194,8 +196,10 @@ constructor(
         assertNotNull(fetchedLayoutPublish)
         assertNotNull(fetchedLayoutPublish2)
 
-        val (publishLocationTracks, _) = publicationDao.fetchPublishedLocationTracks(fetchedLayoutPublish.id)
-        val (publish2LocationTracks, _) = publicationDao.fetchPublishedLocationTracks(fetchedLayoutPublish2.id)
+        val (publishLocationTracks, _) =
+            publicationDao.fetchPublishedLocationTracks(setOf(fetchedLayoutPublish.id)).getValue(fetchedLayoutPublish.id)
+        val (publish2LocationTracks, _) =
+            publicationDao.fetchPublishedLocationTracks(setOf(fetchedLayoutPublish2.id)).getValue(fetchedLayoutPublish2.id)
 
         assertEquals(1, publishLocationTracks.size)
         assertEquals(1, publish2LocationTracks.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -260,9 +260,12 @@ constructor(
             ),
         )
 
-        val publishedTrackNumbers = publicationDao.fetchPublishedTrackNumbers(publicationId)
-        val publishedLocationTracks = publicationDao.fetchPublishedLocationTracks(publicationId)
-        val publishedSwitches = publicationDao.fetchPublishedSwitches(publicationId)
+        val publishedTrackNumbers =
+            publicationDao.fetchPublishedTrackNumbers(setOf(publicationId)).getValue(publicationId)
+        val publishedLocationTracks =
+            publicationDao.fetchPublishedLocationTracks(setOf(publicationId)).getValue(publicationId)
+        val publishedSwitches =
+            publicationDao.fetchPublishedSwitches(setOf(publicationId)).getValue(publicationId)
         assertTrue(publishedTrackNumbers.directChanges.all { it.id == trackNumberId })
         assertEquals(
             changes.directChanges.trackNumberChanges.flatMap { it.changedKmNumbers }.sorted(),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1441,7 +1441,7 @@ constructor(
             publicationTestSupportService
                 .publishAndVerify(designBranch, publicationRequestIds(switches = listOf(switch)))
                 .publicationId!!
-        val changes = publicationDao.fetchPublishedSwitches(publicationId)
+        val changes = publicationDao.fetchPublishedSwitches(setOf(publicationId)).getValue(publicationId)
         assertEquals(setOf(trackNumber), changes.directChanges[0].trackNumberIds)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -92,7 +92,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
 
         assertEquals(BulkTransferState.FAILED, updatedSplit.bulkTransferState)
         assertEquals(publicationId, updatedSplit.publicationId)
-        assertEquals(split.id, splitDao.fetchSplitIdByPublication(publicationId))
+        assertEquals(split.id, splitDao.fetchSplitIdsByPublication(setOf(publicationId)).getValue(publicationId))
     }
 
     @Test

--- a/ui/src/map/plan-download/plan-download-area-section.tsx
+++ b/ui/src/map/plan-download/plan-download-area-section.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from 'react-i18next';
 import {
     LocationTrackItemValue,
     SearchDropdown,
-    SearchItemType,
     SearchItemValue,
-    SearchType,
+    SearchItemType,
     TrackNumberItemValue,
 } from 'tool-bar/search-dropdown';
 import { LayoutContext, officialMainLayoutContext } from 'common/common-model';
@@ -36,7 +35,7 @@ import { getKmPostsOnTrackNumber } from 'track-layout/layout-km-post-api';
 import { Dropdown } from 'vayla-design-lib/dropdown/dropdown';
 
 type AreaSelectionType = 'TRACK_METERS' | 'MAINTENANCE_AREA' | 'MAP_AREA';
-const ASSET_SEARCH_TYPES = [SearchType.TRACK_NUMBER, SearchType.LOCATION_TRACK];
+const ASSET_SEARCH_TYPES = [SearchItemType.TRACK_NUMBER, SearchItemType.LOCATION_TRACK];
 
 const inferDropdownItemValue = (
     downloadAsset: PlanDownloadAsset | undefined,
@@ -95,7 +94,7 @@ export const PlanDownloadAreaSection: React.FC<{
                 : [];
             const startKm = selectedAsset?.startAndEnd?.start?.address?.kmNumber;
             const endKm = selectedAsset?.startAndEnd?.end?.address?.kmNumber;
-            
+
             return startKm && endKm
                 ? kmPosts.filter((kmPost) => kmPost.kmNumber >= startKm && kmPost.kmNumber <= endKm)
                 : kmPosts;
@@ -116,7 +115,7 @@ export const PlanDownloadAreaSection: React.FC<{
         });
     };
 
-    const onItemSelected = (item: SearchItemValue) => {
+    const onItemSelected = (item: SearchItemValue<SearchItemType>) => {
         switch (item.type) {
             case SearchItemType.TRACK_NUMBER:
                 return updateProp('asset', {
@@ -149,7 +148,7 @@ export const PlanDownloadAreaSection: React.FC<{
 
     const selectedDropdownValue = inferDropdownItemValue(selectedAsset);
 
-    const getName = (item: SearchItemValue) => {
+    const getName = (item: SearchItemValue<SearchItemType>) => {
         switch (item.type) {
             case SearchItemType.TRACK_NUMBER:
                 return item.trackNumber.number;

--- a/ui/src/publication/log/publication-log.scss
+++ b/ui/src/publication/log/publication-log.scss
@@ -18,7 +18,7 @@
 
     &__actions {
         display: grid;
-        grid-template-columns: max-content max-content auto;
+        grid-template-columns: max-content max-content max-content auto;
         gap: 12px;
     }
 

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -13,6 +13,7 @@ import {
     getPublicationsAsTableItems,
     getPublicationsCsvUri,
     MAX_RETURNED_PUBLICATION_LOG_ROWS,
+    PublishableObjectIdAndType,
 } from 'publication/publication-api';
 import PublicationTable from 'publication/table/publication-table';
 import { Button } from 'vayla-design-lib/button/button';
@@ -37,12 +38,16 @@ import { debounceAsync } from 'utils/async-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { SortDirection } from 'utils/table-utils';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
+import { SearchDropdown, SearchItemType, SearchItemValue } from 'tool-bar/search-dropdown';
+import { officialMainLayoutContext } from 'common/common-model';
+import { DropdownSize } from 'vayla-design-lib/dropdown/dropdown';
 
 const MAX_SEARCH_DAYS = 180;
 
 type TableFetchFn = (
     from?: Date,
     to?: Date,
+    specificItem?: PublishableObjectIdAndType,
     sortBy?: PublicationDetailsTableSortField,
     order?: SortDirection,
 ) => Promise<Page<PublicationTableItem>>;
@@ -107,6 +112,39 @@ const PublicationLogTableHeading: React.FC<PublicationLogTableHeadingProps> = ({
     );
 };
 
+export type SearchablePublicationLogItem =
+    | SearchItemType.LOCATION_TRACK
+    | SearchItemType.TRACK_NUMBER
+    | SearchItemType.SWITCH;
+
+function searchableItemIdAndType(
+    item: SearchItemValue<SearchablePublicationLogItem>,
+): PublishableObjectIdAndType {
+    switch (item.type) {
+        case SearchItemType.LOCATION_TRACK:
+            return { type: item.type, id: item.locationTrack.id };
+        case SearchItemType.TRACK_NUMBER:
+            return { type: item.type, id: item.trackNumber.id };
+        case SearchItemType.SWITCH:
+            return { type: item.type, id: item.layoutSwitch.id };
+        default:
+            return exhaustiveMatchingGuard(item);
+    }
+}
+
+function getSearchableItemName(item: SearchItemValue<SearchablePublicationLogItem>): string {
+    switch (item.type) {
+        case SearchItemType.LOCATION_TRACK:
+            return item.locationTrack.name;
+        case SearchItemType.TRACK_NUMBER:
+            return item.trackNumber.number;
+        case SearchItemType.SWITCH:
+            return item.layoutSwitch.name;
+        default:
+            return exhaustiveMatchingGuard(item);
+    }
+}
+
 const PublicationLog: React.FC = () => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
@@ -122,6 +160,7 @@ const PublicationLog: React.FC = () => {
 
     const storedStartDate = parseISOOrUndefined(selectedPublicationSearch?.startDate);
     const storedEndDate = parseISOOrUndefined(selectedPublicationSearch?.endDate);
+    const storedSpecificItem = selectedPublicationSearch?.specificItem;
 
     const [sortInfo, setSortInfo] =
         React.useState<PublicationDetailsTableSortInformation>(InitiallyUnsorted);
@@ -136,6 +175,7 @@ const PublicationLog: React.FC = () => {
         updatePublicationsTable(
             storedStartDate ?? parseISOOrUndefined(defaultPublicationSearch.startDate),
             storedEndDate ?? parseISOOrUndefined(defaultPublicationSearch.endDate),
+            storedSpecificItem,
             sortInfo,
             getPublicationsAsTableItems,
         );
@@ -146,12 +186,26 @@ const PublicationLog: React.FC = () => {
             updatePublicationsTable(
                 storedStartDate,
                 storedEndDate,
+                storedSpecificItem,
                 updatedSort,
                 publicationTableFetchFunctionByChangeMethod('SORTING_CHANGED'),
             ).then(() => setSortInfo(updatedSort));
         } else {
             setSortInfo(updatedSort);
         }
+    };
+
+    const setSpecificItem = (
+        newSpecificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
+    ) => {
+        trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem(newSpecificItem);
+        updatePublicationsTable(
+            storedStartDate,
+            storedEndDate,
+            newSpecificItem,
+            sortInfo,
+            publicationTableFetchFunctionByChangeMethod('PICKER'),
+        );
     };
 
     const setStartDate = (newStartDate: Date | undefined, source: DataSourceChangeMethod) => {
@@ -161,6 +215,7 @@ const PublicationLog: React.FC = () => {
         updatePublicationsTable(
             newStartDate,
             storedEndDate,
+            storedSpecificItem,
             sortInfo,
             publicationTableFetchFunctionByChangeMethod(source),
         );
@@ -171,21 +226,25 @@ const PublicationLog: React.FC = () => {
         updatePublicationsTable(
             storedStartDate,
             newEndDate,
+            storedSpecificItem,
             sortInfo,
             publicationTableFetchFunctionByChangeMethod(source),
         );
     };
 
     const isValidPublicationLogSearchRange = (
+        specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
         start: Date | undefined,
         end: Date | undefined,
     ): boolean => {
         return (
-            start !== undefined && end !== undefined && daysBetween(start, end) < MAX_SEARCH_DAYS
+            specificItem !== undefined || // go nuts with single-item searches, they're cheap
+            (start !== undefined && end !== undefined && daysBetween(start, end) < MAX_SEARCH_DAYS)
         );
     };
 
     const isStoredSearchRangeValid = isValidPublicationLogSearchRange(
+        storedSpecificItem,
         storedStartDate,
         storedEndDate,
     );
@@ -193,10 +252,11 @@ const PublicationLog: React.FC = () => {
     const updatePublicationsTable = (
         startDate: Date | undefined,
         endDate: Date | undefined,
+        specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
         sortInfo: PublicationDetailsTableSortInformation,
         fetchFn: TableFetchFn,
     ): Promise<Page<PublicationTableItem> | undefined> => {
-        if (!isValidPublicationLogSearchRange(startDate, endDate)) {
+        if (!isValidPublicationLogSearchRange(specificItem, startDate, endDate)) {
             clearPublicationsTable();
             return Promise.resolve(undefined);
         }
@@ -207,6 +267,7 @@ const PublicationLog: React.FC = () => {
         return fetchFn(
             startDate && startOfDay(startDate),
             endDate && endOfDay(endDate),
+            specificItem === undefined ? undefined : searchableItemIdAndType(specificItem),
             sortInfo.propName,
             sortInfo.direction,
         ).then((r) => {
@@ -277,6 +338,29 @@ const PublicationLog: React.FC = () => {
                         }
                         errors={endDateErrors}
                     />
+                    <FieldLayout
+                        label={t('publication-log.specific-object')}
+                        value={
+                            <SearchDropdown
+                                layoutContext={officialMainLayoutContext()}
+                                splittingState={undefined}
+                                placeholder={t('publication-log.search-specific-object')}
+                                onItemSelected={setSpecificItem}
+                                value={storedSpecificItem}
+                                getName={getSearchableItemName}
+                                disabled={false}
+                                size={DropdownSize.MEDIUM}
+                                searchTypes={[
+                                    SearchItemType.LOCATION_TRACK,
+                                    SearchItemType.SWITCH,
+                                    SearchItemType.TRACK_NUMBER,
+                                ]}
+                                wide={false}
+                                useAnchorElementWidth={false}
+                                clearable
+                            />
+                        }
+                    />
                     <PrivilegeRequired privilege={DOWNLOAD_PUBLICATION}>
                         <div className={styles['publication-log__export_button']}>
                             <Button
@@ -293,6 +377,9 @@ const PublicationLog: React.FC = () => {
                                     (location.href = getPublicationsCsvUri(
                                         storedStartDate,
                                         storedEndDate && endOfDay(storedEndDate),
+                                        storedSpecificItem === undefined
+                                            ? undefined
+                                            : searchableItemIdAndType(storedSpecificItem),
                                         sortInfo?.propName,
                                         sortInfo?.direction,
                                     ))

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -33,6 +33,13 @@ import { SortDirection } from 'utils/table-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { createPublicationCandidateReference } from 'publication/publication-utils';
 import { DesignBranch, LayoutBranch, PublicationState } from 'common/common-model';
+import {
+    LayoutKmPostId,
+    LayoutSwitchId,
+    LayoutTrackNumberId,
+    LocationTrackId,
+    ReferenceLineId,
+} from 'track-layout/track-layout-model';
 
 const PUBLICATION_URL = `${API_URI}/publications`;
 
@@ -259,6 +266,7 @@ export const MAX_RETURNED_PUBLICATION_LOG_ROWS = 500;
 export const getPublicationsAsTableItems = (
     from?: Date,
     to?: Date,
+    specificItem?: PublishableObjectIdAndType,
     sortBy?: PublicationDetailsTableSortField,
     order?: SortDirection,
 ) => {
@@ -267,6 +275,8 @@ export const getPublicationsAsTableItems = (
     const params = queryParams({
         from: from ? from.toISOString() : undefined,
         to: to ? to.toISOString() : undefined,
+        type: specificItem ? specificItem.type : undefined,
+        id: specificItem ? specificItem.id : undefined,
         sortBy: isSorted && sortBy ? sortBy : undefined,
         order: isSorted ? order : undefined,
         lang: i18next.language,
@@ -275,9 +285,23 @@ export const getPublicationsAsTableItems = (
     return getNonNull<Page<PublicationTableItem>>(`${PUBLICATION_URL}/table-rows${params}`);
 };
 
+export type PublishableObjectIdAndType =
+    | TrackNumberIdAndType
+    | ReferenceLineIdAndType
+    | LocationTrackIdAndType
+    | SwitchIdAndType
+    | KmPostIdAndType;
+
+export type TrackNumberIdAndType = { id: LayoutTrackNumberId; type: 'TRACK_NUMBER' };
+export type ReferenceLineIdAndType = { id: ReferenceLineId; type: 'REFERENCE_LINE' };
+export type LocationTrackIdAndType = { id: LocationTrackId; type: 'LOCATION_TRACK' };
+export type SwitchIdAndType = { id: LayoutSwitchId; type: 'SWITCH' };
+export type KmPostIdAndType = { id: LayoutKmPostId; type: 'KM_POST' };
+
 export const getPublicationsCsvUri = (
     fromDate?: Date,
     toDate?: Date,
+    specificObjectId?: PublishableObjectIdAndType,
     sortBy?: PublicationDetailsTableSortField,
     order?: SortDirection,
 ): string => {
@@ -286,6 +310,8 @@ export const getPublicationsCsvUri = (
     const params = queryParams({
         from: fromDate ? fromDate.toISOString() : undefined,
         to: toDate ? toDate.toISOString() : undefined,
+        id: specificObjectId ? specificObjectId.id : undefined,
+        type: specificObjectId ? specificObjectId.type : undefined,
         sortBy: isSorted && sortBy ? sortBy : undefined,
         order: isSorted ? order : undefined,
         timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -25,6 +25,8 @@ import { BoundingBox, Point } from 'model/geometry';
 import { LocalizationParams } from 'i18n/config';
 import { SplitTargetOperation } from 'tool-panel/location-track/split-store';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { SearchItemValue } from 'tool-bar/search-dropdown';
+import { SearchablePublicationLogItem } from 'publication/log/publication-log';
 
 export type LayoutValidationIssue = {
     type: LayoutValidationIssueType;
@@ -382,6 +384,7 @@ export type PublicationTableItem = {
 export type PublicationSearch = {
     startDate: TimeStamp | undefined;
     endDate: TimeStamp | undefined;
+    specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined;
 };
 
 export type SplitInPublication = {

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -18,6 +18,7 @@ import { mapLazy } from 'utils/array-utils';
 export const defaultPublicationSearch: PublicationSearch = {
     startDate: subMonths(currentDay, 1).toISOString(),
     endDate: currentDay.toISOString(),
+    specificItem: undefined,
 };
 
 export const conditionallyUpdateCandidates = (

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -24,6 +24,8 @@ import {
 import { PublicationId, PublicationSearch } from 'publication/publication-model';
 import { defaultPublicationSearch } from 'publication/publication-utils';
 import { TimeStamp } from 'common/common-model';
+import { SearchablePublicationLogItem } from 'publication/log/publication-log';
+import { SearchItemValue } from 'tool-bar/search-dropdown';
 
 export function createEmptyItemCollections(): ItemCollections {
     return {
@@ -325,6 +327,17 @@ export const selectionReducers = {
             state.publicationSearch = defaultPublicationSearch;
         }
         state.publicationSearch.endDate = newEndDate;
+    },
+    setSelectedPublicationSearchSearchableItem: (
+        state: Selection,
+        {
+            payload: newSearchItem,
+        }: PayloadAction<SearchItemValue<SearchablePublicationLogItem> | undefined>,
+    ) => {
+        if (!state.publicationSearch) {
+            state.publicationSearch = defaultPublicationSearch;
+        }
+        state.publicationSearch.specificItem = newSearchItem;
     },
     clearPublicationSelection: (state: Selection) => {
         state.publicationId = undefined;

--- a/ui/src/tool-bar/search-dropdown.tsx
+++ b/ui/src/tool-bar/search-dropdown.tsx
@@ -14,13 +14,6 @@ import { LayoutContext } from 'common/common-model';
 import { debounceAsync } from 'utils/async-utils';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 
-export enum SearchItemType {
-    LOCATION_TRACK = 'LOCATION_TRACK',
-    SWITCH = 'SWITCH',
-    TRACK_NUMBER = 'TRACK_NUMBER',
-    OPERATING_POINT = 'OPERATING_POINT',
-}
-
 export type LocationTrackItemValue = {
     locationTrack: LayoutLocationTrack;
     type: SearchItemType.LOCATION_TRACK;
@@ -99,8 +92,8 @@ async function getOptions(
     layoutContext: LayoutContext,
     searchTerm: string,
     locationTrackSearchScope: LocationTrackId | undefined,
-    searchTypes: SearchType[],
-): Promise<Item<SearchItemValue>[]> {
+    searchTypes: SearchItemType[],
+): Promise<Item<SearchItemValue<SearchItemType>>[]> {
     if (isNilOrBlank(searchTerm) || !searchTerm.match(SEARCH_REGEX)) {
         return Promise.resolve([]);
     }
@@ -127,33 +120,42 @@ async function getOptions(
 // Use debounced function to collect keystrokes before triggering a search
 const debouncedGetOptions = debounceAsync(getOptions, 250);
 
-export type SearchItemValue =
-    | LocationTrackItemValue
-    | SwitchItemValue
-    | TrackNumberItemValue
-    | OperatingPointItemValue;
+export type SearchItemValue<SearchTypes extends SearchItemType> =
+    SearchTypes extends 'LOCATION_TRACK'
+        ? LocationTrackItemValue
+        : never | SearchTypes extends 'SWITCH'
+          ? SwitchItemValue
+          : never | SearchTypes extends 'TRACK_NUMBER'
+            ? TrackNumberItemValue
+            : never | SearchTypes extends 'OPERATING_POINT'
+              ? OperatingPointItemValue
+              : never;
 
-type SearchDropdownProps = {
+type SearchDropdownProps<SearchTypes extends SearchItemType> = {
     layoutContext: LayoutContext;
     splittingState?: SplittingState;
     placeholder: string;
     disabled?: boolean;
-    onItemSelected: (item: SearchItemValue | undefined) => void;
-    searchTypes: SearchType[];
+    onItemSelected: (item: SearchItemValue<SearchTypes> | undefined) => void;
+    searchTypes: SearchTypes[];
     onBlur?: () => void;
     hasError?: boolean;
-    value?: SearchItemValue;
-    getName?: (item: SearchItemValue) => string;
+    value?: SearchItemValue<SearchTypes>;
+    getName?: (item: SearchItemValue<SearchTypes>) => string;
+    size?: DropdownSize;
+    wide?: boolean;
+    useAnchorElementWidth?: boolean;
+    clearable?: boolean;
 };
 
-export enum SearchType {
+export enum SearchItemType {
     LOCATION_TRACK = 'LOCATION_TRACK',
     SWITCH = 'SWITCH',
     TRACK_NUMBER = 'TRACK_NUMBER',
     OPERATING_POINT = 'OPERATING_POINT',
 }
 
-export const SearchDropdown: React.FC<SearchDropdownProps> = ({
+export const SearchDropdown = <SearchTypes extends SearchItemType>({
     layoutContext,
     placeholder,
     disabled = false,
@@ -164,7 +166,11 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({
     hasError,
     value,
     getName,
-}) => {
+    size = DropdownSize.STRETCH,
+    wide = true,
+    useAnchorElementWidth,
+    clearable,
+}: SearchDropdownProps<SearchTypes>) => {
     // Use memoized function to make debouncing functionality to work when re-rendering
     const memoizedDebouncedGetOptions = React.useCallback(
         (searchTerm: string) =>
@@ -184,14 +190,16 @@ export const SearchDropdown: React.FC<SearchDropdownProps> = ({
             options={memoizedDebouncedGetOptions}
             searchable
             onChange={onItemSelected}
-            size={DropdownSize.STRETCH}
+            size={size}
             onBlur={onBlur}
             hasError={hasError}
             value={value}
             getName={getName}
             wideList
-            wide
+            wide={wide}
+            useAnchorElementWidth={useAnchorElementWidth}
             qa-id="search-box"
+            clearable={clearable}
         />
     );
 };

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -53,12 +53,7 @@ import { getLayoutDesign, updateLayoutDesign } from 'track-layout/layout-design-
 import { getChangeTimes, updateLayoutDesignChangeTime } from 'common/change-time-api';
 import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-dialog';
-import {
-    SearchDropdown,
-    SearchItemType,
-    SearchItemValue,
-    SearchType,
-} from 'tool-bar/search-dropdown';
+import { SearchDropdown, SearchItemValue, SearchItemType } from 'tool-bar/search-dropdown';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
 
 const DESIGN_SELECT_POPUP_MARGIN_WHEN_SELECTED = 6;
@@ -168,7 +163,7 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         ),
     ];
 
-    function onItemSelected(item: SearchItemValue | undefined) {
+    function onItemSelected(item: SearchItemValue<SearchItemType> | undefined) {
         if (!item) {
             return;
         }
@@ -476,10 +471,10 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                         onItemSelected={onItemSelected}
                         disabled={!canSearch}
                         searchTypes={[
-                            SearchType.LOCATION_TRACK,
-                            SearchType.SWITCH,
-                            SearchType.TRACK_NUMBER,
-                            SearchType.OPERATING_POINT,
+                            SearchItemType.LOCATION_TRACK,
+                            SearchItemType.SWITCH,
+                            SearchItemType.TRACK_NUMBER,
+                            SearchItemType.OPERATING_POINT,
                         ]}
                     />
                 </div>

--- a/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
@@ -5,25 +5,50 @@ import InfoboxField from 'tool-panel/infobox/infobox-field';
 import { formatDateShort } from 'utils/date-utils';
 import Infobox from 'tool-panel/infobox/infobox';
 import { useLocationTrackChangeTimes } from 'track-layout/track-layout-react-utils';
-import { LocationTrackId } from 'track-layout/track-layout-model';
+import { LayoutLocationTrack } from 'track-layout/track-layout-model';
 import { LayoutContext } from 'common/common-model';
-import { LocationTrackInfoboxVisibilities } from 'track-layout/track-layout-slice';
+import {
+    LocationTrackInfoboxVisibilities,
+    trackLayoutActionCreators as TrackLayoutActions,
+} from 'track-layout/track-layout-slice';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { createDelegates } from 'store/store-utils';
+import { useAppNavigate } from 'common/navigate';
+import { SearchItemType } from 'tool-bar/search-dropdown';
 
 type LocationTrackChangeInfoInfoboxProps = {
-    locationTrackId: LocationTrackId;
+    locationTrack: LayoutLocationTrack;
     layoutContext: LayoutContext;
     visibilities: LocationTrackInfoboxVisibilities;
     visibilityChange: (key: keyof LocationTrackInfoboxVisibilities) => void;
 };
 
 export const LocationTrackChangeInfoInfobox: React.FC<LocationTrackChangeInfoInfoboxProps> = ({
-    locationTrackId,
+    locationTrack,
     layoutContext,
     visibilities,
     visibilityChange,
 }) => {
     const { t } = useTranslation();
+    const locationTrackId = locationTrack.id;
     const locationTrackChangeInfo = useLocationTrackChangeTimes(locationTrackId, layoutContext);
+
+    const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
+    const navigate = useAppNavigate();
+
+    const openPublicationLog = React.useCallback(() => {
+        if (locationTrackChangeInfo?.created) {
+            delegates.setSelectedPublicationSearchStartDate(locationTrackChangeInfo.created);
+        }
+        if (locationTrackChangeInfo?.changed) {
+            delegates.setSelectedPublicationSearchEndDate(locationTrackChangeInfo.changed);
+        }
+        delegates.setSelectedPublicationSearchSearchableItem({
+            type: SearchItemType.LOCATION_TRACK,
+            locationTrack,
+        });
+        navigate('publication-search');
+    }, [locationTrack, locationTrackChangeInfo]);
 
     return (
         locationTrackChangeInfo && (
@@ -46,6 +71,14 @@ export const LocationTrackChangeInfoInfobox: React.FC<LocationTrackChangeInfoInf
                             formatDateShort(locationTrackChangeInfo.changed)
                         }
                     />
+                    <div>
+                        <Button
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
+                            onClick={openPublicationLog}>
+                            {t('tool-panel.show-in-publication-log')}
+                        </Button>
+                    </div>
                 </InfoboxContent>
             </Infobox>
         )

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -170,7 +170,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 }
             />
             <LocationTrackChangeInfoInfobox
-                locationTrackId={locationTrack.id}
+                locationTrack={locationTrack}
                 layoutContext={layoutContext}
                 visibilities={visibilities}
                 visibilityChange={visibilityChange}

--- a/ui/src/tool-panel/switch/switch-change-info-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-change-info-infobox.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import { formatDateShort } from 'utils/date-utils';
+import Infobox from 'tool-panel/infobox/infobox';
+import { useSwitchChangeTimes } from 'track-layout/track-layout-react-utils';
+import { LayoutSwitch } from 'track-layout/track-layout-model';
+import { LayoutContext } from 'common/common-model';
+import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { createDelegates } from 'store/store-utils';
+import { useAppNavigate } from 'common/navigate';
+import { SearchItemType } from 'tool-bar/search-dropdown';
+
+type SwitchChangeInfoInfoboxProps = {
+    layoutSwitch: LayoutSwitch;
+    layoutContext: LayoutContext;
+    visible: boolean;
+    visibilityChange: () => void;
+};
+
+export const SwitchChangeInfoInfobox: React.FC<SwitchChangeInfoInfoboxProps> = ({
+    layoutSwitch,
+    layoutContext,
+    visible,
+    visibilityChange,
+}) => {
+    const { t } = useTranslation();
+    const switchId = layoutSwitch.id;
+    const switchChangeInfo = useSwitchChangeTimes(switchId, layoutContext);
+
+    const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
+    const navigate = useAppNavigate();
+
+    const openPublicationLog = React.useCallback(() => {
+        if (switchChangeInfo) {
+            delegates.setSelectedPublicationSearchStartDate(switchChangeInfo.created);
+            delegates.setSelectedPublicationSearchEndDate(switchChangeInfo.changed);
+            delegates.setSelectedPublicationSearchSearchableItem({
+                type: SearchItemType.SWITCH,
+                layoutSwitch,
+            });
+            navigate('publication-search');
+        }
+    }, [layoutSwitch, switchChangeInfo]);
+
+    return (
+        switchChangeInfo && (
+            <Infobox
+                contentVisible={visible}
+                onContentVisibilityChange={visibilityChange}
+                title={t('tool-panel.switch.layout.change-info-heading')}
+                qa-id="switch-log-infobox">
+                <InfoboxContent>
+                    <InfoboxField
+                        qaId="switch-created-date"
+                        label={t('tool-panel.created')}
+                        value={formatDateShort(switchChangeInfo.created)}
+                    />
+                    <InfoboxField
+                        qaId="switch-changed-date"
+                        label={t('tool-panel.changed')}
+                        value={
+                            switchChangeInfo.changed && formatDateShort(switchChangeInfo.changed)
+                        }
+                    />
+                    <div>
+                        <Button
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
+                            onClick={openPublicationLog}>
+                            {t('tool-panel.show-in-publication-log')}
+                        </Button>
+                    </div>
+                </InfoboxContent>
+            </Infobox>
+        )
+    );
+};

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -44,16 +44,13 @@ import { getSwitch, getSwitchJointConnections } from 'track-layout/layout-switch
 import { AssetValidationInfoboxContainer } from 'tool-panel/asset-validation-infobox-container';
 import { ChangeTimes } from 'common/common-slice';
 import { SwitchInfoboxVisibilities } from 'track-layout/track-layout-slice';
-import { formatDateShort } from 'utils/date-utils';
-import {
-    refreshSwitchSelection,
-    useSwitchChangeTimes,
-} from 'track-layout/track-layout-react-utils';
+import { refreshSwitchSelection } from 'track-layout/track-layout-react-utils';
 import { OnSelectOptions, OptionalUnselectableItemCollections } from 'selection/selection-model';
 import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
 import { SwitchOid } from 'track-layout/oid';
+import { SwitchChangeInfoInfobox } from 'tool-panel/switch/switch-change-info-infobox';
 
 type SwitchInfoboxProps = {
     switchId: LayoutSwitchId;
@@ -162,7 +159,6 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
         () => getSwitchJointConnections(layoutContext, switchId),
         [layoutContext.branch, layoutContext.publicationState, layoutSwitch],
     );
-    const switchChangeTimes = useSwitchChangeTimes(layoutSwitch?.id, layoutContext);
 
     const switchJointTrackMeters = useLoader(() => {
         return switchJointConnections
@@ -396,38 +392,22 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                 </InfoboxContent>
             </Infobox>
             {layoutSwitch && (
-                <AssetValidationInfoboxContainer
-                    contentVisible={visibilities.validation}
-                    onContentVisibilityChange={() => visibilityChange('validation')}
-                    idAndType={{ id: layoutSwitch.id, type: 'SWITCH' }}
-                    layoutContext={layoutContext}
-                    changeTime={changeTimes.layoutSwitch}
-                />
+                <React.Fragment>
+                    <AssetValidationInfoboxContainer
+                        contentVisible={visibilities.validation}
+                        onContentVisibilityChange={() => visibilityChange('validation')}
+                        idAndType={{ id: layoutSwitch.id, type: 'SWITCH' }}
+                        layoutContext={layoutContext}
+                        changeTime={changeTimes.layoutSwitch}
+                    />
+                    <SwitchChangeInfoInfobox
+                        layoutSwitch={layoutSwitch}
+                        layoutContext={layoutContext}
+                        visible={visibilities.log}
+                        visibilityChange={() => visibilityChange('log')}
+                    />
+                </React.Fragment>
             )}
-            <Infobox
-                contentVisible={visibilities.log}
-                onContentVisibilityChange={() => visibilityChange('log')}
-                title={t('tool-panel.switch.layout.change-info-heading')}
-                qa-id="switch-heading-infobox">
-                <InfoboxContent>
-                    {switchChangeTimes && (
-                        <React.Fragment>
-                            <InfoboxField
-                                label={t('tool-panel.created')}
-                                value={formatDateShort(switchChangeTimes.created)}
-                            />
-                            <InfoboxField
-                                label={t('tool-panel.changed')}
-                                value={
-                                    switchChangeTimes.changed &&
-                                    formatDateShort(switchChangeTimes.changed)
-                                }
-                            />
-                        </React.Fragment>
-                    )}
-                </InfoboxContent>
-            </Infobox>
-
             {showEditDialog && (
                 <SwitchEditDialogContainer
                     switchId={layoutSwitch?.id}

--- a/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import InfoboxContent from 'tool-panel/infobox/infobox-content';
+import InfoboxField from 'tool-panel/infobox/infobox-field';
+import { formatDateShort, getMaxTimestamp, getMinTimestamp } from 'utils/date-utils';
+import Infobox from 'tool-panel/infobox/infobox';
+import {
+    useReferenceLineChangeTimes,
+    useTrackNumberChangeTimes,
+} from 'track-layout/track-layout-react-utils';
+import { LayoutReferenceLine, LayoutTrackNumber } from 'track-layout/track-layout-model';
+import { LayoutContext } from 'common/common-model';
+import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { createDelegates } from 'store/store-utils';
+import { useAppNavigate } from 'common/navigate';
+import { SearchItemType } from 'tool-bar/search-dropdown';
+
+type TrackNumberChangeInfoInfoboxProps = {
+    trackNumber: LayoutTrackNumber;
+    referenceLine: LayoutReferenceLine | undefined;
+    layoutContext: LayoutContext;
+    visible: boolean;
+    visibilityChange: () => void;
+};
+
+export const TrackNumberChangeInfoInfobox: React.FC<TrackNumberChangeInfoInfoboxProps> = ({
+    trackNumber,
+    referenceLine,
+    layoutContext,
+    visible,
+    visibilityChange,
+}) => {
+    const { t } = useTranslation();
+    const trackNumberChangeInfo = useTrackNumberChangeTimes(trackNumber.id, layoutContext);
+    const tnChangeTimes = useTrackNumberChangeTimes(trackNumber?.id, layoutContext);
+    const rlChangeTimes = useReferenceLineChangeTimes(referenceLine?.id, layoutContext);
+    const createdTime =
+        tnChangeTimes?.created && rlChangeTimes?.created
+            ? getMinTimestamp(tnChangeTimes.created, rlChangeTimes.created)
+            : tnChangeTimes?.created || rlChangeTimes?.created;
+    const changedTime =
+        tnChangeTimes?.changed && rlChangeTimes?.changed
+            ? getMaxTimestamp(tnChangeTimes.changed, rlChangeTimes.changed)
+            : tnChangeTimes?.changed || rlChangeTimes?.changed;
+
+    const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
+    const navigate = useAppNavigate();
+
+    const openPublicationLog = React.useCallback(() => {
+        console.log({ createdTime, changedTime });
+        if (createdTime) {
+            delegates.setSelectedPublicationSearchStartDate(createdTime);
+        }
+        if (changedTime) {
+            delegates.setSelectedPublicationSearchEndDate(changedTime);
+        }
+        delegates.setSelectedPublicationSearchSearchableItem({
+            type: SearchItemType.TRACK_NUMBER,
+            trackNumber,
+        });
+        navigate('publication-search');
+    }, [trackNumber, createdTime, changedTime]);
+
+    return (
+        trackNumberChangeInfo && (
+            <Infobox
+                contentVisible={visible}
+                onContentVisibilityChange={visibilityChange}
+                title={t('tool-panel.reference-line.change-info-heading')}
+                qa-id="trackNumber-log-infobox">
+                <InfoboxContent>
+                    <InfoboxField
+                        qaId="trackNumber-created-date"
+                        label={t('tool-panel.created')}
+                        value={createdTime === undefined ? '' : formatDateShort(createdTime)}
+                    />
+                    <InfoboxField
+                        qaId="TrackNumber-changed-date"
+                        label={t('tool-panel.changed')}
+                        value={changedTime === undefined ? '' : formatDateShort(changedTime)}
+                    />
+                    <div>
+                        <Button
+                            size={ButtonSize.SMALL}
+                            variant={ButtonVariant.SECONDARY}
+                            onClick={openPublicationLog}>
+                            {t('tool-panel.show-in-publication-log')}
+                        </Button>
+                    </div>
+                </InfoboxContent>
+            </Infobox>
+        )
+    );
+};

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -17,9 +17,7 @@ import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import {
     refreshTrackNumberSelection,
     useCoordinateSystem,
-    useReferenceLineChangeTimes,
     useReferenceLineStartAndEnd,
-    useTrackNumberChangeTimes,
 } from 'track-layout/track-layout-react-utils';
 import { LinkingAlignment, LinkingState, LinkingType, LinkInterval } from 'linking/linking-model';
 import { BoundingBox } from 'model/geometry';
@@ -27,7 +25,7 @@ import { updateReferenceLineGeometry } from 'linking/linking-api';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Precision, roundToPrecision } from 'utils/rounding';
-import { formatDateShort, getMaxTimestamp, getMinTimestamp } from 'utils/date-utils';
+import { getMaxTimestamp } from 'utils/date-utils';
 import { TrackNumberEditDialogContainer } from './dialog/track-number-edit-dialog';
 import { TrackNumberGeometryInfobox } from 'tool-panel/track-number/track-number-geometry-infobox';
 import { MapViewport } from 'map/map-model';
@@ -42,6 +40,7 @@ import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT, VIEW_GEOMETRY } from 'user/user-model';
 import { draftLayoutContext, LayoutContext } from 'common/common-model';
 import { TrackNumberOid } from 'track-layout/oid';
+import { TrackNumberChangeInfoInfobox } from 'tool-panel/track-number/track-number-change-info-infobox';
 
 type TrackNumberInfoboxProps = {
     trackNumber: LayoutTrackNumber;
@@ -106,16 +105,6 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
         trackNumberChangeTime,
     );
     const coordinateSystem = useCoordinateSystem(LAYOUT_SRID);
-    const tnChangeTimes = useTrackNumberChangeTimes(trackNumber?.id, layoutContext);
-    const rlChangeTimes = useReferenceLineChangeTimes(referenceLine?.id, layoutContext);
-    const createdTime =
-        tnChangeTimes?.created && rlChangeTimes?.created
-            ? getMinTimestamp(tnChangeTimes.created, rlChangeTimes.created)
-            : tnChangeTimes?.created || rlChangeTimes?.created;
-    const changedTime =
-        tnChangeTimes?.changed && rlChangeTimes?.changed
-            ? getMaxTimestamp(tnChangeTimes.changed, rlChangeTimes.changed)
-            : tnChangeTimes?.changed || rlChangeTimes?.changed;
     const [showEditDialog, setShowEditDialog] = React.useState(false);
     const [canUpdate, setCanUpdate] = React.useState<boolean>();
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
@@ -377,26 +366,13 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                 layoutContext={layoutContext}
                 changeTime={trackNumberChangeTime}
             />
-            {createdTime && changedTime && (
-                <Infobox
-                    contentVisible={visibilities.log}
-                    onContentVisibilityChange={() => visibilityChange('log')}
-                    title={t('tool-panel.reference-line.change-info-heading')}
-                    qa-id="track-number-log-infobox">
-                    <InfoboxContent>
-                        <InfoboxField
-                            qaId="track-number-created-date"
-                            label={t('tool-panel.created')}
-                            value={formatDateShort(createdTime)}
-                        />
-                        <InfoboxField
-                            qaId="track-number-changed-date"
-                            label={t('tool-panel.changed')}
-                            value={formatDateShort(changedTime)}
-                        />
-                    </InfoboxContent>
-                </Infobox>
-            )}
+            <TrackNumberChangeInfoInfobox
+                trackNumber={trackNumber}
+                referenceLine={referenceLine}
+                layoutContext={layoutContext}
+                visible={visibilities.log}
+                visibilityChange={() => visibilityChange('log')}
+            />
             {showEditDialog && (
                 <TrackNumberEditDialogContainer
                     editTrackNumberId={trackNumber.id}

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -8,7 +8,7 @@ import {
 import { getNonNull, queryParams } from 'api/api-fetch';
 import { TRACK_LAYOUT_URI, contextInUri } from 'track-layout/track-layout-api';
 import { LayoutContext } from 'common/common-model';
-import { SearchType } from 'tool-bar/search-dropdown';
+import { SearchItemType } from 'tool-bar/search-dropdown';
 
 export interface LayoutSearchResult {
     switches: LayoutSwitch[];
@@ -20,7 +20,7 @@ export interface LayoutSearchResult {
 export async function getBySearchTerm(
     searchTerm: string,
     layoutContext: LayoutContext,
-    types: SearchType[],
+    types: SearchItemType[],
     locationTrackSearchScope?: LocationTrackId,
     limitPerResultType: number = 10,
 ): Promise<LayoutSearchResult> {

--- a/ui/src/vayla-design-lib/dropdown/dropdown.scss
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.scss
@@ -175,6 +175,7 @@ $dropdown-border-error: 2px;
 
 .dropdown--wide-list {
     .dropdown__list-container {
+        width: 100%;
         max-width: none;
     }
 }

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -60,7 +60,8 @@ export type DropdownProps<TItemValue> = {
     displaySelectedName?: boolean;
     value?: TItemValue;
     getName?: (value: TItemValue) => string;
-    canUnselect?: boolean;
+    clearable?: boolean; // makes the icon X to clear the dropdown
+    canUnselect?: boolean; // adds a "none" option
     searchable?: boolean;
     filter?: (option: Item<TItemValue>, searchTerm: string) => boolean;
     options?: DropdownOptions<TItemValue>;
@@ -81,6 +82,7 @@ export type DropdownProps<TItemValue> = {
     openOverride?: boolean;
     popupMode?: DropdownPopupMode;
     customIcon?: IconComponent;
+    useAnchorElementWidth?: boolean;
 } & Pick<React.HTMLProps<HTMLInputElement>, 'disabled' | 'title'>;
 
 function isOptionsArray<TItemValue>(
@@ -464,7 +466,9 @@ export const Dropdown = function <TItemValue>({
                     />
                 </div>
                 <div className={styles['dropdown__icon']}>
-                    {CustomIcon ? (
+                    {props.clearable && props.value !== undefined ? (
+                        <Icons.Close size={IconSize.SMALL} onClick={unselect} />
+                    ) : CustomIcon ? (
                         <CustomIcon
                             size={IconSize.SMALL}
                             color={props.disabled ? IconColor.INHERIT : undefined}
@@ -485,7 +489,7 @@ export const Dropdown = function <TItemValue>({
             {openOrOverridden &&
                 (popupMode === DropdownPopupMode.Modal ? (
                     <CloseableModal
-                        useAnchorElementWidth
+                        useAnchorElementWidth={props.useAnchorElementWidth ?? true}
                         onClickOutside={() => setOpen(false)}
                         className={createClassName(
                             styles['dropdown__list-container'],


### PR DESCRIPTION
Suurin osa muutoksista on julkaisulokin optimointia sitä varten, että siitä saa kohtuuajassa haettua näitä yhteen olioon liittyviä julkaisumuutosjoukkoja pitemmältä ajalta. Tämä näkyy isoimpana teemana siinä, että PublicationLogService#getPublicationDetails ajetaan nyt isommalle julkaisujoukolle massana, ja kaikki sen käyttämät funktiot (eli kasa PublicationDaon metodeja eri olioiden julkaisumuutosten hakuun) on myös massoitettu.

Varsinaiset "juuri tästä oliosta on kyse"-tiedot kulkevat yleensä nimellä specificObjectId.