### PR TITLE
GVT-3140: Esikatselun julkaistavat muutokset -taulukko nollaantuu suunnitelmatilassa

### DIFF
--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -313,6 +313,7 @@ export const Dropdown = function <TItemValue>({
 
     function handleInputKeyUp(e: React.KeyboardEvent<HTMLInputElement>) {
         switch (e.code) {
+            case 'Delete':
             case 'Backspace': {
                 if (isEmpty(valueShownInInput) && props.canUnselect) {
                     select(undefined);

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -291,6 +291,7 @@ export const Dropdown = function <TItemValue>({
                             select(item?.value || undefined);
                         }
                     }
+                    break;
                 }
             }
         } else {
@@ -304,7 +305,19 @@ export const Dropdown = function <TItemValue>({
                     if (isEmpty(valueShownInInput)) {
                         select(undefined);
                     }
+                    break;
                 }
+            }
+        }
+    }
+
+    function handleInputKeyUp(e: React.KeyboardEvent<HTMLInputElement>) {
+        switch (e.code) {
+            case 'Backspace': {
+                if (isEmpty(valueShownInInput) && props.canUnselect) {
+                    select(undefined);
+                }
+                break;
             }
         }
     }
@@ -460,6 +473,7 @@ export const Dropdown = function <TItemValue>({
                         onBlur={handleInputBlur}
                         onKeyPress={handleInputKeyPress}
                         onKeyDown={handleInputKeyDown}
+                        onKeyUp={handleInputKeyUp}
                         disabled={props.disabled}
                         value={valueShownInInput}
                         onChange={(e) => handleInputChange(e.target.value)}

--- a/ui/src/vayla-design-lib/dropdown/dropdown.tsx
+++ b/ui/src/vayla-design-lib/dropdown/dropdown.tsx
@@ -240,6 +240,9 @@ export const Dropdown = function <TItemValue>({
             searchFor(value);
             setOptionFocusIndex(0);
         }
+        if (value === '' && props.canUnselect) {
+            select(undefined);
+        }
     }
 
     function getItemClassName(item: Item<TItemValue> | undefined, index: number) {
@@ -307,18 +310,6 @@ export const Dropdown = function <TItemValue>({
                     }
                     break;
                 }
-            }
-        }
-    }
-
-    function handleInputKeyUp(e: React.KeyboardEvent<HTMLInputElement>) {
-        switch (e.code) {
-            case 'Delete':
-            case 'Backspace': {
-                if (isEmpty(valueShownInInput) && props.canUnselect) {
-                    select(undefined);
-                }
-                break;
             }
         }
     }
@@ -474,7 +465,6 @@ export const Dropdown = function <TItemValue>({
                         onBlur={handleInputBlur}
                         onKeyPress={handleInputKeyPress}
                         onKeyDown={handleInputKeyDown}
-                        onKeyUp={handleInputKeyUp}
                         disabled={props.disabled}
                         value={valueShownInInput}
                         onChange={(e) => handleInputChange(e.target.value)}


### PR DESCRIPTION
Tämä ei ollutkaan ihan niin simppeli ongelma kuin alunperin ajattelin sen olevan. Käytännössä tämä täytyi kyhätä ominaisuudeksi Dropdowniin itseensä. Nyt siis käytännössä tehdään erikoistarkistelu sille, että jos Dropdownin input-kentän teksti on muutoseventissä tyhjä ja Dropdownissa on unselectaus päällä, niin tyhjätään valinta.

Aiemminhan dropdown on toiminut kaikissa tällaisissa tilanteissa siten, että aiempi arvo on säilytetty. Niin tehdään edelleen mikäli Dropdowniin jäi jotain tekstiä tai mikäli Dropdownissa ei ole unselect päällä. Tämä epäsynkka johtaa tämän tiketin myötä melko erilaiseen käyttökokemukseen dropdownin clearauksessa riippuen siitä onko unselect sallittu operaatio vai ei. Esimerkiksi ihan jo sijaintiraiteen muokkausdialogissa kentät kuten Duplikaatti raiteelle ja Kuvauksen lisäosa clearaantuvat tyhjennettäess. Kentät kuten Tila ja Raidetyyppi puolestaan taas säilyttävät arvonsa. Tuo ehkä kaipaisi jonkinlaista yhtenäistystä, mutta voidaan turista siitä vaikka dailyssä.