### PR TITLE
GVT-3170: Suunnitelmatyötilan poiston näyttö julkaisukortissa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -125,6 +125,7 @@ data class PublishedInDesign(
 enum class PublicationCause {
     MANUAL, // the usual cause: All user-created publications
     LAYOUT_DESIGN_CHANGE,
+    LAYOUT_DESIGN_DELETE,
     LAYOUT_DESIGN_CANCELLATION,
     MERGE_FINALIZATION,
     CALCULATED_CHANGE,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -45,9 +45,11 @@ class LayoutDesignService(
                 deleteDraftsInDesign(designBranch)
             }
             if (dao.designHasPublications(id)) {
-                makeEmptyPublicationForDesign(designBranch)
                 if (request.designState == DesignState.DELETED) {
+                    makeEmptyPublicationForDesignDeletion(designBranch)
                     cancelUnpublishedObjectsInDesign(designBranch)
+                } else {
+                    makeEmptyPublicationForDesignChange(designBranch)
                 }
             }
             dao.update(id, request)
@@ -126,12 +128,21 @@ class LayoutDesignService(
         )
     }
 
-    private fun makeEmptyPublicationForDesign(designBranch: DesignBranch) =
+    private fun makeEmptyPublicationForDesignChange(designBranch: DesignBranch) =
         publicationService.publishChanges(
             designBranch,
             ValidationVersions.emptyWithTarget(ValidateContext(designBranch.official)),
             CalculatedChanges.empty(),
             FreeTextWithNewLines.of(""),
             PublicationCause.LAYOUT_DESIGN_CHANGE,
+        )
+
+    private fun makeEmptyPublicationForDesignDeletion(designBranch: DesignBranch) =
+        publicationService.publishChanges(
+            designBranch,
+            ValidationVersions.emptyWithTarget(ValidateContext(designBranch.official)),
+            CalculatedChanges.empty(),
+            FreeTextWithNewLines.of(""),
+            PublicationCause.LAYOUT_DESIGN_DELETE,
         )
 }

--- a/infra/src/main/resources/db/migration/prod/V123__add_layout_design_delete_to_publication_cause.sql
+++ b/infra/src/main/resources/db/migration/prod/V123__add_layout_design_delete_to_publication_cause.sql
@@ -1,0 +1,1 @@
+alter type publication.publication_cause add value 'LAYOUT_DESIGN_DELETE';

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1840,6 +1840,10 @@
         "transfer-starts-shortly": "Vienti käynnistyy automaattisesti hetken kuluttua",
         "transfer-starts-after-reconnect": "Vienti käynnistyy automaattisesti Ratko-yhteyden palautumisen jälkeen",
         "bulk-transfer-marked-as-successful": "Kohteiden siirto merkitty onnistuneeksi",
+        "design-publication-cause": {
+            "design-cancellation": "{{designName}}: Suunnitelman poisto",
+            "design-change": "{{designName}}: Suunnitelman metatietojen muutos"
+        },
         "push-error": {
             "location-track": "Sijaintiraiteen",
             "track-number": "Ratanumeron",

--- a/ui/src/publication/card/publication-list.scss
+++ b/ui/src/publication/card/publication-list.scss
@@ -110,4 +110,10 @@
         font-weight: 600;
         margin-right: 2px;
     }
+
+    &--design-publication {
+        font-style: italic;
+        color: vayla-design.$color-black-lighter;
+        fill: vayla-design.$color-black-lighter;
+    }
 }

--- a/ui/src/publication/card/publication-list.tsx
+++ b/ui/src/publication/card/publication-list.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PublicationDetails } from 'publication/publication-model';
+import { PublicationCause, PublicationDetails } from 'publication/publication-model';
 import { PublicationListRow } from 'publication/card/publication-list-row';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
@@ -7,6 +7,11 @@ import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 type PublicationListProps = {
     publications: PublicationDetails[];
 };
+
+const HIDDEN_PUBLICATION_CAUSES = [
+    PublicationCause.LAYOUT_DESIGN_CANCELLATION,
+    PublicationCause.CALCULATED_CHANGE,
+];
 
 export const PublicationList: React.FC<PublicationListProps> = ({ publications }) => {
     const trackLayoutActionDelegates = React.useMemo(
@@ -16,13 +21,17 @@ export const PublicationList: React.FC<PublicationListProps> = ({ publications }
 
     return (
         <div qa-id="publication-list">
-            {publications.map((publication) => (
-                <PublicationListRow
-                    key={publication.id}
-                    publication={publication}
-                    setSelectedPublicationId={trackLayoutActionDelegates.setSelectedPublicationId}
-                />
-            ))}
+            {publications
+                .filter((p) => !HIDDEN_PUBLICATION_CAUSES.includes(p.cause))
+                .map((publication) => (
+                    <PublicationListRow
+                        key={publication.id}
+                        publication={publication}
+                        setSelectedPublicationId={
+                            trackLayoutActionDelegates.setSelectedPublicationId
+                        }
+                    />
+                ))}
         </div>
     );
 };

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -208,6 +208,15 @@ type PublishedInDesign = {
 
 export type PublishedInBranch = PublishedInMain | PublishedInDesign;
 
+export enum PublicationCause {
+    MANUAL = 'MANUAL',
+    LAYOUT_DESIGN_CHANGE = 'LAYOUT_DESIGN_CHANGE',
+    LAYOUT_DESIGN_DELETE = 'LAYOUT_DESIGN_DELETE',
+    LAYOUT_DESIGN_CANCELLATION = 'LAYOUT_DESIGN_CANCELLATION',
+    MERGE_FINALIZATION = 'MERGE_FINALIZATION',
+    CALCULATED_CHANGE = 'CALCULATED_CHANGE',
+}
+
 export type PublicationDetails = {
     id: PublicationId;
     publicationTime: TimeStamp;
@@ -223,6 +232,7 @@ export type PublicationDetails = {
     calculatedChanges: PublishedCalculatedChanges;
     message?: string;
     split?: SplitHeader;
+    cause: PublicationCause;
 };
 
 export type PublishedTrackNumber = {


### PR DESCRIPTION
Päädyin varsinaisen tiketille merkatun homman lisäksi tekemään hieman muutakin jumppaa näille, koska näin sen kannattavaksi. Käytännössä täällä tehty seuraavat:
- Suunnitelman poistojulkaisu näkymään etusivun kortilla ikoni edessä, harmaalla fontilla ja italicseilla. Lisäksi julkaisun viestin sijasta (joka olisi aina tyhjä, koska kyseessä on autogeneroitu julkaisu) näytetään teksti "Suunnitelman poisto" (🍖)
- Myös muiden suunnitelman metatietojen muutoksista aiheutuvien julkaisujen (esim. suunnitelman nimen muutos) esitys on muutettu samankaltaiseksi kuin poistojen esitys, sillä erotuksella että niille näytetään eri ikoni ja teksti "Suunnitelman metatietojen muutos" 
- Jotta suunnitelman poisto- ja metatietojen muokkausjulkaisut saatiin erotettua toisistaan, aiempi `LAYOUT_DESIGN_CHANGE`-julkaisusyy on hajotettu erillisiksi `LAYOUT_DESIGN_CHANGE`- ja `LAYOUT_DESIGN_DELETE`-syiksi, jotta pelkän julkaisun perusteella voidaan selvittää kumpi oli kyseessä
- `LAYOUT_DESIGN_CANCELLATION`- ja `CALCULATED_CHANGE`-syiden julkaisut on piilotettu etusivun julkaisukortilta. Näistä lisää varsinaisen koodin yhteydessä