### PR TITLE
GVT-3171: Poistettujen suunnitelmatilojen nimet eivät näy julkaisukortissa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignController.kt
@@ -10,14 +10,18 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 
 @GeoviiteController("/track-layout/layout-design")
 class LayoutDesignController(val layoutDesignService: LayoutDesignService) {
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping("/")
-    fun getLayoutDesigns(): List<LayoutDesign> {
-        return layoutDesignService.list()
+    fun getLayoutDesigns(
+        @RequestParam("includeDeleted") includeDeleted: Boolean = false,
+        @RequestParam("includeCompleted") includeCompleted: Boolean = false,
+    ): List<LayoutDesign> {
+        return layoutDesignService.list(includeCompleted = includeCompleted, includeDeleted = includeDeleted)
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -29,8 +29,8 @@ class LayoutDesignService(
     private val switchDao: LayoutSwitchDao,
     private val kmPostDao: LayoutKmPostDao,
 ) {
-    fun list(): List<LayoutDesign> {
-        return dao.list()
+    fun list(includeCompleted: Boolean, includeDeleted: Boolean): List<LayoutDesign> {
+        return dao.list(includeCompleted = includeCompleted, includeDeleted = includeDeleted)
     }
 
     fun getOrThrow(id: IntId<LayoutDesign>): LayoutDesign {

--- a/ui/src/tool-bar/workspace-dialog.tsx
+++ b/ui/src/tool-bar/workspace-dialog.tsx
@@ -40,6 +40,7 @@ const saveRequest = (name: string, estimatedCompletion: Date): LayoutDesignSaveR
 });
 
 export const DESIGN_NAME_REGEX = /^[A-Za-zÄÖÅäöå0-9 \-+_!?.,"/()<>:&*#€$]*$/g;
+
 function validateDesignName(name: string, committed: boolean): string[] {
     return [
         committed && name.length < 2 ? 'name-too-short' : undefined,
@@ -65,7 +66,7 @@ export const WorkspaceDialog: React.FC<WorkspaceDialogProps> = ({
     const nameInputRef = React.useRef<HTMLInputElement>(null);
 
     const [allDesigns, allDesignsFetchStatus] = useLoaderWithStatus(
-        () => getLayoutDesigns(getChangeTimes().layoutDesign),
+        () => getLayoutDesigns(false, false, getChangeTimes().layoutDesign),
         [getChangeTimes().layoutDesign],
     );
     const designNameErrors = validateDesignName(name.trim(), nameCommitted);

--- a/ui/src/tool-bar/workspace-selection.tsx
+++ b/ui/src/tool-bar/workspace-selection.tsx
@@ -62,7 +62,7 @@ export const DesignSelection: React.FC<DesignSelectionProps> = ({ designId, onDe
     });
 
     const [designs, _] = useLoaderWithStatus(
-        () => getLayoutDesigns(getChangeTimes().layoutDesign),
+        () => getLayoutDesigns(false, false, getChangeTimes().layoutDesign),
         [getChangeTimes().layoutDesign],
     );
 


### PR DESCRIPTION
Aiempi ongelma johtui siitä, että peruutettuja ja poistettuja suunnitelmia ei ylipäätään palautettu frontille tuossa haussa. Parametrisoin tuon haun nyt siten, että ne saa välitettyä frontille ja otin sen käyttöön etusivun julkaisukortilla. Karttanäkymän hauissa ja luontinäkymissä näytetään edelleen pelkästään aktiiviset suunnitelmat 