### PR TITLE
General: Use stricter types in geocoding contexts to avoid casts and extraneous template types

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
@@ -10,9 +10,9 @@ import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.Uuid
 import fi.fta.geoviite.infra.geocoding.AlignmentEndPoint
-import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingDao
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.Resolution
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationDao
@@ -121,7 +121,7 @@ constructor(
 
     private fun getExtLocationTrackGeometry(
         locationTrackVersion: LayoutRowVersion<LocationTrack>,
-        geocodingContextCacheKey: GeocodingContextCacheKey,
+        geocodingContextCacheKey: LayoutGeocodingContextCacheKey,
         trackIntervalFilter: ExtTrackKilometerIntervalV1,
         resolution: Resolution,
         coordinateSystem: Srid,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/AddressPointsCache.kt
@@ -13,12 +13,12 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
-import java.util.*
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 data class AddressPointCacheKey(
     val locationTrackVersion: LayoutRowVersion<LocationTrack>,
-    val geocodingContextCacheKey: GeocodingContextCacheKey,
+    val geocodingContextCacheKey: LayoutGeocodingContextCacheKey,
     val resolution: Resolution,
 )
 
@@ -70,8 +70,7 @@ class AddressPointsCache(
             .orElse(null)
 
     fun getAddressPointCalculationData(cacheKey: AddressPointCacheKey): AddressPointCalculationData? =
-        geocodingCacheService.getGeocodingContext<ReferenceLineM>(cacheKey.geocodingContextCacheKey)?.let {
-            geocodingContext ->
+        geocodingCacheService.getGeocodingContext(cacheKey.geocodingContextCacheKey)?.let { geocodingContext ->
             AddressPointCalculationData(cacheKey, alignmentDao.fetch(cacheKey.locationTrackVersion), geocodingContext)
         }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
@@ -11,7 +11,6 @@ import fi.fta.geoviite.infra.configuration.CACHE_PLAN_GEOCODING_CONTEXTS
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.geometry.PlanLayoutService
 import fi.fta.geoviite.infra.map.MapAlignmentType
-import fi.fta.geoviite.infra.tracklayout.GeocodingAlignmentM
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
@@ -68,19 +67,22 @@ class GeocodingCacheService(
     @Autowired @Lazy lateinit var geocodingCacheService: GeocodingCacheService
 
     @Transactional(readOnly = true)
-    fun <M : GeocodingAlignmentM<M>> getGeocodingContext(key: GeocodingContextCacheKey): GeocodingContext<M>? =
-        getGeocodingContextWithReasons(key)?.geocodingContext as GeocodingContext<M>?
+    fun getGeocodingContext(key: LayoutGeocodingContextCacheKey): GeocodingContext<ReferenceLineM>? =
+        getGeocodingContextWithReasons(key)?.geocodingContext
 
     @Transactional(readOnly = true)
-    fun <M : GeocodingAlignmentM<M>> getGeocodingContextWithReasons(
-        key: GeocodingContextCacheKey
-    ): GeocodingContextCreateResult<M>? =
-        when (key) {
-            is LayoutGeocodingContextCacheKey -> geocodingCacheService.getLayoutGeocodingContext(key)
-            is GeometryGeocodingContextCacheKey -> geocodingCacheService.getGeometryGeocodingContext(key)
-        }
-        // caller's responsibility to not cast a layout geocoding context to a geometry one/vice versa
-        as GeocodingContextCreateResult<M>?
+    fun getGeocodingContext(key: GeometryGeocodingContextCacheKey): GeocodingContext<PlanLayoutAlignmentM>? =
+        getGeocodingContextWithReasons(key)?.geocodingContext
+
+    @Transactional(readOnly = true)
+    fun getGeocodingContextWithReasons(
+        key: LayoutGeocodingContextCacheKey
+    ): GeocodingContextCreateResult<ReferenceLineM>? = geocodingCacheService.getLayoutGeocodingContext(key)
+
+    @Transactional(readOnly = true)
+    fun getGeocodingContextWithReasons(
+        key: GeometryGeocodingContextCacheKey
+    ): GeocodingContextCreateResult<PlanLayoutAlignmentM>? = geocodingCacheService.getGeometryGeocodingContext(key)
 
     @Transactional(readOnly = true)
     @Cacheable(CACHE_GEOCODING_CONTEXTS, sync = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDao.kt
@@ -95,7 +95,7 @@ class GeocodingDao(
         branch: LayoutBranch,
         trackNumberId: IntId<LayoutTrackNumber>,
         moment: Instant,
-    ): GeocodingContextCacheKey? {
+    ): LayoutGeocodingContextCacheKey? {
         // language=SQL
         val sql =
             """
@@ -207,7 +207,7 @@ class GeocodingDao(
     fun getLayoutGeocodingContextCacheKey(
         trackNumberId: IntId<LayoutTrackNumber>,
         versions: ValidationVersions,
-    ): GeocodingContextCacheKey? {
+    ): LayoutGeocodingContextCacheKey? {
         val base = getLayoutGeocodingContextCacheKey(versions.target.baseContext, trackNumberId)
         val trackNumberVersion = versions.findTrackNumber(trackNumberId) ?: base?.trackNumberVersion
         // We have to fetch the actual objects (reference line & km-post) here to check references

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingService.kt
@@ -22,10 +22,10 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.*
 import kotlin.jvm.optionals.getOrNull
-import org.springframework.transaction.annotation.Transactional
 
 @GeoviiteService
 class GeocodingService(
@@ -44,7 +44,7 @@ class GeocodingService(
     }
 
     fun getAddressPoints(
-        contextKey: GeocodingContextCacheKey,
+        contextKey: LayoutGeocodingContextCacheKey,
         trackVersion: LayoutRowVersion<LocationTrack>,
         resolution: Resolution = Resolution.ONE_METER,
     ): AlignmentAddresses<LocationTrackM>? {
@@ -125,7 +125,7 @@ class GeocodingService(
     ): GeocodingContext<ReferenceLineM>? =
         if (trackNumberId is IntId) getGeocodingContext(layoutContext, trackNumberId) else null
 
-    fun getGeocodingContext(geocodingContextCacheKey: GeocodingContextCacheKey) =
+    fun getGeocodingContext(geocodingContextCacheKey: LayoutGeocodingContextCacheKey) =
         geocodingCacheService.getGeocodingContext(geocodingContextCacheKey)
 
     fun getGeocodingContext(
@@ -160,11 +160,11 @@ class GeocodingService(
     fun getGeocodingContextCacheKey(
         trackNumberId: IntId<LayoutTrackNumber>,
         versions: ValidationVersions,
-    ): GeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, versions)
+    ): LayoutGeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(trackNumberId, versions)
 
     fun getGeocodingContextCacheKey(
         branch: LayoutBranch,
         trackNumberId: IntId<LayoutTrackNumber>,
         moment: Instant,
-    ): GeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(branch, trackNumberId, moment)
+    ): LayoutGeocodingContextCacheKey? = geocodingDao.getLayoutGeocodingContextCacheKey(branch, trackNumberId, moment)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
@@ -4,8 +4,8 @@ import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
-import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.tracklayout.AlignmentM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackM
@@ -78,8 +78,8 @@ class AddressChangesService(val geocodingService: GeocodingService) {
     fun getAddressChanges(
         beforeTrack: LocationTrack?,
         afterTrack: LocationTrack,
-        beforeContextKey: GeocodingContextCacheKey?,
-        afterContextKey: GeocodingContextCacheKey?,
+        beforeContextKey: LayoutGeocodingContextCacheKey?,
+        afterContextKey: LayoutGeocodingContextCacheKey?,
     ): AddressChanges =
         if (beforeTrack == afterTrack && beforeContextKey == afterContextKey) {
             AddressChanges(setOf(), startPointChanged = false, endPointChanged = false)
@@ -89,7 +89,7 @@ class AddressChangesService(val geocodingService: GeocodingService) {
 
     private fun getAddresses(
         track: LocationTrack?,
-        contextKey: GeocodingContextCacheKey?,
+        contextKey: LayoutGeocodingContextCacheKey?,
     ): AlignmentAddresses<LocationTrackM>? =
         if (track == null || contextKey == null || !track.exists) null
         else geocodingService.getAddressPoints(contextKey, track.getVersionOrThrow())

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/ChangeContext.kt
@@ -2,9 +2,8 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.error.NoSuchEntityException
-import fi.fta.geoviite.infra.geocoding.GeocodingContext
-import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutAssetDao
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
@@ -13,7 +12,6 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
-import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import java.time.Instant
 import kotlin.reflect.KClass
 
@@ -30,20 +28,16 @@ class ChangeContext(
     val kmPosts: TypedChangeContext<LayoutKmPost>,
     val locationTracks: TypedChangeContext<LocationTrack>,
     val switches: TypedChangeContext<LayoutSwitch>,
-    val geocodingKeysBefore: LazyMap<IntId<LayoutTrackNumber>, GeocodingContextCacheKey?>,
-    val geocodingKeysAfter: LazyMap<IntId<LayoutTrackNumber>, GeocodingContextCacheKey?>,
+    val geocodingKeysBefore: LazyMap<IntId<LayoutTrackNumber>, LayoutGeocodingContextCacheKey?>,
+    val geocodingKeysAfter: LazyMap<IntId<LayoutTrackNumber>, LayoutGeocodingContextCacheKey?>,
     val getTrackNumberTracksBefore: (trackNumberId: IntId<LayoutTrackNumber>) -> List<LayoutRowVersion<LocationTrack>>,
 ) {
 
     fun getGeocodingContextBefore(id: IntId<LayoutTrackNumber>) =
-        geocodingKeysBefore[id]?.let { key ->
-            geocodingService.getGeocodingContext(key) as? GeocodingContext<ReferenceLineM>
-        }
+        geocodingKeysBefore[id]?.let { key -> geocodingService.getGeocodingContext(key) }
 
     fun getGeocodingContextAfter(id: IntId<LayoutTrackNumber>) =
-        geocodingKeysAfter[id]?.let { key ->
-            geocodingService.getGeocodingContext(key) as? GeocodingContext<ReferenceLineM>
-        }
+        geocodingKeysAfter[id]?.let { key -> geocodingService.getGeocodingContext(key) }
 }
 
 inline fun <reified T : LayoutAsset<T>> createTypedContext(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -5,8 +5,8 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.error.PublicationFailureException
 import fi.fta.geoviite.infra.geocoding.GeocodingCacheService
-import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.split.SplitLayoutValidationIssues
 import fi.fta.geoviite.infra.split.SplitService
@@ -24,7 +24,6 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
-import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -582,18 +581,18 @@ constructor(
     }
 
     private fun validateGeocodingContext(
-        cacheKey: GeocodingContextCacheKey?,
+        cacheKey: LayoutGeocodingContextCacheKey?,
         localizationKey: String,
         trackNumber: TrackNumber,
     ) =
         cacheKey
-            ?.let { key -> geocodingCacheService.getGeocodingContextWithReasons<ReferenceLineM>(key) }
+            ?.let { key -> geocodingCacheService.getGeocodingContextWithReasons(key) }
             ?.let { context -> validateGeocodingContext(context, trackNumber) }
             ?: listOf(noGeocodingContext(localizationKey))
 
     private fun validateAddressPoints(
         trackNumber: LayoutTrackNumber,
-        contextKey: GeocodingContextCacheKey,
+        contextKey: LayoutGeocodingContextCacheKey,
         track: LocationTrack,
         validationTargetLocalizationPrefix: String,
     ): List<LayoutValidationIssue> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -7,8 +7,8 @@ import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
-import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -100,7 +100,7 @@ class ValidationContext(
     private val switchTrackLinks = ReferenceCache<LayoutSwitch, LocationTrack>()
     private val trackDuplicateLinks = ReferenceCache<LocationTrack, LocationTrack>()
 
-    private val geocodingContextKeys = NullableCache<IntId<LayoutTrackNumber>, GeocodingContextCacheKey>()
+    private val geocodingContextKeys = NullableCache<IntId<LayoutTrackNumber>, LayoutGeocodingContextCacheKey>()
     private val switchNameCache = NameCache(::fetchSwitchesByName)
     private val trackNameCache = NameCache(::fetchLocationTracksByName)
     private val trackNumberNumberCache = NameCache(::fetchTrackNumbersByNumber)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -9,9 +9,9 @@ import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
-import fi.fta.geoviite.infra.geocoding.GeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.GeocodingDao
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.geography.GeometryPoint
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
@@ -47,16 +47,16 @@ import fi.fta.geoviite.infra.tracklayout.splitSegment
 import fi.fta.geoviite.infra.tracklayout.toAlignmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
 import kotlin.math.ceil
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -761,10 +761,8 @@ constructor(
         end: Pair<Point, TrackMeter>,
     ): AlignmentAddresses<M> =
         AlignmentAddresses(
-            startPoint = AddressPoint(
-                AlignmentPoint(start.first.x, start.first.y, null, LineM<M>(0.0), null),
-                start.second
-            ),
+            startPoint =
+                AddressPoint(AlignmentPoint(start.first.x, start.first.y, null, LineM<M>(0.0), null), start.second),
             endPoint =
                 AddressPoint(
                     AlignmentPoint(end.first.x, end.first.y, null, LineM<M>(lineLength(start.first, end.first)), null),
@@ -808,7 +806,7 @@ constructor(
     fun <M : AlignmentM<M>> someAddressPoint() =
         AddressPoint(AlignmentPoint(0.0, 0.0, null, LineM<M>(0.0), null), TrackMeter(0, 0))
 
-    fun getAllKms(geocodingContextCacheKey: GeocodingContextCacheKey, start: IPoint, end: IPoint): Set<KmNumber> {
+    fun getAllKms(geocodingContextCacheKey: LayoutGeocodingContextCacheKey, start: IPoint, end: IPoint): Set<KmNumber> {
         val context = geocodingService.getGeocodingContext(geocodingContextCacheKey)!!
         val startKm = context.getAddress(start)!!.first.kmNumber
         val endKm = context.getAddress(end)!!.first.kmNumber


### PR DESCRIPTION
Koitin katsella tiettyjä juttuja noissa m-arvoissa että voisiko castailuja ja ylimääräisiä tyypityksiä jostain vähentää. Kokeilin paria eri polkua ja ne ei ihan mutkitta menneet, mutta tämä vaikutti suhteellisen harmittomalta muutokselta. Muutama muu ajatus olisi vielä kokeiltavaksi mutta katsotaan kerkiääkö niitä kokeilla.
