### PR TITLE
GVT-3188 Suunnitelman valinta pystygeometrian kuvaajasta -bugfix

### DIFF
--- a/ui/src/vertical-geometry/plan-linking-header-item.tsx
+++ b/ui/src/vertical-geometry/plan-linking-header-item.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { Coordinates, mToX } from 'vertical-geometry/coordinates';
 import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
-import { OnSelectOptions } from 'selection/selection-model';
 import ElevationMeasurementMethod from 'geoviite-design-lib/elevation-measurement-method/elevation-measurement-method';
+import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 
 export interface PlanLinkingItemHeaderProps {
     coordinates: Coordinates;
     planLinkingSummaryItem: PlanLinkingSummaryItem;
-    onSelect: (options: OnSelectOptions) => void;
+    onSelectGeometryAlignment: (geometryId: GeometryAlignmentId, planId: GeometryPlanId) => void;
 }
 
 export const PlanLinkingHeaderItem: React.FC<PlanLinkingItemHeaderProps> = ({
     coordinates,
     planLinkingSummaryItem,
-    onSelect,
+    onSelectGeometryAlignment,
 }) => {
     const textLineOneYPx = 8;
     const textLineTwoYPx = 18;
@@ -45,14 +45,7 @@ export const PlanLinkingHeaderItem: React.FC<PlanLinkingItemHeaderProps> = ({
                 onClick={() =>
                     planId &&
                     alignmentHeader &&
-                    onSelect({
-                        geometryAlignmentIds: [
-                            {
-                                geometryId: alignmentHeader.id,
-                                planId: planId,
-                            },
-                        ],
-                    })
+                    onSelectGeometryAlignment(alignmentHeader.id, planId)
                 }
                 className={styles['vertical-geometry-diagram__plan-link']}
                 x={textStartX}

--- a/ui/src/vertical-geometry/plan-linking-header.tsx
+++ b/ui/src/vertical-geometry/plan-linking-header.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
-import { OnSelectOptions } from 'selection/selection-model';
 import { Coordinates } from 'vertical-geometry/coordinates';
 import { PlanLinkingHeaderItem } from 'vertical-geometry/plan-linking-header-item';
+import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 
 export interface PlanLinkingHeaderProps {
     planLinkingSummary: PlanLinkingSummaryItem[] | undefined;
-    planLinkingOnSelect: (options: OnSelectOptions) => void;
+    onSelectGeometryAlignment: (geometryId: GeometryAlignmentId, planId: GeometryPlanId) => void;
     coordinates: Coordinates;
 }
 
 export const PlanLinkingHeaders: React.FC<PlanLinkingHeaderProps> = ({
     planLinkingSummary,
-    planLinkingOnSelect,
+    onSelectGeometryAlignment,
     coordinates,
 }) => {
     return (
@@ -34,7 +34,7 @@ export const PlanLinkingHeaders: React.FC<PlanLinkingHeaderProps> = ({
                         key={i}
                         coordinates={coordinates}
                         planLinkingSummaryItem={summary}
-                        onSelect={planLinkingOnSelect}
+                        onSelectGeometryAlignment={onSelectGeometryAlignment}
                     />
                 ))}
         </>

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-container.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-container.tsx
@@ -71,6 +71,14 @@ export const VerticalGeometryDiagramContainer: React.FC = () => {
         [trackLayoutDelegates, alignmentId],
     );
 
+    const onSelectGeometryAlignment = React.useCallback(
+        (geometryId: GeometryAlignmentId, planId: GeometryPlanId) => {
+            trackLayoutDelegates.onSelect({ geometryAlignmentIds: [{ geometryId, planId }] });
+            trackLayoutDelegates.setToolPanelTab({ type: 'GEOMETRY_ALIGNMENT', id: geometryId });
+        },
+        [trackLayoutDelegates],
+    );
+
     return (
         <>
             {alignmentId && (
@@ -78,7 +86,7 @@ export const VerticalGeometryDiagramContainer: React.FC = () => {
                     alignmentId={alignmentId}
                     changeTimes={changeTimes}
                     onCloseDiagram={closeDiagram}
-                    onSelect={trackLayoutDelegates.onSelect}
+                    onSelectGeometryAlignment={onSelectGeometryAlignment}
                     showArea={trackLayoutDelegates.showArea}
                     setSavedVisibleExtentM={setVisibleExtentM}
                     savedVisibleExtentLookup={

--- a/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram-holder.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { VerticalGeometryDiagram } from 'vertical-geometry/vertical-geometry-diagram';
 import { useAlignmentHeights } from 'vertical-geometry/km-heights-api';
 import { ChangeTimes } from 'common/common-slice';
-import { VerticalGeometryDiagramDisplayItem } from 'geometry/geometry-model';
+import {
+    GeometryAlignmentId,
+    GeometryPlanId,
+    VerticalGeometryDiagramDisplayItem,
+} from 'geometry/geometry-model';
 import {
     getGeometryPlanVerticalGeometry,
     getLocationTrackLinkingSummary,
@@ -17,7 +21,6 @@ import {
 import { getLocationTrackStartAndEnd } from 'track-layout/layout-location-track-api';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
-import { OnSelectOptions } from 'selection/selection-model';
 import { BoundingBox } from 'model/geometry';
 import { processLayoutGeometries, processPlanGeometries } from 'vertical-geometry/util';
 import { useTranslation } from 'react-i18next';
@@ -38,7 +41,7 @@ type VerticalGeometryDiagramHolderProps = {
     alignmentId: VerticalGeometryDiagramAlignmentId;
     changeTimes: ChangeTimes;
     onCloseDiagram: () => void;
-    onSelect: (options: OnSelectOptions) => void;
+    onSelectGeometryAlignment: (geometryId: GeometryAlignmentId, planId: GeometryPlanId) => void;
     showArea: (area: BoundingBox) => void;
 
     setSavedVisibleExtentM: (
@@ -91,7 +94,7 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
     alignmentId,
     changeTimes,
     onCloseDiagram,
-    onSelect,
+    onSelectGeometryAlignment,
     showArea,
     setSavedVisibleExtentM,
     savedVisibleExtentLookup,
@@ -274,7 +277,7 @@ export const VerticalGeometryDiagramHolder: React.FC<VerticalGeometryDiagramHold
                     visibleEndM={alignmentAndExtents?.endM ?? endM}
                     onMove={onMove}
                     showArea={showArea}
-                    onSelect={onSelect}
+                    onSelectGeometryAlignment={onSelectGeometryAlignment}
                     horizontalTick={horizontalTickLengthMeters}
                     height={diagramHeight}
                     width={diagramWidth}

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -117,6 +117,8 @@ const VerticalGeometryDiagramM: React.FC<VerticalGeometryDiagramProps> = ({
     const drawTangentArrows =
         coordinates.mMeterLengthPxOverM > minimumPixelWidthToDrawTangentArrows;
 
+    const pointerCapturePointerId = React.useRef<undefined | PointerEvent['pointerId']>(undefined);
+
     const onMouseMove: React.EventHandler<React.MouseEvent<unknown>> = (
         e: React.MouseEvent<SVGSVGElement>,
     ) => {
@@ -128,6 +130,10 @@ const VerticalGeometryDiagramM: React.FC<VerticalGeometryDiagramProps> = ({
         setMousePositionInElement([e.clientX - elementBounds.x, e.clientY - elementBounds.y]);
 
         if (panning) {
+            if (pointerCapturePointerId.current !== undefined) {
+                ref?.current?.setPointerCapture(pointerCapturePointerId.current);
+                pointerCapturePointerId.current = undefined;
+            }
             const requestedPanDistance = (panning - e.clientX) / coordinates.mMeterLengthPxOverM;
             const panDistance = Math.min(
                 endM - visibleEndM,
@@ -200,7 +206,7 @@ const VerticalGeometryDiagramM: React.FC<VerticalGeometryDiagramProps> = ({
         <div
             className={diagramClasses}
             onPointerDown={(e) => {
-                ref?.current?.setPointerCapture(e.pointerId);
+                pointerCapturePointerId.current = e.pointerId;
                 e.preventDefault();
                 setPanning(e.clientX);
             }}

--- a/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
+++ b/ui/src/vertical-geometry/vertical-geometry-diagram.tsx
@@ -13,14 +13,17 @@ import { getSnappedPoint } from 'vertical-geometry/snapped-point';
 import { Coordinates, xToM } from 'vertical-geometry/coordinates';
 import { getBottomAndTopTicks, sumPaddings, zeroSafeDivision } from 'vertical-geometry/util';
 import { PlanLinkingSummaryItem, TrackKmHeights } from 'geometry/geometry-api';
-import { VerticalGeometryDiagramDisplayItem } from 'geometry/geometry-model';
+import {
+    GeometryAlignmentId,
+    GeometryPlanId,
+    VerticalGeometryDiagramDisplayItem,
+} from 'geometry/geometry-model';
 import {
     findTrackMeterIndexContainingM,
     getTrackMeterPairAroundIndex,
 } from 'vertical-geometry/track-meter-index';
 import { calculateBoundingBoxToShowAroundLocation } from 'map/map-utils';
 import { BoundingBox } from 'model/geometry';
-import { OnSelectOptions } from 'selection/selection-model';
 import { PlanLinkingHeaders } from 'vertical-geometry/plan-linking-header';
 import { DisplayedPositionGuide } from 'vertical-geometry/displayed-position-guide';
 
@@ -38,7 +41,7 @@ type VerticalGeometryDiagramProps = {
     endM: number;
     showArea: (area: BoundingBox) => void;
     linkingSummary: PlanLinkingSummaryItem[] | undefined;
-    onSelect: (options: OnSelectOptions) => void;
+    onSelectGeometryAlignment: (geometryId: GeometryAlignmentId, planId: GeometryPlanId) => void;
     onMove: (startM: number, endM: number) => void;
     horizontalTick: number;
     width: number;
@@ -52,7 +55,7 @@ const VerticalGeometryDiagramM: React.FC<VerticalGeometryDiagramProps> = ({
     visibleEndM,
     showArea,
     linkingSummary,
-    onSelect,
+    onSelectGeometryAlignment,
     onMove,
     horizontalTick,
     startM,
@@ -247,7 +250,7 @@ const VerticalGeometryDiagramM: React.FC<VerticalGeometryDiagramProps> = ({
                     <PlanLinkingHeaders
                         coordinates={coordinates}
                         planLinkingSummary={linkingSummary}
-                        planLinkingOnSelect={onSelect}
+                        onSelectGeometryAlignment={onSelectGeometryAlignment}
                     />
                     <DisplayedPositionGuide coordinates={coordinates} maxMeters={endM} />
                     <Translate x={0} y={240}>


### PR DESCRIPTION
setPointerCapture-kutsu esti mouseclick-elementtejä pääsemästä PlanLinkingHeaderItemeihin asti. Se oli aiemmin lisätty, jotta kaaviota pystyy hilaamaan niin, että kursori saa mennä pois elementistä mutta hilaaminen jatkuu. Siksi myöhennetty kutsu tapahtumaan vasta silloin, kun hilaaminen alkaa.

Toolpanelin tabin valinta ei näemmä myöskään tapahtunut enää pelkällä onSelectillä, eli se tehty nyt eksplisiittisesti.