### PR TITLE
GVT-3178: Fix location track description display format in edit dialog

### DIFF
--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -566,11 +566,11 @@ export function formatTrackDescription(
         case 'NONE':
             return descriptionBase;
         case 'SWITCH_TO_BUFFER':
-            return `${getShortName(startSwitch ?? endSwitch)} - ${t('location-track-dialog.buffer')}`;
+            return `${descriptionBase} ${getShortName(startSwitch ?? endSwitch)} - ${t('location-track-dialog.buffer')}`;
         case 'SWITCH_TO_OWNERSHIP_BOUNDARY':
-            return `${getShortName(startSwitch ?? endSwitch)} - ${t('location-track-dialog.ownership-boundary')}`;
+            return `${descriptionBase} ${getShortName(startSwitch ?? endSwitch)} - ${t('location-track-dialog.ownership-boundary')}`;
         case 'SWITCH_TO_SWITCH':
-            return `${getShortName(startSwitch)} - ${getShortName(endSwitch)}`;
+            return `${descriptionBase} ${getShortName(startSwitch)} - ${getShortName(endSwitch)}`;
         default:
             return exhaustiveMatchingGuard(descriptionSuffix);
     }


### PR DESCRIPTION
Muuttuja oli siis jäänyt UI-koodin formatoinneista vain uupumaan.

Halutessaan voi verrata bäkkäripuolen formatointifunkkariin: https://github.com/finnishtransportagency/geoviite/blob/89976229c09617cdf5ffb6386baec7fedd3f7e62/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt#L194-L209