### PR TITLE
General: Adjust OID copy icon spacing

### DIFF
--- a/ui/src/track-layout/oid.scss
+++ b/ui/src/track-layout/oid.scss
@@ -6,5 +6,5 @@
 .oid-icon-container {
     display: flex;
     cursor: pointer;
-    padding: 0 4px;
+    padding: 0 6px;
 }


### PR DESCRIPTION
The earlier spacing of the OID copy icon was the same as the "target icon" (which centers the map around a specific track address). However, as the icons are different, the visual spacing seemed different with the copy icon as it is more left-aligned. Solution is to increase the padding a bit to help with visual similarity.

This also increases the click area which makes it easier to click the "copy-to-clipboard" button.