### PR TITLE
Useita pieniä korjauksia sijaintiraidetarkenteeseen (GVT-3180 & GVT-3199 & GVT-3210 & GVT-3229 & GVT-3231)

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -111,13 +111,10 @@ sealed class LocationTrackNameStructure {
                     LocationTrackNameWithinOperatingPoint(
                         requireNotNull(freeText) { "Naming scheme of type $scheme must have a free text part" }
                     )
-                LocationTrackNamingScheme.BETWEEN_OPERATING_POINTS ->
-                    LocationTrackNameBetweenOperatingPoints(
-                        requireNotNull(specifier) { "Naming scheme of type $scheme must have a name specifier part" }
-                    )
+                LocationTrackNamingScheme.BETWEEN_OPERATING_POINTS -> LocationTrackNameBetweenOperatingPoints(specifier)
                 LocationTrackNamingScheme.TRACK_NUMBER_TRACK ->
                     LocationTrackNameByTrackNumber(
-                        requireNotNull(freeText) { "Naming scheme of type $scheme must have a free text part" },
+                        freeText,
                         requireNotNull(specifier) { "Naming scheme of type $scheme must have a name specifier part" },
                     )
                 LocationTrackNamingScheme.CHORD -> LocationTrackNameChord
@@ -144,21 +141,31 @@ data class LocationTrackNameWithinOperatingPoint(override val freeText: Alignmen
 }
 
 data class LocationTrackNameByTrackNumber(
-    override val freeText: AlignmentName,
+    override val freeText: AlignmentName?,
     override val specifier: LocationTrackNameSpecifier,
 ) : LocationTrackNameStructure() {
     override val scheme: LocationTrackNamingScheme = LocationTrackNamingScheme.TRACK_NUMBER_TRACK
 
-    fun format(trackNumber: TrackNumber): AlignmentName =
-        AlignmentName("$trackNumber ${specifier.properForm} $freeText".trim())
+    fun format(trackNumber: TrackNumber): AlignmentName {
+        val nameString =
+            if (freeText != null) "$trackNumber ${specifier.properForm} $freeText"
+            else "$trackNumber ${specifier.properForm}"
+
+        return AlignmentName(nameString.trim())
+    }
 }
 
-data class LocationTrackNameBetweenOperatingPoints(override val specifier: LocationTrackNameSpecifier) :
+data class LocationTrackNameBetweenOperatingPoints(override val specifier: LocationTrackNameSpecifier?) :
     LocationTrackNameStructure() {
     override val scheme: LocationTrackNamingScheme = LocationTrackNamingScheme.BETWEEN_OPERATING_POINTS
 
-    fun format(startSwitch: LayoutSwitch?, endSwitch: LayoutSwitch?): AlignmentName =
-        AlignmentName("${specifier.properForm} ${getShortName(startSwitch)}-${getShortName(endSwitch)}")
+    fun format(startSwitch: LayoutSwitch?, endSwitch: LayoutSwitch?): AlignmentName {
+        val nameString =
+            if (specifier != null) "${specifier.properForm} ${getShortName(startSwitch)}-${getShortName(endSwitch)}"
+            else "${getShortName(startSwitch)}-${getShortName(endSwitch)}"
+
+        return AlignmentName(nameString.trim())
+    }
 }
 
 data object LocationTrackNameChord : LocationTrackNameStructure() {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -500,6 +500,7 @@
         "name-in-use-deleted": "Huomaa, että ratanumerolla on poistettu raide samalla tunnuksella",
         "move-to-edit-deleted": "Voit siirtyä palauttamaan poistetun raiteen tästä",
         "track-already-has-duplicates": "Tällä raiteella on jo duplikaattiraiteita",
+        "name-specifier-placeholder": "Ei tarkennetta",
         "name-specifiers": {
             "PR": "PR",
             "ER": "ER",

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog-name-section.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog-name-section.tsx
@@ -42,6 +42,11 @@ type LocationTrackNameBetweenOperatingPointsProps = {
     getSpecifierErrors: () => string[];
 };
 
+const NAMING_SCHEMES_WITHOUT_FULL_NAME: LocationTrackNamingScheme[] = [
+    LocationTrackNamingScheme.FREE_TEXT,
+    LocationTrackNamingScheme.WITHIN_OPERATING_POINT,
+];
+
 const LocationTrackNameFreeText: React.FC<LocationTrackNameFreeTextProps> = ({
     request,
     updateFreeText,
@@ -85,6 +90,8 @@ const LocationTrackNameTrackNumber: React.FC<LocationTrackNameTrackNumberProps> 
                         qa-id="location-track-name-specifier"
                         value={request.nameSpecifier}
                         options={locationTrackNameSpecifiers}
+                        placeholder={t('location-track-dialog.name-specifier-placeholder')}
+                        unselectText={t('location-track-dialog.name-specifier-placeholder')}
                         canUnselect={true}
                         onChange={(e) => updateSpecifier && updateSpecifier(e)}
                         onBlur={() => onCommitSpecifier && onCommitSpecifier()}
@@ -94,7 +101,7 @@ const LocationTrackNameTrackNumber: React.FC<LocationTrackNameTrackNumberProps> 
                 errors={getSpecifierErrors()}
             />
             <FieldLayout
-                label={`${t('location-track-dialog.operating-point-range')} *`}
+                label={`${t('location-track-dialog.operating-point-range')}`}
                 value={
                     <TextField
                         qa-id="location-track-name-operating-point-range"
@@ -116,12 +123,14 @@ const LocationTrackNameBetweenOperatingPoints: React.FC<
     const { t } = useTranslation();
     return (
         <FieldLayout
-            label={`${t('location-track-dialog.name-specifier')} *`}
+            label={`${t('location-track-dialog.name-specifier')}`}
             value={
                 <Dropdown
                     qa-id="location-track-name-specifier"
                     value={request.nameSpecifier}
                     options={locationTrackNameSpecifiers}
+                    placeholder={t('location-track-dialog.name-specifier-placeholder')}
+                    unselectText={t('location-track-dialog.name-specifier-placeholder')}
                     canUnselect={true}
                     onChange={(e) => updateSpecifier && updateSpecifier(e)}
                     onBlur={() => onCommitSpecifier && onCommitSpecifier()}
@@ -248,10 +257,15 @@ export const LocationTrackEditDialogNameSection: React.FC<
                             onCommitField={onCommitField}
                             getVisibleErrorsByProp={getVisibleErrorsByProp}
                         />
-                        <FieldLayout
-                            label={`${t('location-track-dialog.full-name')}`}
-                            value={fullName}
-                        />
+                        {state.locationTrack.namingScheme &&
+                            !NAMING_SCHEMES_WITHOUT_FULL_NAME.includes(
+                                state.locationTrack.namingScheme,
+                            ) && (
+                                <FieldLayout
+                                    label={`${t('location-track-dialog.full-name')}`}
+                                    value={fullName}
+                                />
+                            )}
                         {trackWithSameName && (
                             <>
                                 <div className={styles['location-track-edit-dialog__alert-color']}>

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -6,6 +6,7 @@ import {
     LocationTrackDescriptionSuffixMode,
     LocationTrackId,
     LocationTrackNamingScheme,
+    locationTrackNameFieldsSanitized,
 } from 'track-layout/track-layout-model';
 import { Dialog, DialogVariant, DialogWidth } from 'geoviite-design-lib/dialog/dialog';
 import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
@@ -287,15 +288,15 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
 
     function save() {
         if (canSaveLocationTrack(state) && state.locationTrack) {
-            const locationTrackWithTrimmedStrings = {
+            const saveRequestWithSanitizedNameAndDescription = {
                 ...state.locationTrack,
-                nameFreeText: state.locationTrack.nameFreeText?.trim(),
+                ...locationTrackNameFieldsSanitized(state.locationTrack),
                 descriptionBase: state.locationTrack.descriptionBase?.trim(),
             };
 
             stateActions.onStartSaving();
             if (state.isNewLocationTrack) {
-                insertLocationTrack(layoutContextDraft, locationTrackWithTrimmedStrings)
+                insertLocationTrack(layoutContextDraft, saveRequestWithSanitizedNameAndDescription)
                     .then((locationTrackId) => {
                         props.onSave && props.onSave(locationTrackId);
                         Snackbar.success('location-track-dialog.created-successfully');
@@ -306,12 +307,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                 updateLocationTrack(
                     layoutContextDraft,
                     state.existingLocationTrack.id,
-                    locationTrackWithTrimmedStrings,
+                    saveRequestWithSanitizedNameAndDescription,
                 )
                     .then((locationTrackId) => {
                         props.onSave && props.onSave(locationTrackId);
                         const successMessage =
-                            locationTrackWithTrimmedStrings.state === 'DELETED'
+                            saveRequestWithSanitizedNameAndDescription.state === 'DELETED'
                                 ? 'location-track-dialog.deleted-successfully'
                                 : 'location-track-dialog.modified-successfully';
                         Snackbar.success(successMessage);

--- a/ui/src/tool-panel/location-track/dialog/location-track-validation.ts
+++ b/ui/src/tool-panel/location-track/dialog/location-track-validation.ts
@@ -9,15 +9,18 @@ export const ALIGNMENT_NAME_REGEX = /^[A-Za-zÄÖÅäöå0-9 \-_]+$/g;
 export const ALIGNMENT_DESCRIPTION_REGEX = /^[A-ZÄÖÅa-zäöå0-9 _\-–—+().,'"/\\<>:!?&]+$/g;
 export const ALIGNMENT_NAME_MAX_LENGTH = 50;
 
-const freeTextSchemes = [
+const MANDATORY_FREE_TEXT_SCHEMES: LocationTrackNamingScheme[] = [
     LocationTrackNamingScheme.FREE_TEXT,
     LocationTrackNamingScheme.WITHIN_OPERATING_POINT,
+] as const;
+const ALL_FREE_TEXT_SCHEMES: LocationTrackNamingScheme[] = [
     LocationTrackNamingScheme.TRACK_NUMBER_TRACK,
-];
-const specifierSchemes = [
+    ...MANDATORY_FREE_TEXT_SCHEMES,
+] as const;
+
+const MANDATORY_NAME_SPECIFIER_SCHEMES: LocationTrackNamingScheme[] = [
     LocationTrackNamingScheme.TRACK_NUMBER_TRACK,
-    LocationTrackNamingScheme.BETWEEN_OPERATING_POINTS,
-];
+] as const;
 
 export const validateLocationTrackName = (
     name: string | undefined,
@@ -65,7 +68,7 @@ export const validateLocationTrackNameStructure = (
                   type: FieldValidationIssueType.ERROR,
               }
             : undefined,
-        freeTextSchemes.includes(namingScheme ?? LocationTrackNamingScheme.FREE_TEXT) &&
+        MANDATORY_FREE_TEXT_SCHEMES.includes(namingScheme ?? LocationTrackNamingScheme.FREE_TEXT) &&
         isNilOrBlank(nameFreeText)
             ? {
                   field: 'nameFreeText' as keyof LocationTrackSaveRequest,
@@ -73,7 +76,7 @@ export const validateLocationTrackNameStructure = (
                   type: FieldValidationIssueType.ERROR,
               }
             : undefined,
-        freeTextSchemes.includes(namingScheme ?? LocationTrackNamingScheme.FREE_TEXT) &&
+        ALL_FREE_TEXT_SCHEMES.includes(namingScheme ?? LocationTrackNamingScheme.FREE_TEXT) &&
         !isNilOrBlank(nameFreeText) &&
         (!nameFreeText?.match(ALIGNMENT_NAME_REGEX) ||
             nameFreeText.length > ALIGNMENT_NAME_MAX_LENGTH)
@@ -83,8 +86,9 @@ export const validateLocationTrackNameStructure = (
                   type: FieldValidationIssueType.ERROR,
               }
             : undefined,
-        specifierSchemes.includes(namingScheme ?? LocationTrackNamingScheme.FREE_TEXT) &&
-        isNil(nameSpecifier)
+        MANDATORY_NAME_SPECIFIER_SCHEMES.includes(
+            namingScheme ?? LocationTrackNamingScheme.FREE_TEXT,
+        ) && isNil(nameSpecifier)
             ? {
                   field: 'nameSpecifier' as keyof LocationTrackSaveRequest,
                   reason: 'mandatory-field',

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -24,9 +24,10 @@ import {
 } from 'common/common-model';
 import { deduplicateById } from 'utils/array-utils';
 import { AlignmentPolyLine, GeometryAlignmentHeader } from './layout-map-api';
-import { GeometryPlanLinkStatus } from 'linking/linking-model';
+import { GeometryPlanLinkStatus, LocationTrackSaveRequest } from 'linking/linking-model';
 import { exhaustiveMatchingGuard, ifDefined } from 'utils/type-utils';
 import { Brand } from 'common/brand';
+import { isNilOrBlank } from 'utils/string-utils';
 
 export type LayoutState = 'IN_USE' | 'NOT_IN_USE' | 'DELETED';
 export type LocationTrackState = 'BUILT' | 'IN_USE' | 'NOT_IN_USE' | 'DELETED';
@@ -178,6 +179,43 @@ export function getNameSpecifier(
 ): LocationTrackNameSpecifier | undefined {
     return nameStructure && 'specifier' in nameStructure ? nameStructure.specifier : undefined;
 }
+
+export const locationTrackNameFieldsSanitized = (
+    saveRequest: LocationTrackSaveRequest,
+): Pick<LocationTrackSaveRequest, 'nameFreeText' | 'nameSpecifier'> => {
+    const freeText = !isNilOrBlank(saveRequest.nameFreeText)
+        ? saveRequest.nameFreeText?.trim()
+        : undefined;
+    const specifier = saveRequest.nameSpecifier;
+
+    switch (saveRequest.namingScheme) {
+        case LocationTrackNamingScheme.FREE_TEXT:
+        case LocationTrackNamingScheme.WITHIN_OPERATING_POINT:
+            return {
+                nameFreeText: freeText,
+                nameSpecifier: undefined,
+            };
+        case LocationTrackNamingScheme.TRACK_NUMBER_TRACK:
+            return {
+                nameFreeText: freeText,
+                nameSpecifier: specifier,
+            };
+        case LocationTrackNamingScheme.BETWEEN_OPERATING_POINTS:
+            return {
+                nameFreeText: undefined,
+                nameSpecifier: specifier,
+            };
+        case LocationTrackNamingScheme.CHORD:
+            return {
+                nameFreeText: undefined,
+                nameSpecifier: undefined,
+            };
+        case undefined:
+            throw Error('Naming scheme is mandatory for location track save request!');
+        default:
+            return exhaustiveMatchingGuard(saveRequest.namingScheme);
+    }
+};
 
 export type LocationTrackDescriptionStructure = {
     base?: string;
@@ -537,7 +575,9 @@ export function formatTrackName(
         case LocationTrackNamingScheme.TRACK_NUMBER_TRACK:
             return `${withPlaceholder(trackNumber)} ${toProperForm(nameSpecifier)} ${nameFreeText ?? ''}`.trim();
         case LocationTrackNamingScheme.BETWEEN_OPERATING_POINTS:
-            return `${toProperForm(nameSpecifier)} ${getShortName(startSwitch)}-${getShortName(endSwitch)}`;
+            return nameSpecifier
+                ? `${toProperForm(nameSpecifier)} ${getShortName(startSwitch)}-${getShortName(endSwitch)}`
+                : `${getShortName(startSwitch)}-${getShortName(endSwitch)}`;
         case LocationTrackNamingScheme.CHORD: {
             if (startSwitch !== undefined && startSwitch?.prefix === endSwitch?.prefix) {
                 return `${startSwitch.prefix} ${getShortNumber(startSwitch)}-${getShortNumber(endSwitch)}`;


### PR DESCRIPTION
Tällä pullarilla tehty siis useampia pieniä juttuja. Monet niistä olivat joko niin pieniä tai liittyivät toisiinsa niin voimakkaasti etten katsonut järkeväksi jakaa niitä omiin pullareihinsa. Merkkaan kommenteilla mikä muutos liittyy mihinkin. Muutokset ovat pääosin fronttijuttuja, mutta osa niistä piti duplikoida myös bäkkärille