### PR TITLE
GVT-3185: Fix preview table sorting by track number, improve typing

### DIFF
--- a/ui/src/preview/change-table-sorting.ts
+++ b/ui/src/preview/change-table-sorting.ts
@@ -2,6 +2,7 @@ import { LayoutValidationIssue, validationIssueIsError } from 'publication/publi
 import { fieldComparator } from 'utils/array-utils';
 import { nextSortDirection, SortDirection } from 'utils/table-utils';
 import { publicationOperationCompare } from 'sorting/publication-sorting';
+import { PreviewTableEntry } from 'preview/preview-table';
 
 export enum SortProps {
     NAME = 'NAME',
@@ -29,13 +30,25 @@ const issueSeverityPriority = (issues: LayoutValidationIssue[]) => {
     return priority;
 };
 
-const nameCompare = fieldComparator((entry: { name: string }) => entry.name.toLocaleLowerCase());
-const trackNumberCompare = fieldComparator((entry: { trackNumber: string }) => entry.trackNumber);
-const userNameCompare = fieldComparator((entry: { userName: string }) => entry.userName);
-const changeTimeCompare = fieldComparator((entry: { changeTime: string }) => entry.changeTime);
+const nameCompare = fieldComparator((entry: Pick<PreviewTableEntry, 'name'>) =>
+    entry.name.toLocaleLowerCase(),
+);
+
+const trackNumberCompare = fieldComparator((entry: Pick<PreviewTableEntry, 'trackNumbers'>) =>
+    entry.trackNumbers.join(','),
+);
+
+const userNameCompare = fieldComparator(
+    (entry: Pick<PreviewTableEntry, 'userName'>) => entry.userName,
+);
+
+const changeTimeCompare = fieldComparator(
+    (entry: Pick<PreviewTableEntry, 'changeTime'>) => entry.changeTime,
+);
+
 const issueListCompare = (
-    a: { issues: LayoutValidationIssue[] },
-    b: { issues: LayoutValidationIssue[] },
+    a: Pick<PreviewTableEntry, 'issues'>,
+    b: Pick<PreviewTableEntry, 'issues'>,
 ) => {
     const priorityBySeverity = issueSeverityPriority(b.issues) - issueSeverityPriority(a.issues);
     return priorityBySeverity !== 0 ? priorityBySeverity : b.issues.length - a.issues.length;

--- a/ui/src/sorting/publication-sorting.ts
+++ b/ui/src/sorting/publication-sorting.ts
@@ -1,5 +1,6 @@
-import { Operation } from 'publication/publication-model';
+import { Operation, PublicationTableItem } from 'publication/publication-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
+import { ChangeTableEntry } from 'preview/change-table-entry-mapping';
 
 export const publicationOperationSortPriority = (operation: Operation | undefined) => {
     switch (operation) {
@@ -22,6 +23,6 @@ export const publicationOperationSortPriority = (operation: Operation | undefine
 };
 
 export const publicationOperationCompare = (
-    a: { operation: Operation },
-    b: { operation: Operation },
+    a: Pick<ChangeTableEntry, 'operation'> | Pick<PublicationTableItem, 'operation'>,
+    b: Pick<ChangeTableEntry, 'operation'> | Pick<PublicationTableItem, 'operation'>,
 ) => publicationOperationSortPriority(b.operation) - publicationOperationSortPriority(a.operation);


### PR DESCRIPTION
Näissä järjestysoperaatioissa näytti olevan vähän tyyppisynkkausepäselvyyksiä. Nähtävästi esikatselunäkymän entry-tyypin ratanumerokenttä on muutettu arrayksi, muttei sorttausfunkkaria oltu muistettu päivittää, koska tyyppisynkkausta sorttausfunkkarien ja varsinaisen näkymäkomponentin välillä ei ollut. Sorttausfunkkari hyödynsi anonyymiä tyyppiä ja luotti argumenttina passattuun arvoon, joka ei ollutkaan ajonaikana oletettua muotoa.

Korjattu järjestelybugi ja lisätty tyyppisynkkausta näille sorttausfunktioille. Jos siis jatkossa menee kenttien nimiä tai muotoja säätämään vaikkapa PreviewTableEntrystä, niin sorttausfunkkareista lentää myös TS-virheitä ellei niitä käy myös muuttamassa oikeaan muotoon.