### PR TITLE
GVT-3198: Add privilege gate to display debug layer menu

### DIFF
--- a/ui/src/map/layer-menu/map-layer-menu.tsx
+++ b/ui/src/map/layer-menu/map-layer-menu.tsx
@@ -16,7 +16,7 @@ import {
     layersToHideByProxy,
     layersToShowByProxy,
 } from 'map/map-store';
-import { VIEW_GEOMETRY } from 'user/user-model';
+import { VIEW_GEOMETRY, VIEW_LAYOUT_DRAFT } from 'user/user-model';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 
@@ -182,12 +182,14 @@ export const MapLayerMenu: React.FC<MapLayerMenuProps> = ({
                         />
                     </PrivilegeRequired>
                     <EnvRestricted restrictTo="dev">
-                        <MapLayerGroup
-                            title={t('map-layer-menu.debug-title')}
-                            menuItemVisibilities={mapLayerMenuGroups.debug}
-                            onMenuChange={onMenuChange}
-                            mapLayerVisibilities={visibleLayers}
-                        />
+                        <PrivilegeRequired privilege={VIEW_LAYOUT_DRAFT}>
+                            <MapLayerGroup
+                                title={t('map-layer-menu.debug-title')}
+                                menuItemVisibilities={mapLayerMenuGroups.debug}
+                                onMenuChange={onMenuChange}
+                                mapLayerVisibilities={visibleLayers}
+                            />
+                        </PrivilegeRequired>
                     </EnvRestricted>
                 </CloseableModal>
             )}


### PR DESCRIPTION
Bäkkärillä oli siis käytössä tuo VIEW_LAYOUT_DRAFT-privilege raidegraafi-karttatasolle, joka esti sen näyttämisen konsultti- ja virastokäyttäjille jo aiemmin (dev-ympäristössä). Aktivoinnista päätyi siis toast-virhe, joskin nähtävästi tämä bugi olikin olemassa vain dev-ympäristössä. 

Toki voisi miettiä, että haluttaisiinko raidegraafi-tasoa(/muita debug-työkaluja) käyttää myös tuotannossa (ilman redux-tilan manuaalikikkailua, jolla se olisi jo nytkin mahdollista).
