### PR TITLE
GVT-3163 Linkify publication log

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -36,8 +36,34 @@ enum class PublicationTableColumn {
     CHANGES,
 }
 
+sealed class PublishedAsset {
+    abstract val type: PublishableObjectType
+}
+
+data class PublishedAssetTrackNumber(val asset: LayoutTrackNumber) : PublishedAsset() {
+    override val type = PublishableObjectType.TRACK_NUMBER
+}
+
+data class PublishedAssetReferenceLine(val asset: ReferenceLine) : PublishedAsset() {
+    override val type = PublishableObjectType.REFERENCE_LINE
+}
+
+data class PublishedAssetLocationTrack(val asset: LocationTrack) : PublishedAsset() {
+    override val type = PublishableObjectType.LOCATION_TRACK
+}
+
+data class PublishedAssetSwitch(val asset: LayoutSwitch) : PublishedAsset() {
+    override val type = PublishableObjectType.SWITCH
+}
+
+data class PublishedAssetKmPost(val asset: LayoutKmPost) : PublishedAsset() {
+    override val type = PublishableObjectType.KM_POST
+}
+
 data class PublicationTableItem(
     val name: FreeText,
+    val publicationId: IntId<Publication>,
+    val asset: PublishedAsset,
     val trackNumbers: List<TrackNumber>,
     val changedKmNumbers: List<Range<KmNumber>>,
     val operation: Operation,

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -409,6 +409,7 @@ const PublicationLog: React.FC = () => {
                     items={pagedPublications?.items || []}
                     sortInfo={sortInfo}
                     onSortChange={updateTableSorting}
+                    displaySingleItemHistory={setSpecificItem}
                 />
             </div>
         </div>

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -34,8 +34,13 @@ import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { createPublicationCandidateReference } from 'publication/publication-utils';
 import { DesignBranch, LayoutBranch, PublicationState } from 'common/common-model';
 import {
+    LayoutKmPost,
     LayoutKmPostId,
+    LayoutLocationTrack,
+    LayoutReferenceLine,
+    LayoutSwitch,
     LayoutSwitchId,
+    LayoutTrackNumber,
     LayoutTrackNumberId,
     LocationTrackId,
     ReferenceLineId,
@@ -297,6 +302,19 @@ export type ReferenceLineIdAndType = { id: ReferenceLineId; type: 'REFERENCE_LIN
 export type LocationTrackIdAndType = { id: LocationTrackId; type: 'LOCATION_TRACK' };
 export type SwitchIdAndType = { id: LayoutSwitchId; type: 'SWITCH' };
 export type KmPostIdAndType = { id: LayoutKmPostId; type: 'KM_POST' };
+
+export type PublishedAsset =
+    | PublishedAssetTrackNumber
+    | PublishedAssetReferenceLine
+    | PublishedAssetLocationTrack
+    | PublishedAssetSwitch
+    | PublishedAssetKmPost;
+
+export type PublishedAssetTrackNumber = { asset: LayoutTrackNumber; type: 'TRACK_NUMBER' };
+export type PublishedAssetReferenceLine = { asset: LayoutReferenceLine; type: 'REFERENCE_LINE' };
+export type PublishedAssetLocationTrack = { asset: LayoutLocationTrack; type: 'LOCATION_TRACK' };
+export type PublishedAssetSwitch = { asset: LayoutSwitch; type: 'SWITCH' };
+export type PublishedAssetKmPost = { asset: LayoutKmPost; type: 'KM_POST' };
 
 export const getPublicationsCsvUri = (
     fromDate?: Date,

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -27,6 +27,7 @@ import { SplitTargetOperation } from 'tool-panel/location-track/split-store';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { SearchItemValue } from 'tool-bar/search-dropdown';
 import { SearchablePublicationLogItem } from 'publication/log/publication-log';
+import { PublishedAsset } from 'publication/publication-api';
 
 export type LayoutValidationIssue = {
     type: LayoutValidationIssueType;
@@ -370,6 +371,8 @@ export type PublishedCalculatedChanges = {
 
 export type PublicationTableItem = {
     id: string; //Auto generated
+    asset: PublishedAsset;
+    publicationId: PublicationId;
     name: string;
     trackNumbers: TrackNumber[];
     changedKmNumbers: Range<string>[];

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -19,6 +19,10 @@ import {
     PublicationDetailsTableSortInformation,
 } from 'publication/table/publication-table-utils';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
+import { createDelegates } from 'store/store-utils';
+import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
+import { SearchItemValue } from 'tool-bar/search-dropdown';
+import { SearchablePublicationLogItem } from 'publication/log/publication-log';
 
 export type PublicationDetailsViewProps = {
     publication: PublicationDetails;
@@ -39,6 +43,10 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     const [isLoading, setIsLoading] = React.useState(true);
     const [sortInfo, setSortInfo] =
         React.useState<PublicationDetailsTableSortInformation>(InitiallyUnsorted);
+    const trackLayoutActionDelegates = React.useMemo(
+        () => createDelegates(trackLayoutActionCreators),
+        [],
+    );
 
     React.useEffect(() => {
         setIsLoading(true);
@@ -49,6 +57,13 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
             setIsLoading(false);
         });
     }, [publication.id, changeTime]);
+
+    const displaySingleItemHistory = (
+        item: SearchItemValue<SearchablePublicationLogItem> | undefined,
+    ) => {
+        trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem(item);
+        navigate('publication-search');
+    };
 
     return (
         <div className={styles['publication-details']}>
@@ -85,6 +100,7 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
                     items={publicationItems}
                     sortInfo={sortInfo}
                     onSortChange={setSortInfo}
+                    displaySingleItemHistory={displaySingleItemHistory}
                 />
             </div>
             {(ratkoPushFailed(publication.ratkoPushStatus) || unpublishedToRatko) && (

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -315,7 +315,7 @@ export const selectionReducers = {
         { payload: newStartDate }: PayloadAction<TimeStamp | undefined>,
     ) => {
         if (!state.publicationSearch) {
-            state.publicationSearch = defaultPublicationSearch;
+            state.publicationSearch = { ...defaultPublicationSearch };
         }
         state.publicationSearch.startDate = newStartDate;
     },
@@ -324,7 +324,7 @@ export const selectionReducers = {
         { payload: newEndDate }: PayloadAction<TimeStamp | undefined>,
     ) => {
         if (!state.publicationSearch) {
-            state.publicationSearch = defaultPublicationSearch;
+            state.publicationSearch = { ...defaultPublicationSearch };
         }
         state.publicationSearch.endDate = newEndDate;
     },
@@ -335,7 +335,7 @@ export const selectionReducers = {
         }: PayloadAction<SearchItemValue<SearchablePublicationLogItem> | undefined>,
     ) => {
         if (!state.publicationSearch) {
-            state.publicationSearch = defaultPublicationSearch;
+            state.publicationSearch = { ...defaultPublicationSearch };
         }
         state.publicationSearch.specificItem = newSearchItem;
     },


### PR DESCRIPTION
Lisätään julkaisulokiin linkit, joilla pääsee suoraan julkaisuun liittyvää oliota napsauttamalla katsomaan sen muutoshistoriaa. Hieman ärsyttävästi tosin meidän hakuboksi toimii niin, että se olettaa, että sillä on saatavilla haettavien olioiden koko sisällöt: Tässä tapauksessa katsoin selkeimmäksi tuoda nämä sisällöt vaan julkaisulokiriveissä mukana.