### PR TITLE
GVT-3183: Fix missing switch prefixes in automatically generated location track splits

### DIFF
--- a/ui/src/tool-panel/location-track/split-store.ts
+++ b/ui/src/tool-panel/location-track/split-store.ts
@@ -513,7 +513,7 @@ function getNameForTarget(
     const nameSpecifier: LocationTrackNameSpecifier | undefined = undefined;
     const nameFreeText =
         startSwitch?.nameParts !== undefined && endSwitch?.nameParts !== undefined
-            ? `${startSwitch.nameParts.shortNumberPart}-${endSwitch.nameParts.shortNumberPart}`
+            ? `${startSwitch.nameParts.prefix} ${startSwitch.nameParts.shortNumberPart}-${endSwitch.nameParts.prefix} ${endSwitch.nameParts.shortNumberPart}`
             : '';
 
     return {


### PR DESCRIPTION
Palauttaa siis aiemman toiminnallisuuden. Näihin toki kaavaillaan muutakin automatiikkaa sijaintiraidetarkenteen vuoksi.