### PR TITLE
GVT-3141 Allow search for design object by main oid

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
@@ -90,7 +90,7 @@ constructor(
             } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
 
         val locationTrackId =
-            locationTrackDao.lookupByExternalId(oid)?.id
+            locationTrackDao.lookupByExternalId(oid.toString())?.id
                 ?: throw ExtOidNotFoundExceptionV1("location track lookup failed for oid=$oid")
 
         return locationTrackDao

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -81,7 +81,7 @@ constructor(
             } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
 
         val locationTrackId =
-            locationTrackDao.lookupByExternalId(oid)?.id
+            locationTrackDao.lookupByExternalId(oid.toString())?.id
                 ?: throw ExtOidNotFoundExceptionV1("location track lookup failed for oid=$oid")
 
         return locationTrackDao
@@ -121,7 +121,7 @@ constructor(
             null
         } else {
             val locationTrackId =
-                locationTrackDao.lookupByExternalId(oid)?.id
+                locationTrackDao.lookupByExternalId(oid.toString())?.id
                     ?: throw ExtOidNotFoundExceptionV1("location track lookup failed, oid=$oid")
 
             val fromLocationTrackVersion =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -434,7 +434,7 @@ constructor(
             val oidDuplicationIssues =
                 validateSwitchOidDuplication(
                     switch,
-                    switch.draftOid?.let(switchDao::lookupByExternalId)?.let { row ->
+                    switch.draftOid?.toString()?.let(switchDao::lookupByExternalId)?.let { row ->
                         switchDao.get(row.context, row.id)
                     },
                 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/IExternallyIdentifiedLayoutAssetDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/IExternallyIdentifiedLayoutAssetDao.kt
@@ -6,11 +6,11 @@ import fi.fta.geoviite.infra.ratko.IExternalIdDao
 
 interface IExternallyIdentifiedLayoutAssetDao<T : LayoutAsset<T>> : LayoutAssetReader<T>, IExternalIdDao<T> {
     fun getByExternalId(oid: Oid<T>): T? {
-        return lookupByExternalId(oid)?.let { rowByOid -> get(rowByOid.context, rowByOid.id) }
+        return lookupByExternalId(oid.toString())?.let { rowByOid -> get(rowByOid.context, rowByOid.id) }
     }
 
     fun getByExternalIds(context: LayoutContext, oids: List<Oid<T>>): Map<Oid<T>, T?> {
-        val oidMapping = lookupByExternalIds(oids)
+        val oidMapping = lookupByExternalIds(oids.map { it.toString() })
         val oidToNonNullId = oidMapping.mapNotNull { (oid, rowId) -> rowId?.let { oid to rowId.id } }.toMap()
         val assets = getMany(context, oidToNonNullId.values.toList()).associateBy { asset -> asset.id }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -41,7 +41,11 @@ constructor(
         return locationTrackService
             .list(layoutContext, true)
             .let { list ->
-                locationTrackService.filterBySearchTerm(list, searchTerm, locationTrackService.idMatches(layoutContext))
+                locationTrackService.filterBySearchTerm(
+                    list,
+                    searchTerm,
+                    locationTrackService.idMatches(layoutContext, searchTerm),
+                )
             }
             .sortedBy(LocationTrack::name)
             .take(limit)
@@ -50,7 +54,9 @@ constructor(
     fun searchAllSwitches(layoutContext: LayoutContext, searchTerm: FreeText, limit: Int): List<LayoutSwitch> {
         return switchService
             .list(layoutContext, true)
-            .let { list -> switchService.filterBySearchTerm(list, searchTerm, switchService.idMatches(layoutContext)) }
+            .let { list ->
+                switchService.filterBySearchTerm(list, searchTerm, switchService.idMatches(layoutContext, searchTerm))
+            }
             .sortedBy(LayoutSwitch::name)
             .take(limit)
     }
@@ -59,7 +65,11 @@ constructor(
         return trackNumberService
             .list(layoutContext, true)
             .let { list ->
-                trackNumberService.filterBySearchTerm(list, searchTerm, trackNumberService.idMatches(layoutContext))
+                trackNumberService.filterBySearchTerm(
+                    list,
+                    searchTerm,
+                    trackNumberService.idMatches(layoutContext, searchTerm),
+                )
             }
             .sortedBy(LayoutTrackNumber::number)
             .take(limit)
@@ -109,9 +119,10 @@ constructor(
             else emptyList()
         val trackNumbers = emptyList<LayoutTrackNumber>()
 
-        val switchIdMatch = switchService.idMatches(layoutContext, switches.map { it.id as IntId })
-        val ltIdMatch = locationTrackService.idMatches(layoutContext, locationTracks.map { it.id as IntId })
-        val trackNumberIdMatch = trackNumberService.idMatches(layoutContext, trackNumbers.map { it.id as IntId })
+        val switchIdMatch = switchService.idMatches(layoutContext, searchTerm, switches.map { it.id as IntId })
+        val ltIdMatch = locationTrackService.idMatches(layoutContext, searchTerm, locationTracks.map { it.id as IntId })
+        val trackNumberIdMatch =
+            trackNumberService.idMatches(layoutContext, searchTerm, trackNumbers.map { it.id as IntId })
 
         return TrackLayoutSearchResult(
             switches =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -16,6 +16,7 @@ import fi.fta.geoviite.infra.ratko.RatkoClient
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.page
@@ -98,7 +99,7 @@ constructor(
         SwitchOidPresence(
             existsInRatko = checkRatkoOidPresence(oid),
             existsInGeoviiteAs =
-                dao.lookupByExternalId(oid)?.let { rowByOid ->
+                dao.lookupByExternalId(oid.toString())?.let { rowByOid ->
                     dao.get(rowByOid.context, rowByOid.id)?.let { existingSwitch ->
                         GeoviiteSwitchOidPresence(rowByOid.id, existingSwitch.stateCategory, existingSwitch.name)
                     }
@@ -118,11 +119,9 @@ constructor(
 
     fun idMatches(
         layoutContext: LayoutContext,
-        possibleIds: List<IntId<LayoutSwitch>>? = null,
-    ): ((term: String, item: LayoutSwitch) -> Boolean) =
-        dao.fetchExternalIds(layoutContext.branch, possibleIds).let { externalIds ->
-            { term, item -> externalIds[item.id]?.oid?.toString() == term || item.id.toString() == term }
-        }
+        searchTerm: FreeText,
+        onlyIds: Collection<IntId<LayoutSwitch>>? = null,
+    ): ((term: String, item: LayoutSwitch) -> Boolean) = idMatches(dao, layoutContext, searchTerm, onlyIds)
 
     override fun contentMatches(term: String, item: LayoutSwitch) =
         item.exists && item.name.toString().replace("  ", " ").contains(term, true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -28,10 +28,13 @@ import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.util.CsvEntry
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.printCsv
 import java.time.Instant
 import java.util.stream.Collectors
+import kotlin.text.get
+import kotlin.toString
 import org.springframework.transaction.annotation.Transactional
 
 const val KM_LENGTHS_CSV_TRANSLATION_PREFIX = "data-products.km-lengths.csv"
@@ -94,11 +97,9 @@ class LayoutTrackNumberService(
 
     fun idMatches(
         layoutContext: LayoutContext,
-        possibleIds: List<IntId<LayoutTrackNumber>>? = null,
-    ): ((term: String, item: LayoutTrackNumber) -> Boolean) =
-        dao.fetchExternalIds(layoutContext.branch, possibleIds).let { externalIds ->
-            { term, item -> externalIds[item.id]?.oid?.toString() == term || item.id.toString() == term }
-        }
+        searchTerm: FreeText,
+        onlyIds: Collection<IntId<LayoutTrackNumber>>? = null,
+    ): ((term: String, item: LayoutTrackNumber) -> Boolean) = idMatches(dao, layoutContext, searchTerm, onlyIds)
 
     override fun contentMatches(term: String, item: LayoutTrackNumber) =
         item.exists && item.number.toString().replace("  ", " ").contains(term, true)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber


### PR DESCRIPTION
Nähtiin järkeväksi, että kai nyt design-versioita olioista pitäisi pystyä hakemaan mainin oidilla, ja onhan se järkevää. Koska oideja ei oikein kakuteta, siirsin varsinaisen haun tietokannan puolelle, jottei tässä nyt ihan koko maailman kaikkia oideja tarvitse ladata joka kerta kun hakukenttää käytetään.