### PR TITLE
GVT-3208 Add publication asset base versions + Change with non-null end-state

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -57,14 +57,14 @@ import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsLastComparator
 import fi.fta.geoviite.infra.util.processFlattened
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import withUser
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.stream.Collectors
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
-import withUser
 
 val unknownSwitchName = SwitchName("-")
 
@@ -189,7 +189,7 @@ constructor(
             }
         val structure = switch.switchStructureId?.let(switchLibraryService::getSwitchStructure)
         return if (transformation != null && structure != null) {
-            toLayoutSwitch(switch, structure, transformation)
+            toLayoutSwitch(switch, structure, transformation, switchLibraryService.getDefaultSwitchOwner().id)
         } else {
             null
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.geography.ToGkFinTransformation
 import fi.fta.geoviite.infra.geography.Transformation
 import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
@@ -123,6 +124,7 @@ class PlanLayoutCache(
                 heightTriangles,
                 planToGkTransformation,
                 { id -> switchLibraryService.getSwitchStructure(id) },
+                switchLibraryService.getDefaultSwitchOwner().id,
                 logger,
             )
         // caching is optional because some callers just want the transformation, but don't have a
@@ -143,6 +145,7 @@ private fun transformToLayoutPlan(
     heightTriangles: List<HeightTriangle>,
     planToGkTransformation: ToGkFinTransformation,
     getStructure: (IntId<SwitchStructure>) -> SwitchStructure,
+    ownerId: IntId<SwitchOwner>,
     logger: Logger,
 ): Pair<GeometryPlanLayout?, TransformationError?> =
     try {
@@ -155,6 +158,7 @@ private fun transformToLayoutPlan(
             pointListStepLength = pointListStepLength,
             planToGkTransformation = planToGkTransformation,
             getStructure = getStructure,
+            ownerId = ownerId,
         ) to null
     } catch (e: CoordinateTransformationException) {
         logger.warn(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -42,12 +42,12 @@ import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsFirstComparator
 import fi.fta.geoviite.infra.util.printCsv
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.ZoneId
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 
 const val DISTANCE_CHANGE_THRESHOLD = 0.0005
 
@@ -748,7 +748,7 @@ constructor(
             ),
             compareChangeValues(
                 changes.measurementMethod,
-                { it.name },
+                { it?.name },
                 PropKey("measurement-method"),
                 null,
                 "MeasurementMethod",
@@ -823,17 +823,14 @@ constructor(
                     previousComparisonTime,
                 )
         val publicationKmPostChanges =
-            if (canSkipLoadingChanges(publication, specificObjectId, PublishableObjectType.KM_POST))
-                mapOf()
+            if (canSkipLoadingChanges(publication, specificObjectId, PublishableObjectType.KM_POST)) mapOf()
             else publicationDao.fetchPublicationKmPostChanges(publication.id)
 
         val publicationReferenceLineChanges =
-            if (canSkipLoadingChanges(publication, specificObjectId, PublishableObjectType.REFERENCE_LINE))
-                mapOf()
+            if (canSkipLoadingChanges(publication, specificObjectId, PublishableObjectType.REFERENCE_LINE)) mapOf()
             else publicationDao.fetchPublicationReferenceLineChanges(publication.id)
         val publicationSwitchChanges =
-            if (canSkipLoadingChanges(publication, specificObjectId, PublishableObjectType.SWITCH))
-                mapOf()
+            if (canSkipLoadingChanges(publication, specificObjectId, PublishableObjectType.SWITCH)) mapOf()
             else publicationDao.fetchPublicationSwitchChanges(publication.id)
 
         val trackNumbers =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -422,11 +422,11 @@ constructor(
             publicationId,
             calculatedChanges,
             PublishedVersions(
-                trackNumbers.map { it.published },
-                referenceLines.map { it.published },
-                locationTracks.map { it.published },
-                switches.map { it.published },
-                kmPosts.map { it.published },
+                trackNumbers.map { it.versionChange },
+                referenceLines.map { it.versionChange },
+                locationTracks.map { it.versionChange },
+                switches.map { it.versionChange },
+                kmPosts.map { it.versionChange },
             ),
         )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
@@ -17,6 +17,10 @@ class SwitchLibraryService(
         structures.associateBy { switchStructure -> switchStructure.id }
     }
 
+    fun getDefaultSwitchOwner(): SwitchOwner {
+        return requireNotNull(getSwitchOwner(IntId(1))) { "Default switch owner not found" }
+    }
+
     fun getSwitchStructures(): List<SwitchStructure> = structures
 
     fun getSwitchStructuresById(): Map<IntId<SwitchStructure>, SwitchStructure> = structuresById

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
@@ -43,7 +43,7 @@ data class LayoutSwitch(
     val joints: List<LayoutSwitchJoint>,
     val sourceId: DomainId<GeometrySwitch>?,
     val trapPoint: Boolean?,
-    val ownerId: IntId<SwitchOwner>?,
+    val ownerId: IntId<SwitchOwner>,
     val source: GeometrySource,
     val draftOid: Oid<LayoutSwitch>?,
     @JsonIgnore override val contextData: LayoutContextData<LayoutSwitch>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -422,7 +422,7 @@ class LayoutSwitchDao(
                     accuracies = rs.getNullableEnumArray<LocationAccuracy>("joint_location_accuracies"),
                 ),
             trapPoint = rs.getBooleanOrNull("trap_point"),
-            ownerId = rs.getIntIdOrNull("owner_id"),
+            ownerId = rs.getIntId("owner_id"),
             source = rs.getEnum("source"),
             draftOid = rs.getOidOrNull("draft_oid"),
             contextData =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -31,6 +31,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Point3DM
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
 import fi.fta.geoviite.infra.math.round
+import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.LayoutState.DELETED
 import fi.fta.geoviite.infra.tracklayout.LayoutState.IN_USE
@@ -50,6 +51,7 @@ fun toTrackLayout(
     includeGeometryData: Boolean,
     planToGkTransformation: ToGkFinTransformation,
     getStructure: (IntId<SwitchStructure>) -> SwitchStructure,
+    ownerId: IntId<SwitchOwner>,
 ): GeometryPlanLayout {
     val switches =
         toLayoutSwitches(
@@ -57,6 +59,7 @@ fun toTrackLayout(
                 s.switchStructureId?.let(getStructure)?.let { structure -> s to structure }
             },
             planToLayout,
+            ownerId,
         )
 
     val alignments: List<PlanLayoutAlignment> =
@@ -113,7 +116,12 @@ fun toLayoutKmPosts(
     }
 }
 
-fun toLayoutSwitch(switch: GeometrySwitch, structure: SwitchStructure, toMapCoordinate: Transformation): LayoutSwitch =
+fun toLayoutSwitch(
+    switch: GeometrySwitch,
+    structure: SwitchStructure,
+    toMapCoordinate: Transformation,
+    ownerId: IntId<SwitchOwner>,
+): LayoutSwitch =
     LayoutSwitch(
         name = switch.name,
         switchStructureId = structure.id,
@@ -129,7 +137,7 @@ fun toLayoutSwitch(switch: GeometrySwitch, structure: SwitchStructure, toMapCoor
             },
         sourceId = switch.id,
         trapPoint = null,
-        ownerId = null,
+        ownerId = ownerId,
         source = GeometrySource.PLAN,
         contextData = LayoutContextData.newDraft(LayoutBranch.main, id = null),
         draftOid = null,
@@ -138,9 +146,10 @@ fun toLayoutSwitch(switch: GeometrySwitch, structure: SwitchStructure, toMapCoor
 fun toLayoutSwitches(
     geometrySwitches: List<Pair<GeometrySwitch, SwitchStructure>>,
     planToLayout: Transformation,
+    ownerId: IntId<SwitchOwner>,
 ): Map<DomainId<GeometrySwitch>, LayoutSwitch> =
     geometrySwitches
-        .map { (switch, structure) -> toLayoutSwitch(switch, structure, planToLayout).let { switch.id to it } }
+        .map { (switch, structure) -> toLayoutSwitch(switch, structure, planToLayout, ownerId).let { switch.id to it } }
         .associate { it }
 
 fun toMapAlignments(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -8,12 +8,12 @@ import fi.fta.geoviite.infra.logging.AccessType.VERSION_FETCH
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.util.FetchType.MULTI
 import fi.fta.geoviite.infra.util.FetchType.SINGLE
-import java.sql.ResultSet
-import java.time.Instant
-import kotlin.reflect.KClass
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.sql.ResultSet
+import java.time.Instant
+import kotlin.reflect.KClass
 
 enum class FetchType {
     SINGLE,
@@ -52,7 +52,7 @@ enum class LayoutAssetTable(val dbTable: DbTable, val idTable: String, layoutCon
     val versionTable: String = dbTable.versionTable
 }
 
-enum class DbTable(schema: String, table: String, sortColumns: List<String> = listOf("id")) {
+enum class DbTable(schema: String, val table: String, sortColumns: List<String> = listOf("id")) {
     COMMON_SWITCH_STRUCTURE("common", "switch_structure"),
     LAYOUT_ALIGNMENT("layout", "alignment"),
     LAYOUT_LOCATION_TRACK("layout", "location_track"),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -380,20 +380,35 @@ fun ResultSet.getPVId(name: String): PVId = verifyNotNull(name, ::getPVIdOrNull)
 
 fun ResultSet.getPVIdOrNull(name: String): PVId? = getString(name)?.let(::PVId)
 
-fun <T> ResultSet.getChange(name: String, getter: (name: String) -> T?): Change<T> =
+fun <T> ResultSet.getChange(name: String, nullableGetter: (name: String) -> T?): Change<T> =
+    Change(
+        nullableGetter("old_$name"),
+        requireNotNull(nullableGetter(name)) { "Change new value was null: column=$name" },
+    )
+
+fun <T> ResultSet.getNullableChange(name: String, getter: (name: String) -> T?): Change<T?> =
     Change(getter("old_$name"), getter(name))
 
-fun ResultSet.getChangePoint(nameX: String, nameY: String) =
+fun ResultSet.getChangePoint(nameX: String, nameY: String): Change<Point> =
+    Change(getPointOrNull("old_$nameX", "old_$nameY"), getPoint(nameX, nameY))
+
+fun ResultSet.getNullableChangePoint(nameX: String, nameY: String) =
     Change(getPointOrNull("old_$nameX", "old_$nameY"), getPointOrNull(nameX, nameY))
 
-fun ResultSet.getChangeGeometryPoint(nameX: String, nameY: String, sridName: String) =
+fun ResultSet.getChangeGeometryPoint(nameX: String, nameY: String, sridName: String): Change<GeometryPoint> =
+    Change(
+        getGeometryPointOrNull("old_$nameX", "old_$nameY", "old_$sridName"),
+        getGeometryPoint(nameX, nameY, sridName),
+    )
+
+fun ResultSet.getNullableChangeGeometryPoint(nameX: String, nameY: String, sridName: String) =
     Change(
         getGeometryPointOrNull("old_$nameX", "old_$nameY", "old_$sridName"),
         getGeometryPointOrNull(nameX, nameY, sridName),
     )
 
 fun <T> ResultSet.getChangeRowVersion(idName: String, versionName: String): Change<RowVersion<T>> =
-    Change(getRowVersionOrNull("old_$idName", "old_$versionName"), getRowVersionOrNull(idName, versionName))
+    Change(getRowVersionOrNull("old_$idName", "old_$versionName"), getRowVersion(idName, versionName))
 
 fun ResultSet.getLayoutContext(contextIdName: String): LayoutContext =
     verifyNotNull(contextIdName, ::getLayoutContextOrNull)

--- a/infra/src/main/resources/db/migration/prod/V123__make_switch_owner_non_null.sql
+++ b/infra/src/main/resources/db/migration/prod/V123__make_switch_owner_non_null.sql
@@ -1,0 +1,4 @@
+alter table layout.switch
+  alter column owner_id set not null;
+alter table layout.switch_version
+  alter column owner_id set not null;

--- a/infra/src/main/resources/db/migration/prod/V124__add_base_versions_to_published_assets.sql
+++ b/infra/src/main/resources/db/migration/prod/V124__add_base_versions_to_published_assets.sql
@@ -1,0 +1,157 @@
+-- Simplify publication table composite key column names to match version tables
+-- As elsewhere in Geoviite, the pattern is now that the item's own id is just 'id', not 'item_id'
+
+alter table publication.track_number
+  rename column track_number_id to id;
+alter table publication.track_number
+  rename column track_number_version to version;
+
+alter table publication.reference_line
+  rename column reference_line_id to id;
+alter table publication.reference_line
+  rename column reference_line_version to version;
+
+alter table publication.km_post
+  rename column km_post_id to id;
+alter table publication.km_post
+  rename column km_post_version to version;
+
+alter table publication.location_track
+  rename column location_track_id to id;
+alter table publication.location_track
+  rename column location_track_version to version;
+
+alter table publication.switch
+  rename column switch_id to id;
+alter table publication.switch
+  rename column switch_version to version;
+
+-- Add new base-version columns to ease finding it, since the base version can be of a different context
+-- Note, the asset ID can not change, so there is no base_id
+-- Base version is nullable, since a new asset can't have a base version
+
+alter table publication.track_number
+  add column base_version           int     null,
+  add column base_layout_context_id varchar null,
+  add constraint publication_base_track_number_version_fkey
+    foreign key (id, base_layout_context_id, base_version)
+      references layout.track_number_version (id, layout_context_id, version);
+
+alter table publication.reference_line
+  add column base_version           int     null,
+  add column base_layout_context_id varchar null,
+  add constraint publication_base_reference_line_version_fkey
+    foreign key (id, base_layout_context_id, base_version)
+      references layout.reference_line_version (id, layout_context_id, version);
+
+alter table publication.km_post
+  add column base_version           int     null,
+  add column base_layout_context_id varchar null,
+  add constraint publication_base_km_post_version_fkey
+    foreign key (id, base_layout_context_id, base_version)
+      references layout.km_post_version (id, layout_context_id, version);
+
+alter table publication.location_track
+  add column base_version           int     null,
+  add column base_layout_context_id varchar null,
+  add constraint publication_base_location_track_version_fkey
+    foreign key (id, base_layout_context_id, base_version)
+      references layout.location_track_version (id, layout_context_id, version);
+
+alter table publication.switch
+  add column base_version           int     null,
+  add column base_layout_context_id varchar null,
+  add constraint publication_base_switch_version_fkey
+    foreign key (id, base_layout_context_id, base_version)
+      references layout.switch_version (id, layout_context_id, version);
+
+update publication.location_track
+set
+  base_version = version,
+  base_layout_context_id = layout_context_id
+  where direct_change = false;
+
+-- For non-direct changes, we can set the base version to the current version, as it didn't change in that publication
+-- For the others, we don't actually have any designs yet, so we can simply set the base version to
+-- be the previous version of the same (always main) context. In the future, this must be set when
+-- saving the publication
+
+update publication.track_number publication_asset
+set
+  base_version = base_version.version,
+  base_layout_context_id = base_version.layout_context_id
+  from (
+    select id, layout_context_id, version
+      from layout.track_number_version
+      where deleted = false
+  ) base_version
+  where publication_asset.id = base_version.id
+    and publication_asset.layout_context_id = base_version.layout_context_id
+    and publication_asset.version = base_version.version + 1
+    and publication_asset.direct_change = true;
+
+update publication.reference_line publication_asset
+set
+  base_version = base_version.version,
+  base_layout_context_id = base_version.layout_context_id
+  from (
+    select id, layout_context_id, version
+      from layout.reference_line_version
+      where deleted = false
+  ) base_version
+  where publication_asset.id = base_version.id
+    and publication_asset.layout_context_id = base_version.layout_context_id
+    and publication_asset.version = base_version.version + 1;
+
+update publication.km_post publication_asset
+set
+  base_version = base_version.version,
+  base_layout_context_id = base_version.layout_context_id
+  from (
+    select id, layout_context_id, version
+      from layout.km_post_version
+      where deleted = false
+  ) base_version
+  where publication_asset.id = base_version.id
+    and publication_asset.layout_context_id = base_version.layout_context_id
+    and publication_asset.version = base_version.version + 1;
+
+update publication.track_number
+set
+  base_version = version,
+  base_layout_context_id = layout_context_id
+  where direct_change = false;
+
+update publication.location_track publication_asset
+set
+  base_version = base_version.version,
+  base_layout_context_id = base_version.layout_context_id
+  from (
+    select id, layout_context_id, version
+      from layout.location_track_version
+      where deleted = false
+  ) base_version
+  where publication_asset.id = base_version.id
+    and publication_asset.layout_context_id = base_version.layout_context_id
+    and publication_asset.version = base_version.version + 1
+    and publication_asset.direct_change = true;
+
+update publication.switch
+set
+  base_version = version,
+  base_layout_context_id = layout_context_id
+  where direct_change = false;
+
+update publication.switch publication_asset
+set
+  base_version = base_version.version,
+  base_layout_context_id = base_version.layout_context_id
+  from (
+    select id, layout_context_id, version
+      from layout.switch_version
+      where deleted = false
+  ) base_version
+  where publication_asset.id = base_version.id
+    and publication_asset.layout_context_id = base_version.layout_context_id
+    and publication_asset.version = base_version.version + 1
+    and publication_asset.direct_change = true;

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -27,6 +27,7 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndAlignment
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -546,7 +547,7 @@ constructor(
                 kmPost(
                     trackNumberId = geocodableTrack.trackNumber.id as IntId,
                     km = KmNumber(index + 1),
-                    roughLayoutLocation = kmPostLocation,
+                    gkLocation = kmPostGkLocation(kmPostLocation),
                     draft = false,
                 )
             }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -23,6 +23,7 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.assertEquals
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -110,21 +111,22 @@ constructor(
 
         kmPostService.saveDraft(
             LayoutBranch.main,
-            kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 14.5), draft = true),
+            kmPost(trackNumberId, KmNumber("0155"), kmPostGkLocation(0.0, 14.5), draft = true),
         )
         kmPostService.saveDraft(
             LayoutBranch.main,
-            kmPost(trackNumberId, KmNumber("0156"), Point(0.0, 27.6), draft = true),
+            kmPost(trackNumberId, KmNumber("0156"), kmPostGkLocation(0.0, 27.6), draft = true),
         )
 
         // tickLength = 5 => normal ticks less than 2.5 distance apart from a neighbor get dropped
-        val actual = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            LineM(0.0),
-            LineM(30.0),
-            5
-        )!!
+        val actual =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                LineM(0.0),
+                LineM(30.0),
+                5,
+            )!!
 
         // location track starts 1 m after reference line start; reference line start address is
         // 123.4; so first address
@@ -134,10 +136,11 @@ constructor(
         // start.
         val expectedData =
             listOf(
-                "0154" to listOf(124.4 to 0.0, 125.0 to 0.6, 130.0 to 5.6, 135.0 to 10.6),
-                "0155" to listOf(0.0 to 13.5, 5.0 to 18.5, 10.0 to 23.5),
-                "0156" to listOf(0.0 to 26.6, 1.4 to 28.0),
-            ).map { (kmNumber, ms) -> kmNumber to ms.map { (meter, m) -> meter to LineM<LocationTrackM>(m) } }
+                    "0154" to listOf(124.4 to 0.0, 125.0 to 0.6, 130.0 to 5.6, 135.0 to 10.6),
+                    "0155" to listOf(0.0 to 13.5, 5.0 to 18.5, 10.0 to 23.5),
+                    "0156" to listOf(0.0 to 26.6, 1.4 to 28.0),
+                )
+                .map { (kmNumber, ms) -> kmNumber to ms.map { (meter, m) -> meter to LineM<LocationTrackM>(m) } }
 
         actual.forEachIndexed { kmIndex, actualKm ->
             val expectedKm = expectedData[kmIndex]
@@ -210,13 +213,14 @@ constructor(
                     ),
                 )
                 .id
-        val kmHeights = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            LineM(0.0),
-            LineM(20.0),
-            5
-        )!!
+        val kmHeights =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                LineM(0.0),
+                LineM(20.0),
+                5,
+            )!!
         // this track is exactly straight on the reference line, so m-values and track meters
         // coincide perfectly; also,
         // the profile is at exactly 50 meters height at every point where it's linked
@@ -235,12 +239,13 @@ constructor(
                     13 to 50,
                     15 to 50,
                     17 to 50,
-                ).map { (m, h) ->
+                )
+                .map { (m, h) ->
                     TrackMeterHeight(
                         LineM<LocationTrackM>(m.toDouble()),
                         m.toDouble(),
                         h?.toDouble(),
-                        Point(0.0, m.toDouble())
+                        Point(0.0, m.toDouble()),
                     )
                 }
         assertEquals(expected, kmHeights[0].trackMeterHeights)
@@ -287,16 +292,17 @@ constructor(
         // its position back to exactly 10, causing the 9..10 connection segment's end address to
         // also be in
         // track km 0155
-        val post = kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 10.00001), draft = true)
+        val post = kmPost(trackNumberId, KmNumber("0155"), kmPostGkLocation(0.0, 10.00001), draft = true)
         kmPostService.saveDraft(LayoutBranch.main, post)
 
-        val actual = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            LineM(0.0),
-            LineM(20.0),
-            5
-        )!!
+        val actual =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                LineM(0.0),
+                LineM(20.0),
+                5,
+            )!!
 
         val expected =
             listOf(
@@ -335,19 +341,20 @@ constructor(
                 .id
         kmPostService.saveDraft(
             LayoutBranch.main,
-            kmPost(trackNumberId, KmNumber("0155"), Point(0.0, 8.0), draft = true),
+            kmPost(trackNumberId, KmNumber("0155"), kmPostGkLocation(0.0, 8.0), draft = true),
         )
         kmPostService.saveDraft(
             LayoutBranch.main,
-            kmPost(trackNumberId, KmNumber("0156"), Point(0.0, 9.0), draft = true),
+            kmPost(trackNumberId, KmNumber("0156"), kmPostGkLocation(0.0, 9.0), draft = true),
         )
-        val actual = geometryService.getLocationTrackHeights(
-            MainLayoutContext.draft,
-            locationTrackId,
-            LineM(0.0),
-            LineM(20.0),
-            5
-        )!!
+        val actual =
+            geometryService.getLocationTrackHeights(
+                MainLayoutContext.draft,
+                locationTrackId,
+                LineM(0.0),
+                LineM(20.0),
+                5,
+            )!!
         assertEquals(3, actual.size)
         assertEquals(2, actual[0].trackMeterHeights.size)
         assertEquals(1, actual[1].trackMeterHeights.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -40,6 +40,7 @@ import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.fixMValues
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -644,7 +645,7 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumber.id as IntId,
                         km = KmNumber(1),
-                        roughLayoutLocation = refPoint + 5.0,
+                        gkLocation = kmPostGkLocation(refPoint + 5.0),
                         draft = false,
                     )
                 )
@@ -655,7 +656,7 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumber.id as IntId,
                         km = KmNumber(2),
-                        roughLayoutLocation = refPoint + 10.0,
+                        gkLocation = kmPostGkLocation(refPoint + 10.0),
                         draft = false,
                     )
                 )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -50,6 +50,7 @@ import fi.fta.geoviite.infra.tracklayout.addTopologyStartSwitchIntoLocationTrack
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.moveKmPostLocation
 import fi.fta.geoviite.infra.tracklayout.moveLocationTrackGeometryPointsAndUpdate
@@ -506,7 +507,7 @@ constructor(
         moveLocationTrackGeometryPointsAndUpdate(
             locationTrack3,
             alignment3,
-            { point -> if (point.m.distance <200) point + 2.0 else point.toPoint() },
+            { point -> if (point.m.distance < 200) point + 2.0 else point.toPoint() },
             locationTrackService = locationTrackService,
         )
 
@@ -1067,8 +1068,7 @@ constructor(
     fun `changes done in a main publication can be inherited to assets edited in design`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
         mainOfficialContext.save(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
-        val kmPost =
-            mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), roughLayoutLocation = Point(3.0, 0.0))).id
+        val kmPost = mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(3.0, 0.0))).id
         val switch = mainOfficialContext.save(switch(joints = listOf(switchJoint(1, Point(7.0, 0.0))))).id
         val locationTrack =
             mainOfficialContext
@@ -1134,8 +1134,7 @@ constructor(
         mainOfficialContext.save(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
         val designBranch = testDBService.createDesignBranch()
         val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
-        val kmPost =
-            mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), roughLayoutLocation = Point(3.0, 0.0))).id
+        val kmPost = mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(3.0, 0.0))).id
         val switch = designDraftContext.save(switch(joints = listOf(switchJoint(1, Point(7.0, 0.0))))).id
         val locationTrack =
             designDraftContext
@@ -1195,8 +1194,7 @@ constructor(
     fun `changes to main objects that are overridden in design don't cause inherited changes`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
         mainOfficialContext.save(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
-        val kmPost =
-            mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), roughLayoutLocation = Point(3.0, 0.0))).id
+        val kmPost = mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(3.0, 0.0))).id
         val switch =
             mainOfficialContext
                 .save(
@@ -1257,9 +1255,9 @@ constructor(
     fun `getChangedSwitchesFromChangedLocationTrackKms happy path`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
         mainOfficialContext.save(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(12.0, 0.0))))
-        mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), roughLayoutLocation = Point(3.0, 0.0))).id
-        mainOfficialContext.save(kmPost(trackNumber, KmNumber(2), roughLayoutLocation = Point(6.0, 0.0))).id
-        mainOfficialContext.save(kmPost(trackNumber, KmNumber(3), roughLayoutLocation = Point(9.0, 0.0))).id
+        mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(3.0, 0.0))).id
+        mainOfficialContext.save(kmPost(trackNumber, KmNumber(2), kmPostGkLocation(6.0, 0.0))).id
+        mainOfficialContext.save(kmPost(trackNumber, KmNumber(3), kmPostGkLocation(9.0, 0.0))).id
         val switchAt0 = mainDraftContext.save(switch(joints = listOf(switchJoint(1, Point(4.0, 0.0))))).id
         val switchAt4 = mainDraftContext.save(switch(joints = listOf(switchJoint(1, Point(4.0, 0.0))))).id
         val locationTrack =
@@ -1324,7 +1322,7 @@ constructor(
     fun `getChangedSwitchesFromChangedLocationTrackKms accepts cancelled location tracks created in design`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
         mainOfficialContext.save(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(12.0, 0.0))))
-        mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), roughLayoutLocation = Point(3.0, 0.0))).id
+        mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(3.0, 0.0))).id
         val switch = mainOfficialContext.save(switch(joints = listOf(switchJoint(1, Point(4.0, 0.0))))).id
         val designBranch = testDBService.createDesignBranch()
         val designOfficialContext = testDBService.testContext(designBranch, PublicationState.OFFICIAL)
@@ -1431,7 +1429,7 @@ constructor(
                         kmPost(
                             trackNumberId = trackNumber.id as IntId,
                             km = kmNumber,
-                            roughLayoutLocation = refPoint + location,
+                            gkLocation = kmPostGkLocation(refPoint + location),
                             draft = false,
                         )
                     )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/RatkoPushDaoIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.publication.Change
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
@@ -21,16 +22,16 @@ import fi.fta.geoviite.infra.tracklayout.publishedVersions
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getInstantOrNull
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -67,7 +68,7 @@ constructor(
         val locationTrackResponse = insertAndPublishLocationTrack()
         locationTrackId = locationTrackResponse.id
         val beforePublish = ratkoPushDao.getLatestPublicationMoment()
-        publicationId = createPublication(locationTracks = listOf(locationTrackResponse))
+        publicationId = createPublication(locationTracks = listOf(Change(null, locationTrackResponse)))
         publicationMoment = publicationDao.getPublication(publicationId).publicationTime
         assertTrue(publicationMoment > beforePublish)
         assertEquals(publicationMoment, ratkoPushDao.getLatestPublicationMoment())
@@ -184,7 +185,8 @@ constructor(
     @Test
     fun shouldReturnMultipleUnpublishedLayoutPublishes() {
         val locationTrack2Response = insertAndPublishLocationTrack()
-        val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response), message = "Test")
+        val publicationId2 =
+            createPublication(locationTracks = listOf(Change(null, locationTrack2Response)), message = "Test")
 
         val latestPushedMoment = ratkoPushDao.getLatestPushedPublicationMoment(LayoutBranch.main)
         assertTrue(latestPushedMoment < publicationMoment)
@@ -197,9 +199,13 @@ constructor(
         assertNotNull(fetchedLayoutPublish2)
 
         val (publishLocationTracks, _) =
-            publicationDao.fetchPublishedLocationTracks(setOf(fetchedLayoutPublish.id)).getValue(fetchedLayoutPublish.id)
+            publicationDao
+                .fetchPublishedLocationTracks(setOf(fetchedLayoutPublish.id))
+                .getValue(fetchedLayoutPublish.id)
         val (publish2LocationTracks, _) =
-            publicationDao.fetchPublishedLocationTracks(setOf(fetchedLayoutPublish2.id)).getValue(fetchedLayoutPublish2.id)
+            publicationDao
+                .fetchPublishedLocationTracks(setOf(fetchedLayoutPublish2.id))
+                .getValue(fetchedLayoutPublish2.id)
 
         assertEquals(1, publishLocationTracks.size)
         assertEquals(1, publish2LocationTracks.size)
@@ -211,9 +217,11 @@ constructor(
     @Test
     fun `Should return latest publications`() {
         val locationTrack1Response = insertAndPublishLocationTrack()
-        val publicationId1 = createPublication(locationTracks = listOf(locationTrack1Response), message = "Test")
+        val publicationId1 =
+            createPublication(locationTracks = listOf(Change(null, locationTrack1Response)), message = "Test")
         val locationTrack2Response = insertAndPublishLocationTrack()
-        val publicationId2 = createPublication(locationTracks = listOf(locationTrack2Response), message = "Test")
+        val publicationId2 =
+            createPublication(locationTracks = listOf(Change(null, locationTrack2Response)), message = "Test")
 
         val publications = publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, 2)
 
@@ -255,11 +263,11 @@ constructor(
 
     fun createPublication(
         layoutBranch: LayoutBranch = LayoutBranch.main,
-        trackNumbers: List<LayoutRowVersion<LayoutTrackNumber>> = listOf(),
-        referenceLines: List<LayoutRowVersion<ReferenceLine>> = listOf(),
-        locationTracks: List<LayoutRowVersion<LocationTrack>> = listOf(),
-        switches: List<LayoutRowVersion<LayoutSwitch>> = listOf(),
-        kmPosts: List<LayoutRowVersion<LayoutKmPost>> = listOf(),
+        trackNumbers: List<Change<LayoutRowVersion<LayoutTrackNumber>>> = listOf(),
+        referenceLines: List<Change<LayoutRowVersion<ReferenceLine>>> = listOf(),
+        locationTracks: List<Change<LayoutRowVersion<LocationTrack>>> = listOf(),
+        switches: List<Change<LayoutRowVersion<LayoutSwitch>>> = listOf(),
+        kmPosts: List<Change<LayoutRowVersion<LayoutKmPost>>> = listOf(),
         message: String = "",
     ): IntId<Publication> =
         publicationDao
@@ -274,12 +282,12 @@ constructor(
                     CalculatedChanges(
                         directChanges =
                             DirectChanges(
-                                kmPostChanges = kmPosts.map { it.id },
-                                referenceLineChanges = referenceLines.map { it.id },
+                                kmPostChanges = kmPosts.map { it.new.id },
+                                referenceLineChanges = referenceLines.map { it.new.id },
                                 trackNumberChanges =
                                     trackNumbers.map {
                                         TrackNumberChange(
-                                            trackNumberId = it.id,
+                                            trackNumberId = it.new.id,
                                             changedKmNumbers = emptySet(),
                                             isStartChanged = false,
                                             isEndChanged = false,
@@ -288,13 +296,13 @@ constructor(
                                 locationTrackChanges =
                                     locationTracks.map {
                                         LocationTrackChange(
-                                            locationTrackId = it.id,
+                                            locationTrackId = it.new.id,
                                             changedKmNumbers = emptySet(),
                                             isStartChanged = false,
                                             isEndChanged = false,
                                         )
                                     },
-                                switchChanges = switches.map { SwitchChange(it.id, emptyList()) },
+                                switchChanges = switches.map { SwitchChange(it.new.id, emptyList()) },
                             ),
                         indirectChanges =
                             IndirectChanges(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -199,9 +199,9 @@ constructor(
 
     @Test
     fun allCalculatedChangesAreRecorded() {
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val locationTrackId = insertAndCheck(locationTrack(trackNumberId, draft = false)).first.id
-        val switchId = insertAndCheck(switch(draft = false)).first.id
+        val trackNumberVersion = mainOfficialContext.createLayoutTrackNumber()
+        val locationTrackVersion = insertAndCheck(locationTrack(trackNumberVersion.id, draft = false)).first
+        val switchVersion = insertAndCheck(switch(draft = false)).first
 
         val switchJointChange =
             SwitchJointChange(
@@ -209,9 +209,9 @@ constructor(
                 false,
                 TrackMeter(1234, "AA", 12.34, 3),
                 Point(100.0, 200.0),
-                locationTrackId,
+                locationTrackVersion.id,
                 Oid("123.456.789"),
-                trackNumberId,
+                trackNumberVersion.id,
                 Oid("1.234.567"),
             )
 
@@ -222,7 +222,7 @@ constructor(
                         trackNumberChanges =
                             listOf(
                                 TrackNumberChange(
-                                    trackNumberId,
+                                    trackNumberVersion.id,
                                     setOf(KmNumber(1234), KmNumber(45, "AB")),
                                     isStartChanged = true,
                                     isEndChanged = false,
@@ -233,13 +233,13 @@ constructor(
                         locationTrackChanges =
                             listOf(
                                 LocationTrackChange(
-                                    locationTrackId,
+                                    locationTrackVersion.id,
                                     setOf(KmNumber(456)),
                                     isStartChanged = false,
                                     isEndChanged = true,
                                 )
                             ),
-                        switchChanges = listOf(SwitchChange(switchId, listOf(switchJointChange))),
+                        switchChanges = listOf(SwitchChange(switchVersion.id, listOf(switchJointChange))),
                     ),
                 indirectChanges = IndirectChanges(emptyList(), emptyList(), emptyList()),
             )
@@ -254,9 +254,9 @@ constructor(
             publicationId,
             changes,
             publishedVersions(
-                trackNumbers = listOf(trackNumberDao.fetchVersion(MainLayoutContext.official, trackNumberId)!!),
-                locationTracks = listOf(locationTrackDao.fetchVersion(MainLayoutContext.official, locationTrackId)!!),
-                switches = listOf(switchDao.fetchVersion(MainLayoutContext.official, switchId)!!),
+                trackNumbers = listOf(Change(null, trackNumberVersion)),
+                locationTracks = listOf(Change(null, locationTrackVersion)),
+                switches = listOf(Change(null, switchVersion)),
             ),
         )
 
@@ -264,21 +264,20 @@ constructor(
             publicationDao.fetchPublishedTrackNumbers(setOf(publicationId)).getValue(publicationId)
         val publishedLocationTracks =
             publicationDao.fetchPublishedLocationTracks(setOf(publicationId)).getValue(publicationId)
-        val publishedSwitches =
-            publicationDao.fetchPublishedSwitches(setOf(publicationId)).getValue(publicationId)
-        assertTrue(publishedTrackNumbers.directChanges.all { it.id == trackNumberId })
+        val publishedSwitches = publicationDao.fetchPublishedSwitches(setOf(publicationId)).getValue(publicationId)
+        assertTrue(publishedTrackNumbers.directChanges.all { it.id == trackNumberVersion.id })
         assertEquals(
             changes.directChanges.trackNumberChanges.flatMap { it.changedKmNumbers }.sorted(),
             publishedTrackNumbers.directChanges.flatMap { it.changedKmNumbers }.sorted(),
         )
 
-        assertTrue(publishedLocationTracks.directChanges.all { it.id == locationTrackId })
+        assertTrue(publishedLocationTracks.directChanges.all { it.id == locationTrackVersion.id })
         assertEquals(
             changes.directChanges.locationTrackChanges.flatMap { it.changedKmNumbers }.sorted(),
             publishedLocationTracks.directChanges.flatMap { it.changedKmNumbers }.sorted(),
         )
 
-        assertTrue(publishedSwitches.directChanges.all { it.id == switchId })
+        assertTrue(publishedSwitches.directChanges.all { it.id == switchVersion.id })
         assertEquals(listOf(switchJointChange), publishedSwitches.directChanges.flatMap { it.changedJoints })
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -49,6 +49,7 @@ import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLine
@@ -1902,7 +1903,7 @@ constructor(
             designOfficialContext
                 .save(referenceLine(trackNumber), alignment(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
-        val kmPost = designOfficialContext.save(kmPost(trackNumber, KmNumber(1), Point(1.0, 0.0))).id
+        val kmPost = designOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(1.0, 0.0))).id
         designDraftContext.save(designOfficialContext.fetch(kmPost)!!)
         trackNumberService.cancel(designBranch, trackNumber)
         referenceLineService.cancel(designBranch, referenceLine)
@@ -2009,19 +2010,23 @@ constructor(
         val alignment = alignment(segment(Point(0.0, 0.0), Point(40.0, 0.0)))
         mainOfficialContext.save(referenceLine(trackNumberId), alignment).id
 
-        mainOfficialContext.save(kmPost(trackNumberId, KmNumber(1), Point(1.0, 0.0)))
-        mainOfficialContext.save(kmPost(trackNumberId, KmNumber(2), Point(2.0, 0.0)))
-        mainOfficialContext.save(kmPost(trackNumberId, KmNumber(3), Point(3.0, 0.0), state = LayoutState.DELETED))
-        mainOfficialContext.save(kmPost(trackNumberId, KmNumber(4), Point(4.0, 0.0), state = LayoutState.DELETED))
-        val kp1 = designOfficialContext.save(kmPost(trackNumberId, KmNumber(1), Point(1.0, 0.0))).id
+        mainOfficialContext.save(kmPost(trackNumberId, KmNumber(1), kmPostGkLocation(1.0, 0.0)))
+        mainOfficialContext.save(kmPost(trackNumberId, KmNumber(2), kmPostGkLocation(2.0, 0.0)))
+        mainOfficialContext.save(
+            kmPost(trackNumberId, KmNumber(3), kmPostGkLocation(3.0, 0.0), state = LayoutState.DELETED)
+        )
+        mainOfficialContext.save(
+            kmPost(trackNumberId, KmNumber(4), kmPostGkLocation(4.0, 0.0), state = LayoutState.DELETED)
+        )
+        val kp1 = designOfficialContext.save(kmPost(trackNumberId, KmNumber(1), kmPostGkLocation(1.0, 0.0))).id
         val kp2 =
             designOfficialContext
-                .save(kmPost(trackNumberId, KmNumber(2), Point(2.0, 0.0), state = LayoutState.DELETED))
+                .save(kmPost(trackNumberId, KmNumber(2), kmPostGkLocation(2.0, 0.0), state = LayoutState.DELETED))
                 .id
-        val kp3 = designOfficialContext.save(kmPost(trackNumberId, KmNumber(3), Point(3.0, 0.0))).id
+        val kp3 = designOfficialContext.save(kmPost(trackNumberId, KmNumber(3), kmPostGkLocation(3.0, 0.0))).id
         val kp4 =
             designOfficialContext
-                .save(kmPost(trackNumberId, KmNumber(4), Point(4.0, 0.0), state = LayoutState.DELETED))
+                .save(kmPost(trackNumberId, KmNumber(4), kmPostGkLocation(4.0, 0.0), state = LayoutState.DELETED))
                 .id
 
         val validation =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -40,6 +40,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.offsetGeometry
 import fi.fta.geoviite.infra.tracklayout.rawPoints
@@ -413,8 +414,8 @@ class PublicationValidationTest {
                 geocodingContext(
                     toSegmentPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(
-                        kmPost(IntId(1), KmNumber(1), Point(12.0, 0.0), draft = true),
-                        kmPost(IntId(1), KmNumber(2), Point(18.0, 0.0), draft = true),
+                        kmPost(IntId(1), KmNumber(1), kmPostGkLocation(12.0, 0.0), draft = true),
+                        kmPost(IntId(1), KmNumber(2), kmPostGkLocation(18.0, 0.0), draft = true),
                     ),
                 ),
                 TrackNumber("001"),
@@ -428,8 +429,8 @@ class PublicationValidationTest {
                 geocodingContext(
                     toSegmentPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
                     listOf(
-                        kmPost(IntId(1), KmNumber(2), Point(18.0, 0.0), draft = true),
-                        kmPost(IntId(1), KmNumber(1), Point(12.0, 0.0), draft = true),
+                        kmPost(IntId(1), KmNumber(2), kmPostGkLocation(18.0, 0.0), draft = true),
+                        kmPost(IntId(1), KmNumber(1), kmPostGkLocation(12.0, 0.0), draft = true),
                     ),
                 ),
                 TrackNumber("001"),
@@ -448,7 +449,7 @@ class PublicationValidationTest {
             validateGeocodingContext(
                 geocodingContext(
                     toSegmentPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
-                    listOf(kmPost(IntId(1), KmNumber(1), Point(15.0, 0.0), draft = true)),
+                    listOf(kmPost(IntId(1), KmNumber(1), kmPostGkLocation(15.0, 0.0), draft = true)),
                 ),
                 TrackNumber("001"),
             ),
@@ -459,7 +460,7 @@ class PublicationValidationTest {
             validateGeocodingContext(
                 geocodingContext(
                     toSegmentPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
-                    listOf(kmPost(IntId(1), KmNumber(1), Point(5.0, 0.0), draft = true)),
+                    listOf(kmPost(IntId(1), KmNumber(1), kmPostGkLocation(5.0, 0.0), draft = true)),
                 ),
                 TrackNumber("001"),
             ),
@@ -470,7 +471,7 @@ class PublicationValidationTest {
             validateGeocodingContext(
                 geocodingContext(
                     toSegmentPoints(Point(10.0, 0.0), Point(20.0, 0.0)),
-                    listOf(kmPost(IntId(1), KmNumber(1), Point(25.0, 0.0), draft = true)),
+                    listOf(kmPost(IntId(1), KmNumber(1), kmPostGkLocation(25.0, 0.0), draft = true)),
                 ),
                 TrackNumber("001"),
             ),
@@ -995,7 +996,11 @@ class PublicationValidationTest {
         tracks: List<Pair<LocationTrack, LocationTrackGeometry>>,
     ): List<LayoutValidationIssue> = validateSwitchLocationTrackLinkStructure(switch, structure, tracks)
 
-    private fun <M: AlignmentM<M>> assertAddressPointError(hasError: Boolean, geocode: () -> AlignmentAddresses<M>?, error: String) {
+    private fun <M : AlignmentM<M>> assertAddressPointError(
+        hasError: Boolean,
+        geocode: () -> AlignmentAddresses<M>?,
+        error: String,
+    ) {
         assertContainsError(
             hasError,
             validateAddressPoints(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -86,6 +86,7 @@ import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -777,12 +778,12 @@ constructor(
         val kmPost1 =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumberId, KmNumber(1), Point(2.0, 0.0), draft = true),
+                kmPost(trackNumberId, KmNumber(1), kmPostGkLocation(2.0, 0.0), draft = true),
             )
         val kmPost2 =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumberId, KmNumber(2), Point(4.0, 0.0), draft = true),
+                kmPost(trackNumberId, KmNumber(2), kmPostGkLocation(4.0, 0.0), draft = true),
             )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumberId)
@@ -830,12 +831,12 @@ constructor(
         val kmPost1 =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true),
+                kmPost(trackNumber.id, KmNumber(1), kmPostGkLocation(2.0, 0.0), draft = true),
             )
         val kmPost2 =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true),
+                kmPost(trackNumber.id, KmNumber(2), kmPostGkLocation(4.0, 0.0), draft = true),
             )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
@@ -878,12 +879,12 @@ constructor(
         val kmPost1 =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumber.id, KmNumber(1), Point(2.0, 0.0), draft = true),
+                kmPost(trackNumber.id, KmNumber(1), kmPostGkLocation(2.0, 0.0), draft = true),
             )
         val kmPost2 =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumber.id, KmNumber(2), Point(4.0, 0.0), draft = true),
+                kmPost(trackNumber.id, KmNumber(2), kmPostGkLocation(4.0, 0.0), draft = true),
             )
 
         val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
@@ -1154,7 +1155,7 @@ constructor(
         val kmPost =
             kmPostService.saveDraft(
                 LayoutBranch.main,
-                kmPost(trackNumber.id, KmNumber(1), roughLayoutLocation = Point(5.0, 0.0), draft = true),
+                kmPost(trackNumber.id, KmNumber(1), kmPostGkLocation(5.0, 0.0), draft = true),
             )
         publishAndPush(kmPosts = listOf(kmPost.id))
         val deletions = fakeRatko.getRouteNumberPointDeletions("1.2.3.4.5")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDaoIT.kt
@@ -37,17 +37,20 @@ class LayoutKmPostDaoIT @Autowired constructor(private val kmPostDao: LayoutKmPo
             kmPost(
                 trackNumberId = trackNumberId,
                 km = KmNumber(123),
-                gkLocation = GeometryPoint(25500000.0, 6675000.0, Srid(3879)),
+                gkLocation =
+                    kmPostGkLocation(
+                        GeometryPoint(25500000.0, 6675000.0, Srid(3879)),
+                        KmPostGkLocationSource.FROM_GEOMETRY,
+                        true,
+                    ),
                 state = IN_USE,
                 draft = false,
-                gkLocationConfirmed = true,
-                gkLocationSource = KmPostGkLocationSource.FROM_GEOMETRY,
             )
         val post2 =
             kmPost(
                 trackNumberId = trackNumberId,
                 km = KmNumber(125),
-                gkLocation = GeometryPoint(25500005.0, 6675005.0, Srid(3879)),
+                gkLocation = kmPostGkLocation(GeometryPoint(25500005.0, 6675005.0, Srid(3879))),
                 state = NOT_IN_USE,
                 draft = false,
             )
@@ -111,7 +114,7 @@ class LayoutKmPostDaoIT @Autowired constructor(private val kmPostDao: LayoutKmPo
     @Test
     fun kmPostVersioningWorks() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val tempPost = kmPost(trackNumberId, KmNumber(1), roughLayoutLocation = null)
+        val tempPost = kmPost(trackNumberId, KmNumber(1), gkLocation = null)
         val insertVersion = mainOfficialContext.save(tempPost)
         val id = insertVersion.id
         val inserted = kmPostDao.fetch(insertVersion)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -7,13 +7,13 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.linking.LayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.Point
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -35,7 +35,7 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumberId,
                         km = KmNumber(1),
-                        roughLayoutLocation = Point(1.0, 1.0),
+                        gkLocation = kmPostGkLocation(1.0, 1.0),
                         draft = false,
                     )
                 )
@@ -46,29 +46,27 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumberId,
                         km = KmNumber(2),
-                        roughLayoutLocation = Point(2.0, 1.0),
-                        draft = false,
+                        gkLocation = kmPostGkLocation(2.0, 1.0),
+                        draft = true,
                     )
                 )
             )
         val kmPost3 =
             kmPostDao.fetch(
-                kmPostDao.save(
-                    kmPost(trackNumberId = trackNumberId, km = KmNumber(3), roughLayoutLocation = null, draft = false)
-                )
+                kmPostDao.save(kmPost(trackNumberId = trackNumberId, km = KmNumber(3), gkLocation = null, draft = true))
             )
 
         kmPostDao.save(
             kmPost(
                 trackNumberId = mainOfficialContext.createLayoutTrackNumber().id,
                 km = KmNumber(4),
-                roughLayoutLocation = null,
-                draft = false,
+                gkLocation = null,
+                draft = true,
             )
         )
 
         val actual =
-            kmPostService.listNearbyOnTrackPaged(MainLayoutContext.official, Point(0.0, 0.0), trackNumberId, 0, null)
+            kmPostService.listNearbyOnTrackPaged(MainLayoutContext.draft, Point(0.0, 0.0), trackNumberId, 0, null)
         val expected = listOf(kmPost3, kmPost1, kmPost2)
         assertEquals(expected, actual)
     }
@@ -82,7 +80,7 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumberId,
                         km = KmNumber(1),
-                        roughLayoutLocation = Point(1.0, 1.0),
+                        gkLocation = kmPostGkLocation(1.0, 1.0),
                         draft = false,
                     )
                 )
@@ -100,7 +98,7 @@ constructor(
             kmPost(
                 trackNumberId = trackNumberId,
                 km = KmNumber(1),
-                roughLayoutLocation = Point(1.0, 1.0),
+                gkLocation = kmPostGkLocation(1.0, 1.0),
                 draft = false,
             )
         )
@@ -118,7 +116,7 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumber1Id,
                         km = KmNumber(1),
-                        roughLayoutLocation = Point(1.0, 1.0),
+                        gkLocation = kmPostGkLocation(1.0, 1.0),
                         draft = false,
                     )
                 )
@@ -174,12 +172,18 @@ constructor(
         )
         val kmPosts =
             listOf(
-                kmPost(trackNumberId, KmNumber(1), Point(0.0, 3.0), draft = true),
-                kmPost(trackNumberId, KmNumber(2), Point(0.0, 5.0), draft = true),
+                kmPost(trackNumberId, KmNumber(1), kmPostGkLocation(0.0, 3.0), draft = true),
+                kmPost(trackNumberId, KmNumber(2), kmPostGkLocation(0.0, 5.0), draft = true),
                 kmPost(trackNumberId, KmNumber(3), null, draft = true),
-                kmPost(trackNumberId, KmNumber(4), Point(0.0, 6.0), state = LayoutState.NOT_IN_USE, draft = true),
-                kmPost(trackNumberId, KmNumber(5, "A"), Point(3.0, 14.0), draft = true),
-                kmPost(trackNumberId, KmNumber(5, "AA"), Point(6.0, 18.0), draft = true),
+                kmPost(
+                    trackNumberId,
+                    KmNumber(4),
+                    kmPostGkLocation(0.0, 6.0),
+                    state = LayoutState.NOT_IN_USE,
+                    draft = true,
+                ),
+                kmPost(trackNumberId, KmNumber(5, "A"), kmPostGkLocation(3.0, 14.0), draft = true),
+                kmPost(trackNumberId, KmNumber(5, "AA"), kmPostGkLocation(6.0, 18.0), draft = true),
             )
         val kmPostSaveResults = kmPosts.map { d -> kmPostService.saveDraft(LayoutBranch.main, d) }.map { it.id }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -6,7 +6,6 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
@@ -116,13 +115,13 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumber.id,
                         km = KmNumber(2),
-                        roughLayoutLocation = Point(1.0, 0.0),
+                        gkLocation = kmPostGkLocation(1.0, 0.0),
                         draft = false,
                     ),
                     kmPost(
                         trackNumberId = trackNumber.id,
                         km = KmNumber(3),
-                        roughLayoutLocation = Point(3.0, 0.0),
+                        gkLocation = kmPostGkLocation(3.0, 0.0),
                         draft = false,
                     ),
                 )
@@ -213,10 +212,10 @@ constructor(
                     kmPost(
                         trackNumberId = trackNumber.id,
                         km = KmNumber(2),
-                        roughLayoutLocation = Point(1.0, 0.0),
+                        gkLocation = kmPostGkLocation(1.0, 0.0),
                         draft = false,
                     ),
-                    kmPost(trackNumberId = trackNumber.id, km = KmNumber(3), roughLayoutLocation = null, draft = false),
+                    kmPost(trackNumberId = trackNumber.id, km = KmNumber(3), gkLocation = null, draft = false),
                 )
                 .map(kmPostDao::save)
 
@@ -441,18 +440,18 @@ constructor(
                 .id
 
         mainOfficialContext.saveAndFetch(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(1), roughLayoutLocation = Point(0.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(1), gkLocation = kmPostGkLocation(0.0, 0.0))
         )
         val kmPost2 =
             mainOfficialContext.saveAndFetch(
-                kmPost(trackNumberId = trackNumberId, km = KmNumber(2), roughLayoutLocation = Point(1000.0, 0.0))
+                kmPost(trackNumberId = trackNumberId, km = KmNumber(2), gkLocation = kmPostGkLocation(1000.0, 0.0))
             )
         val kmPost3 =
             mainOfficialContext.saveAndFetch(
-                kmPost(trackNumberId = trackNumberId, km = KmNumber(3), roughLayoutLocation = Point(2000.0, 0.0))
+                kmPost(trackNumberId = trackNumberId, km = KmNumber(3), gkLocation = kmPostGkLocation(2000.0, 0.0))
             )
         mainOfficialContext.saveAndFetch(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(4), roughLayoutLocation = Point(3000.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(4), gkLocation = kmPostGkLocation(3000.0, 0.0))
         )
 
         val polygon =
@@ -494,10 +493,18 @@ constructor(
                 )
                 .id
 
-        mainOfficialContext.save(kmPost(trackNumberId = id, km = KmNumber(1), roughLayoutLocation = Point(1000.0, 0.0)))
-        mainOfficialContext.save(kmPost(trackNumberId = id, km = KmNumber(2), roughLayoutLocation = Point(2000.0, 0.0)))
-        mainOfficialContext.save(kmPost(trackNumberId = id, km = KmNumber(3), roughLayoutLocation = Point(3000.0, 0.0)))
-        mainOfficialContext.save(kmPost(trackNumberId = id, km = KmNumber(4), roughLayoutLocation = Point(4000.0, 0.0)))
+        mainOfficialContext.save(
+            kmPost(trackNumberId = id, km = KmNumber(1), gkLocation = kmPostGkLocation(1000.0, 0.0))
+        )
+        mainOfficialContext.save(
+            kmPost(trackNumberId = id, km = KmNumber(2), gkLocation = kmPostGkLocation(2000.0, 0.0))
+        )
+        mainOfficialContext.save(
+            kmPost(trackNumberId = id, km = KmNumber(3), gkLocation = kmPostGkLocation(3000.0, 0.0))
+        )
+        mainOfficialContext.save(
+            kmPost(trackNumberId = id, km = KmNumber(4), gkLocation = kmPostGkLocation(4000.0, 0.0))
+        )
 
         fun getPolygon(startKm: KmNumber?, endKm: KmNumber?) =
             trackNumberService.getReferenceLinePolygon(MainLayoutContext.official, id, startKm, endKm, 1.0)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -873,18 +873,18 @@ constructor(
             )
 
         mainOfficialContext.saveAndFetch(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(1), roughLayoutLocation = Point(0.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(1), gkLocation = kmPostGkLocation(0.0, 0.0))
         )
         val kmPost2 =
             mainOfficialContext.saveAndFetch(
-                kmPost(trackNumberId = trackNumberId, km = KmNumber(2), roughLayoutLocation = Point(1000.0, 0.0))
+                kmPost(trackNumberId = trackNumberId, km = KmNumber(2), gkLocation = kmPostGkLocation(1000.0, 0.0))
             )
         val kmPost3 =
             mainOfficialContext.saveAndFetch(
-                kmPost(trackNumberId = trackNumberId, km = KmNumber(3), roughLayoutLocation = Point(2000.0, 0.0))
+                kmPost(trackNumberId = trackNumberId, km = KmNumber(3), gkLocation = kmPostGkLocation(2000.0, 0.0))
             )
         mainOfficialContext.saveAndFetch(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(4), roughLayoutLocation = Point(3000.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(4), gkLocation = kmPostGkLocation(3000.0, 0.0))
         )
 
         val polygon =
@@ -929,13 +929,13 @@ constructor(
             )
 
         mainOfficialContext.save(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(2), roughLayoutLocation = Point(2000.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(2), gkLocation = kmPostGkLocation(2000.0, 0.0))
         )
         mainOfficialContext.save(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(3), roughLayoutLocation = Point(3000.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(3), gkLocation = kmPostGkLocation(3000.0, 0.0))
         )
         mainOfficialContext.save(
-            kmPost(trackNumberId = trackNumberId, km = KmNumber(4), roughLayoutLocation = Point(4000.0, 0.0))
+            kmPost(trackNumberId = trackNumberId, km = KmNumber(4), gkLocation = kmPostGkLocation(4000.0, 0.0))
         )
 
         fun getPolygon(startKm: KmNumber?, endKm: KmNumber?) =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -43,6 +43,7 @@ import fi.fta.geoviite.infra.math.Point4DZM
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.math.boundingBoxCombining
 import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.publication.Change
 import fi.fta.geoviite.infra.publication.PublishedVersions
 import fi.fta.geoviite.infra.switchLibrary.SwitchOwner
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
@@ -711,13 +712,13 @@ fun toSegmentPoints(points: List<IPoint3DM<SegmentM>>) =
         )
     }
 
-fun <M: AlignmentM<M>> toAlignmentPoints(vararg points: IPoint) = toAlignmentPoints(to3DMPoints<M>(points.asList()))
+fun <M : AlignmentM<M>> toAlignmentPoints(vararg points: IPoint) = toAlignmentPoints(to3DMPoints<M>(points.asList()))
 
-fun <M: AlignmentM<M>>  toAlignmentPoints(vararg points: Point3DZ) = toAlignmentPoints(to3DMPoints<M>(points.asList()))
+fun <M : AlignmentM<M>> toAlignmentPoints(vararg points: Point3DZ) = toAlignmentPoints(to3DMPoints<M>(points.asList()))
 
-fun <M: AlignmentM<M>> toAlignmentPoints(vararg points: IPoint3DM<M>) = toAlignmentPoints(points.asList())
+fun <M : AlignmentM<M>> toAlignmentPoints(vararg points: IPoint3DM<M>) = toAlignmentPoints(points.asList())
 
-fun <M: AlignmentM<M>> toAlignmentPoints(points: List<IPoint3DM<M>>) =
+fun <M : AlignmentM<M>> toAlignmentPoints(points: List<IPoint3DM<M>>) =
     points.map { point ->
         AlignmentPoint(
             point.x,
@@ -732,7 +733,7 @@ fun <M: AlignmentM<M>> toAlignmentPoints(points: List<IPoint3DM<M>>) =
         )
     }
 
-fun  <M: AnyM<M>> to3DMPoints(points: List<IPoint>, start: Double = 0.0): List<IPoint3DM<M>> {
+fun <M : AnyM<M>> to3DMPoints(points: List<IPoint>, start: Double = 0.0): List<IPoint3DM<M>> {
     val pointsWithDistance =
         points.mapIndexed { index, point ->
             val distance = points.getOrNull(index - 1)?.let { prev -> lineLength(prev, point) } ?: 0.0
@@ -829,7 +830,7 @@ fun switch(
     stateCategory: LayoutStateCategory = LayoutStateCategory.EXISTING,
     id: IntId<LayoutSwitch>? = null,
     draft: Boolean = false,
-    ownerId: IntId<SwitchOwner>? = switchOwnerVayla().id,
+    ownerId: IntId<SwitchOwner> = switchOwnerVayla().id,
     contextData: LayoutContextData<LayoutSwitch> = createMainContext(id, draft),
     draftOid: Oid<LayoutSwitch>? = null,
 ) =
@@ -879,12 +880,9 @@ fun switchJoint(
 fun kmPost(
     trackNumberId: IntId<LayoutTrackNumber>?,
     km: KmNumber,
-    roughLayoutLocation: Point? = Point(1.0, 1.0),
-    gkLocation: GeometryPoint? = null,
+    gkLocation: LayoutKmPostGkLocation? = null,
     draft: Boolean = false,
     state: LayoutState = LayoutState.IN_USE,
-    gkLocationConfirmed: Boolean = false,
-    gkLocationSource: KmPostGkLocationSource = KmPostGkLocationSource.MANUAL,
     sourceId: IntId<GeometryKmPost>? = null,
     contextData: LayoutContextData<LayoutKmPost> = createMainContext(null, draft),
 ): LayoutKmPost {
@@ -894,23 +892,33 @@ fun kmPost(
         state = state,
         sourceId = sourceId,
         contextData = contextData,
-        gkLocation =
-            if (gkLocation != null || roughLayoutLocation != null)
-                LayoutKmPostGkLocation(
-                    location =
-                        if (gkLocation == null && roughLayoutLocation != null) {
-                            transformFromLayoutToGKCoordinate(roughLayoutLocation)
-                        } else gkLocation!!,
-                    confirmed = gkLocationConfirmed,
-                    source = gkLocationSource,
-                )
-            else null,
+        gkLocation = gkLocation,
     )
 }
 
+fun kmPostGkLocation(
+    gkLocation: GeometryPoint,
+    gkLocationSource: KmPostGkLocationSource = KmPostGkLocationSource.MANUAL,
+    gkLocationConfirmed: Boolean = false,
+) = LayoutKmPostGkLocation(location = gkLocation, confirmed = gkLocationConfirmed, source = gkLocationSource)
+
+fun kmPostGkLocation(x: Double, y: Double) = kmPostGkLocation(Point(x, y))
+
+fun kmPostGkLocation(
+    roughLayoutLocation: Point,
+    gkLocationSource: KmPostGkLocationSource = KmPostGkLocationSource.FROM_LAYOUT,
+    gkLocationConfirmed: Boolean = false,
+) =
+    LayoutKmPostGkLocation(
+        location = transformFromLayoutToGKCoordinate(roughLayoutLocation),
+        confirmed = gkLocationConfirmed,
+        source = gkLocationSource,
+    )
+
 fun segmentPoint(x: Double, y: Double, m: Double = 1.0) = SegmentPoint(x, y, null, LineM(m), null)
 
-fun <M: AlignmentM<M>> alignmentPoint(x: Double, y: Double, m: Double = 1.0) = AlignmentPoint(x, y, null, LineM<M>(m), null)
+fun <M : AlignmentM<M>> alignmentPoint(x: Double, y: Double, m: Double = 1.0) =
+    AlignmentPoint(x, y, null, LineM<M>(m), null)
 
 fun locationTrackPoint(x: Double, y: Double, m: Double) = AlignmentPoint(x, y, null, LineM<LocationTrackM>(m), null)
 
@@ -923,7 +931,7 @@ fun rawPoints(count: Int, minX: Double, maxX: Double, minY: Double, maxY: Double
         )
     )
 
-fun <M: AlignmentM<M>> points(count: Int, minX: Double, maxX: Double, minY: Double, maxY: Double) =
+fun <M : AlignmentM<M>> points(count: Int, minX: Double, maxX: Double, minY: Double, maxY: Double) =
     toAlignmentPoints(
         to3DMPoints<M>(
             (1..count).map { pointNumber ->
@@ -1024,7 +1032,12 @@ fun switchLinkingAtHalf(
         jointNumber,
     )
 
-fun switchLinkingAt(locationTrackId: DomainId<LocationTrack>, segmentIndex: Int, m: LineM<LocationTrackM>, jointNumber: Int) =
+fun switchLinkingAt(
+    locationTrackId: DomainId<LocationTrack>,
+    segmentIndex: Int,
+    m: LineM<LocationTrackM>,
+    jointNumber: Int,
+) =
     FittedSwitchJointMatch(
         locationTrackId = locationTrackId as IntId<LocationTrack>,
         segmentIndex = segmentIndex,
@@ -1059,9 +1072,9 @@ fun geocodingContextCacheKey(
     )
 
 fun publishedVersions(
-    trackNumbers: List<LayoutRowVersion<LayoutTrackNumber>> = listOf(),
-    referenceLines: List<LayoutRowVersion<ReferenceLine>> = listOf(),
-    locationTracks: List<LayoutRowVersion<LocationTrack>> = listOf(),
-    switches: List<LayoutRowVersion<LayoutSwitch>> = listOf(),
-    kmPosts: List<LayoutRowVersion<LayoutKmPost>> = listOf(),
+    trackNumbers: List<Change<LayoutRowVersion<LayoutTrackNumber>>> = listOf(),
+    referenceLines: List<Change<LayoutRowVersion<ReferenceLine>>> = listOf(),
+    locationTracks: List<Change<LayoutRowVersion<LocationTrack>>> = listOf(),
+    switches: List<Change<LayoutRowVersion<LayoutSwitch>>> = listOf(),
+    kmPosts: List<Change<LayoutRowVersion<LayoutKmPost>>> = listOf(),
 ) = PublishedVersions(trackNumbers, referenceLines, locationTracks, switches, kmPosts)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/HelsinkiTestData.kt
@@ -32,6 +32,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
@@ -178,19 +179,19 @@ class HelsinkiTestData private constructor() {
                 kmPost(
                     trackNumberId = trackNumberId,
                     km = KmNumber("0001we"),
-                    roughLayoutLocation = point1,
+                    gkLocation = kmPostGkLocation(point1),
                     draft = false,
                 ),
                 kmPost(
                     trackNumberId = trackNumberId,
                     km = KmNumber("0002we"),
-                    roughLayoutLocation = point2,
+                    gkLocation = kmPostGkLocation(point2),
                     draft = false,
                 ),
                 kmPost(
                     trackNumberId = trackNumberId,
                     km = KmNumber("0003we"),
-                    roughLayoutLocation = point3,
+                    gkLocation = kmPostGkLocation(point3),
                     draft = false,
                 ),
             )
@@ -205,19 +206,19 @@ class HelsinkiTestData private constructor() {
                 kmPost(
                     trackNumberId = trackNumberId,
                     km = KmNumber("0001es"),
-                    roughLayoutLocation = point1,
+                    gkLocation = kmPostGkLocation(point1),
                     draft = false,
                 ),
                 kmPost(
                     trackNumberId = trackNumberId,
                     km = KmNumber("0002es"),
-                    roughLayoutLocation = point2,
+                    gkLocation = kmPostGkLocation(point2),
                     draft = false,
                 ),
                 kmPost(
                     trackNumberId = trackNumberId,
                     km = KmNumber("0003es"),
-                    roughLayoutLocation = point3,
+                    gkLocation = kmPostGkLocation(point3),
                     draft = false,
                 ),
             )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.integration.IndirectChanges
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
 import fi.fta.geoviite.infra.integration.TrackNumberChange
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.Change
 import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.ratko.FakeRatkoService
@@ -28,13 +29,13 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.frontpage.E2EFrontPage
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
-import java.time.Instant
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -73,7 +74,7 @@ constructor(
         publicationDao.insertCalculatedChanges(
             successfulPublicationId,
             changesTouchingTrackNumber(trackNumberId),
-            publishedVersions(trackNumbers = listOf(originalTrackNumber)),
+            publishedVersions(trackNumbers = listOf(Change(null, originalTrackNumber))),
         )
 
         val updatedTrackNumberVersion =
@@ -92,7 +93,7 @@ constructor(
         publicationDao.insertCalculatedChanges(
             failingPublicationId,
             changesTouchingTrackNumber(trackNumberId),
-            publishedVersions(trackNumbers = listOf(updatedTrackNumberVersion)),
+            publishedVersions(trackNumbers = listOf(Change(originalTrackNumber, updatedTrackNumberVersion))),
         )
 
         val failedRatkoPushId = ratkoPushDao.startPushing(listOf(failingPublicationId))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/KilometerLengthsTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/KilometerLengthsTestUI.kt
@@ -10,6 +10,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -17,14 +18,14 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -53,9 +54,9 @@ constructor(
             locationTrack(trackNumberId = trackNumberId, name = "foo bar", draft = false),
             trackGeometryOfSegments(lineSegments),
         )
-        kmPostDao.save(kmPost(trackNumberId, KmNumber(1), Point(900.0, 1.0), draft = false))
-        kmPostDao.save(kmPost(trackNumberId, KmNumber(2), Point(2000.0, -1.0), draft = false))
-        kmPostDao.save(kmPost(trackNumberId, KmNumber(3), Point(3000.0, 0.0), draft = false))
+        kmPostDao.save(kmPost(trackNumberId, KmNumber(1), kmPostGkLocation(900.0, 1.0), draft = false))
+        kmPostDao.save(kmPost(trackNumberId, KmNumber(2), kmPostGkLocation(2000.0, -1.0), draft = false))
+        kmPostDao.save(kmPost(trackNumberId, KmNumber(3), kmPostGkLocation(3000.0, 0.0), draft = false))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -20,6 +20,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switch
@@ -258,8 +259,22 @@ constructor(
     @Test
     fun `Link geometry KM-Post to nearest track layout KM-post`() {
         val (trackNumber, trackNumberId) = mainOfficialContext.createTrackNumberAndId()
-        kmPostDao.save(kmPost(trackNumberId, KmNumber("0123"), DEFAULT_BASE_POINT + Point(5.0, 5.0), draft = false))
-        kmPostDao.save(kmPost(trackNumberId, KmNumber("0124"), DEFAULT_BASE_POINT + Point(17.0, 18.0), draft = false))
+        kmPostDao.save(
+            kmPost(
+                trackNumberId,
+                KmNumber("0123"),
+                kmPostGkLocation(DEFAULT_BASE_POINT + Point(5.0, 5.0)),
+                draft = false,
+            )
+        )
+        kmPostDao.save(
+            kmPost(
+                trackNumberId,
+                KmNumber("0124"),
+                kmPostGkLocation(DEFAULT_BASE_POINT + Point(17.0, 18.0)),
+                draft = false,
+            )
+        )
 
         val plan =
             testGeometryPlanService

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
@@ -23,18 +23,19 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.kmPost
+import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ETrackLayoutPage
-import java.math.BigDecimal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.math.BigDecimal
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -64,7 +65,7 @@ constructor(
             kmPost(
                 trackNumberId = trackNumberId,
                 km = KmNumber(0),
-                roughLayoutLocation = DEFAULT_BASE_POINT + Point(0.0, 0.0),
+                gkLocation = kmPostGkLocation(DEFAULT_BASE_POINT + Point(0.0, 0.0)),
                 draft = false,
             )
         )


### PR DESCRIPTION
Koska designien myötä julkaisutauluista "edellisen" version päättely menee monimutkaisemmaksi, lisäsin nyt (kun designeja ei vielä ole) julkaisun asseteille base-versio tiedon (context+version). Samalla nimetty columnit menemään samalla kaavalla kuin päätaulujenkin tapauksessa. Tuota pohjaversiota tarvitaan siis ennenkaikkea siihen että voidaan helposti näyttää mikä on julkaisun aiheuttama muutos - vertailu tehdään pohjaversion ja uuden version välillä.

Eli näyttää nyt tältä:
- publication.location_track.id (raiteen id)
- publication.location_track.layout_context_id (julkaisun konteksti == uuden raideversion konteksti)
- publication.location_track.version (uuden raideversion konteksti)
- publication.location_track.base_layout_context_id (raiteen pohjaversion konteksti - ei välttämättä sama kuin julkaisun sillä designit rakentuu mainin päälle)
- publication.location_track.base_version (raiteen pohjaversion versionumero)

Samalla myös hiukan tiukennettu julkaislokin tyypityksiä. Erityisesti siis Change-tyyppi (jota käytetään julkaisun muutoksiin) on tyypitetty niin että uusi versio tiedosta on aina olemassa. Jos kyseessä on nullable kenttä niin tietenkin voi edelleen tehdä esim `Change<Int?>` tyypityksen, mutta jos se on `Change<Int>` niin uusi versio on aina olemassa. Näin julkaisulogin muutosdiffailussakin voi paremmin luottaa että kyllä sillä julkaistulla raiteella nimi on, jne.

Tiedostoja tuli muutokseen aika monta koska tuo tyypitys pakotti mälväämään testejä vähän laajemmalla skaalalla. Muutokset niissä on kuitenkin aika lailla triviaaleja, pääpointti muutoksessa on julkaisu-dao ja migrat.