### PR TITLE
GVT-3194 Reset publication log search date range upon clicking in from a publication

### DIFF
--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -23,6 +23,7 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { SearchItemValue } from 'tool-bar/search-dropdown';
 import { SearchablePublicationLogItem } from 'publication/log/publication-log';
+import { START_OF_2022 } from 'vayla-design-lib/datepicker/datepicker';
 
 export type PublicationDetailsViewProps = {
     publication: PublicationDetails;
@@ -61,6 +62,10 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     const displaySingleItemHistory = (
         item: SearchItemValue<SearchablePublicationLogItem> | undefined,
     ) => {
+        trackLayoutActionDelegates.setSelectedPublicationSearchStartDate(
+            START_OF_2022.toISOString(),
+        );
+        trackLayoutActionDelegates.setSelectedPublicationSearchEndDate(new Date().toISOString());
         trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem(item);
         navigate('publication-search');
     };


### PR DESCRIPTION
Hyvin laiskasti tehty, mutta täysin toimiva toimintatapa: Haut takana on riittävän nopeita, että eipä ne oikeastaan tuosta päivämäärävälistä edes juuri välitä. Koska tässä ei ole helposti käsillä olion luontihetkeä tai viimeisintä muokkaushetkeä, käytetään siis vaan koko historiaa muutosaikavälinä.