### PR TITLE
GVT-3212 Also fix happy case rendering

### DIFF
--- a/ui/src/geoviite-design-lib/elevation-measurement-method/elevation-measurement-method.tsx
+++ b/ui/src/geoviite-design-lib/elevation-measurement-method/elevation-measurement-method.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { ElevationMeasurementMethod } from 'common/common-model';
+import { ElevationMeasurementMethod as ElevationMeasurementMethodT } from 'common/common-model';
 import { useTranslation } from 'react-i18next';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 
 type ElevationMeasurementMethodProps = {
-    method: ElevationMeasurementMethod | undefined;
+    method: ElevationMeasurementMethodT | undefined;
     lowerCase?: boolean;
     includeTermContextForUnknownMethod?: boolean;
 };
 
 function getTranslationKey(
-    method: ElevationMeasurementMethod | undefined,
+    method: ElevationMeasurementMethodT | undefined,
     includeTermContextForUnknownMethod: boolean,
 ) {
     switch (method) {
@@ -31,16 +31,31 @@ const ElevationMeasurementMethod: React.FC<ElevationMeasurementMethodProps> = ({
 }: ElevationMeasurementMethodProps) => {
     const { t } = useTranslation();
 
+    return (
+        <React.Fragment>
+            {elevationMeasurementMethodText(
+                t,
+                method,
+                lowerCase,
+                includeTermContextForUnknownMethod,
+            )}
+        </React.Fragment>
+    );
+};
+export default ElevationMeasurementMethod;
+
+export function elevationMeasurementMethodText(
+    t: ReturnType<typeof useTranslation>['t'],
+    method: ElevationMeasurementMethodT | undefined,
+    lowerCase = false,
+    includeTermContextForUnknownMethod = false,
+) {
     const measurementMethodTranslationKey = getTranslationKey(
         method,
         includeTermContextForUnknownMethod,
     );
 
-    const text = lowerCase
+    return lowerCase
         ? t(`enum.ElevationMeasurementMethod.${measurementMethodTranslationKey}`).toLowerCase()
         : t(`enum.ElevationMeasurementMethod.${measurementMethodTranslationKey}`);
-
-    return <React.Fragment>{text}</React.Fragment>;
-};
-
-export default ElevationMeasurementMethod;
+}

--- a/ui/src/vertical-geometry/plan-linking-header-item.tsx
+++ b/ui/src/vertical-geometry/plan-linking-header-item.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Coordinates, mToX } from 'vertical-geometry/coordinates';
 import { PlanLinkingSummaryItem } from 'geometry/geometry-api';
 import styles from 'vertical-geometry/vertical-geometry-diagram.scss';
-import ElevationMeasurementMethod from 'geoviite-design-lib/elevation-measurement-method/elevation-measurement-method';
+import { elevationMeasurementMethodText } from 'geoviite-design-lib/elevation-measurement-method/elevation-measurement-method';
 import { GeometryAlignmentId, GeometryPlanId } from 'geometry/geometry-model';
 import { useTranslation } from 'react-i18next';
 
@@ -20,7 +20,7 @@ export const PlanLinkingHeaderItem: React.FC<PlanLinkingItemHeaderProps> = ({
     const { t } = useTranslation();
 
     const textLineOneYPx = 8;
-    const textLineTwoYPx = 18;
+    const textLineTwoYPx = 20;
 
     const textDropAreaPx = 3;
 
@@ -65,14 +65,7 @@ export const PlanLinkingHeaderItem: React.FC<PlanLinkingItemHeaderProps> = ({
                                 {t('vertical-geometry-diagram.no-vertical-coordinate-system')}
                             </tspan>
                         ) : (
-                            <>
-                                {verticalCoordinateSystem},
-                                <ElevationMeasurementMethod
-                                    method={elevationMeasurementMethod}
-                                    lowerCase={true}
-                                    includeTermContextForUnknownMethod={true}
-                                />
-                            </>
+                            `${verticalCoordinateSystem}, ${elevationMeasurementMethodText(t, elevationMeasurementMethod, true, true)}`
                         )}
                     </tspan>
                 </text>


### PR DESCRIPTION
Släkissä mainittua SVG-nysväystä: HTML:ssä voi luottaa siihen, että jos elementissä on useampi tekstinoodi, niin ne piirtyy kyllä ihan vaan yhteen lyötynä. SVG:ssä ei näemmä ole näin, ainakaan Firefoxilla ja Chromella vilkuilun perusteella, vaan eri tekstinoodit piirtyvät varmaan jollain tavalla erillisinä elementteinä niin, että tulos näyttää hieman oudolta. Siksi joudutaan vähän tökerösti rakentamaan koko näytettävä merkkijono yhdeksi pompsiksi.