### PR TITLE
GVT-3187 Handle specificObjectness in publication log CSV export path

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
@@ -327,6 +328,7 @@ constructor(
         layoutBranch: LayoutBranch,
         from: Instant? = null,
         to: Instant? = null,
+        specificId: PublishableObjectIdAndType? = null,
         sortBy: PublicationTableColumn? = null,
         order: SortOrder? = null,
         timeZone: ZoneId? = null,
@@ -337,6 +339,7 @@ constructor(
                 layoutBranch = layoutBranch,
                 from = from,
                 to = to,
+                specificId = specificId,
                 sortBy = sortBy,
                 order = order,
                 translation = translation,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -2169,6 +2169,7 @@
         "vertical-geometry-list-plan-csv": "Pystygeometria {{planFileName}}.csv",
         "vertical-geometry-list-entire-track-network": "Pystygeometria (koko rataverkko) {{date}}.csv",
         "publication-log": "Julkaisuloki {{dateRange}}.csv",
+        "publication-log-for-object": "Julkaisuloki {{objectName}} {{dateRange}}.csv",
         "split-details": "Raiteen jakaminen {{locationTrackName}}.csv",
         "geometries-folder": "Geometriat",
         "geometry-plans-summary-csv": "Yhteenveto {{date}} {{applicability}} {{alignmentName}}.csv",

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -379,7 +379,11 @@ const PublicationLog: React.FC = () => {
                                         storedEndDate && endOfDay(storedEndDate),
                                         storedSpecificItem === undefined
                                             ? undefined
-                                            : searchableItemIdAndType(storedSpecificItem),
+                                            : {
+                                                  idAndType:
+                                                      searchableItemIdAndType(storedSpecificItem),
+                                                  name: getSearchableItemName(storedSpecificItem),
+                                              },
                                         sortInfo?.propName,
                                         sortInfo?.direction,
                                     ))

--- a/ui/src/publication/publication-api.ts
+++ b/ui/src/publication/publication-api.ts
@@ -319,7 +319,7 @@ export type PublishedAssetKmPost = { asset: LayoutKmPost; type: 'KM_POST' };
 export const getPublicationsCsvUri = (
     fromDate?: Date,
     toDate?: Date,
-    specificObjectId?: PublishableObjectIdAndType,
+    specificObject?: { idAndType: PublishableObjectIdAndType; name: string },
     sortBy?: PublicationDetailsTableSortField,
     order?: SortDirection,
 ): string => {
@@ -328,8 +328,9 @@ export const getPublicationsCsvUri = (
     const params = queryParams({
         from: fromDate ? fromDate.toISOString() : undefined,
         to: toDate ? toDate.toISOString() : undefined,
-        id: specificObjectId ? specificObjectId.id : undefined,
-        type: specificObjectId ? specificObjectId.type : undefined,
+        id: specificObject?.idAndType?.id,
+        type: specificObject?.idAndType?.type,
+        filenameObjectPart: specificObject?.name,
         sortBy: isSorted && sortBy ? sortBy : undefined,
         order: isSorted ? order : undefined,
         timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -23,6 +23,7 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { SearchItemValue } from 'tool-bar/search-dropdown';
 import { SearchablePublicationLogItem } from 'publication/log/publication-log';
+import { START_OF_2022 } from 'vayla-design-lib/datepicker/datepicker';
 
 export type PublicationDetailsViewProps = {
     publication: PublicationDetails;
@@ -61,6 +62,10 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     const displaySingleItemHistory = (
         item: SearchItemValue<SearchablePublicationLogItem> | undefined,
     ) => {
+        trackLayoutActionDelegates.setSelectedPublicationSearchStartDate(
+            START_OF_2022.toISOString(),
+        );
+        trackLayoutActionDelegates.setSelectedPublicationSearchEndDate(new Date().toISOString());
         trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem(item);
         navigate('publication-search');
     };


### PR DESCRIPTION
Ajattelin järkeväksi käytettävyysominaisuudeksi tunkea julkaisulokifiluun tiedoston nimeen tutkittavan olion nimen. Olkoonkin, että pienellä laiskuudellahan se frontista tulee, missä se sattuu tässä tapauksessa olemaan kätevästi saatavilla.