### PR TITLE
GVT-3232 Optimize publication log / ext-api / geocoding

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterErrorV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterErrorV1.kt
@@ -36,7 +36,7 @@ enum class FrameConverterErrorV1(private val localizationSuffix: String) {
     TrackNumberNotFound("track-number-not-found"),
     InputCoordinateTransformationFailed("input-coordinate-transformation-failed");
 
-    val localizationKey: LocalizationKey by lazy { LocalizationKey("$BASE.$localizationSuffix") }
+    val localizationKey: LocalizationKey by lazy { LocalizationKey.of("$BASE.$localizationSuffix") }
 
     companion object {
         private const val BASE: String = "ext-api.frame-converter.v1.error"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -94,7 +94,7 @@ class WebConfig(
         registry.addStringConstructorConverter(::AuthCode)
         registry.addStringConstructorConverter(::FreeText)
         registry.addStringConstructorConverter(FreeTextWithNewLines::of)
-        registry.addStringConstructorConverter(::LocalizationKey)
+        registry.addStringConstructorConverter(LocalizationKey::of)
 
         registry.addStringConstructorConverter(UserName::of)
         registry.addStringConstructorConverter(AuthName::of)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -34,7 +34,7 @@ open class ClientException(
         cause: Throwable?,
         localizedMessageKey: String,
         localizedMessageParams: LocalizationParams = LocalizationParams.empty,
-    ) : this(status, message, cause, LocalizationKey(localizedMessageKey), localizedMessageParams)
+    ) : this(status, message, cause, LocalizationKey.of(localizedMessageKey), localizedMessageParams)
 }
 
 class GeocodingFailureException(message: String, cause: Throwable? = null) :

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ErrorHandling.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ErrorHandling.kt
@@ -317,7 +317,7 @@ data class ErrorDescription(
         key: String,
         params: LocalizationParams = LocalizationParams.empty,
         priority: ErrorPriority = ErrorPriority.AVERAGE,
-    ) : this(message, LocalizationKey(key), params, priority)
+    ) : this(message, LocalizationKey.of(key), params, priority)
 }
 
 fun getPSQLExceptionConstraintAndDetailOrRethrow(psqlException: PSQLException): Pair<String, String> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -49,12 +49,12 @@ import fi.fta.geoviite.infra.util.Right
 import fi.fta.geoviite.infra.util.getIndexRangeForRangeInOrderedList
 import fi.fta.geoviite.infra.util.processRights
 import fi.fta.geoviite.infra.util.processSortedBy
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.PI
 import kotlin.math.abs
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 data class AddressPoint<M : AnyM<M>>(val point: AlignmentPoint<M>, val address: TrackMeter) {
     fun isSame(other: AddressPoint<M>) = address.isSame(other.address) && point.isSame(other.point)
@@ -443,7 +443,7 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
             location: IPoint,
             kmNumber: KmNumber,
             referenceLineGeometry: IAlignment<M>,
-        ) =
+        ): GeocodingReferencePoint<M>? =
             referenceLineGeometry.getClosestPointM(location)?.let { (distance, intersectType) ->
                 val pointOnLine =
                     requireNotNull(referenceLineGeometry.getPointAtM(distance)) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -2,12 +2,25 @@ package fi.fta.geoviite.infra.geometry
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.codeDictionary.FeatureType
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.FeatureTypeCode
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.SwitchName
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geometry.CantRotationPoint.CENTER
-import fi.fta.geoviite.infra.geometry.GeometryIssueType.*
+import fi.fta.geoviite.infra.geometry.GeometryIssueType.OBSERVATION_MAJOR
+import fi.fta.geoviite.infra.geometry.GeometryIssueType.OBSERVATION_MINOR
+import fi.fta.geoviite.infra.geometry.GeometryIssueType.VALIDATION_ERROR
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.localization.LocalizationKey
-import fi.fta.geoviite.infra.math.*
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.math.angleDiffRads
+import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.math.radsToDegrees
+import fi.fta.geoviite.infra.math.round
+import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
 import fi.fta.geoviite.infra.switchLibrary.calculateSwitchLocationDelta
@@ -50,7 +63,7 @@ data class GeometryValidationIssueData(
         parentKey: String,
         errorKey: String,
         errorType: GeometryIssueType,
-    ) : this(LocalizationKey("$VALIDATION.$parentKey.$errorKey"), errorType)
+    ) : this(LocalizationKey.of("$VALIDATION.$parentKey.$errorKey"), errorType)
 }
 
 data class MetadataError(@JsonIgnore private val data: GeometryValidationIssueData, val value: String?) :

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
@@ -29,7 +29,7 @@ const val INFRAMODEL_TRANSFORMATION_KEY_PARENT = "error.infra-model.transformati
 
 data class TransformationError(private val key: String, private val units: GeometryUnits) : GeometryValidationIssue {
     override val issueType = GeometryIssueType.TRANSFORMATION_ERROR
-    override val localizationKey = LocalizationKey("$INFRAMODEL_TRANSFORMATION_KEY_PARENT.$key")
+    override val localizationKey = LocalizationKey.of("$INFRAMODEL_TRANSFORMATION_KEY_PARENT.$key")
     val srid = units.coordinateSystemSrid
     val coordinateSystemName = units.coordinateSystemName
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelApi.kt
@@ -1,8 +1,21 @@
 package fi.fta.geoviite.infra.inframodel
 
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.ElevationMeasurementMethod
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.MeasurementMethod
+import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.error.HasLocalizedMessage
-import fi.fta.geoviite.infra.geometry.*
+import fi.fta.geoviite.infra.geometry.Author
+import fi.fta.geoviite.infra.geometry.GeometryPlan
+import fi.fta.geoviite.infra.geometry.GeometryValidationIssue
+import fi.fta.geoviite.infra.geometry.PlanApplicability
+import fi.fta.geoviite.infra.geometry.PlanDecisionPhase
+import fi.fta.geoviite.infra.geometry.PlanName
+import fi.fta.geoviite.infra.geometry.PlanPhase
+import fi.fta.geoviite.infra.geometry.PlanSource
+import fi.fta.geoviite.infra.geometry.Project
 import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
 import fi.fta.geoviite.infra.util.FreeTextWithNewLines
@@ -47,7 +60,7 @@ fun tryParsing(source: PlanSource?, op: () -> ValidationResponse): ValidationRes
                 listOf(
                     ParsingError(
                         if (e is HasLocalizedMessage) e.localizationKey
-                        else LocalizationKey(INFRAMODEL_PARSING_KEY_GENERIC)
+                        else LocalizationKey.of(INFRAMODEL_PARSING_KEY_GENERIC)
                     )
                 ),
             geometryPlan = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -60,19 +60,18 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchHand
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.switchLibrary.switchTypeRequiresHandedness
-import fi.fta.geoviite.infra.switchLibrary.tryParseSwitchType
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.formatForException
 import fi.fta.geoviite.infra.util.formatForLog
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.math.BigDecimal.ZERO
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 const val INFRAMODEL_SWITCH_CODE = "IM_switch"
 const val INFRAMODEL_SWITCH_TYPE = "switchType"
@@ -562,7 +561,7 @@ fun collectGeometrySwitches(
                 verifySameField("Switch typeName", xmlSwitches, TempSwitch::typeName, TempSwitch::name)
             val switchTypeName = normalizeSwitchTypeName(switchTypeNameAliases, switchTypeNameXml)
             val switchTypeRequiresHandedness =
-                tryParseSwitchType(switchTypeName).let { switchType ->
+                SwitchType.tryParse(switchTypeName).let { switchType ->
                     if (switchType != null) switchTypeRequiresHandedness(switchType.parts.baseType) else false
                 }
             val switchTypeHand = verifySameField("Switch hand", xmlSwitches, TempSwitch::hand, TempSwitch::name)
@@ -572,7 +571,7 @@ fun collectGeometrySwitches(
                     else "$switchTypeName-${hand.abbreviation}"
                 }
 
-            val switchType = tryParseSwitchType(fullSwitchTypeName)
+            val switchType = SwitchType.tryParse(fullSwitchTypeName)
             val switchStructure = switchType?.let { type -> switchStructuresByType[type] }
 
             if (switchType == null) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelService.kt
@@ -41,7 +41,7 @@ import org.springframework.web.multipart.MultipartFile
 
 const val VALIDATION_LAYOUT_POINTS_RESOLUTION = 10
 
-val noFileValidationError = ParsingError(LocalizationKey(INFRAMODEL_PARSING_KEY_EMPTY))
+val noFileValidationError = ParsingError(LocalizationKey.of(INFRAMODEL_PARSING_KEY_EMPTY))
 const val START_KM_PARAM_KEY = "startKm"
 const val END_KM_PARAM_KEY = "endKm"
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationKey.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationKey.kt
@@ -4,11 +4,16 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.util.StringSanitizer
+import java.util.concurrent.ConcurrentHashMap
 
-data class LocalizationKey @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+data class LocalizationKey @JsonCreator(mode = DELEGATING) private constructor(private val value: String) :
     Comparable<LocalizationKey>, CharSequence by value {
 
     companion object {
+        private val keyCache = ConcurrentHashMap<String, LocalizationKey>()
+
+        fun of(value: String): LocalizationKey = keyCache.computeIfAbsent(value) { LocalizationKey(it) }
+
         val allowedLength = 1..100
         const val ALLOWED_CHARACTERS = "A-Za-z0-9_\\-."
         val sanitizer = StringSanitizer(LocalizationKey::class, ALLOWED_CHARACTERS, allowedLength)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -3,9 +3,9 @@ package fi.fta.geoviite.infra.localization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.util.FileName
+import org.springframework.beans.factory.annotation.Value
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
-import org.springframework.beans.factory.annotation.Value
 
 private val LOCALIZATION_PARAMS_PLACEHOLDER_REGEX = Regex("\\{\\{[a-zA-Z0-9_\\s\\-]*\\}\\}")
 
@@ -14,9 +14,9 @@ data class Translation(val lang: LocalizationLanguage, val localization: String)
 
     fun t(key: LocalizationKey) = t(key, LocalizationParams.empty)
 
-    fun t(key: String) = t(LocalizationKey(key), LocalizationParams.empty)
+    fun t(key: String) = t(LocalizationKey.of(key), LocalizationParams.empty)
 
-    fun t(key: String, params: LocalizationParams) = t(LocalizationKey(key), params)
+    fun t(key: String, params: LocalizationParams) = t(LocalizationKey.of(key), params)
 
     fun t(key: LocalizationKey, params: LocalizationParams): String {
         var node = jsonRoot

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/localization/LocalizationService.kt
@@ -11,6 +11,7 @@ private val LOCALIZATION_PARAMS_PLACEHOLDER_REGEX = Regex("\\{\\{[a-zA-Z0-9_\\s\
 
 data class Translation(val lang: LocalizationLanguage, val localization: String) {
     private val jsonRoot = JsonMapper().readTree(localization)
+    private val nodeTextCache = ConcurrentHashMap<LocalizationKey, String>()
 
     fun t(key: LocalizationKey) = t(key, LocalizationParams.empty)
 
@@ -18,16 +19,18 @@ data class Translation(val lang: LocalizationLanguage, val localization: String)
 
     fun t(key: String, params: LocalizationParams) = t(LocalizationKey.of(key), params)
 
-    fun t(key: LocalizationKey, params: LocalizationParams): String {
-        var node = jsonRoot
-        key.split(".").let { keyPart -> keyPart.forEach { part -> node = node.path(part) } }
-
-        val nodeText = if (node.isMissingNode) key.toString() else node.asText()
-        return nodeText.replace(LOCALIZATION_PARAMS_PLACEHOLDER_REGEX) {
-            val propKey = it.value.substring(2, it.value.length - 2).trim()
+    fun t(key: LocalizationKey, params: LocalizationParams): String =
+        getNodeText(key).replace(LOCALIZATION_PARAMS_PLACEHOLDER_REGEX) { prop ->
+            val propKey = prop.value.substring(2, prop.value.length - 2).trim()
             params.get(propKey)
         }
-    }
+
+    private fun getNodeText(key: LocalizationKey) =
+        nodeTextCache.computeIfAbsent(key) { k ->
+            var node = jsonRoot
+            k.split(".").let { keyPart -> keyPart.forEach { part -> node = node.path(part) } }
+            if (node.isMissingNode) key.toString() else node.asText()
+        }
 
     fun filename(key: String, params: LocalizationParams, branch: String = "filename"): FileName {
         return t("$branch.$key", params).let(::FileName)
@@ -48,7 +51,7 @@ class TranslationCache {
     private val translations = ConcurrentHashMap<LocalizationLanguage, Translation>()
 
     fun getOrLoadTranslation(lang: LocalizationLanguage): Translation =
-        translations.getOrPut(lang) {
+        translations.computeIfAbsent(lang) {
             this::class.java.classLoader.getResource("i18n/translations.${lang.lowercase()}.json").let {
                 Translation(lang, it?.readText() ?: "")
             }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -186,7 +186,15 @@ fun <M : AlignmentM<M>> simplify(
                 }
 
                 s.segmentPoints.mapIndexedNotNull { pIndex, p ->
-                    if (isPointIncluded(pIndex, p.m.segmentToAlignmentM(m.min), isEndPoint, isOverResolution, bboxContains)) {
+                    if (
+                        isPointIncluded(
+                            pIndex,
+                            p.m.segmentToAlignmentM(m.min),
+                            isEndPoint,
+                            isOverResolution,
+                            bboxContains,
+                        )
+                    ) {
                         if (!isSegmentEndPoint(pIndex)) {
                             // segment end points should be additional points,
                             // so increase m-counter only when handling middle points

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/projektivelho/PVDao.kt
@@ -38,12 +38,12 @@ import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.getUnsafeString
 import fi.fta.geoviite.infra.util.getUnsafeStringOrNull
 import fi.fta.geoviite.infra.util.setUser
-import java.sql.Timestamp
-import java.time.Instant
-import kotlin.reflect.KClass
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.Instant
+import kotlin.reflect.KClass
 
 data class PVDocumentCounts(val suggested: Int, val rejected: Int)
 
@@ -66,51 +66,51 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
             metadata.description?.let { desc -> clipToLength(PVApiDocumentMetadata::class, "description", 500, desc) }
         val sql =
             """
-            insert into projektivelho.document(
-                oid,
-                status,
-                filename,
-                description,
-                document_version,
-                document_change_time,
-                document_type_code,
-                material_state_code,
-                material_category_code,
-                material_group_code,
-                assignment_oid,
-                project_oid,
-                project_group_oid
-            ) values (
-                :oid,
-                :status::projektivelho.document_status,
-                :filename,
-                :description,
-                :document_version,
-                :document_change_time,
-                :document_type,
-                :material_state,
-                :material_category,
-                :material_group,
-                :assignment_oid,
-                :project_oid,
-                :project_group_oid
-            ) 
-            on conflict (oid) do 
-              update set
-                status = :status::projektivelho.document_status,
-                filename = :filename,
-                description = :description,
-                document_version = :document_version,
-                document_change_time = :document_change_time,
-                document_type_code = :document_type,
-                material_state_code = :material_state,
-                material_category_code = :material_category,
-                material_group_code = :material_group,
-                assignment_oid = :assignment_oid,
-                project_oid = :project_oid,
-                project_group_oid = :project_group_oid
-              where projektivelho.document.document_version <> :document_version
-        """
+                insert into projektivelho.document(
+                    oid,
+                    status,
+                    filename,
+                    description,
+                    document_version,
+                    document_change_time,
+                    document_type_code,
+                    material_state_code,
+                    material_category_code,
+                    material_group_code,
+                    assignment_oid,
+                    project_oid,
+                    project_group_oid
+                ) values (
+                    :oid,
+                    :status::projektivelho.document_status,
+                    :filename,
+                    :description,
+                    :document_version,
+                    :document_change_time,
+                    :document_type,
+                    :material_state,
+                    :material_category,
+                    :material_group,
+                    :assignment_oid,
+                    :project_oid,
+                    :project_group_oid
+                ) 
+                on conflict (oid) do 
+                  update set
+                    status = :status::projektivelho.document_status,
+                    filename = :filename,
+                    description = :description,
+                    document_version = :document_version,
+                    document_change_time = :document_change_time,
+                    document_type_code = :document_type,
+                    material_state_code = :material_state,
+                    material_category_code = :material_category,
+                    material_group_code = :material_group,
+                    assignment_oid = :assignment_oid,
+                    project_oid = :project_oid,
+                    project_group_oid = :project_group_oid
+                  where projektivelho.document.document_version <> :document_version
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -146,18 +146,18 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         val name = clipToLength(PVApiProject::class, "name", PVProjectName.length.last, project.properties.name)
         val sql =
             """
-            insert into projektivelho.project (oid, name, state_code, created_at, modified)
-            values (:oid, :name, :state_code, :created_at, :modified)
-            on conflict (oid) do update 
-              set name = :name, 
-                  state_code = :state_code,
-                  created_at = :created_at,
-                  modified = :modified
-              where projektivelho.project.name <> :name
-                 or projektivelho.project.state_code <> :state_code
-                 or projektivelho.project.created_at <> :created_at
-                 or projektivelho.project.modified <> :modified;
-        """
+                insert into projektivelho.project (oid, name, state_code, created_at, modified)
+                values (:oid, :name, :state_code, :created_at, :modified)
+                on conflict (oid) do update 
+                  set name = :name, 
+                      state_code = :state_code,
+                      created_at = :created_at,
+                      modified = :modified
+                  where projektivelho.project.name <> :name
+                     or projektivelho.project.state_code <> :state_code
+                     or projektivelho.project.created_at <> :created_at
+                     or projektivelho.project.modified <> :modified;
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -178,18 +178,18 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
             clipToLength(PVApiProjectGroup::class, "name", PVProjectName.length.last, projectGroup.properties.name)
         val sql =
             """
-            insert into projektivelho.project_group (oid, name, state_code, created_at, modified)
-            values (:oid, :name, :state_code, :created_at, :modified)
-            on conflict (oid) do update 
-              set name = :name,
-                  state_code = :state_code,
-                  created_at = :created_at,
-                  modified = :modified
-              where projektivelho.project_group.name <> :name
-                 or projektivelho.project_group.state_code <> :state_code
-                 or projektivelho.project_group.created_at <> :created_at
-                 or projektivelho.project_group.modified <> :modified
-        """
+                insert into projektivelho.project_group (oid, name, state_code, created_at, modified)
+                values (:oid, :name, :state_code, :created_at, :modified)
+                on conflict (oid) do update 
+                  set name = :name,
+                      state_code = :state_code,
+                      created_at = :created_at,
+                      modified = :modified
+                  where projektivelho.project_group.name <> :name
+                     or projektivelho.project_group.state_code <> :state_code
+                     or projektivelho.project_group.created_at <> :created_at
+                     or projektivelho.project_group.modified <> :modified
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -209,18 +209,18 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         val name = clipToLength(PVApiAssignment::class, "name", PVProjectName.length.last, assignment.properties.name)
         val sql =
             """
-            insert into projektivelho.assignment (oid, name, state_code, created_at, modified)
-            values (:oid, :name, :state_code, :created_at, :modified)
-            on conflict (oid) do update 
-              set name = :name,
-                  state_code = :state_code,
-                  created_at = :created_at,
-                  modified = :modified
-              where projektivelho.assignment.name <> :name
-                 or projektivelho.assignment.state_code <> :state_code
-                 or projektivelho.assignment.created_at <> :created_at
-                 or projektivelho.assignment.modified <> :modified
-        """
+                insert into projektivelho.assignment (oid, name, state_code, created_at, modified)
+                values (:oid, :name, :state_code, :created_at, :modified)
+                on conflict (oid) do update 
+                  set name = :name,
+                      state_code = :state_code,
+                      created_at = :created_at,
+                      modified = :modified
+                  where projektivelho.assignment.name <> :name
+                     or projektivelho.assignment.state_code <> :state_code
+                     or projektivelho.assignment.created_at <> :created_at
+                     or projektivelho.assignment.modified <> :modified
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -239,14 +239,14 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun insertDocumentContent(content: String, documentId: IntId<PVDocument>) {
         val sql =
             """
-            insert into projektivelho.document_content(
-                content,
-                document_id
-            ) values (
-                xmlparse(document :content),
-                :document_id
-            )
-        """
+                insert into projektivelho.document_content(
+                    content,
+                    document_id
+                ) values (
+                    xmlparse(document :content),
+                    :document_id
+                )
+            """
                 .trimIndent()
         jdbcTemplate.setUser()
         val params = mapOf("document_id" to documentId.intValue, "content" to content)
@@ -258,16 +258,16 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun insertFetchInfo(searchToken: PVId, validUntil: Instant): IntId<PVSearch> {
         val sql =
             """
-            insert into projektivelho.search(
-                status,
-                token,
-                valid_until
-            ) values (
-                :status::projektivelho.search_status,
-                :token,
-                :valid_until
-            ) returning id
-        """
+                insert into projektivelho.search(
+                    status,
+                    token,
+                    valid_until
+                ) values (
+                    :status::projektivelho.search_status,
+                    :token,
+                    :valid_until
+                ) returning id
+            """
                 .trimIndent()
         jdbcTemplate.setUser()
         val params =
@@ -282,11 +282,11 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun updateFetchState(id: IntId<PVSearch>, status: PVFetchStatus): IntId<PVSearch> {
         val sql =
             """
-            update projektivelho.search 
-            set status = :status::projektivelho.search_status
-            where id = :id
-            returning id
-        """
+                update projektivelho.search 
+                set status = :status::projektivelho.search_status
+                where id = :id
+                returning id
+            """
                 .trimIndent()
         jdbcTemplate.setUser()
         return jdbcTemplate
@@ -300,11 +300,11 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun fetchLatestDocument(): Pair<Oid<PVDocument>, Instant>? {
         val sql =
             """
-            select document_change_time, oid 
-            from projektivelho.document 
-            order by document_change_time desc, oid desc 
-            limit 1
-        """
+                select document_change_time, oid 
+                from projektivelho.document 
+                order by document_change_time desc, oid desc 
+                limit 1
+            """
                 .trimIndent()
         return jdbcTemplate
             .query(sql, emptyMap<String, Any>()) { rs, _ ->
@@ -317,13 +317,13 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun fetchLatestActiveSearch(): PVSearch? {
         val sql =
             """
-            select id, token, status, valid_until 
-            from projektivelho.search 
-            where status not in ('ERROR', 'FINISHED')
-              and valid_until >= now()
-            order by valid_until desc 
-            limit 1
-        """
+                select id, token, status, valid_until 
+                from projektivelho.search 
+                where status not in ('ERROR', 'FINISHED')
+                  and valid_until >= now()
+                order by valid_until desc 
+                limit 1
+            """
                 .trimIndent()
         return jdbcTemplate
             .query(sql, emptyMap<String, Any>()) { rs, _ ->
@@ -343,11 +343,11 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         if (ids.isEmpty()) return emptyList()
         val sql =
             """
-            update projektivelho.document
-            set status = :status::projektivelho.document_status
-            where id in (:ids)
-            returning id
-        """
+                update projektivelho.document
+                set status = :status::projektivelho.document_status
+                where id in (:ids)
+                returning id
+            """
                 .trimIndent()
         val params = mapOf("ids" to ids.map { it.intValue }, "status" to status.name)
         jdbcTemplate.setUser()
@@ -360,10 +360,10 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun insertRejection(documentRowVersion: RowVersion<PVDocument>, reason: String): IntId<PVDocumentRejection> {
         val sql =
             """
-            insert into projektivelho.document_rejection(document_id, document_version, reason)
-            values (:id, :version, :reason)
-            returning id
-        """
+                insert into projektivelho.document_rejection(document_id, document_version, reason)
+                values (:id, :version, :reason)
+                returning id
+            """
                 .trimIndent()
         val params =
             mapOf("id" to documentRowVersion.id.intValue, "version" to documentRowVersion.version, "reason" to reason)
@@ -379,10 +379,10 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         logger.daoAccess(FETCH, PVDocumentRejection::class)
         val sql =
             """
-            select id, document_id, document_version, reason 
-            from projektivelho.document_rejection
-            where document_id = :document_id and document_version = :document_version
-        """
+                select id, document_id, document_version, reason 
+                from projektivelho.document_rejection
+                where document_id = :document_id and document_version = :document_version
+            """
                 .trimIndent()
         val params =
             mapOf("document_id" to documentRowVersion.id.intValue, "document_version" to documentRowVersion.version)
@@ -393,7 +393,7 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
                 PVDocumentRejection(
                     id = rs.getIntId("id"),
                     documentVersion = rs.getRowVersion("document_id", "document_version"),
-                    reason = LocalizationKey(rs.getString("reason")),
+                    reason = LocalizationKey.of(rs.getString("reason")),
                 )
             },
         )
@@ -404,41 +404,41 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun getDocumentHeaders(status: PVDocumentStatus? = null, id: IntId<PVDocument>? = null): List<PVDocumentHeader> {
         val sql =
             """
-            select 
-              document.id,
-              document.oid,
-              document.filename,
-              document.version,
-              document.description,
-              document.change_time, 
-              document.status,
-              document.project_oid,
-              project.name as project_name,
-              project_state.name as project_state,
-              document.project_group_oid,
-              project_group.name as project_group_name,
-              project_group_state.name as project_group_state,
-              document.assignment_oid,
-              assignment.name as assignment_name,
-              assignment_state.name as assignment_state,
-              document_type.name as document_type,
-              material_state.name as material_state,
-              material_group.name as material_group,
-              material_category.name as material_category
-            from projektivelho.document
-              left join projektivelho.project on project.oid = document.project_oid
-              left join projektivelho.project_state on project.state_code = project_state.code
-              left join projektivelho.project_group on project_group.oid = document.project_group_oid
-              left join projektivelho.project_state project_group_state on project_group.state_code = project_group_state.code
-              left join projektivelho.assignment on assignment.oid = document.assignment_oid
-              left join projektivelho.project_state assignment_state on assignment.state_code = assignment_state.code
-              left join projektivelho.document_type on document_type.code = document.document_type_code
-              left join projektivelho.material_state on material_state.code = document.material_state_code
-              left join projektivelho.material_group on material_group.code = document.material_group_code
-              left join projektivelho.material_category on material_category.code = document.material_category_code
-            where (:status::projektivelho.document_status is null or status = :status::projektivelho.document_status)
-              and (:id::int is null or id = :id)
-        """
+                select 
+                  document.id,
+                  document.oid,
+                  document.filename,
+                  document.version,
+                  document.description,
+                  document.change_time, 
+                  document.status,
+                  document.project_oid,
+                  project.name as project_name,
+                  project_state.name as project_state,
+                  document.project_group_oid,
+                  project_group.name as project_group_name,
+                  project_group_state.name as project_group_state,
+                  document.assignment_oid,
+                  assignment.name as assignment_name,
+                  assignment_state.name as assignment_state,
+                  document_type.name as document_type,
+                  material_state.name as material_state,
+                  material_group.name as material_group,
+                  material_category.name as material_category
+                from projektivelho.document
+                  left join projektivelho.project on project.oid = document.project_oid
+                  left join projektivelho.project_state on project.state_code = project_state.code
+                  left join projektivelho.project_group on project_group.oid = document.project_group_oid
+                  left join projektivelho.project_state project_group_state on project_group.state_code = project_group_state.code
+                  left join projektivelho.assignment on assignment.oid = document.assignment_oid
+                  left join projektivelho.project_state assignment_state on assignment.state_code = assignment_state.code
+                  left join projektivelho.document_type on document_type.code = document.document_type_code
+                  left join projektivelho.material_state on material_state.code = document.material_state_code
+                  left join projektivelho.material_group on material_group.code = document.material_group_code
+                  left join projektivelho.material_category on material_category.code = document.material_category_code
+                where (:status::projektivelho.document_status is null or status = :status::projektivelho.document_status)
+                  and (:id::int is null or id = :id)
+            """
                 .trimIndent()
         val params = mapOf("id" to id?.intValue, "status" to status?.name)
         return jdbcTemplate
@@ -489,11 +489,11 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
     fun getDocumentCounts(): PVDocumentCounts {
         val sql =
             """
-            select 
-              count(*) filter (where status = 'SUGGESTED') as suggested_count, 
-              count(*) filter (where status = 'REJECTED') as rejected_count
-            from projektivelho.document
-        """
+                select 
+                  count(*) filter (where status = 'SUGGESTED') as suggested_count, 
+                  count(*) filter (where status = 'REJECTED') as rejected_count
+                from projektivelho.document
+            """
                 .trimIndent()
         return jdbcTemplate
             .query(sql, emptyMap<String, Any>()) { rs, _ ->
@@ -508,13 +508,13 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         logger.daoAccess(FETCH, InfraModelFile::class, id)
         val sql =
             """
-            select 
-              document.filename,
-              xmlserialize(document document_content.content as varchar) as file_content
-            from projektivelho.document
-              inner join projektivelho.document_content on document.id = document_content.document_id
-            where document.id = :id
-        """
+                select 
+                  document.filename,
+                  xmlserialize(document document_content.content as varchar) as file_content
+                from projektivelho.document
+                  inner join projektivelho.document_content on document.id = document_content.document_id
+                where document.id = :id
+            """
                 .trimIndent()
         val params = mapOf("id" to id.intValue)
         return getOptional(
@@ -530,10 +530,10 @@ class PVDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTempla
         val tableName = tableName(type)
         val sql =
             """
-            insert into $tableName(code, name) 
-              values (:code, :name) 
-              on conflict (code) do update set name = :name where $tableName.name <> :name
-        """
+                insert into $tableName(code, name) 
+                  values (:code, :name) 
+                  on conflict (code) do update set name = :name where $tableName.name <> :name
+            """
                 .trimIndent()
         val params = entries.map { entry -> mapOf("code" to entry.code, "name" to entry.name) }.toTypedArray()
         jdbcTemplate.setUser()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -117,7 +117,7 @@ data class ChangeValue<T>(val oldValue: T?, val newValue: T?, val localizationKe
         oldValue: T?,
         newValue: T?,
         localizationKey: String?,
-    ) : this(oldValue, newValue, localizationKey?.let(::LocalizationKey))
+    ) : this(oldValue, newValue, localizationKey?.let(LocalizationKey::of))
 }
 
 data class PublicationChange<T>(
@@ -129,7 +129,10 @@ data class PublicationChange<T>(
 )
 
 data class PropKey(val key: LocalizationKey, val params: LocalizationParams = LocalizationParams.empty) {
-    constructor(key: String, params: LocalizationParams = LocalizationParams.empty) : this(LocalizationKey(key), params)
+    constructor(
+        key: String,
+        params: LocalizationParams = LocalizationParams.empty,
+    ) : this(LocalizationKey.of(key), params)
 }
 
 open class Publication(
@@ -478,7 +481,7 @@ data class LayoutValidationIssue(
         type: LayoutValidationIssueType,
         key: String,
         params: Map<String, Any?> = emptyMap(),
-    ) : this(type, LocalizationKey(key), localizationParams(params))
+    ) : this(type, LocalizationKey.of(key), localizationParams(params))
 }
 
 interface PublicationCandidate<T : LayoutAsset<T>> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -108,22 +108,22 @@ class PublicationDao(
     ): List<TrackNumberPublicationCandidate> {
         val sql =
             """
-            select id, design_id, draft, version, number, change_time, change_user, design_asset_state,
-              layout.infer_operation_from_state_transition(
-                (select state
-                 from layout.track_number_in_layout_context('OFFICIAL', null) tilc
-                 where tilc.id = candidate_track_number.id),
-                candidate_track_number.state
-              ) as operation
-            from layout.track_number candidate_track_number
-            where draft = (:candidate_state = 'DRAFT') and design_id is not distinct from :candidate_design_id
-              and not (design_id is not null and not draft and (design_asset_state = 'CANCELLED' or exists (
-                select * from layout.track_number drafted_cancellation
-                where drafted_cancellation.draft
-                  and drafted_cancellation.design_id = candidate_track_number.design_id
-                  and drafted_cancellation.id = candidate_track_number.id
-                  and drafted_cancellation.design_asset_state = 'CANCELLED')))
-        """
+                select id, design_id, draft, version, number, change_time, change_user, design_asset_state,
+                  layout.infer_operation_from_state_transition(
+                    (select state
+                     from layout.track_number_in_layout_context('OFFICIAL', null) tilc
+                     where tilc.id = candidate_track_number.id),
+                    candidate_track_number.state
+                  ) as operation
+                from layout.track_number candidate_track_number
+                where draft = (:candidate_state = 'DRAFT') and design_id is not distinct from :candidate_design_id
+                  and not (design_id is not null and not draft and (design_asset_state = 'CANCELLED' or exists (
+                    select * from layout.track_number drafted_cancellation
+                    where drafted_cancellation.draft
+                      and drafted_cancellation.design_id = candidate_track_number.design_id
+                      and drafted_cancellation.id = candidate_track_number.id
+                      and drafted_cancellation.design_asset_state = 'CANCELLED')))
+            """
                 .trimIndent()
         val candidates =
             jdbcTemplate.query(sql, publicationCandidateSqlArguments(transition)) { rs, _ ->
@@ -154,52 +154,52 @@ class PublicationDao(
     ): List<ReferenceLinePublicationCandidate> {
         val sql =
             """
-            select 
-              candidate_reference_line.id,
-              candidate_reference_line.design_id,
-              candidate_reference_line.draft,
-              candidate_reference_line.version,
-              candidate_reference_line.track_number_id,
-              candidate_reference_line.change_time,
-              candidate_reference_line.change_user,
-              candidate_track_number.number as name,
-              candidate_reference_line.design_asset_state,
-              layout.infer_operation_from_state_transition(
-                (select state
-                 from layout.track_number_in_layout_context('OFFICIAL', null)
-                 where id = track_number_id),
-                candidate_track_number.state
-              ) as operation,
-              postgis.st_astext(alignment_version.bounding_box) as bounding_box
-            from layout.reference_line candidate_reference_line
-              left join lateral
-                (
-                select *
-                from (
-                  select * from layout.track_number same_context_tn
-                  where same_context_tn.draft = (:candidate_state = 'DRAFT')
-                    and same_context_tn.design_id is not distinct from :candidate_design_id
-                    and same_context_tn.id = candidate_reference_line.track_number_id
-                  union all
-                  select *
-                  from layout.track_number_in_layout_context(:candidate_state::layout.publication_state,
-                                                             :candidate_design_id)) visible_tn
-                  where visible_tn.id = candidate_reference_line.track_number_id
-                limit 1
-                ) candidate_track_number on (true)
-              left join layout.alignment_version alignment_version
-                on candidate_reference_line.alignment_id = alignment_version.id
-                  and candidate_reference_line.alignment_version = alignment_version.version
-            where candidate_reference_line.draft = (:candidate_state = 'DRAFT')
-              and candidate_reference_line.design_id is not distinct from :candidate_design_id
-              and not (candidate_reference_line.design_id is not null and not candidate_reference_line.draft
-                         and (candidate_reference_line.design_asset_state = 'CANCELLED' or exists (
-                           select * from layout.reference_line drafted_cancellation
-                           where drafted_cancellation.draft
-                             and drafted_cancellation.design_id = candidate_reference_line.design_id
-                             and drafted_cancellation.id = candidate_reference_line.id
-                             and drafted_cancellation.design_asset_state = 'CANCELLED')))
-        """
+                select
+                  candidate_reference_line.id,
+                  candidate_reference_line.design_id,
+                  candidate_reference_line.draft,
+                  candidate_reference_line.version,
+                  candidate_reference_line.track_number_id,
+                  candidate_reference_line.change_time,
+                  candidate_reference_line.change_user,
+                  candidate_track_number.number as name,
+                  candidate_reference_line.design_asset_state,
+                  layout.infer_operation_from_state_transition(
+                    (select state
+                     from layout.track_number_in_layout_context('OFFICIAL', null)
+                     where id = track_number_id),
+                    candidate_track_number.state
+                  ) as operation,
+                  postgis.st_astext(alignment_version.bounding_box) as bounding_box
+                from layout.reference_line candidate_reference_line
+                  left join lateral
+                    (
+                    select *
+                    from (
+                      select * from layout.track_number same_context_tn
+                      where same_context_tn.draft = (:candidate_state = 'DRAFT')
+                        and same_context_tn.design_id is not distinct from :candidate_design_id
+                        and same_context_tn.id = candidate_reference_line.track_number_id
+                      union all
+                      select *
+                      from layout.track_number_in_layout_context(:candidate_state::layout.publication_state,
+                                                                 :candidate_design_id)) visible_tn
+                      where visible_tn.id = candidate_reference_line.track_number_id
+                    limit 1
+                    ) candidate_track_number on (true)
+                  left join layout.alignment_version alignment_version
+                    on candidate_reference_line.alignment_id = alignment_version.id
+                      and candidate_reference_line.alignment_version = alignment_version.version
+                where candidate_reference_line.draft = (:candidate_state = 'DRAFT')
+                  and candidate_reference_line.design_id is not distinct from :candidate_design_id
+                  and not (candidate_reference_line.design_id is not null and not candidate_reference_line.draft
+                             and (candidate_reference_line.design_asset_state = 'CANCELLED' or exists (
+                               select * from layout.reference_line drafted_cancellation
+                               where drafted_cancellation.draft
+                                 and drafted_cancellation.design_id = candidate_reference_line.design_id
+                                 and drafted_cancellation.id = candidate_reference_line.id
+                                 and drafted_cancellation.design_asset_state = 'CANCELLED')))
+            """
                 .trimIndent()
         val candidates =
             jdbcTemplate.query(sql, publicationCandidateSqlArguments(transition)) { rs, _ ->
@@ -228,57 +228,57 @@ class PublicationDao(
     ): List<LocationTrackPublicationCandidate> {
         val sql =
             """
-            with splits as (
+                with splits as (
+                    select
+                        split.id as split_id,
+                        source.id as source_track_id,
+                        array_agg(stlt.location_track_id) as target_track_ids,
+                        array_agg(split_updated_duplicates.duplicate_location_track_id) as split_updated_duplicate_ids
+                    from publication.split
+                        inner join layout.location_track_version source
+                            on source.id = split.source_location_track_id
+                              and source.layout_context_id = split.layout_context_id
+                              and source.version = split.source_location_track_version
+                        inner join publication.split_target_location_track stlt on stlt.split_id = split.id
+                        left join publication.split_updated_duplicate split_updated_duplicates
+                            on split_updated_duplicates.split_id = split.id
+                    where split.publication_id is null
+                    group by split.id, source.id
+                )
                 select
-                    split.id as split_id,
-                    source.id as source_track_id,
-                    array_agg(stlt.location_track_id) as target_track_ids,
-                    array_agg(split_updated_duplicates.duplicate_location_track_id) as split_updated_duplicate_ids
-                from publication.split
-                    inner join layout.location_track_version source 
-                        on source.id = split.source_location_track_id
-                          and source.layout_context_id = split.layout_context_id
-                          and source.version = split.source_location_track_version
-                    inner join publication.split_target_location_track stlt on stlt.split_id = split.id
-                    left join publication.split_updated_duplicate split_updated_duplicates 
-                        on split_updated_duplicates.split_id = split.id
-                where split.publication_id is null
-                group by split.id, source.id
-            )
-            select 
-              candidate_location_track.id,
-              candidate_location_track.design_id,
-              candidate_location_track.draft,
-              candidate_location_track.version,
-              candidate_location_track.name,
-              candidate_location_track.track_number_id,
-              candidate_location_track.change_time,
-              candidate_location_track.duplicate_of_location_track_id,
-              candidate_location_track.change_user,
-              candidate_location_track.design_asset_state,
-              layout.infer_operation_from_location_track_state_transition(
-                (select state
-                 from layout.location_track_in_layout_context('OFFICIAL', null) base_lt
-                 where base_lt.id = candidate_location_track.id),
-                candidate_location_track.state
-              ) as operation,
-              postgis.st_astext(candidate_location_track.bounding_box) as bounding_box,
-              splits.split_id
-            from layout.location_track candidate_location_track
-                left join splits 
-                    on splits.source_track_id = candidate_location_track.id
-                        or candidate_location_track.id = any(splits.target_track_ids)
-                        or candidate_location_track.id = any(splits.split_updated_duplicate_ids)
-            where candidate_location_track.draft = (:candidate_state = 'DRAFT')
-              and candidate_location_track.design_id is not distinct from :candidate_design_id and
-              not (candidate_location_track.design_id is not null and not candidate_location_track.draft
-                   and (design_asset_state = 'CANCELLED' or exists (
-                     select * from layout.location_track drafted_cancellation
-                     where drafted_cancellation.draft
-                       and drafted_cancellation.design_id = candidate_location_track.design_id
-                       and drafted_cancellation.id = candidate_location_track.id
-                       and drafted_cancellation.design_asset_state = 'CANCELLED')))
-        """
+                  candidate_location_track.id,
+                  candidate_location_track.design_id,
+                  candidate_location_track.draft,
+                  candidate_location_track.version,
+                  candidate_location_track.name,
+                  candidate_location_track.track_number_id,
+                  candidate_location_track.change_time,
+                  candidate_location_track.duplicate_of_location_track_id,
+                  candidate_location_track.change_user,
+                  candidate_location_track.design_asset_state,
+                  layout.infer_operation_from_location_track_state_transition(
+                    (select state
+                     from layout.location_track_in_layout_context('OFFICIAL', null) base_lt
+                     where base_lt.id = candidate_location_track.id),
+                    candidate_location_track.state
+                  ) as operation,
+                  postgis.st_astext(candidate_location_track.bounding_box) as bounding_box,
+                  splits.split_id
+                from layout.location_track candidate_location_track
+                    left join splits
+                        on splits.source_track_id = candidate_location_track.id
+                            or candidate_location_track.id = any(splits.target_track_ids)
+                            or candidate_location_track.id = any(splits.split_updated_duplicate_ids)
+                where candidate_location_track.draft = (:candidate_state = 'DRAFT')
+                  and candidate_location_track.design_id is not distinct from :candidate_design_id and
+                  not (candidate_location_track.design_id is not null and not candidate_location_track.draft
+                       and (design_asset_state = 'CANCELLED' or exists (
+                         select * from layout.location_track drafted_cancellation
+                         where drafted_cancellation.draft
+                           and drafted_cancellation.design_id = candidate_location_track.design_id
+                           and drafted_cancellation.id = candidate_location_track.id
+                           and drafted_cancellation.design_asset_state = 'CANCELLED')))
+            """
                 .trimIndent()
         val candidates =
             jdbcTemplate.query(sql, publicationCandidateSqlArguments(transition)) { rs, _ ->
@@ -308,57 +308,57 @@ class PublicationDao(
     fun fetchSwitchPublicationCandidates(transition: LayoutContextTransition): List<SwitchPublicationCandidate> {
         val sql =
             """
-            with splits as (
+                with splits as (
+                    select
+                        split.id as split_id,
+                        array_agg(split_relinked_switches.switch_id) as split_relinked_switch_ids
+                    from publication.split
+                        inner join publication.split_relinked_switch split_relinked_switches
+                            on split_relinked_switches.split_id = split.id
+                    where split.publication_id is null
+                    group by split.id
+                )
                 select
-                    split.id as split_id,
-                    array_agg(split_relinked_switches.switch_id) as split_relinked_switch_ids
-                from publication.split
-                    inner join publication.split_relinked_switch split_relinked_switches 
-                        on split_relinked_switches.split_id = split.id
-                where split.publication_id is null
-                group by split.id
-            )
-            select 
-              candidate_switch.id,
-              candidate_switch.design_id,
-              candidate_switch.draft,
-              candidate_switch.version,
-              candidate_switch.name,
-              candidate_switch.change_time,
-              candidate_switch.change_user,
-              (select array_agg(sltn)
-                 from layout.switch_linked_track_numbers(candidate_switch.id,
-                                                         :candidate_state::layout.publication_state,
-                                                         :candidate_design_id) sltn
-              ) as track_numbers,
-              layout.infer_operation_from_state_category_transition(
-                (select state_category
-                 from layout.switch_in_layout_context('OFFICIAL', null) official_switch
-                 where official_switch.id = candidate_switch.id),
-                candidate_switch.state_category
-              ) as operation,
-              postgis.st_x(joint_version.location) as point_x, 
-              postgis.st_y(joint_version.location) as point_y,
-              candidate_switch.design_asset_state,
-              splits.split_id
-            from layout.switch candidate_switch
-              left join common.switch_structure on candidate_switch.switch_structure_id = switch_structure.id
-              left join layout.switch_version_joint joint_version
-                on joint_version.switch_id = candidate_switch.id
-                  and joint_version.switch_layout_context_id = candidate_switch.layout_context_id
-                  and joint_version.switch_version = candidate_switch.version
-                  and joint_version.number = switch_structure.presentation_joint_number
-             left join splits on candidate_switch.id = any(splits.split_relinked_switch_ids)
-            where candidate_switch.draft = (:candidate_state = 'DRAFT')
-              and candidate_switch.design_id is not distinct from :candidate_design_id
-              and not (candidate_switch.design_id is not null and not candidate_switch.draft
-                       and (design_asset_state = 'CANCELLED' or exists (
-                         select * from layout.switch drafted_cancellation
-                         where drafted_cancellation.draft
-                           and drafted_cancellation.design_id = design_id
-                           and drafted_cancellation.id = candidate_switch.id
-                           and drafted_cancellation.design_asset_state = 'CANCELLED')))
-        """
+                  candidate_switch.id,
+                  candidate_switch.design_id,
+                  candidate_switch.draft,
+                  candidate_switch.version,
+                  candidate_switch.name,
+                  candidate_switch.change_time,
+                  candidate_switch.change_user,
+                  (select array_agg(sltn)
+                     from layout.switch_linked_track_numbers(candidate_switch.id,
+                                                             :candidate_state::layout.publication_state,
+                                                             :candidate_design_id) sltn
+                  ) as track_numbers,
+                  layout.infer_operation_from_state_category_transition(
+                    (select state_category
+                     from layout.switch_in_layout_context('OFFICIAL', null) official_switch
+                     where official_switch.id = candidate_switch.id),
+                    candidate_switch.state_category
+                  ) as operation,
+                  postgis.st_x(joint_version.location) as point_x,
+                  postgis.st_y(joint_version.location) as point_y,
+                  candidate_switch.design_asset_state,
+                  splits.split_id
+                from layout.switch candidate_switch
+                  left join common.switch_structure on candidate_switch.switch_structure_id = switch_structure.id
+                  left join layout.switch_version_joint joint_version
+                    on joint_version.switch_id = candidate_switch.id
+                      and joint_version.switch_layout_context_id = candidate_switch.layout_context_id
+                      and joint_version.switch_version = candidate_switch.version
+                      and joint_version.number = switch_structure.presentation_joint_number
+                 left join splits on candidate_switch.id = any(splits.split_relinked_switch_ids)
+                where candidate_switch.draft = (:candidate_state = 'DRAFT')
+                  and candidate_switch.design_id is not distinct from :candidate_design_id
+                  and not (candidate_switch.design_id is not null and not candidate_switch.draft
+                           and (design_asset_state = 'CANCELLED' or exists (
+                             select * from layout.switch drafted_cancellation
+                             where drafted_cancellation.draft
+                               and drafted_cancellation.design_id = design_id
+                               and drafted_cancellation.id = candidate_switch.id
+                               and drafted_cancellation.design_asset_state = 'CANCELLED')))
+            """
                 .trimIndent()
         val candidates =
             jdbcTemplate.query(sql, publicationCandidateSqlArguments(transition)) { rs, _ ->
@@ -382,35 +382,35 @@ class PublicationDao(
     fun fetchKmPostPublicationCandidates(transition: LayoutContextTransition): List<KmPostPublicationCandidate> {
         val sql =
             """
-            select
-              candidate_km_post.id,
-              candidate_km_post.design_id,
-              candidate_km_post.draft,
-              candidate_km_post.version,
-              candidate_km_post.track_number_id,
-              candidate_km_post.km_number,
-              candidate_km_post.change_time,
-              candidate_km_post.change_user,
-              layout.infer_operation_from_state_transition(
-                (select state
-                 from layout.km_post_in_layout_context('OFFICIAL', null)
-                 where id = candidate_km_post.id),
-                candidate_km_post.state
-              ) as operation,
-              candidate_km_post.design_asset_state,
-              postgis.st_x(candidate_km_post.layout_location) as point_x,
-              postgis.st_y(candidate_km_post.layout_location) as point_y
-            from layout.km_post candidate_km_post
-            where draft = (:candidate_state = 'DRAFT')
-              and design_id is not distinct from :candidate_design_id
-              and not (design_id is not null and not draft and (design_asset_state = 'CANCELLED' or exists (
-                select * from layout.km_post drafted_cancellation
-                where drafted_cancellation.draft
-                  and drafted_cancellation.design_id = design_id
-                  and drafted_cancellation.id = candidate_km_post.id
-                  and drafted_cancellation.design_asset_state = 'CANCELLED')))
-            order by km_number
-        """
+                select
+                  candidate_km_post.id,
+                  candidate_km_post.design_id,
+                  candidate_km_post.draft,
+                  candidate_km_post.version,
+                  candidate_km_post.track_number_id,
+                  candidate_km_post.km_number,
+                  candidate_km_post.change_time,
+                  candidate_km_post.change_user,
+                  layout.infer_operation_from_state_transition(
+                    (select state
+                     from layout.km_post_in_layout_context('OFFICIAL', null)
+                     where id = candidate_km_post.id),
+                    candidate_km_post.state
+                  ) as operation,
+                  candidate_km_post.design_asset_state,
+                  postgis.st_x(candidate_km_post.layout_location) as point_x,
+                  postgis.st_y(candidate_km_post.layout_location) as point_y
+                from layout.km_post candidate_km_post
+                where draft = (:candidate_state = 'DRAFT')
+                  and design_id is not distinct from :candidate_design_id
+                  and not (design_id is not null and not draft and (design_asset_state = 'CANCELLED' or exists (
+                    select * from layout.km_post drafted_cancellation
+                    where drafted_cancellation.draft
+                      and drafted_cancellation.design_id = design_id
+                      and drafted_cancellation.id = candidate_km_post.id
+                      and drafted_cancellation.design_asset_state = 'CANCELLED')))
+                order by km_number
+            """
                 .trimIndent()
         val candidates =
             jdbcTemplate.query(sql, publicationCandidateSqlArguments(transition)) { rs, _ ->
@@ -439,24 +439,24 @@ class PublicationDao(
         jdbcTemplate.setUser()
         val sql =
             """
-            insert into publication.publication(
-              publication_user,
-              publication_time,
-              message,
-              design_id,
-              design_version,
-              cause,
-              parent_publication_id)
-            (select
-              current_setting('geoviite.edit_user'),
-              now(),
-              :message,
-              :design_id,
-              (select version from layout.design where id = :design_id),
-              :cause::publication.publication_cause,
-              :parent)
-            returning id
-        """
+                insert into publication.publication(
+                  publication_user,
+                  publication_time,
+                  message,
+                  design_id,
+                  design_version,
+                  cause,
+                  parent_publication_id)
+                (select
+                  current_setting('geoviite.edit_user'),
+                  now(),
+                  :message,
+                  :design_id,
+                  (select version from layout.design where id = :design_id),
+                  :cause::publication.publication_cause,
+                  :parent)
+                returning id
+            """
                 .trimIndent()
         val publicationId: IntId<Publication> =
             jdbcTemplate.queryForObject(
@@ -552,11 +552,11 @@ class PublicationDao(
     ): Map<IntId<LocationTrack>, List<LayoutRowVersion<LocationTrack>>> {
         val sql =
             """
-            select id, design_id, draft, version, duplicate_of_location_track_id
-            from layout.location_track_in_layout_context(:publication_state::layout.publication_state, :design_id)
-            where duplicate_of_location_track_id in (:ids)
-              and state != 'DELETED'
-        """
+                select id, design_id, draft, version, duplicate_of_location_track_id
+                from layout.location_track_in_layout_context(:publication_state::layout.publication_state, :design_id)
+                where duplicate_of_location_track_id in (:ids)
+                  and state != 'DELETED'
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -582,19 +582,19 @@ class PublicationDao(
     fun getPublications(publicationIds: Set<IntId<Publication>>): Map<IntId<Publication>, Publication> {
         val sql =
             """
-            select
-              id,
-              publication_uuid,
-              publication_user,
-              publication_time,
-              message,
-              design_id,
-              design_version,
-              cause,
-              parent_publication_id
-            from publication.publication
-            where publication.id = any(array[:ids]::int[])
-        """
+                select
+                  id,
+                  publication_uuid,
+                  publication_user,
+                  publication_time,
+                  message,
+                  design_id,
+                  design_version,
+                  cause,
+                  parent_publication_id
+                from publication.publication
+                where publication.id = any(array[:ids]::int[])
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -658,21 +658,21 @@ class PublicationDao(
     fun fetchPublicationsBetween(layoutBranch: LayoutBranch, from: Instant?, to: Instant?): List<Publication> {
         val sql =
             """
-            select 
-              id, 
-              publication_uuid, 
-              publication_user,
-              publication_time, 
-              message, 
-              design_id, 
-              design_version, 
-              cause, 
-              parent_publication_id
-            from publication.publication
-            where (:from <= publication_time or :from::timestamptz is null) and (publication_time < :to or :to::timestamptz is null)
-              and design_id is not distinct from :design_id
-            order by id
-        """
+                select
+                  id,
+                  publication_uuid,
+                  publication_user,
+                  publication_time,
+                  message,
+                  design_id,
+                  design_version,
+                  cause,
+                  parent_publication_id
+                from publication.publication
+                where (:from <= publication_time or :from::timestamptz is null) and (publication_time < :to or :to::timestamptz is null)
+                  and design_id is not distinct from :design_id
+                order by id
+            """
                 .trimIndent()
 
         val params =
@@ -700,20 +700,20 @@ class PublicationDao(
     fun list(branchType: LayoutBranchType): List<Publication> {
         val sql =
             """
-            select 
-              id, 
-              publication_uuid, 
-              publication_user, 
-              publication_time, 
-              message, 
-              design_id, 
-              design_version, 
-              cause, 
-              parent_publication_id
-            from publication.publication
-            where case when :branch_type = 'MAIN' then design_id is null else design_id is not null end
-            order by id desc
-        """
+                select
+                  id,
+                  publication_uuid,
+                  publication_user,
+                  publication_time,
+                  message,
+                  design_id,
+                  design_version,
+                  cause,
+                  parent_publication_id
+                from publication.publication
+                where case when :branch_type = 'MAIN' then design_id is null else design_id is not null end
+                order by id desc
+            """
                 .trimIndent()
 
         val params = mapOf("branch_type" to branchType.name)
@@ -736,20 +736,20 @@ class PublicationDao(
     fun fetchLatestPublications(branchType: LayoutBranchType, count: Int): List<Publication> {
         val sql =
             """
-            select 
-              id, 
-              publication_uuid, 
-              publication_user, 
-              publication_time, 
-              message, 
-              design_id, 
-              design_version, 
-              cause, 
-              parent_publication_id
-            from publication.publication
-            where case when :branch_type = 'MAIN' then design_id is null else design_id is not null end
-            order by id desc limit :count
-        """
+                select
+                  id,
+                  publication_uuid,
+                  publication_user,
+                  publication_time,
+                  message,
+                  design_id,
+                  design_version,
+                  cause,
+                  parent_publication_id
+                from publication.publication
+                where case when :branch_type = 'MAIN' then design_id is null else design_id is not null end
+                order by id desc limit :count
+            """
                 .trimIndent()
 
         val params = mapOf("count" to count, "branch_type" to branchType.name)
@@ -772,10 +772,10 @@ class PublicationDao(
     fun fetchPublicationTimes(layoutBranch: LayoutBranch): Map<Instant, IntId<Publication>> {
         val sql =
             """
-            select id, publication_time
-            from publication.publication
-            where design_id is not distinct from :design_id
-        """
+                select id, publication_time
+                from publication.publication
+                where design_id is not distinct from :design_id
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -794,52 +794,52 @@ class PublicationDao(
         assertMainBranch(layoutBranch)
         val sql =
             """
-            select
-              tn.id as tn_id,
-              tn.number as track_number,
-              old_tn.number as old_track_number,
-              tn.description as description,
-              old_tn.description as old_description,
-              tn.state as state,
-              old_tn.state as old_state,
-              rl.start_address as start_address,
-              old_rl.start_address as old_start_address,
-              postgis.st_x(postgis.st_endpoint(old_sg_last.geometry)) as old_end_x,
-              postgis.st_y(postgis.st_endpoint(old_sg_last.geometry)) as old_end_y,
-              postgis.st_x(postgis.st_endpoint(sg_last.geometry)) as end_x,
-              postgis.st_y(postgis.st_endpoint(sg_last.geometry)) as end_y
-            from publication.track_number
-              left join layout.track_number_version tn
-                on tn.id = track_number.id
-                  and tn.version = track_number.version
-                  and tn.layout_context_id = track_number.layout_context_id
-              left join publication.publication p on p.id = publication_id
-              left join lateral
-                (select * from layout.reference_line_version rl
-                 where rl.track_number_id = tn.id and not rl.draft and rl.design_id is null
-                   and rl.change_time <= p.publication_time
-                 order by change_time desc
-                 limit 1) rl on (true)
-              left join layout.alignment_version av on av.id = rl.alignment_id and av.version = rl.alignment_version
-              left join layout.segment_version sv_last on av.id = sv_last.alignment_id and av.version = sv_last.alignment_version and sv_last.segment_index = av.segment_count - 1
-              left join layout.segment_geometry sg_last on sv_last.geometry_id = sg_last.id
-              left join layout.track_number_version old_tn 
-                on old_tn.id = track_number.id
-                  and old_tn.version = track_number.base_version
-                  and old_tn.layout_context_id = track_number.base_layout_context_id
-              left join lateral (
-                select * from layout.reference_line_version rl
-                 where rl.track_number_id = tn.id and not rl.draft and rl.design_id is null
-                   and rl.change_time <= :comparison_time
-                 order by change_time desc
-                 limit 1) old_rl on (true)
-              left join layout.alignment_version old_av on old_av.id = old_rl.alignment_id and old_av.version = old_rl.alignment_version
-              left join layout.segment_version old_sv_first on old_av.id = old_sv_first.alignment_id and old_av.version = old_sv_first.alignment_version and old_sv_first.segment_index = 0
-              left join layout.segment_geometry old_sg_first on old_sv_first.geometry_id = old_sg_first.id
-              left join layout.segment_version old_sv_last on old_av.id = old_sv_last.alignment_id and old_av.version = old_sv_last.alignment_version and old_sv_last.segment_index = old_av.segment_count - 1
-              left join layout.segment_geometry old_sg_last on old_sv_last.geometry_id = old_sg_last.id
-            where publication_id = :publication_id
-        """
+                select
+                  tn.id as tn_id,
+                  tn.number as track_number,
+                  old_tn.number as old_track_number,
+                  tn.description as description,
+                  old_tn.description as old_description,
+                  tn.state as state,
+                  old_tn.state as old_state,
+                  rl.start_address as start_address,
+                  old_rl.start_address as old_start_address,
+                  postgis.st_x(postgis.st_endpoint(old_sg_last.geometry)) as old_end_x,
+                  postgis.st_y(postgis.st_endpoint(old_sg_last.geometry)) as old_end_y,
+                  postgis.st_x(postgis.st_endpoint(sg_last.geometry)) as end_x,
+                  postgis.st_y(postgis.st_endpoint(sg_last.geometry)) as end_y
+                from publication.track_number
+                  left join layout.track_number_version tn
+                    on tn.id = track_number.id
+                      and tn.version = track_number.version
+                      and tn.layout_context_id = track_number.layout_context_id
+                  left join publication.publication p on p.id = publication_id
+                  left join lateral
+                    (select * from layout.reference_line_version rl
+                     where rl.track_number_id = tn.id and not rl.draft and rl.design_id is null
+                       and rl.change_time <= p.publication_time
+                     order by change_time desc
+                     limit 1) rl on (true)
+                  left join layout.alignment_version av on av.id = rl.alignment_id and av.version = rl.alignment_version
+                  left join layout.segment_version sv_last on av.id = sv_last.alignment_id and av.version = sv_last.alignment_version and sv_last.segment_index = av.segment_count - 1
+                  left join layout.segment_geometry sg_last on sv_last.geometry_id = sg_last.id
+                  left join layout.track_number_version old_tn
+                    on old_tn.id = track_number.id
+                      and old_tn.version = track_number.base_version
+                      and old_tn.layout_context_id = track_number.base_layout_context_id
+                  left join lateral (
+                    select * from layout.reference_line_version rl
+                     where rl.track_number_id = tn.id and not rl.draft and rl.design_id is null
+                       and rl.change_time <= :comparison_time
+                     order by change_time desc
+                     limit 1) old_rl on (true)
+                  left join layout.alignment_version old_av on old_av.id = old_rl.alignment_id and old_av.version = old_rl.alignment_version
+                  left join layout.segment_version old_sv_first on old_av.id = old_sv_first.alignment_id and old_av.version = old_sv_first.alignment_version and old_sv_first.segment_index = 0
+                  left join layout.segment_geometry old_sg_first on old_sv_first.geometry_id = old_sg_first.id
+                  left join layout.segment_version old_sv_last on old_av.id = old_sv_last.alignment_id and old_av.version = old_sv_last.alignment_version and old_sv_last.segment_index = old_av.segment_count - 1
+                  left join layout.segment_geometry old_sg_last on old_sv_last.geometry_id = old_sg_last.id
+                where publication_id = :publication_id
+            """
                 .trimIndent()
 
         val params =
@@ -875,67 +875,68 @@ class PublicationDao(
         specificObjectId: PublishableObjectIdAndType?,
     ): Map<IntId<Publication>, Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>> {
         require((layoutBranch != null) != (publicationId != null)) {
-            """"Must provide exactly one of layoutBranch or publicationId, but provided:
-                |layoutBranch=$layoutBranch, publicationId=$publicationId"""
+            """
+            |"Must provide exactly one of layoutBranch or publicationId, but provided:
+            |layoutBranch=$layoutBranch, publicationId=$publicationId"""
                 .trimMargin()
         }
         require(layoutBranch == null || layoutBranch == LayoutBranch.main) { """Only main branch supported""" }
 
         val sql =
             """
-            select
-              change_side,
-              plt.publication_id,
-              plt.id as location_track_id,
-              switch_version.id as switch_id,
-              switch_version.name as switch_name,
-              switch_external_id.external_id as switch_oid
-              from publication.publication
-                join publication.location_track plt on publication.id = plt.publication_id
-                join lateral (
-                  select 'new' as change_side, ltv.id, ltv.layout_context_id, ltv.version
-                    from layout.location_track_version ltv
-                    where plt.id = ltv.id
-                      and plt.layout_context_id = ltv.layout_context_id
-                      and plt.version = ltv.version
-                  union all
-                  select 'old' as change_side, ltv.id, ltv.layout_context_id, ltv.version
-                    from layout.location_track_version ltv
-                    where plt.id = ltv.id
-                      and plt.base_layout_context_id = ltv.layout_context_id
-                      and plt.base_version = ltv.version
-                      and not ltv.draft
-                ) ltv on (true)
-                join lateral (
-                  select distinct switch_id from layout.location_track_version_switch_view ltvs
-                    where ltvs.location_track_id = ltv.id
-                      and ltvs.location_track_layout_context_id = ltv.layout_context_id
-                      and ltvs.location_track_version = ltv.version
-                ) switch_ids on (true)
-                join layout.switch_version on switch_ids.switch_id = switch_version.id and not switch_version.draft
-                  and switch_version.design_id is null
-                left join layout.switch_external_id
-                  on switch_version.id = switch_external_id.id
-                    and switch_version.layout_context_id = switch_external_id.layout_context_id
-              where direct_change
-                and not exists(
-                  select *
-                  from publication.switch psw
-                    join publication.publication psw_publication on psw.publication_id = psw_publication.id
-                  where psw.id = switch_version.id
-                    and psw.layout_context_id = switch_version.layout_context_id
-                    and psw_publication.design_id is not distinct from publication.design_id
-                    and direct_change
-                    and (psw.version = switch_version.version and psw.publication_id > plt.publication_id
-                      or psw.version > switch_version.version and psw.publication_id <= plt.publication_id))
-                and case when :publicationId::integer is not null
-                      then :publicationId = publication.id
-                      else :design_id is not distinct from publication.design_id end
-                and (:from::timestamptz is null or :from <= publication_time)
-                and (:to::timestamptz is null or :to >= publication_time)
-                and (:specific_location_track_id::int is null or :specific_location_track_id = plt.id)
-              order by change_side, switch_id;
-        """
+                select
+                  change_side,
+                  plt.publication_id,
+                  plt.id as location_track_id,
+                  switch_version.id as switch_id,
+                  switch_version.name as switch_name,
+                  switch_external_id.external_id as switch_oid
+                  from publication.publication
+                    join publication.location_track plt on publication.id = plt.publication_id
+                    join lateral (
+                      select 'new' as change_side, ltv.id, ltv.layout_context_id, ltv.version
+                        from layout.location_track_version ltv
+                        where plt.id = ltv.id
+                          and plt.layout_context_id = ltv.layout_context_id
+                          and plt.version = ltv.version
+                      union all
+                      select 'old' as change_side, ltv.id, ltv.layout_context_id, ltv.version
+                        from layout.location_track_version ltv
+                        where plt.id = ltv.id
+                          and plt.base_layout_context_id = ltv.layout_context_id
+                          and plt.base_version = ltv.version
+                          and not ltv.draft
+                    ) ltv on (true)
+                    join lateral (
+                      select distinct switch_id from layout.location_track_version_switch_view ltvs
+                        where ltvs.location_track_id = ltv.id
+                          and ltvs.location_track_layout_context_id = ltv.layout_context_id
+                          and ltvs.location_track_version = ltv.version
+                    ) switch_ids on (true)
+                    join layout.switch_version on switch_ids.switch_id = switch_version.id and not switch_version.draft
+                      and switch_version.design_id is null
+                    left join layout.switch_external_id
+                      on switch_version.id = switch_external_id.id
+                        and switch_version.layout_context_id = switch_external_id.layout_context_id
+                  where direct_change
+                    and not exists(
+                      select *
+                      from publication.switch psw
+                        join publication.publication psw_publication on psw.publication_id = psw_publication.id
+                      where psw.id = switch_version.id
+                        and psw.layout_context_id = switch_version.layout_context_id
+                        and psw_publication.design_id is not distinct from publication.design_id
+                        and direct_change
+                        and (psw.version = switch_version.version and psw.publication_id > plt.publication_id
+                          or psw.version > switch_version.version and psw.publication_id <= plt.publication_id))
+                    and case when :publicationId::integer is not null
+                          then :publicationId = publication.id
+                          else :design_id is not distinct from publication.design_id end
+                    and (:from::timestamptz is null or :from <= publication_time)
+                    and (:to::timestamptz is null or :to >= publication_time)
+                    and (:specific_location_track_id::int is null or :specific_location_track_id = plt.id)
+                  order by change_side, switch_id;
+            """
                 .trimIndent()
 
         data class ResultRow(
@@ -986,58 +987,59 @@ class PublicationDao(
     ): Map<IntId<LocationTrack>, LocationTrackChanges> {
         val sql =
             """
-            select
-              location_track.id as location_track_id,
-              location_track.version as location_track_version,
-              ltv.name,
-              old_ltv.name as old_name,
-              ltv.description_base,
-              old_ltv.description_base as old_description_base,
-              ltv.description_suffix,
-              old_ltv.description_suffix as old_description_suffix,
-              ltv.duplicate_of_location_track_id,
-              old_ltv.duplicate_of_location_track_id as old_duplicate_of_location_track_id,
-              ltv.state,
-              old_ltv.state as old_state,
-              ltv.type,
-              old_ltv.type as old_type,
-              ltv.length,
-              old_ltv.length as old_length,
-              ltv.track_number_id as track_number_id,
-              old_ltv.track_number_id as old_track_number_id,
-              ltv.owner_id,
-              old_ltv.owner_id as old_owner_id,
-              postgis.st_x(old_ltv_ends.start_point) as old_start_x,
-              postgis.st_y(old_ltv_ends.start_point) as old_start_y,
-              postgis.st_x(old_ltv_ends.end_point) as old_end_x,
-              postgis.st_y(old_ltv_ends.end_point) as old_end_y,
-              postgis.st_x(ltv_ends.start_point) as start_x,
-              postgis.st_y(ltv_ends.start_point) as start_y,
-              postgis.st_x(ltv_ends.end_point) as end_x,
-              postgis.st_y(ltv_ends.end_point) as end_y,
-              geometry_change_summary_computed
-              from publication.location_track
-                join publication.publication on location_track.publication_id = publication.id
-                left join layout.location_track_version ltv
-                          on location_track.id = ltv.id
-                            and location_track.layout_context_id = ltv.layout_context_id
-                            and location_track.version = ltv.version
-                left join layout.location_track_version_ends_view ltv_ends
-                          on ltv_ends.id = ltv.id
-                            and ltv_ends.layout_context_id = ltv.layout_context_id
-                            and ltv_ends.version = ltv.version
-                left join layout.location_track_version old_ltv
-                          on old_ltv.id = ltv.id
-                            and old_ltv.layout_context_id = location_track.base_layout_context_id
-                            and old_ltv.version = location_track.base_version
-                left join layout.location_track_version_ends_view old_ltv_ends
-                          on old_ltv.id = old_ltv_ends.id
-                            and old_ltv.layout_context_id = old_ltv_ends.layout_context_id
-                            and old_ltv.version = old_ltv_ends.version
-              where publication_id = :publication_id
-        """
+                select
+                  location_track.id as location_track_id,
+                  location_track.version as location_track_version,
+                  ltv.name,
+                  old_ltv.name as old_name,
+                  ltv.description_base,
+                  old_ltv.description_base as old_description_base,
+                  ltv.description_suffix,
+                  old_ltv.description_suffix as old_description_suffix,
+                  ltv.duplicate_of_location_track_id,
+                  old_ltv.duplicate_of_location_track_id as old_duplicate_of_location_track_id,
+                  ltv.state,
+                  old_ltv.state as old_state,
+                  ltv.type,
+                  old_ltv.type as old_type,
+                  ltv.length,
+                  old_ltv.length as old_length,
+                  ltv.track_number_id as track_number_id,
+                  old_ltv.track_number_id as old_track_number_id,
+                  ltv.owner_id,
+                  old_ltv.owner_id as old_owner_id,
+                  postgis.st_x(old_ltv_ends.start_point) as old_start_x,
+                  postgis.st_y(old_ltv_ends.start_point) as old_start_y,
+                  postgis.st_x(old_ltv_ends.end_point) as old_end_x,
+                  postgis.st_y(old_ltv_ends.end_point) as old_end_y,
+                  postgis.st_x(ltv_ends.start_point) as start_x,
+                  postgis.st_y(ltv_ends.start_point) as start_y,
+                  postgis.st_x(ltv_ends.end_point) as end_x,
+                  postgis.st_y(ltv_ends.end_point) as end_y,
+                  geometry_change_summary_computed
+                  from publication.location_track
+                    join publication.publication on location_track.publication_id = publication.id
+                    left join layout.location_track_version ltv
+                              on location_track.id = ltv.id
+                                and location_track.layout_context_id = ltv.layout_context_id
+                                and location_track.version = ltv.version
+                    left join layout.location_track_version_ends_view ltv_ends
+                              on ltv_ends.id = ltv.id
+                                and ltv_ends.layout_context_id = ltv.layout_context_id
+                                and ltv_ends.version = ltv.version
+                    left join layout.location_track_version old_ltv
+                              on old_ltv.id = ltv.id
+                                and old_ltv.layout_context_id = location_track.base_layout_context_id
+                                and old_ltv.version = location_track.base_version
+                    left join layout.location_track_version_ends_view old_ltv_ends
+                              on old_ltv.id = old_ltv_ends.id
+                                and old_ltv.layout_context_id = old_ltv_ends.layout_context_id
+                                and old_ltv.version = old_ltv_ends.version
+                  where publication_id = :publication_id
+            """
                 .trimIndent()
 
+        val summaries = fetchGeometryChangeSummaries(publicationId)
         return jdbcTemplate
             .query(sql, mapOf("publication_id" to publicationId.intValue)) { rs, _ ->
                 val id = rs.getIntId<LocationTrack>("location_track_id")
@@ -1059,7 +1061,7 @@ class PublicationDao(
                         length = rs.getChange("length", rs::getDoubleOrNull),
                         geometryChangeSummaries =
                             if (!rs.getBoolean("geometry_change_summary_computed")) null
-                            else fetchGeometryChangeSummaries(publicationId, rs.getIntId("location_track_id")),
+                            else summaries[id] ?: emptyList(),
                         owner = rs.getChange("owner_id", rs::getIntIdOrNull),
                     )
             }
@@ -1068,28 +1070,27 @@ class PublicationDao(
     }
 
     fun fetchGeometryChangeSummaries(
-        publicationId: IntId<Publication>,
-        locationTrackId: IntId<LocationTrack>,
-    ): List<GeometryChangeSummary> {
+        publicationId: IntId<Publication>
+    ): Map<IntId<LocationTrack>, List<GeometryChangeSummary>> {
         val sql =
             """
-            select changed_length_m, max_distance, start_km, end_km, start_km_m, end_km_m
-            from publication.location_track_geometry_change_summary
-            where publication_id = :publicationId and location_track_id = :locationTrackId
-            order by remark_order
-        """
+                select location_track_id, changed_length_m, max_distance, start_km, end_km, start_km_m, end_km_m
+                from publication.location_track_geometry_change_summary
+                where publication_id = :publicationId
+                order by remark_order
+            """
                 .trimIndent()
-        return jdbcTemplate.query(
-            sql,
-            mapOf("publicationId" to publicationId.intValue, "locationTrackId" to locationTrackId.intValue),
-        ) { rs, _ ->
-            GeometryChangeSummary(
-                changedLengthM = rs.getDouble("changed_length_m"),
-                maxDistance = rs.getDouble("max_distance"),
-                startAddress = TrackMeter(rs.getKmNumber("start_km"), rs.getBigDecimal("start_km_m")),
-                endAddress = TrackMeter(rs.getKmNumber("end_km"), rs.getBigDecimal("end_km_m")),
-            )
-        }
+        return jdbcTemplate
+            .query(sql, mapOf("publicationId" to publicationId.intValue)) { rs, _ ->
+                rs.getIntId<LocationTrack>("location_track_id") to
+                    GeometryChangeSummary(
+                        changedLengthM = rs.getDouble("changed_length_m"),
+                        maxDistance = rs.getDouble("max_distance"),
+                        startAddress = TrackMeter(rs.getKmNumber("start_km"), rs.getBigDecimal("start_km_m")),
+                        endAddress = TrackMeter(rs.getKmNumber("end_km"), rs.getBigDecimal("end_km_m")),
+                    )
+            }
+            .groupBy({ it.first }, { it.second })
     }
 
     data class UnprocessedGeometryChange(
@@ -1115,27 +1116,27 @@ class PublicationDao(
         val limitClause = if (maxCount != null) "limit :max_count" else ""
         val sql =
             """
-            select
-              plt.publication_id,
-              publication.design_id,
-              plt.id as location_track_id,
-              new_ltv.layout_context_id as new_layout_context_id,
-              new_ltv.version as new_track_version,
-              old_ltv.layout_context_id as old_layout_context_id,
-              old_ltv.version as old_track_version,
-              new_ltv.track_number_id as track_number_id,
-              publication.publication_time
-            from publication.location_track plt
-              join publication.publication on plt.publication_id = publication.id
-              join layout.location_track_version new_ltv
-                on plt.id = new_ltv.id and plt.layout_context_id = new_ltv.layout_context_id and plt.version = new_ltv.version
-              left join layout.location_track_version old_ltv
-                on plt.id = old_ltv.id and plt.base_layout_context_id = old_ltv.layout_context_id and plt.base_version = old_ltv.version
-            where not geometry_change_summary_computed
-              and (:publication_id::int is null or publication_id = :publication_id)
-            order by plt.publication_id, plt.id
-            $limitClause
-        """
+                select
+                  plt.publication_id,
+                  publication.design_id,
+                  plt.id as location_track_id,
+                  new_ltv.layout_context_id as new_layout_context_id,
+                  new_ltv.version as new_track_version,
+                  old_ltv.layout_context_id as old_layout_context_id,
+                  old_ltv.version as old_track_version,
+                  new_ltv.track_number_id as track_number_id,
+                  publication.publication_time
+                from publication.location_track plt
+                  join publication.publication on plt.publication_id = publication.id
+                  join layout.location_track_version new_ltv
+                    on plt.id = new_ltv.id and plt.layout_context_id = new_ltv.layout_context_id and plt.version = new_ltv.version
+                  left join layout.location_track_version old_ltv
+                    on plt.id = old_ltv.id and plt.base_layout_context_id = old_ltv.layout_context_id and plt.base_version = old_ltv.version
+                where not geometry_change_summary_computed
+                  and (:publication_id::int is null or publication_id = :publication_id)
+                order by plt.publication_id, plt.id
+                $limitClause
+            """
                 .trimIndent()
         val params = mapOf("publication_id" to publicationId?.intValue, "max_count" to maxCount)
         return jdbcTemplate.query(sql, params) { rs, _ ->
@@ -1161,9 +1162,9 @@ class PublicationDao(
     ) {
         val deleteOldsSql =
             """
-            delete from publication.location_track_geometry_change_summary
-            where publication_id = :publicationId and location_track_id = :locationTrackId
-        """
+                delete from publication.location_track_geometry_change_summary
+                where publication_id = :publicationId and location_track_id = :locationTrackId
+            """
                 .trimIndent()
         jdbcTemplate.update(
             deleteOldsSql,
@@ -1172,17 +1173,17 @@ class PublicationDao(
 
         val insertNewsSql =
             """
-            insert into publication.location_track_geometry_change_summary values (
-              :publicationId,
-              :locationTrackId,
-              :remarkOrder,
-              :changedLengthM,
-              :maxDistance,
-              :startKm,
-              :endKm,
-              :startKmM,
-              :endKmM);
-        """
+                insert into publication.location_track_geometry_change_summary values (
+                  :publicationId,
+                  :locationTrackId,
+                  :remarkOrder,
+                  :changedLengthM,
+                  :maxDistance,
+                  :startKm,
+                  :endKm,
+                  :startKmM,
+                  :endKmM);
+            """
                 .trimIndent()
         jdbcTemplate.batchUpdate(
             insertNewsSql,
@@ -1205,10 +1206,10 @@ class PublicationDao(
 
         val updateOkSql =
             """
-            update publication.location_track
-            set geometry_change_summary_computed = true
-            where publication_id = :publicationId and id = :locationTrackId
-        """
+                update publication.location_track
+                set geometry_change_summary_computed = true
+                where publication_id = :publicationId and id = :locationTrackId
+            """
                 .trimIndent()
         jdbcTemplate.update(
             updateOkSql,
@@ -1219,40 +1220,40 @@ class PublicationDao(
     fun fetchPublicationKmPostChanges(publicationId: IntId<Publication>): Map<IntId<LayoutKmPost>, KmPostChanges> {
         val sql =
             """
-            select 
-              km_post.id as km_post_id,
-              km_post.version as km_post_version,
-              km_post_version.km_number,
-              old_km_post_version.km_number as old_km_number,
-              km_post_version.track_number_id,
-              old_km_post_version.track_number_id as old_track_number_id,
-              km_post_version.state,
-              old_km_post_version.state as old_state,
-              postgis.st_x(km_post_version.layout_location) as point_x,
-              postgis.st_y(km_post_version.layout_location) as point_y,
-              postgis.st_x(old_km_post_version.layout_location) as old_point_x,
-              postgis.st_y(old_km_post_version.layout_location) as old_point_y,
-              postgis.st_x(km_post_version.gk_location) as gk_point_x,
-              postgis.st_y(km_post_version.gk_location) as gk_point_y,
-              postgis.st_x(old_km_post_version.gk_location) as old_gk_point_x,
-              postgis.st_y(old_km_post_version.gk_location) as old_gk_point_y,
-              postgis.st_srid(km_post_version.gk_location) as gk_srid,
-              postgis.st_srid(old_km_post_version.gk_location) as old_gk_srid,
-              km_post_version.gk_location_confirmed,
-              old_km_post_version.gk_location_confirmed as old_gk_location_confirmed,
-              km_post_version.gk_location_source,
-              old_km_post_version.gk_location_source as old_gk_location_source
-            from publication.km_post
-              left join layout.km_post_version km_post_version
-                      on km_post_version.id = km_post.id
-                        and km_post_version.layout_context_id = km_post.layout_context_id
-                        and km_post_version.version = km_post.version
-              left join layout.km_post_version old_km_post_version
-                      on old_km_post_version.id = km_post.id
-                        and old_km_post_version.layout_context_id = km_post.base_layout_context_id
-                        and old_km_post_version.version = km_post.base_version
-            where publication_id = :publication_id
-        """
+                select
+                  km_post.id as km_post_id,
+                  km_post.version as km_post_version,
+                  km_post_version.km_number,
+                  old_km_post_version.km_number as old_km_number,
+                  km_post_version.track_number_id,
+                  old_km_post_version.track_number_id as old_track_number_id,
+                  km_post_version.state,
+                  old_km_post_version.state as old_state,
+                  postgis.st_x(km_post_version.layout_location) as point_x,
+                  postgis.st_y(km_post_version.layout_location) as point_y,
+                  postgis.st_x(old_km_post_version.layout_location) as old_point_x,
+                  postgis.st_y(old_km_post_version.layout_location) as old_point_y,
+                  postgis.st_x(km_post_version.gk_location) as gk_point_x,
+                  postgis.st_y(km_post_version.gk_location) as gk_point_y,
+                  postgis.st_x(old_km_post_version.gk_location) as old_gk_point_x,
+                  postgis.st_y(old_km_post_version.gk_location) as old_gk_point_y,
+                  postgis.st_srid(km_post_version.gk_location) as gk_srid,
+                  postgis.st_srid(old_km_post_version.gk_location) as old_gk_srid,
+                  km_post_version.gk_location_confirmed,
+                  old_km_post_version.gk_location_confirmed as old_gk_location_confirmed,
+                  km_post_version.gk_location_source,
+                  old_km_post_version.gk_location_source as old_gk_location_source
+                from publication.km_post
+                  left join layout.km_post_version km_post_version
+                          on km_post_version.id = km_post.id
+                            and km_post_version.layout_context_id = km_post.layout_context_id
+                            and km_post_version.version = km_post.version
+                  left join layout.km_post_version old_km_post_version
+                          on old_km_post_version.id = km_post.id
+                            and old_km_post_version.layout_context_id = km_post.base_layout_context_id
+                            and old_km_post_version.version = km_post.base_version
+                where publication_id = :publication_id
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -1281,59 +1282,59 @@ class PublicationDao(
     ): Map<IntId<ReferenceLine>, ReferenceLineChanges> {
         val sql =
             """
-            select
-              rlv.id as rl_id,
-              rlv.track_number_id as track_number_id,
-              old_rlv.track_number_id as old_track_number_id,
-              av.length,
-              old_av.length as old_length,
-              rlv.alignment_id,
-              old_rlv.alignment_id as old_alignment_id,
-              rlv.alignment_version,
-              old_rlv.alignment_version as old_alignment_version,
-              postgis.st_x(postgis.st_startpoint(old_sg_first.geometry)) as old_start_x,
-              postgis.st_y(postgis.st_startpoint(old_sg_first.geometry)) as old_start_y,
-              postgis.st_x(postgis.st_endpoint(old_sg_last.geometry)) as old_end_x,
-              postgis.st_y(postgis.st_endpoint(old_sg_last.geometry)) as old_end_y,
-              postgis.st_x(postgis.st_startpoint(sg_first.geometry)) as start_x,
-              postgis.st_y(postgis.st_startpoint(sg_first.geometry)) as start_y,
-              postgis.st_x(postgis.st_endpoint(sg_last.geometry)) as end_x,
-              postgis.st_y(postgis.st_endpoint(sg_last.geometry)) as end_y
-              from publication.reference_line publication_rl
-                left join layout.reference_line_version rlv
-                          on publication_rl.id = rlv.id
-                            and publication_rl.layout_context_id = rlv.layout_context_id
-                            and publication_rl.version = rlv.version
-                left join layout.alignment_version av on rlv.alignment_id = av.id and rlv.alignment_version = av.version
-                left join layout.segment_version sv_first
-                          on av.id = sv_first.alignment_id
-                            and av.version = sv_first.alignment_version
-                            and sv_first.segment_index = 0
-                left join layout.segment_geometry sg_first on sv_first.geometry_id = sg_first.id
-                left join layout.segment_version sv_last
-                          on av.id = sv_last.alignment_id
-                            and av.version = sv_last.alignment_version
-                            and sv_last.segment_index = av.segment_count - 1
-                left join layout.segment_geometry sg_last on sv_last.geometry_id = sg_last.id
-                left join layout.reference_line_version old_rlv
-                          on publication_rl.id = old_rlv.id
-                            and publication_rl.base_layout_context_id = old_rlv.layout_context_id
-                            and publication_rl.base_version = old_rlv.version
-                left join layout.alignment_version old_av
-                          on old_rlv.alignment_id = old_av.id
-                            and old_rlv.alignment_version = old_av.version
-                left join layout.segment_version old_sv_first
-                          on old_av.id = old_sv_first.alignment_id
-                            and old_av.version = old_sv_first.alignment_version
-                            and old_sv_first.segment_index = 0
-                left join layout.segment_geometry old_sg_first on old_sv_first.geometry_id = old_sg_first.id
-                left join layout.segment_version old_sv_last
-                          on old_av.id = old_sv_last.alignment_id
-                            and old_av.version = old_sv_last.alignment_version
-                            and old_sv_last.segment_index = old_av.segment_count - 1
-                left join layout.segment_geometry old_sg_last on old_sv_last.geometry_id = old_sg_last.id
-            where publication_id = :publication_id
-        """
+                select
+                  rlv.id as rl_id,
+                  rlv.track_number_id as track_number_id,
+                  old_rlv.track_number_id as old_track_number_id,
+                  av.length,
+                  old_av.length as old_length,
+                  rlv.alignment_id,
+                  old_rlv.alignment_id as old_alignment_id,
+                  rlv.alignment_version,
+                  old_rlv.alignment_version as old_alignment_version,
+                  postgis.st_x(postgis.st_startpoint(old_sg_first.geometry)) as old_start_x,
+                  postgis.st_y(postgis.st_startpoint(old_sg_first.geometry)) as old_start_y,
+                  postgis.st_x(postgis.st_endpoint(old_sg_last.geometry)) as old_end_x,
+                  postgis.st_y(postgis.st_endpoint(old_sg_last.geometry)) as old_end_y,
+                  postgis.st_x(postgis.st_startpoint(sg_first.geometry)) as start_x,
+                  postgis.st_y(postgis.st_startpoint(sg_first.geometry)) as start_y,
+                  postgis.st_x(postgis.st_endpoint(sg_last.geometry)) as end_x,
+                  postgis.st_y(postgis.st_endpoint(sg_last.geometry)) as end_y
+                  from publication.reference_line publication_rl
+                    left join layout.reference_line_version rlv
+                              on publication_rl.id = rlv.id
+                                and publication_rl.layout_context_id = rlv.layout_context_id
+                                and publication_rl.version = rlv.version
+                    left join layout.alignment_version av on rlv.alignment_id = av.id and rlv.alignment_version = av.version
+                    left join layout.segment_version sv_first
+                              on av.id = sv_first.alignment_id
+                                and av.version = sv_first.alignment_version
+                                and sv_first.segment_index = 0
+                    left join layout.segment_geometry sg_first on sv_first.geometry_id = sg_first.id
+                    left join layout.segment_version sv_last
+                              on av.id = sv_last.alignment_id
+                                and av.version = sv_last.alignment_version
+                                and sv_last.segment_index = av.segment_count - 1
+                    left join layout.segment_geometry sg_last on sv_last.geometry_id = sg_last.id
+                    left join layout.reference_line_version old_rlv
+                              on publication_rl.id = old_rlv.id
+                                and publication_rl.base_layout_context_id = old_rlv.layout_context_id
+                                and publication_rl.base_version = old_rlv.version
+                    left join layout.alignment_version old_av
+                              on old_rlv.alignment_id = old_av.id
+                                and old_rlv.alignment_version = old_av.version
+                    left join layout.segment_version old_sv_first
+                              on old_av.id = old_sv_first.alignment_id
+                                and old_av.version = old_sv_first.alignment_version
+                                and old_sv_first.segment_index = 0
+                    left join layout.segment_geometry old_sg_first on old_sv_first.geometry_id = old_sg_first.id
+                    left join layout.segment_version old_sv_last
+                              on old_av.id = old_sv_last.alignment_id
+                                and old_av.version = old_sv_last.alignment_version
+                                and old_sv_last.segment_index = old_av.segment_count - 1
+                    left join layout.segment_geometry old_sg_last on old_sv_last.geometry_id = old_sg_last.id
+                where publication_id = :publication_id
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -1362,150 +1363,150 @@ class PublicationDao(
     fun fetchPublicationSwitchChanges(publicationId: IntId<Publication>): Map<IntId<LayoutSwitch>, SwitchChanges> {
         val sql =
             """
-            with
-              touched_tracks as (
-                select
-                  'NEW' as change_side,
-                  plt.id as location_track_id,
-                  plt.layout_context_id as location_track_layout_context_id,
-                  plt.version as location_track_version
-                  from publication.location_track plt
-                  where plt.publication_id = :publication_id
-                union all
-                select
-                  'OLD' as change_side,
-                  plt.id as location_track_id,
-                  plt.base_layout_context_id as location_track_layout_context_id,
-                  plt.base_version as location_track_version
-                  from publication.location_track plt
-                  where plt.publication_id = :publication_id
-                    and plt.base_layout_context_id is not null
-                union all
-                select
-                  'NA' as change_side,
-                  pslt.location_track_id as location_track_id,
-                  pslt.location_track_layout_context_id as location_track_layout_context_id,
-                  pslt.location_track_version as location_track_version
-                  from publication.switch_location_tracks pslt
-                  where pslt.publication_id = :publication_id
-                    and not exists (
-                      select * 
-                      from publication.location_track plt 
-                      where pslt.publication_id = :publication_id
-                        and pslt.location_track_id = plt.id
-                    )
-              ),
-              touched_joint_locations as (
-                select
-                  joints.switch_id,
-                  array_agg(
-                    track.change_side
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_change_sides,
-                  array_agg(
-                    track.location_track_id
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_ids,
-                  array_agg(
-                    ltv.track_number_id
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_track_number_ids,
-                  array_agg(
-                    ltv.name
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_names,
-                  array_agg(
-                    joints.joint_number
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_joint_numbers,
-                  array_agg(
-                    postgis.st_x(joints.location)
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_joint_locations_x,
-                  array_agg(
-                    postgis.st_y(joints.location)
-                    order by track.change_side, track.location_track_id, joints.sort
-                  ) as track_joint_locations_y
-                  from touched_tracks track
-                    inner join layout.location_track_version ltv
-                               on ltv.id = track.location_track_id
-                                 and ltv.layout_context_id = track.location_track_layout_context_id
-                                 and ltv.version = track.location_track_version
-                    inner join lateral (
-                    select
-                      start_np.switch_id as switch_id,
-                      start_np.switch_joint_number as joint_number,
-                      e.start_location as location,
-                      0 as sort
-                      from layout.location_track_version_edge first_ltv_e
-                        inner join layout.edge e on first_ltv_e.edge_id = e.id
-                        inner join layout.node_port start_np on start_np.node_id = e.start_node_id and start_np.port = e.start_node_port
-                      where first_ltv_e.location_track_id = track.location_track_id
-                        and first_ltv_e.location_track_layout_context_id = track.location_track_layout_context_id
-                        and first_ltv_e.location_track_version = track.location_track_version
-                        and first_ltv_e.edge_index = 0
-                    union all
-                    select
-                      end_np.switch_id as switch_id,
-                      end_np.switch_joint_number as joint_number,
-                      e.end_location as location,
-                      ltv_e.edge_index+1 as sort
-                      from layout.location_track_version_edge ltv_e
-                        inner join layout.edge e on ltv_e.edge_id = e.id
-                        inner join layout.node_port end_np on end_np.node_id = e.end_node_id and end_np.port = e.end_node_port
-                      where ltv_e.location_track_id = track.location_track_id
-                        and ltv_e.location_track_layout_context_id = track.location_track_layout_context_id
-                        and ltv_e.location_track_version = track.location_track_version
-                    ) joints on true
-                  where joint_number is not null
-                  group by joints.switch_id
-              )
-          select
-            switch.id as switch_id,
-            switch_version.state_category,
-            old_switch_version.state_category as old_state_category,
-            switch_version.name,
-            old_switch_version.name as old_name,
-            switch_version.trap_point,
-            old_switch_version.trap_point as old_trap_point,
-            switch_owner.name as owner,
-            old_switch_owner.name as old_owner,
-            switch_structure.type,
-            old_switch_structure.type as old_type,
-            plan.measurement_method,
-            old_plan.measurement_method as old_measurement_method,
-            switch_structure.presentation_joint_number,
-            old_switch_structure.presentation_joint_number old_presentation_joint_number,
-            joints.track_change_sides,
-            joints.track_ids,
-            joints.track_track_number_ids,
-            joints.track_names,
-            joints.track_joint_numbers,
-            joints.track_joint_locations_x,
-            joints.track_joint_locations_y
-            from publication.switch
-              join publication.publication on switch.publication_id = publication.id
-              left join layout.switch_version switch_version
-                        on switch.id = switch_version.id
-                          and switch.layout_context_id = switch_version.layout_context_id
-                          and switch.version = switch_version.version
-              left join common.switch_structure switch_structure
-                        on switch_structure.id = switch_version.switch_structure_id
-              left join common.switch_owner on switch_owner.id = switch_version.owner_id
-              left join geometry.switch gs on switch_version.geometry_switch_id = gs.id
-              left join geometry.plan plan on gs.plan_id = plan.id
-              left join layout.switch_version old_switch_version
-                        on switch.id = old_switch_version.id
-                          and switch.base_layout_context_id = old_switch_version.layout_context_id
-                          and switch.base_version = old_switch_version.version
-              left join common.switch_structure old_switch_structure
-                        on old_switch_structure.id = old_switch_version.switch_structure_id
-              left join common.switch_owner old_switch_owner on old_switch_owner.id = old_switch_version.owner_id
-              left join geometry.switch old_gs on old_switch_version.geometry_switch_id = old_gs.id
-              left join geometry.plan old_plan on old_gs.plan_id = old_plan.id
-              left join touched_joint_locations joints on joints.switch_id = switch.id
-            where publication_id = :publication_id
-            """
+              with
+                touched_tracks as (
+                  select
+                    'NEW' as change_side,
+                    plt.id as location_track_id,
+                    plt.layout_context_id as location_track_layout_context_id,
+                    plt.version as location_track_version
+                    from publication.location_track plt
+                    where plt.publication_id = :publication_id
+                  union all
+                  select
+                    'OLD' as change_side,
+                    plt.id as location_track_id,
+                    plt.base_layout_context_id as location_track_layout_context_id,
+                    plt.base_version as location_track_version
+                    from publication.location_track plt
+                    where plt.publication_id = :publication_id
+                      and plt.base_layout_context_id is not null
+                  union all
+                  select
+                    'NA' as change_side,
+                    pslt.location_track_id as location_track_id,
+                    pslt.location_track_layout_context_id as location_track_layout_context_id,
+                    pslt.location_track_version as location_track_version
+                    from publication.switch_location_tracks pslt
+                    where pslt.publication_id = :publication_id
+                      and not exists (
+                        select *
+                        from publication.location_track plt
+                        where pslt.publication_id = :publication_id
+                          and pslt.location_track_id = plt.id
+                      )
+                ),
+                touched_joint_locations as (
+                  select
+                    joints.switch_id,
+                    array_agg(
+                      track.change_side
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_change_sides,
+                    array_agg(
+                      track.location_track_id
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_ids,
+                    array_agg(
+                      ltv.track_number_id
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_track_number_ids,
+                    array_agg(
+                      ltv.name
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_names,
+                    array_agg(
+                      joints.joint_number
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_joint_numbers,
+                    array_agg(
+                      postgis.st_x(joints.location)
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_joint_locations_x,
+                    array_agg(
+                      postgis.st_y(joints.location)
+                      order by track.change_side, track.location_track_id, joints.sort
+                    ) as track_joint_locations_y
+                    from touched_tracks track
+                      inner join layout.location_track_version ltv
+                                 on ltv.id = track.location_track_id
+                                   and ltv.layout_context_id = track.location_track_layout_context_id
+                                   and ltv.version = track.location_track_version
+                      inner join lateral (
+                      select
+                        start_np.switch_id as switch_id,
+                        start_np.switch_joint_number as joint_number,
+                        e.start_location as location,
+                        0 as sort
+                        from layout.location_track_version_edge first_ltv_e
+                          inner join layout.edge e on first_ltv_e.edge_id = e.id
+                          inner join layout.node_port start_np on start_np.node_id = e.start_node_id and start_np.port = e.start_node_port
+                        where first_ltv_e.location_track_id = track.location_track_id
+                          and first_ltv_e.location_track_layout_context_id = track.location_track_layout_context_id
+                          and first_ltv_e.location_track_version = track.location_track_version
+                          and first_ltv_e.edge_index = 0
+                      union all
+                      select
+                        end_np.switch_id as switch_id,
+                        end_np.switch_joint_number as joint_number,
+                        e.end_location as location,
+                        ltv_e.edge_index+1 as sort
+                        from layout.location_track_version_edge ltv_e
+                          inner join layout.edge e on ltv_e.edge_id = e.id
+                          inner join layout.node_port end_np on end_np.node_id = e.end_node_id and end_np.port = e.end_node_port
+                        where ltv_e.location_track_id = track.location_track_id
+                          and ltv_e.location_track_layout_context_id = track.location_track_layout_context_id
+                          and ltv_e.location_track_version = track.location_track_version
+                      ) joints on true
+                    where joint_number is not null
+                    group by joints.switch_id
+                )
+            select
+              switch.id as switch_id,
+              switch_version.state_category,
+              old_switch_version.state_category as old_state_category,
+              switch_version.name,
+              old_switch_version.name as old_name,
+              switch_version.trap_point,
+              old_switch_version.trap_point as old_trap_point,
+              switch_owner.name as owner,
+              old_switch_owner.name as old_owner,
+              switch_structure.type,
+              old_switch_structure.type as old_type,
+              plan.measurement_method,
+              old_plan.measurement_method as old_measurement_method,
+              switch_structure.presentation_joint_number,
+              old_switch_structure.presentation_joint_number old_presentation_joint_number,
+              joints.track_change_sides,
+              joints.track_ids,
+              joints.track_track_number_ids,
+              joints.track_names,
+              joints.track_joint_numbers,
+              joints.track_joint_locations_x,
+              joints.track_joint_locations_y
+              from publication.switch
+                join publication.publication on switch.publication_id = publication.id
+                left join layout.switch_version switch_version
+                          on switch.id = switch_version.id
+                            and switch.layout_context_id = switch_version.layout_context_id
+                            and switch.version = switch_version.version
+                left join common.switch_structure switch_structure
+                          on switch_structure.id = switch_version.switch_structure_id
+                left join common.switch_owner on switch_owner.id = switch_version.owner_id
+                left join geometry.switch gs on switch_version.geometry_switch_id = gs.id
+                left join geometry.plan plan on gs.plan_id = plan.id
+                left join layout.switch_version old_switch_version
+                          on switch.id = old_switch_version.id
+                            and switch.base_layout_context_id = old_switch_version.layout_context_id
+                            and switch.base_version = old_switch_version.version
+                left join common.switch_structure old_switch_structure
+                          on old_switch_structure.id = old_switch_version.switch_structure_id
+                left join common.switch_owner old_switch_owner on old_switch_owner.id = old_switch_version.owner_id
+                left join geometry.switch old_gs on old_switch_version.geometry_switch_id = old_gs.id
+                left join geometry.plan old_plan on old_gs.plan_id = old_plan.id
+                left join touched_joint_locations joints on joints.switch_id = switch.id
+              where publication_id = :publication_id
+              """
                 .trimIndent()
 
         return jdbcTemplate
@@ -1561,7 +1562,7 @@ class PublicationDao(
                         id,
                         name = rs.getChange("name") { rs.getString(it)?.let(::SwitchName) },
                         state = rs.getChange("state_category") { rs.getEnumOrNull<LayoutStateCategory>(it) },
-                        type = rs.getChange("type") { rs.getString(it)?.let(::SwitchType) },
+                        type = rs.getChange("type") { rs.getString(it)?.let(SwitchType::of) },
                         trapPoint =
                             rs.getChange("trap_point") {
                                 rs.getBooleanOrNull(it).let { value ->
@@ -2058,27 +2059,27 @@ class PublicationDao(
     ): Map<IntId<Publication>, PublishedItemListing<PublishedLocationTrack>> {
         val sql =
             """
-            select
-              plt.publication_id,
-              ltv.id,
-              ltv.design_id,
-              ltv.draft,
-              ltv.version,
-              ltv.name,
-              ltv.track_number_id,
-              layout.infer_operation_from_location_track_state_transition(ltc.old_state, ltc.state) as operation,
-              direct_change,
-              changed_km
-            from publication.location_track plt
-              inner join layout.location_track_version ltv using (id, layout_context_id, version)
-              inner join layout.location_track_change_view ltc using (id, layout_context_id, version)
-              left join lateral(
-                select array_remove(array_agg(pltk.km_number), null) as changed_km
-                from publication.location_track_km pltk
-                where pltk.location_track_id = plt.id and pltk.publication_id = plt.publication_id
-              ) pltk on (true)
-            where plt.publication_id = any(array[:publication_ids]::int[])
-        """
+                select
+                  plt.publication_id,
+                  ltv.id,
+                  ltv.design_id,
+                  ltv.draft,
+                  ltv.version,
+                  ltv.name,
+                  ltv.track_number_id,
+                  layout.infer_operation_from_location_track_state_transition(ltc.old_state, ltc.state) as operation,
+                  direct_change,
+                  changed_km
+                from publication.location_track plt
+                  inner join layout.location_track_version ltv using (id, layout_context_id, version)
+                  inner join layout.location_track_change_view ltc using (id, layout_context_id, version)
+                  left join lateral(
+                    select array_remove(array_agg(pltk.km_number), null) as changed_km
+                    from publication.location_track_km pltk
+                    where pltk.location_track_id = plt.id and pltk.publication_id = plt.publication_id
+                  ) pltk on (true)
+                where plt.publication_id = any(array[:publication_ids]::int[])
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -2089,7 +2090,8 @@ class PublicationDao(
                         name = AlignmentName(rs.getString("name")),
                         trackNumberId = rs.getIntId("track_number_id"),
                         operation = rs.getEnum("operation"),
-                        changedKmNumbers = rs.getStringArrayOrNull("changed_km")?.map(::KmNumber)?.toSet() ?: emptySet(),
+                        changedKmNumbers =
+                            rs.getStringArrayOrNull("changed_km")?.map(::KmNumber)?.toSet() ?: emptySet(),
                     )
             }
             .let { locationTrackRows ->
@@ -2103,34 +2105,34 @@ class PublicationDao(
     ): Map<IntId<Publication>, List<PublishedReferenceLine>> {
         val sql =
             """
-            select
-              prl.publication_id,
-              rl.id,
-              rl.design_id,
-              rl.draft,
-              rl.version,
-              rl.track_number_id,
-              layout.infer_operation_from_state_transition(
-                  tn_old.state,
-                  tn.state
-                ) as operation,
-              (select coalesce(array_agg(ptnk.km_number), '{}')
-               from publication.track_number_km ptnk
-               where ptnk.track_number_id = rl.track_number_id and ptnk.publication_id = ptn.publication_id) as changed_km
-              from publication.reference_line prl
-                inner join layout.reference_line_version rl using (id, layout_context_id, version)
-                left join publication.publication p
-                          on p.id = prl.publication_id
-                left join publication.track_number ptn
-                          on ptn.id = rl.track_number_id and ptn.publication_id = prl.publication_id
-                left join layout.track_number_change_view tn
-                          on tn.id = ptn.id and tn.layout_context_id = ptn.layout_context_id and tn.version = ptn.version
-                left join layout.track_number_version tn_old
-                          on tn_old.id = ptn.id
-                            and tn_old.layout_context_id = ptn.base_layout_context_id
-                            and tn_old.version = ptn.base_version
-              where prl.publication_id = any(array[:publication_ids]::int[])
-        """
+                select
+                  prl.publication_id,
+                  rl.id,
+                  rl.design_id,
+                  rl.draft,
+                  rl.version,
+                  rl.track_number_id,
+                  layout.infer_operation_from_state_transition(
+                      tn_old.state,
+                      tn.state
+                    ) as operation,
+                  (select coalesce(array_agg(ptnk.km_number), '{}')
+                   from publication.track_number_km ptnk
+                   where ptnk.track_number_id = rl.track_number_id and ptnk.publication_id = ptn.publication_id) as changed_km
+                  from publication.reference_line prl
+                    inner join layout.reference_line_version rl using (id, layout_context_id, version)
+                    left join publication.publication p
+                              on p.id = prl.publication_id
+                    left join publication.track_number ptn
+                              on ptn.id = rl.track_number_id and ptn.publication_id = prl.publication_id
+                    left join layout.track_number_change_view tn
+                              on tn.id = ptn.id and tn.layout_context_id = ptn.layout_context_id and tn.version = ptn.version
+                    left join layout.track_number_version tn_old
+                              on tn_old.id = ptn.id
+                                and tn_old.layout_context_id = ptn.base_layout_context_id
+                                and tn_old.version = ptn.base_version
+                  where prl.publication_id = any(array[:publication_ids]::int[])
+            """
                 .trimIndent()
         return jdbcTemplate
             .query(sql, mapOf("publication_ids" to publicationIds.map { it.intValue })) { rs, _ ->
@@ -2151,20 +2153,20 @@ class PublicationDao(
     fun fetchPublishedKmPosts(publicationIds: Set<IntId<Publication>>): Map<IntId<Publication>, List<PublishedKmPost>> {
         val sql =
             """
-            select
-              pkp.publication_id,
-              kmp.id,
-              kmp.design_id,
-              kmp.draft,
-              kmp.version,
-              layout.infer_operation_from_state_transition(kpc.old_state, kpc.state) as operation,
-              kmp.km_number,
-              kmp.track_number_id
-            from publication.km_post pkp
-              inner join layout.km_post_version kmp using (id, layout_context_id, version)
-              inner join layout.km_post_change_view kpc using (id, layout_context_id, version)
-            where publication_id = any(array[:publication_ids]::int[])
-        """
+                select
+                  pkp.publication_id,
+                  kmp.id,
+                  kmp.design_id,
+                  kmp.draft,
+                  kmp.version,
+                  layout.infer_operation_from_state_transition(kpc.old_state, kpc.state) as operation,
+                  kmp.km_number,
+                  kmp.track_number_id
+                from publication.km_post pkp
+                  inner join layout.km_post_version kmp using (id, layout_context_id, version)
+                  inner join layout.km_post_change_view kpc using (id, layout_context_id, version)
+                where publication_id = any(array[:publication_ids]::int[])
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -2187,27 +2189,27 @@ class PublicationDao(
     ): Map<IntId<Publication>, PublishedItemListing<PublishedSwitch>> {
         val sql =
             """
-            select
-              ps.publication_id,
-              sv.id,
-              sv.design_id,
-              sv.draft,
-              sv.version,
-              sv.name,
-              layout.infer_operation_from_state_category_transition(sc.old_state_category, sc.state_category) as operation,
-              direct_change,
-              (select coalesce(array_remove(array_agg(distinct lt.track_number_id), null), '{}')
-               from layout.location_track_version lt
-                 join publication.switch_location_tracks slt
-                   on lt.id = slt.location_track_id
-                     and lt.version = slt.location_track_version
-                     and lt.layout_context_id = slt.location_track_layout_context_id
-              where slt.switch_id = ps.id and slt.publication_id = ps.publication_id) as track_number_ids
-            from publication.switch ps
-              inner join layout.switch_version sv using (id, layout_context_id, version)
-              inner join layout.switch_change_view sc using (id, layout_context_id, version)
-            where ps.publication_id = any(array[:publication_ids]::int[])
-        """
+                select
+                  ps.publication_id,
+                  sv.id,
+                  sv.design_id,
+                  sv.draft,
+                  sv.version,
+                  sv.name,
+                  layout.infer_operation_from_state_category_transition(sc.old_state_category, sc.state_category) as operation,
+                  direct_change,
+                  (select coalesce(array_remove(array_agg(distinct lt.track_number_id), null), '{}')
+                   from layout.location_track_version lt
+                     join publication.switch_location_tracks slt
+                       on lt.id = slt.location_track_id
+                         and lt.version = slt.location_track_version
+                         and lt.layout_context_id = slt.location_track_layout_context_id
+                  where slt.switch_id = ps.id and slt.publication_id = ps.publication_id) as track_number_ids
+                from publication.switch ps
+                  inner join layout.switch_version sv using (id, layout_context_id, version)
+                  inner join layout.switch_change_view sc using (id, layout_context_id, version)
+                where ps.publication_id = any(array[:publication_ids]::int[])
+            """
                 .trimIndent()
 
         val publishedSwitchJoints = publishedSwitchJoints(publicationIds)
@@ -2239,21 +2241,21 @@ class PublicationDao(
     ): Map<IntId<Publication>, Map<IntId<LayoutSwitch>, List<SwitchJointChange>>> {
         val sql =
             """
-            select
-              publication_id,
-              switch_id as id,
-              joint_number,
-              removed,
-              address,
-              postgis.st_x(point) as x,
-              postgis.st_y(point) as y,
-              location_track_id,
-              location_track_external_id,
-              track_number_id,
-              track_number_external_id
-            from publication.switch_joint
-            where publication_id = any(array[:publication_ids]::int[])
-        """
+                select
+                  publication_id,
+                  switch_id as id,
+                  joint_number,
+                  removed,
+                  address,
+                  postgis.st_x(point) as x,
+                  postgis.st_y(point) as y,
+                  location_track_id,
+                  location_track_external_id,
+                  track_number_id,
+                  track_number_external_id
+                from publication.switch_joint
+                where publication_id = any(array[:publication_ids]::int[])
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -2281,27 +2283,27 @@ class PublicationDao(
     ): Map<IntId<Publication>, PublishedItemListing<PublishedTrackNumber>> {
         val sql =
             """
-          select
-            publication.id as publication_id,
-            ptn.id,
-            publication.design_id,
-            version,
-            number,
-            layout.infer_operation_from_state_transition(
-              old_state,
-              state
-            ) as operation,
-            direct_change,
-            (select coalesce(array_remove(array_agg(ptnk.km_number), null), '{}')
-             from publication.track_number_km ptnk
-             where ptnk.publication_id = ptn.publication_id and ptnk.track_number_id = ptn.id)
-               as changed_km
-          from publication.track_number ptn
-            inner join layout.track_number_change_view tn using (id, layout_context_id, version)
-            join publication.publication
-              on ptn.publication_id = publication.id
-          where ptn.publication_id = any(array[:publication_ids]::int[])
-        """
+              select
+                publication.id as publication_id,
+                ptn.id,
+                publication.design_id,
+                version,
+                number,
+                layout.infer_operation_from_state_transition(
+                  old_state,
+                  state
+                ) as operation,
+                direct_change,
+                (select coalesce(array_remove(array_agg(ptnk.km_number), null), '{}')
+                 from publication.track_number_km ptnk
+                 where ptnk.publication_id = ptn.publication_id and ptnk.track_number_id = ptn.id)
+                   as changed_km
+              from publication.track_number ptn
+                inner join layout.track_number_change_view tn using (id, layout_context_id, version)
+                join publication.publication
+                  on ptn.publication_id = publication.id
+              where ptn.publication_id = any(array[:publication_ids]::int[])
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -2329,15 +2331,15 @@ class PublicationDao(
         // language="sql"
         val sql =
             """
-            select previous_in_design.design_version
-              from publication.publication previous_in_design
-              where design_id = :design_id
-                and publication_time < (
-                select publication_time from publication.publication where id = :publication_id
-              )
-              order by publication_time desc
-              limit 1;
-        """
+                select previous_in_design.design_version
+                  from publication.publication previous_in_design
+                  where design_id = :design_id
+                    and publication_time < (
+                    select publication_time from publication.publication where id = :publication_id
+                  )
+                  order by publication_time desc
+                  limit 1;
+            """
                 .trimIndent()
         return jdbcTemplate.queryOptional(
             sql,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogRemarks.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogRemarks.kt
@@ -2,7 +2,6 @@ package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.Point
@@ -45,47 +44,18 @@ fun getPointMovedRemarkOrNull(
     oldPoint: Point?,
     newPoint: Point?,
     translationKey: String = "moved-x-meters",
-): String? {
-    return oldPoint?.let { p1 ->
-        newPoint?.let { p2 ->
-            if (!pointsAreSame(p1, p2)) {
-                // TODO: GVT-3232 How useful is this?
-                val distance = lineLength(p1, p2)
-                //                val distance = calculateDistance(listOf(p1, p2), LAYOUT_SRID)
-                if (distance > DISTANCE_CHANGE_THRESHOLD) {
-                    publicationChangeRemark(translation, translationKey, formatDistance(distance))
-                } else {
-                    null
-                }
-            } else {
-                null
-            }
+): String? =
+    if (oldPoint != null && newPoint != null && !pointsAreSame(oldPoint, newPoint)) {
+        // For the remarks, pythagorean distance is accurate enough
+        val distance = lineLength(oldPoint, newPoint)
+        if (distance > DISTANCE_CHANGE_THRESHOLD) {
+            publicationChangeRemark(translation, translationKey, formatDistance(distance))
+        } else {
+            null
         }
+    } else {
+        null
     }
-}
-
-fun getChangedSwitchTrackNumberAddressesRemarkOrNull(
-    translation: Translation,
-    oldAddresses: List<Pair<TrackNumber, TrackMeter>>?,
-    newAddresses: List<Pair<TrackNumber, TrackMeter>>?,
-): String? {
-    val old =
-        oldAddresses?.filter { (oTn, oAddress) -> newAddresses?.find { (nTn, _) -> nTn == oTn }?.second != oAddress }
-            ?: emptyList()
-    val new =
-        newAddresses?.filter { (nTn, nAddress) -> oldAddresses?.find { (oTn, _) -> oTn == nTn }?.second != nAddress }
-            ?: emptyList()
-    return (old + new)
-        .distinct()
-        .takeIf { it.isNotEmpty() }
-        ?.let { changed ->
-            publicationChangeRemark(
-                translation = translation,
-                key = "track-number-addresses-changed",
-                value = changed.joinToString { (tn, _) -> tn.toString() },
-            )
-        }
-}
 
 fun getAddressMovedRemarkOrNull(translation: Translation, change: Change<TrackMeter?>): String? =
     getAddressMovedRemarkOrNull(translation, change.old, change.new)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogRemarks.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogRemarks.kt
@@ -3,12 +3,11 @@ package fi.fta.geoviite.infra.publication
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
-import fi.fta.geoviite.infra.geography.calculateDistance
 import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.math.roundTo1Decimal
-import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import kotlin.math.abs
 
 fun publicationChangeRemark(translation: Translation, key: String, value: String? = null) =
@@ -50,7 +49,9 @@ fun getPointMovedRemarkOrNull(
     return oldPoint?.let { p1 ->
         newPoint?.let { p2 ->
             if (!pointsAreSame(p1, p2)) {
-                val distance = calculateDistance(listOf(p1, p2), LAYOUT_SRID)
+                // TODO: GVT-3232 How useful is this?
+                val distance = lineLength(p1, p2)
+                //                val distance = calculateDistance(listOf(p1, p2), LAYOUT_SRID)
                 if (distance > DISTANCE_CHANGE_THRESHOLD) {
                     publicationChangeRemark(translation, translationKey, formatDistance(distance))
                 } else {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -34,7 +34,6 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
-import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.TopologicalConnectivityType
@@ -991,7 +990,7 @@ fun validateWithParams(
     issue: () -> Pair<String, LocalizationParams>,
 ): LayoutValidationIssue? =
     if (!valid) {
-        issue().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey(key), params) }
+        issue().let { (key, params) -> LayoutValidationIssue(type, LocalizationKey.of(key), params) }
     } else {
         null
     }
@@ -1003,13 +1002,13 @@ fun validationError(key: String, vararg params: Pair<String, Any?>): LayoutValid
     LayoutValidationIssue(ERROR, key, params.associate { it })
 
 fun validationError(key: String, params: LocalizationParams): LayoutValidationIssue =
-    LayoutValidationIssue(ERROR, LocalizationKey(key), params)
+    LayoutValidationIssue(ERROR, LocalizationKey.of(key), params)
 
 fun validationWarning(key: String, vararg params: Pair<String, Any?>): LayoutValidationIssue =
     LayoutValidationIssue(WARNING, key, params.associate { it })
 
 fun validationWarning(key: String, params: LocalizationParams): LayoutValidationIssue =
-    LayoutValidationIssue(WARNING, LocalizationKey(key), params)
+    LayoutValidationIssue(WARNING, LocalizationKey.of(key), params)
 
 private fun cancelledOrNotPublishedKey(keyPrefix: String, cancelled: Boolean) =
     "$keyPrefix${if (cancelled) ".cancelled" else ".not-published"}"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructureDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructureDao.kt
@@ -52,7 +52,7 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                     version = structureVersion,
                     data =
                         SwitchStructureData(
-                            type = SwitchType(rs.getString("type")),
+                            type = SwitchType.of(rs.getString("type")),
                             presentationJointNumber = rs.getJointNumber("presentation_joint_number"),
                             joints = fetchSwitchStructureJoints(structureVersion),
                             alignments = fetchSwitchStructureAlignments(structureVersion),
@@ -84,7 +84,7 @@ class SwitchStructureDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBa
                     version = structureVersion,
                     data =
                         SwitchStructureData(
-                            type = SwitchType(rs.getString("type")),
+                            type = SwitchType.of(rs.getString("type")),
                             presentationJointNumber = rs.getJointNumber("presentation_joint_number"),
                             joints = fetchSwitchStructureJoints(structureVersion),
                             alignments = fetchSwitchStructureAlignments(structureVersion),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/EV_SJ43_5_9_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/EV_SJ43_5_9_1_9.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun EV_SJ43_5_9_1_9_H() =
     SwitchStructureData(
-        type = SwitchType("EV-SJ43-5,9-1:9-H"),
+        type = SwitchType.of("EV-SJ43-5,9-1:9-H"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -44,4 +44,4 @@ fun EV_SJ43_5_9_1_9_H() =
             ),
     )
 
-fun EV_SJ43_5_9_1_9_V() = EV_SJ43_5_9_1_9_H().flipAlongYAxis().copy(type = SwitchType("EV-SJ43-5,9-1:9-V"))
+fun EV_SJ43_5_9_1_9_V() = EV_SJ43_5_9_1_9_H().flipAlongYAxis().copy(type = SwitchType.of("EV-SJ43-5,9-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_233_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_233_1_9.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KRV43_233_1_9() =
     SwitchStructureData(
-        type = SwitchType("KRV43-233-1:9"),
+        type = SwitchType.of("KRV43-233-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV43_270_1_9_514.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KRV43_270_1_9_514() =
     SwitchStructureData(
-        type = SwitchType("KRV43-270-1:9,514"),
+        type = SwitchType.of("KRV43-270-1:9,514"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KRV54_200_1_9.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KRV54_200_1_9() =
     SwitchStructureData(
-        type = SwitchType("KRV54-200-1:9"),
+        type = SwitchType.of("KRV54-200-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV30_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV30_270_1_9_514.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KV30_270_1_9_514_O() =
     SwitchStructureData(
-        type = SwitchType("KV30-270-1:9,514-O"),
+        type = SwitchType.of("KV30-270-1:9,514-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -61,4 +61,4 @@ fun KV30_270_1_9_514_O() =
             ),
     )
 
-fun KV30_270_1_9_514_V() = KV30_270_1_9_514_O().flipAlongYAxis().copy(type = SwitchType("KV30-270-1:9,514-V"))
+fun KV30_270_1_9_514_V() = KV30_270_1_9_514_O().flipAlongYAxis().copy(type = SwitchType.of("KV30-270-1:9,514-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV43_300_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV43_300_1_9_514.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KV43_300_1_9_514_V() =
     SwitchStructureData(
-        type = SwitchType("KV43-300-1:9,514-V"),
+        type = SwitchType.of("KV43-300-1:9,514-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -52,4 +57,4 @@ fun KV43_300_1_9_514_V() =
             ),
     )
 
-fun KV43_300_1_9_514_O() = KV43_300_1_9_514_V().flipAlongYAxis().copy(type = SwitchType("KV43-300-1:9,514-O"))
+fun KV43_300_1_9_514_O() = KV43_300_1_9_514_V().flipAlongYAxis().copy(type = SwitchType.of("KV43-300-1:9,514-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/KV54_200_1_9.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun KV54_200_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("KV54-200-1:9-O"),
+        type = SwitchType.of("KV54-200-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -57,8 +57,8 @@ fun KV54_200_1_9_O() =
             ),
     )
 
-fun KV54_200_1_9_V() = KV54_200_1_9_O().flipAlongYAxis().copy(type = SwitchType("KV54-200-1:9-V"))
+fun KV54_200_1_9_V() = KV54_200_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("KV54-200-1:9-V"))
 
-fun KV54_200N_1_9_O() = KV54_200_1_9_O().copy(type = SwitchType("KV54-200N-1:9-O"))
+fun KV54_200N_1_9_O() = KV54_200_1_9_O().copy(type = SwitchType.of("KV54-200N-1:9-O"))
 
-fun KV54_200N_1_9_V() = KV54_200_1_9_V().copy(type = SwitchType("KV54-200N-1:9-V"))
+fun KV54_200N_1_9_V() = KV54_200_1_9_V().copy(type = SwitchType.of("KV54-200N-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR43_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR43_1_9_514.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR43_1_9_514() =
     SwitchStructureData(
-        type = SwitchType("RR43-1:9,514"),
+        type = SwitchType.of("RR43-1:9,514"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_3_078.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_3_078.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR54_1_3_078() =
     SwitchStructureData(
-        type = SwitchType("RR54-1:3,078"),
+        type = SwitchType.of("RR54-1:3,078"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_1_9.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR54_1_9() =
     SwitchStructureData(
-        type = SwitchType("RR54-1:9"),
+        type = SwitchType.of("RR54-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_2x1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_2x1_9.kt
@@ -2,11 +2,15 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR54_2x1_9() =
     SwitchStructureData(
-        type = SwitchType("RR54-2x1:9"),
+        type = SwitchType.of("RR54-2x1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_4x1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/RR54_4x1_9.kt
@@ -2,11 +2,15 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun RR54_4x1_9() =
     SwitchStructureData(
-        type = SwitchType("RR54-4x1:9"),
+        type = SwitchType.of("RR54-4x1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_1000_474_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_1000_474_1_15_5.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun SKV60_1000_474_1_15_5_O() =
     SwitchStructureData(
-        type = SwitchType("SKV60-1000/474-1:15,5-O"),
+        type = SwitchType.of("SKV60-1000/474-1:15,5-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -39,4 +39,4 @@ fun SKV60_1000_474_1_15_5_O() =
     )
 
 fun SKV60_1000_474_1_15_5_V() =
-    SKV60_1000_474_1_15_5_O().flipAlongYAxis().copy(type = SwitchType("SKV60-1000/474-1:15,5-V"))
+    SKV60_1000_474_1_15_5_O().flipAlongYAxis().copy(type = SwitchType.of("SKV60-1000/474-1:15,5-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_800_423_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SKV60_800_423_1_15_5.kt
@@ -15,7 +15,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun SKV60_800_423_1_15_5_O() =
     SwitchStructureData(
-        type = SwitchType("SKV60-800/423-1:15,5-V"),
+        type = SwitchType.of("SKV60-800/423-1:15,5-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -43,4 +43,4 @@ fun SKV60_800_423_1_15_5_O() =
     )
 
 fun SKV60_800_423_1_15_5_V() =
-    SKV60_800_423_1_15_5_O().flipAlongYAxis().copy(type = SwitchType("SKV60-800/423-1:15,5-O"))
+    SKV60_800_423_1_15_5_O().flipAlongYAxis().copy(type = SwitchType.of("SKV60-800/423-1:15,5-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_4_8.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_4_8.kt
@@ -13,7 +13,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun SRR54_2x1_9_4_8() =
     SwitchStructureData(
-        type = SwitchType("SRR54-2x1:9-4,8"),
+        type = SwitchType.of("SRR54-2x1:9-4,8"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_6_0.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR54_2x1_9_6_0.kt
@@ -13,7 +13,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun SRR54_2x1_9_6_0() =
     SwitchStructureData(
-        type = SwitchType("SRR54-2x1:9-6,0"),
+        type = SwitchType.of("SRR54-2x1:9-6,0"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR60_2x1_9_4_8.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/SRR60_2x1_9_4_8.kt
@@ -13,7 +13,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun SRR60_2x1_9_4_8() =
     SwitchStructureData(
-        type = SwitchType("SRR60-2x1:9-4,8"),
+        type = SwitchType.of("SRR60-2x1:9-4,8"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun TYV54_200_1_4_44() =
     SwitchStructureData(
-        type = SwitchType("TYV54-200-1:4,44"),
+        type = SwitchType.of("TYV54-200-1:4,44"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44TPE.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_200_1_4_44TPE.kt
@@ -2,7 +2,11 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // Joint number 5 is not accurate and copied from the switch
@@ -11,7 +15,7 @@ import fi.fta.geoviite.infra.switchLibrary.*
 
 fun TYV54_200_1_4_44TPE() =
     SwitchStructureData(
-        type = SwitchType("TYV54-200-1:4,44TPE"),
+        type = SwitchType.of("TYV54-200-1:4,44TPE"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun TYV54_225_1_6_46() =
     SwitchStructureData(
-        type = SwitchType("TYV54-225-1:6,46"),
+        type = SwitchType.of("TYV54-225-1:6,46"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46TPE.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/TYV54_225_1_6_46TPE.kt
@@ -16,7 +16,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun TYV54_225_1_6_46TPE() =
     SwitchStructureData(
-        type = SwitchType("TYV54-225-1:6,46TPE"),
+        type = SwitchType.of("TYV54-225-1:6,46TPE"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1000_244_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1000_244_1_9.kt
@@ -2,6 +2,6 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun UKV54_1000_244_1_9_O() = UKV60_1000_244_1_9_O().copy(type = SwitchType("UKV54-1000/244-1:9-O"))
+fun UKV54_1000_244_1_9_O() = UKV60_1000_244_1_9_O().copy(type = SwitchType.of("UKV54-1000/244-1:9-O"))
 
-fun UKV54_1000_244_1_9_V() = UKV54_1000_244_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV54-1000/244-1:9-V"))
+fun UKV54_1000_244_1_9_V() = UKV54_1000_244_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("UKV54-1000/244-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1500_228_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_1500_228_1_9.kt
@@ -2,7 +2,12 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // This switch type may contain inaccurate point locations and wrong elements
@@ -11,7 +16,7 @@ import fi.fta.geoviite.infra.switchLibrary.*
 
 fun UKV54_1500_228_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("UKV54-1500/228-1:9-O"),
+        type = SwitchType.of("UKV54-1500/228-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -42,4 +47,4 @@ fun UKV54_1500_228_1_9_O() =
             ),
     )
 
-fun UKV54_1500_228_1_9_V() = UKV54_1500_228_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV54-1500/228-1:9-V"))
+fun UKV54_1500_228_1_9_V() = UKV54_1500_228_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("UKV54-1500/228-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_800_258_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV54_800_258_1_9.kt
@@ -2,7 +2,12 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // This switch type may contain inaccurate point locations and wrong elements
@@ -11,7 +16,7 @@ import fi.fta.geoviite.infra.switchLibrary.*
 
 fun UKV54_800_258_1_9_V() =
     SwitchStructureData(
-        type = SwitchType("UKV54-800/258-1:9-V"),
+        type = SwitchType.of("UKV54-800/258-1:9-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,4 +46,4 @@ fun UKV54_800_258_1_9_V() =
             ),
     )
 
-fun UKV54_800_258_1_9_O() = UKV54_800_258_1_9_V().flipAlongYAxis().copy(type = SwitchType("UKV54-800/258-1:9-O"))
+fun UKV54_800_258_1_9_O() = UKV54_800_258_1_9_V().flipAlongYAxis().copy(type = SwitchType.of("UKV54-800/258-1:9-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_1000_244_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_1000_244_1_9.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun UKV60_1000_244_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("UKV60-1000/244-1:9-O"),
+        type = SwitchType.of("UKV60-1000/244-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -39,4 +39,4 @@ fun UKV60_1000_244_1_9_O() =
             ),
     )
 
-fun UKV60_1000_244_1_9_V() = UKV60_1000_244_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV60-1000/244-1:9-V"))
+fun UKV60_1000_244_1_9_V() = UKV60_1000_244_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("UKV60-1000/244-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_600_281_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/UKV60_600_281_1_9.kt
@@ -2,11 +2,15 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun UKV60_600_281_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("UKV60-600/281-1:9-O"),
+        type = SwitchType.of("UKV60-600/281-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -35,4 +39,4 @@ fun UKV60_600_281_1_9_O() =
             ),
     )
 
-fun UKV60_600_281_1_9_V() = UKV60_600_281_1_9_O().flipAlongYAxis().copy(type = SwitchType("UKV60-600/281-1:9-V"))
+fun UKV60_600_281_1_9_V() = UKV60_600_281_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("UKV60-600/281-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YRV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YRV54_200_1_9.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YRV54_200_1_9() =
     SwitchStructureData(
-        type = SwitchType("YRV54-200-1:9"),
+        type = SwitchType.of("YRV54-200-1:9"),
         presentationJointNumber = JointNumber(5),
         joints =
             setOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_7.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV30_270_1_7_V() =
     SwitchStructureData(
-        type = SwitchType("YV30-270-1:7-V"),
+        type = SwitchType.of("YV30-270-1:7-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,4 +41,4 @@ fun YV30_270_1_7_V() =
             ),
     )
 
-fun YV30_270_1_7_O() = YV30_270_1_7_V().flipAlongYAxis().copy(type = SwitchType("YV30-270-1:7-O"))
+fun YV30_270_1_7_O() = YV30_270_1_7_V().flipAlongYAxis().copy(type = SwitchType.of("YV30-270-1:7-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV30_270_1_9_514.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV30_270_1_9_514_V() =
     SwitchStructureData(
-        type = SwitchType("YV30-270-1:9,514-V"),
+        type = SwitchType.of("YV30-270-1:9,514-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,4 +41,4 @@ fun YV30_270_1_9_514_V() =
             ),
     )
 
-fun YV30_270_1_9_514_O() = YV30_270_1_9_514_V().flipAlongYAxis().copy(type = SwitchType("YV30-270-1:9,514-O"))
+fun YV30_270_1_9_514_O() = YV30_270_1_9_514_V().flipAlongYAxis().copy(type = SwitchType.of("YV30-270-1:9,514-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9.kt
@@ -2,6 +2,6 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun YV43_205_1_9_O() = YV43_300_1_9_O().copy(type = SwitchType("YV43-205-1:9-O"))
+fun YV43_205_1_9_O() = YV43_300_1_9_O().copy(type = SwitchType.of("YV43-205-1:9-O"))
 
-fun YV43_205_1_9_V() = YV43_300_1_9_V().copy(type = SwitchType("YV43-205-1:9-V"))
+fun YV43_205_1_9_V() = YV43_300_1_9_V().copy(type = SwitchType.of("YV43-205-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_205_1_9_514.kt
@@ -2,6 +2,6 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
-fun YV43_205_1_9_514_O() = YV43_300_1_9_514_O().copy(type = SwitchType("YV43-205-1:9,514-O"))
+fun YV43_205_1_9_514_O() = YV43_300_1_9_514_O().copy(type = SwitchType.of("YV43-205-1:9,514-O"))
 
-fun YV43_205_1_9_514_V() = YV43_300_1_9_514_V().copy(type = SwitchType("YV43-205-1:9,514-V"))
+fun YV43_205_1_9_514_V() = YV43_300_1_9_514_V().copy(type = SwitchType.of("YV43-205-1:9,514-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_7.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV43_300_1_7_O() =
     SwitchStructureData(
-        type = SwitchType("YV43-300-1:7-O"),
+        type = SwitchType.of("YV43-300-1:7-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,4 +41,4 @@ fun YV43_300_1_7_O() =
             ),
     )
 
-fun YV43_300_1_7_V() = YV43_300_1_7_O().flipAlongYAxis().copy(type = SwitchType("YV43-300-1:7-V"))
+fun YV43_300_1_7_V() = YV43_300_1_7_O().flipAlongYAxis().copy(type = SwitchType.of("YV43-300-1:7-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV43_300_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("YV43-300-1:9-O"),
+        type = SwitchType.of("YV43-300-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -40,4 +45,4 @@ fun YV43_300_1_9_O() =
             ),
     )
 
-fun YV43_300_1_9_V() = YV43_300_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV43-300-1:9-V"))
+fun YV43_300_1_9_V() = YV43_300_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("YV43-300-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9_514.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_300_1_9_514.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV43_300_1_9_514_O() =
     SwitchStructureData(
-        type = SwitchType("YV43-300-1:9,514-O"),
+        type = SwitchType.of("YV43-300-1:9,514-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -36,8 +41,8 @@ fun YV43_300_1_9_514_O() =
             ),
     )
 
-fun YV43_300_1_9_514_V() = YV43_300_1_9_514_O().flipAlongYAxis().copy(type = SwitchType("YV43-300-1:9,514-V"))
+fun YV43_300_1_9_514_V() = YV43_300_1_9_514_O().flipAlongYAxis().copy(type = SwitchType.of("YV43-300-1:9,514-V"))
 
-fun YV43_300_1_9_514_1435_O() = YV43_300_1_9_514_O().copy(type = SwitchType("YV43-300-1:9,514-1435-O"))
+fun YV43_300_1_9_514_1435_O() = YV43_300_1_9_514_O().copy(type = SwitchType.of("YV43-300-1:9,514-1435-O"))
 
-fun YV43_300_1_9_514_1435_V() = YV43_300_1_9_514_V().copy(type = SwitchType("YV43-300-1:9,514-1435-V"))
+fun YV43_300_1_9_514_1435_V() = YV43_300_1_9_514_V().copy(type = SwitchType.of("YV43-300-1:9,514-1435-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_530_1_15.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV43_530_1_15.kt
@@ -15,7 +15,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV43_530_1_15_O() =
     SwitchStructureData(
-        type = SwitchType("YV43-530-1:15-O"),
+        type = SwitchType.of("YV43-530-1:15-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -45,4 +45,4 @@ fun YV43_530_1_15_O() =
             ),
     )
 
-fun YV43_530_1_15_V() = YV43_530_1_15_O().flipAlongYAxis().copy(type = SwitchType("YV43-530-1:15-V"))
+fun YV43_530_1_15_V() = YV43_530_1_15_O().flipAlongYAxis().copy(type = SwitchType.of("YV43-530-1:15-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_165_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_165_1_7.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV54_165_1_7_V() =
     SwitchStructureData(
-        type = SwitchType("YV54-165-1:7-V"),
+        type = SwitchType.of("YV54-165-1:7-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -36,4 +41,4 @@ fun YV54_165_1_7_V() =
             ),
     )
 
-fun YV54_165_1_7_O() = YV54_165_1_7_V().flipAlongYAxis().copy(type = SwitchType("YV54-165-1:7-O"))
+fun YV54_165_1_7_O() = YV54_165_1_7_V().flipAlongYAxis().copy(type = SwitchType.of("YV54-165-1:7-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_190_1_7.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_190_1_7.kt
@@ -14,7 +14,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV54_190_1_7_O() =
     SwitchStructureData(
-        type = SwitchType("YV54-190-1:7-O"),
+        type = SwitchType.of("YV54-190-1:7-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,4 +41,4 @@ fun YV54_190_1_7_O() =
             ),
     )
 
-fun YV54_190_1_7_V() = YV54_190_1_7_O().flipAlongYAxis().copy(type = SwitchType("YV54-190-1:7-V"))
+fun YV54_190_1_7_V() = YV54_190_1_7_O().flipAlongYAxis().copy(type = SwitchType.of("YV54-190-1:7-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_200_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_200_1_9.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV54_200_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("YV54-200-1:9-O"),
+        type = SwitchType.of("YV54-200-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -36,20 +41,20 @@ fun YV54_200_1_9_O() =
             ),
     )
 
-fun YV54_200_1_9_V() = YV54_200_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV54-200-1:9-V"))
+fun YV54_200_1_9_V() = YV54_200_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("YV54-200-1:9-V"))
 
-fun YV54_200N_1_9_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200N-1:9-O"))
+fun YV54_200N_1_9_O() = YV54_200_1_9_O().copy(type = SwitchType.of("YV54-200N-1:9-O"))
 
-fun YV54_200N_1_9_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200N-1:9-V"))
+fun YV54_200N_1_9_V() = YV54_200_1_9_V().copy(type = SwitchType.of("YV54-200N-1:9-V"))
 
-fun YV54_200_1_9_1435_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200-1:9-1435-O"))
+fun YV54_200_1_9_1435_O() = YV54_200_1_9_O().copy(type = SwitchType.of("YV54-200-1:9-1435-O"))
 
-fun YV54_200_1_9_1435_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200-1:9-1435-V"))
+fun YV54_200_1_9_1435_V() = YV54_200_1_9_V().copy(type = SwitchType.of("YV54-200-1:9-1435-V"))
 
-fun YV54_200N_1_9_1435_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200N-1:9-1435-O"))
+fun YV54_200N_1_9_1435_O() = YV54_200_1_9_O().copy(type = SwitchType.of("YV54-200N-1:9-1435-O"))
 
-fun YV54_200N_1_9_1435_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200N-1:9-1435-V"))
+fun YV54_200N_1_9_1435_V() = YV54_200_1_9_V().copy(type = SwitchType.of("YV54-200N-1:9-1435-V"))
 
-fun YV54_200_1_9_1524_1435_O() = YV54_200_1_9_O().copy(type = SwitchType("YV54-200-1:9-1524/1435-O"))
+fun YV54_200_1_9_1524_1435_O() = YV54_200_1_9_O().copy(type = SwitchType.of("YV54-200-1:9-1524/1435-O"))
 
-fun YV54_200_1_9_1524_1435_V() = YV54_200_1_9_V().copy(type = SwitchType("YV54-200-1:9-1524/1435-V"))
+fun YV54_200_1_9_1524_1435_V() = YV54_200_1_9_V().copy(type = SwitchType.of("YV54-200-1:9-1524/1435-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_900_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV54_900_1_15_5.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV54_900_1_15_5_V() =
     SwitchStructureData(
-        type = SwitchType("YV54-900-1:15,5-V"),
+        type = SwitchType.of("YV54-900-1:15,5-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -33,4 +38,4 @@ fun YV54_900_1_15_5_V() =
             ),
     )
 
-fun YV54_900_1_15_5_O() = YV54_900_1_15_5_V().flipAlongYAxis().copy(type = SwitchType("YV54-900-1:15,5-O"))
+fun YV54_900_1_15_5_O() = YV54_900_1_15_5_V().flipAlongYAxis().copy(type = SwitchType.of("YV54-900-1:15,5-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300P_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300P_1_9.kt
@@ -2,7 +2,12 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 // NOTE:
 // This switch type may contain inaccurate point locations and wrong elements
@@ -11,7 +16,7 @@ import fi.fta.geoviite.infra.switchLibrary.*
 
 fun YV60_300P_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-300P-1:9-O"),
+        type = SwitchType.of("YV60-300P-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -40,4 +45,4 @@ fun YV60_300P_1_9_O() =
             ),
     )
 
-fun YV60_300P_1_9_V() = YV60_300P_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV60-300P-1:9-V"))
+fun YV60_300P_1_9_V() = YV60_300P_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-300P-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_10.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_10.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_300_1_10_V() =
     SwitchStructureData(
-        type = SwitchType("YV60-300-1:10-V"),
+        type = SwitchType.of("YV60-300-1:10-V"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -36,4 +41,4 @@ fun YV60_300_1_10_V() =
             ),
     )
 
-fun YV60_300_1_10_O() = YV60_300_1_10_V().flipAlongYAxis().copy(type = SwitchType("YV60-300-1:10-O"))
+fun YV60_300_1_10_O() = YV60_300_1_10_V().flipAlongYAxis().copy(type = SwitchType.of("YV60-300-1:10-O"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_9.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_300_1_9.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_300_1_9_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-300-1:9-O"),
+        type = SwitchType.of("YV60-300-1:9-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,12 +41,12 @@ fun YV60_300_1_9_O() =
             ),
     )
 
-fun YV60_300_1_9_V() = YV60_300_1_9_O().flipAlongYAxis().copy(type = SwitchType("YV60-300-1:9-V"))
+fun YV60_300_1_9_V() = YV60_300_1_9_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-300-1:9-V"))
 
-fun YV60_300A_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType("YV60-300A-1:9-O"))
+fun YV60_300A_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType.of("YV60-300A-1:9-O"))
 
-fun YV60_300A_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType("YV60-300A-1:9-V"))
+fun YV60_300A_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType.of("YV60-300A-1:9-V"))
 
-fun YV60_300E_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType("YV60-300E-1:9-O"))
+fun YV60_300E_1_9_O() = YV60_300_1_9_O().copy(type = SwitchType.of("YV60-300E-1:9-O"))
 
-fun YV60_300E_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType("YV60-300E-1:9-V"))
+fun YV60_300E_1_9_V() = YV60_300_1_9_V().copy(type = SwitchType.of("YV60-300E-1:9-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_2500_1_26.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_2500_1_26.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_5000_2500_1_26_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-5000/2500-1:26-O"),
+        type = SwitchType.of("YV60-5000/2500-1:26-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,4 +46,5 @@ fun YV60_5000_2500_1_26_O() =
             ),
     )
 
-fun YV60_5000_2500_1_26_V() = YV60_5000_2500_1_26_O().flipAlongYAxis().copy(type = SwitchType("YV60-5000/2500-1:26-V"))
+fun YV60_5000_2500_1_26_V() =
+    YV60_5000_2500_1_26_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-5000/2500-1:26-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_3000_1_28.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_5000_3000_1_28.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_5000_3000_1_28_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-5000/3000-1:28-O"),
+        type = SwitchType.of("YV60-5000/3000-1:28-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -40,4 +45,5 @@ fun YV60_5000_3000_1_28_O() =
             ),
     )
 
-fun YV60_5000_3000_1_28_V() = YV60_5000_3000_1_28_O().flipAlongYAxis().copy(type = SwitchType("YV60-5000/3000-1:28-V"))
+fun YV60_5000_3000_1_28_V() =
+    YV60_5000_3000_1_28_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-5000/3000-1:28-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_11_1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_11_1.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_500_1_11_1_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-500-1:11,1-O"),
+        type = SwitchType.of("YV60-500-1:11,1-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -35,8 +40,8 @@ fun YV60_500_1_11_1_O() =
             ),
     )
 
-fun YV60_500_1_11_1_V() = YV60_500_1_11_1_O().flipAlongYAxis().copy(type = SwitchType("YV60-500-1:11,1-V"))
+fun YV60_500_1_11_1_V() = YV60_500_1_11_1_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-500-1:11,1-V"))
 
-fun YV60_500A_1_11_1_O() = YV60_500_1_11_1_O().copy(type = SwitchType("YV60-500A-1:11,1-O"))
+fun YV60_500A_1_11_1_O() = YV60_500_1_11_1_O().copy(type = SwitchType.of("YV60-500A-1:11,1-O"))
 
-fun YV60_500A_1_11_1_V() = YV60_500_1_11_1_V().copy(type = SwitchType("YV60-500A-1:11,1-V"))
+fun YV60_500A_1_11_1_V() = YV60_500_1_11_1_V().copy(type = SwitchType.of("YV60-500A-1:11,1-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_14.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_500_1_14.kt
@@ -11,7 +11,7 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_500_1_14_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-500-1:14-O"),
+        type = SwitchType.of("YV60-500-1:14-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,8 +41,8 @@ fun YV60_500_1_14_O() =
             ),
     )
 
-fun YV60_500_1_14_V() = YV60_500_1_14_O().flipAlongYAxis().copy(type = SwitchType("YV60-500-1:14-V"))
+fun YV60_500_1_14_V() = YV60_500_1_14_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-500-1:14-V"))
 
-fun YV60_500A_1_14_O() = YV60_500_1_14_O().copy(type = SwitchType("YV60-500A-1:14-O"))
+fun YV60_500A_1_14_O() = YV60_500_1_14_O().copy(type = SwitchType.of("YV60-500A-1:14-O"))
 
-fun YV60_500A_1_14_V() = YV60_500_1_14_V().copy(type = SwitchType("YV60-500A-1:14-V"))
+fun YV60_500A_1_14_V() = YV60_500_1_14_V().copy(type = SwitchType.of("YV60-500A-1:14-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_15_5.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_15_5.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_900_1_15_5_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-900-1:15,5-O"),
+        type = SwitchType.of("YV60-900-1:15,5-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -41,12 +46,12 @@ fun YV60_900_1_15_5_O() =
             ),
     )
 
-fun YV60_900_1_15_5_V() = YV60_900_1_15_5_O().flipAlongYAxis().copy(type = SwitchType("YV60-900-1:15,5-V"))
+fun YV60_900_1_15_5_V() = YV60_900_1_15_5_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-900-1:15,5-V"))
 
-fun YV60_900A_1_15_5_O() = YV60_900_1_15_5_O().copy(type = SwitchType("YV60-900A-1:15,5-O"))
+fun YV60_900A_1_15_5_O() = YV60_900_1_15_5_O().copy(type = SwitchType.of("YV60-900A-1:15,5-O"))
 
-fun YV60_900A_1_15_5_V() = YV60_900_1_15_5_V().copy(type = SwitchType("YV60-900A-1:15,5-V"))
+fun YV60_900A_1_15_5_V() = YV60_900_1_15_5_V().copy(type = SwitchType.of("YV60-900A-1:15,5-V"))
 
-fun YV60_900E_1_15_5_O() = YV60_900_1_15_5_O().copy(type = SwitchType("YV60-900E-1:15,5-O"))
+fun YV60_900E_1_15_5_O() = YV60_900_1_15_5_O().copy(type = SwitchType.of("YV60-900E-1:15,5-O"))
 
-fun YV60_900E_1_15_5_V() = YV60_900_1_15_5_V().copy(type = SwitchType("YV60-900E-1:15,5-V"))
+fun YV60_900E_1_15_5_V() = YV60_900_1_15_5_V().copy(type = SwitchType.of("YV60-900E-1:15,5-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_18.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/data/YV60_900_1_18.kt
@@ -2,11 +2,16 @@ package fi.fta.geoviite.infra.switchLibrary.data
 
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.switchLibrary.*
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureCurve
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
+import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
+import fi.fta.geoviite.infra.switchLibrary.SwitchType
 
 fun YV60_900_1_18_O() =
     SwitchStructureData(
-        type = SwitchType("YV60-900-1:18-O"),
+        type = SwitchType.of("YV60-900-1:18-O"),
         presentationJointNumber = JointNumber(1),
         joints =
             setOf(
@@ -36,12 +41,12 @@ fun YV60_900_1_18_O() =
             ),
     )
 
-fun YV60_900_1_18_V() = YV60_900_1_18_O().flipAlongYAxis().copy(type = SwitchType("YV60-900-1:18-V"))
+fun YV60_900_1_18_V() = YV60_900_1_18_O().flipAlongYAxis().copy(type = SwitchType.of("YV60-900-1:18-V"))
 
-fun YV60_900A_1_18_O() = YV60_900_1_18_O().copy(type = SwitchType("YV60-900A-1:18-O"))
+fun YV60_900A_1_18_O() = YV60_900_1_18_O().copy(type = SwitchType.of("YV60-900A-1:18-O"))
 
-fun YV60_900A_1_18_V() = YV60_900_1_18_V().copy(type = SwitchType("YV60-900A-1:18-V"))
+fun YV60_900A_1_18_V() = YV60_900_1_18_V().copy(type = SwitchType.of("YV60-900A-1:18-V"))
 
-fun YV60_900P_1_18_O() = YV60_900_1_18_O().copy(type = SwitchType("YV60-900P-1:18-O"))
+fun YV60_900P_1_18_O() = YV60_900_1_18_O().copy(type = SwitchType.of("YV60-900P-1:18-O"))
 
-fun YV60_900P_1_18_V() = YV60_900_1_18_V().copy(type = SwitchType("YV60-900P-1:18-V"))
+fun YV60_900P_1_18_V() = YV60_900_1_18_V().copy(type = SwitchType.of("YV60-900P-1:18-V"))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -398,9 +398,11 @@ interface ISegmentGeometry {
             PointSeekResult(segmentEnd, segmentPoints.lastIndex, true)
         } else {
             // Binary search will return the index of the matching item
-            // If no item matches, it will return the inverted insertion point -> the index after the M
-            val indexAfter = abs(segmentPoints.binarySearch { p -> segmentM.distance.compareTo(segmentM.distance) })
-            //            .indexOfFirst { p -> p.m >= segmentM }
+            // If no item matches, it will return the inverted insertion point (-insertion point - 1)
+            val indexAfter =
+                segmentPoints
+                    .binarySearch { p -> p.m.distance.compareTo(segmentM.distance) }
+                    .let { i -> if (i >= 0) i else -(i + 1) }
             val pointAfter = segmentPoints[indexAfter]
             segmentPoints.getOrNull(indexAfter - 1)?.let { pointBefore ->
                 val distanceToLast = abs(pointBefore.m.distance - segmentM.distance)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -5,7 +5,6 @@ import com.github.davidmoten.rtree2.RTree
 import com.github.davidmoten.rtree2.geometry.Geometries
 import com.github.davidmoten.rtree2.geometry.Geometry
 import com.github.davidmoten.rtree2.geometry.Line
-import com.github.davidmoten.rtree2.geometry.Rectangle
 import com.github.davidmoten.rtree2.internal.EntryDefault
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DataType
@@ -277,18 +276,12 @@ interface IAlignment<M : AlignmentM<M>> : Loggable {
 private fun segmentRTreeLine(segment: ISegment): Line =
     segment.let { s -> Geometries.line(s.segmentStart.x, s.segmentStart.y, s.segmentEnd.x, s.segmentEnd.y) }
 
-private fun segmentRTreeRect(segment: ISegment): Rectangle =
-    segment.boundingBox.let { b -> Geometries.rectangle(b.x.min, b.y.min, b.x.max, b.y.max) }
-
 data class SegmentSpatialIndex(private val rtree: RTree<Int, Geometry>, private val maxSeekDistance: Double = 1000.0) {
     constructor(
         segments: List<ISegment>
     ) : this(
         segments
             .mapIndexed { index, segment -> EntryDefault<Int, Geometry>(index, segmentRTreeLine(segment)) }
-            //            .mapIndexed { index, segment -> EntryDefault<Int, Geometry>(index, segmentRTreeRect(segment))
-            // }
-            //                        .let { entries -> RTree.star().create<Int, Geometry>(entries) }
             .let { entries -> RTree.create<Int, Geometry>(entries) }
     )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -31,11 +31,9 @@ import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.printCsv
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.stream.Collectors
-import kotlin.text.get
-import kotlin.toString
-import org.springframework.transaction.annotation.Transactional
 
 const val KM_LENGTHS_CSV_TRANSLATION_PREFIX = "data-products.km-lengths.csv"
 
@@ -336,14 +334,14 @@ private fun locationSourceTranslationKey(
                     false -> "$KM_LENGTHS_CSV_TRANSLATION_PREFIX.from-ratko"
                 }
             }
-            ?.let(::LocalizationKey)
+            ?.let(LocalizationKey::of)
 }
 
 private fun gkLocationConfirmedTranslationKey(confirmed: Boolean): LocalizationKey =
     when {
         confirmed -> "$KM_LENGTHS_CSV_TRANSLATION_PREFIX.confirmed"
         else -> "$KM_LENGTHS_CSV_TRANSLATION_PREFIX.not-confirmed"
-    }.let(::LocalizationKey)
+    }.let(LocalizationKey::of)
 
 private fun getLocationByPrecision(kmPost: LayoutKmLengthDetails, precision: KmLengthsLocationPrecision): IPoint? =
     when (precision) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/StringUtils.kt
@@ -54,13 +54,17 @@ inline fun <reified T> assertSanitized(stringValue: String, regex: Regex, length
 
 fun assertSanitized(type: KClass<*>, stringValue: String, regex: Regex, length: IntRange? = null) {
     length?.let { l -> assertLength(type, stringValue, l) }
-    assertInput(type, stringValue.matches(regex), stringValue) {
+    assertInput(type, regex.matches(stringValue), stringValue) {
         "Invalid characters in ${type.simpleName}: ${formatForException(stringValue)}"
     }
 }
 
 fun assertTrimmed(type: KClass<*>, value: String) {
-    assertInput(type, value == value.trim(), value) {
+    assertInput(
+        type,
+        value.firstOrNull()?.isWhitespace() != true && value.lastOrNull()?.isWhitespace() != true,
+        value,
+    ) {
         "Whitespace not allowed at the start or end of ${type.simpleName}: ${formatForException(value)}"
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
@@ -13,12 +13,12 @@ import fi.fta.geoviite.infra.switchLibrary.SwitchStructureLine
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.switchLibrary.data.RR54_2x1_9
 import fi.fta.geoviite.infra.switchLibrary.data.YV60_300A_1_9_O
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -34,7 +34,7 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
     @Test
     fun insertAndFetchSwitchStructureShouldWork() {
         val seq = System.currentTimeMillis()
-        val uniqueSwitchType = SwitchType("YV60-$seq-1:10")
+        val uniqueSwitchType = SwitchType.of("YV60-$seq-1:10")
         val switchStructure =
             SwitchStructureData(
                 type = uniqueSwitchType,
@@ -79,7 +79,7 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
     @Test
     fun `Update switch structure should work as described`() {
         val seq = System.currentTimeMillis()
-        val originalSwitchType = SwitchType("YV60-$seq-1:9")
+        val originalSwitchType = SwitchType.of("YV60-$seq-1:9")
         val originalSwitchStructure = YV60_300A_1_9_O().copy(type = originalSwitchType)
         val originalVersion = switchStructureDao.upsertSwitchStructure(originalSwitchStructure)
         val originalLoadedSwitchStructure = switchStructureDao.fetchSwitchStructure(originalVersion)
@@ -95,7 +95,7 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
     @Test
     fun `Upsert should update modified switch structure`() {
         val seq = System.currentTimeMillis()
-        val switchType = SwitchType("YV60-$seq-1:9")
+        val switchType = SwitchType.of("YV60-$seq-1:9")
         val switchStructure = YV60_300A_1_9_O().copy(type = switchType)
         val version = switchStructureDao.upsertSwitchStructure(switchStructure)
 
@@ -114,7 +114,7 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
     @Test
     fun `Upsert should not update unmodified switch structure`() {
         val seq = System.currentTimeMillis()
-        val switchType = SwitchType("YV60-$seq-1:9")
+        val switchType = SwitchType.of("YV60-$seq-1:9")
         val switchStructure = YV60_300A_1_9_O().copy(type = switchType)
         val versionId = switchStructureDao.upsertSwitchStructure(switchStructure)
 
@@ -132,7 +132,7 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
         val existingSwitchStructuresBeforeUpdate = switchStructureDao.fetchSwitchStructures().map { s -> s.data }
 
         val seq = System.currentTimeMillis()
-        val newSwitchType = SwitchType("YV60-$seq-1:9")
+        val newSwitchType = SwitchType.of("YV60-$seq-1:9")
         val newSwitchStructure = YV60_300A_1_9_O().copy(type = newSwitchType)
 
         switchLibraryService.replaceExistingSwitchStructures(existingSwitchStructuresBeforeUpdate + newSwitchStructure)
@@ -147,7 +147,7 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
         val existingSwitchStructuresBeforeUpdate = switchStructureDao.fetchSwitchStructures().map { s -> s.data }
 
         val seq = System.currentTimeMillis()
-        val newSwitchType = SwitchType("YV60-$seq-1:9")
+        val newSwitchType = SwitchType.of("YV60-$seq-1:9")
         val newSwitchStructure = YV60_300A_1_9_O().copy(type = newSwitchType)
 
         switchLibraryService.replaceExistingSwitchStructures(existingSwitchStructuresBeforeUpdate + newSwitchStructure)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureTest.kt
@@ -122,7 +122,7 @@ class SwitchStructureTest {
 
     private val validSwitchStructure by lazy {
         SwitchStructureData(
-            type = SwitchType("YV60-300-1:9-O"),
+            type = SwitchType.of("YV60-300-1:9-O"),
             presentationJointNumber = JointNumber(1),
             joints =
                 setOf(
@@ -157,40 +157,40 @@ class SwitchStructureTest {
 
     @Test
     fun switchTypeParsingAllowsKnownTypes() {
-        knownSwitchTypes.forEach { type -> assertDoesNotThrow { SwitchType(type) } }
+        knownSwitchTypes.forEach { type -> assertDoesNotThrow { SwitchType.of(type) } }
     }
 
     @Test
     fun switchTypeParsingFindsExpectedParts() {
         assertEquals(
             SwitchTypeParts(SwitchBaseType.YV, 60, listOf(900), "P", "1:18", SwitchHand.RIGHT),
-            SwitchType("YV60-900P-1:18-O").parts,
+            SwitchType.of("YV60-900P-1:18-O").parts,
         )
         assertEquals(
             SwitchTypeParts(SwitchBaseType.KRV, 43, listOf(270), null, "1:9,514", SwitchHand.NONE),
-            SwitchType("KRV43-270-1:9,514").parts,
+            SwitchType.of("KRV43-270-1:9,514").parts,
         )
         assertEquals(
             SwitchTypeParts(SwitchBaseType.YV, 60, listOf(5000, 2500), null, "1:26", SwitchHand.LEFT),
-            SwitchType("YV60-5000/2500-1:26-V").parts,
+            SwitchType.of("YV60-5000/2500-1:26-V").parts,
         )
         assertEquals(
             SwitchTypeParts(SwitchBaseType.SRR, 54, listOf(), null, "2x1:9-6,0", SwitchHand.NONE),
-            SwitchType("SRR54-2x1:9-6,0").parts,
+            SwitchType.of("SRR54-2x1:9-6,0").parts,
         )
         assertEquals(
             SwitchTypeParts(SwitchBaseType.EV, 43, listOf(), null, "1:9", SwitchHand.RIGHT),
-            SwitchType("EV-SJ43-5,9-1:9-H").parts,
+            SwitchType.of("EV-SJ43-5,9-1:9-H").parts,
         )
         assertEquals(
             SwitchTypeParts(SwitchBaseType.EV, 43, listOf(), null, "1:9", SwitchHand.LEFT),
-            SwitchType("EV-SJ43-5,9-1:9-V").parts,
+            SwitchType.of("EV-SJ43-5,9-1:9-V").parts,
         )
     }
 
     @Test
     fun switchTypeDeniesInvalidValues() {
-        assertThrows<IllegalArgumentException> { SwitchType("foo") }
+        assertThrows<IllegalArgumentException> { SwitchType.of("foo") }
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
@@ -1,8 +1,11 @@
 package fi.fta.geoviite.infra.geometry
 
-import fi.fta.geoviite.infra.common.*
+import fi.fta.geoviite.infra.common.FeatureTypeCode
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.RotationDirection
 import fi.fta.geoviite.infra.common.RotationDirection.CCW
 import fi.fta.geoviite.infra.common.RotationDirection.CW
+import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.geometry.CantRotationPoint.INSIDE_RAIL
 import fi.fta.geoviite.infra.geometry.CantTransitionType.LINEAR
 import fi.fta.geoviite.infra.inframodel.PlanElementName
@@ -12,10 +15,10 @@ import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.math.rotateAroundOrigin
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
-import kotlin.math.PI
-import kotlin.math.hypot
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.math.PI
+import kotlin.math.hypot
 
 private const val JOINT_LOCATION_DELTA = 0.01
 
@@ -194,7 +197,7 @@ class ValidationTest {
     private fun assertGeometryValidationIssues(errors: List<GeometryValidationIssue>, keyParts: List<String>) {
         assertEquals(keyParts.size, errors.size, errors.toString())
         errors.forEachIndexed { index, error ->
-            assertEquals(LocalizationKey("$VALIDATION.${keyParts[index]}"), error.localizationKey, errors.toString())
+            assertEquals(LocalizationKey.of("$VALIDATION.${keyParts[index]}"), error.localizationKey, errors.toString())
         }
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelControllerIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelControllerIT.kt
@@ -2,9 +2,6 @@ package fi.fta.geoviite.infra.inframodel
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.localization.LocalizationKey
-import java.io.InputStream
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,6 +9,9 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
+import java.io.InputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -23,7 +23,10 @@ internal class InfraModelControllerIT @Autowired constructor(val infraModelServi
         val result = infraModelService.validateInfraModelFile(emptyFile, null)
         assertNull(result.geometryPlan)
         assertEquals(1, result.geometryValidationIssues.size)
-        assertEquals(LocalizationKey(INFRAMODEL_PARSING_KEY_EMPTY), result.geometryValidationIssues[0].localizationKey)
+        assertEquals(
+            LocalizationKey.of(INFRAMODEL_PARSING_KEY_EMPTY),
+            result.geometryValidationIssues[0].localizationKey,
+        )
     }
 
     @Test
@@ -40,7 +43,7 @@ internal class InfraModelControllerIT @Autowired constructor(val infraModelServi
         assertNull(result.geometryPlan)
         assertEquals(1, result.geometryValidationIssues.size)
         assertEquals(
-            LocalizationKey("$INFRAMODEL_PARSING_KEY_PARENT.wrong-content-type"),
+            LocalizationKey.of("$INFRAMODEL_PARSING_KEY_PARENT.wrong-content-type"),
             result.geometryValidationIssues[0].localizationKey,
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingServiceIT.kt
@@ -24,12 +24,12 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -129,7 +129,7 @@ constructor(
     }
 
     private fun yv60SwitchId() =
-        switchLibraryService.getSwitchStructures().find { it.type == SwitchType("YV60-300-1:9-O") }!!.id
+        switchLibraryService.getSwitchStructures().find { it.type == SwitchType.of("YV60-300-1:9-O") }!!.id
 
     private fun firstSwitchFitResult(
         plan: GeometryPlan,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
@@ -876,7 +876,7 @@ constructor(
                             LayoutValidationIssue(
                                 type = LayoutValidationIssueType.WARNING,
                                 localizationKey =
-                                    LocalizationKey(
+                                    LocalizationKey.of(
                                         "validation.layout.switch.track-linkage.switch-alignment-only-connected-to-duplicate"
                                     ),
                                 params =
@@ -894,7 +894,7 @@ constructor(
                             LayoutValidationIssue(
                                 type = LayoutValidationIssueType.ERROR,
                                 localizationKey =
-                                    LocalizationKey("validation.layout.switch.track-linkage.relinking-failed"),
+                                    LocalizationKey.of("validation.layout.switch.track-linkage.relinking-failed"),
                                 params = LocalizationParams(mapOf("switch" to "unsaveable")),
                             )
                         ),
@@ -1035,7 +1035,7 @@ constructor(
                         LayoutValidationIssue(
                             LayoutValidationIssueType.ERROR,
                             localizationKey =
-                                LocalizationKey("validation.layout.split.track-links-missing-after-relinking"),
+                                LocalizationKey.of("validation.layout.split.track-links-missing-after-relinking"),
                             params = LocalizationParams(mapOf("switchName" to "ok", "sourceName" to "topoTrack")),
                         )
                     ),
@@ -1049,15 +1049,17 @@ constructor(
                         LayoutValidationIssue(
                             LayoutValidationIssueType.WARNING,
                             localizationKey =
-                                LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected"),
+                                LocalizationKey.of("validation.layout.switch.track-linkage.front-joint-not-connected"),
                             params = LocalizationParams(mapOf("switch" to "somewhere else")),
                         ),
                         LayoutValidationIssue(
                             LayoutValidationIssueType.ERROR,
                             localizationKey =
-                                LocalizationKey("validation.layout.split.track-links-missing-after-relinking"),
+                                LocalizationKey.of("validation.layout.split.track-links-missing-after-relinking"),
                             params =
-                                LocalizationParams(mapOf("switchName" to "somewhere else", "sourceName" to "topoTrack")),
+                                LocalizationParams(
+                                    mapOf("switchName" to "somewhere else", "sourceName" to "topoTrack")
+                                ),
                         ),
                     ),
             )
@@ -1351,7 +1353,7 @@ constructor(
                     geometrySwitchId = null,
                 )
             }
-        assertEquals(ex.localizationKey, LocalizationKey("error.linking.switch-deleted"))
+        assertEquals(ex.localizationKey, LocalizationKey.of("error.linking.switch-deleted"))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/projektivelho/PVIntegrationServiceIT.kt
@@ -13,15 +13,15 @@ import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.MATERIAL_STATE
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.PROJECT_STATE
 import fi.fta.geoviite.infra.projektivelho.PVDictionaryType.TECHNICS_FIELD
 import fi.fta.geoviite.infra.util.UnsafeString
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest(properties = ["geoviite.projektivelho=true"])
@@ -190,7 +190,7 @@ constructor(
         val rejection = pvDao.getRejection(version)
 
         assertEquals(version, rejection.documentVersion)
-        assertEquals(LocalizationKey("test"), rejection.reason)
+        assertEquals(LocalizationKey.of("test"), rejection.reason)
     }
 
     private fun assertDocumentExists(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -327,7 +327,7 @@ constructor(
             val trackErrors = validation.validatedAsPublicationUnit.locationTracks[0].issues
             return trackErrors.find { error ->
                 error.localizationKey ==
-                    LocalizationKey(
+                    LocalizationKey.of(
                         "validation.layout.location-track.duplicate-of.publishing-duplicate-while-duplicated"
                     )
             }
@@ -491,15 +491,15 @@ constructor(
         assertTrue(
             errorsWhenDeletingStraightTrack.any { error ->
                 error.localizationKey ==
-                    LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("alignments") == "1-5-2" &&
-                    error.params.get("switch") == "TV123"
+                    LocalizationKey.of(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected"
+                    ) && error.params.get("alignments") == "1-5-2" && error.params.get("switch") == "TV123"
             }
         )
         assertTrue(
             errorsWhenDeletingStraightTrack.any { error ->
                 error.localizationKey ==
-                    LocalizationKey("validation.layout.location-track.switch-linkage.front-joint-not-connected") &&
+                    LocalizationKey.of("validation.layout.location-track.switch-linkage.front-joint-not-connected") &&
                     error.params.get("switch") == "TV123"
             }
         )
@@ -516,15 +516,15 @@ constructor(
         assertTrue(
             errorsWhenDeletingBranchingTrack.any { error ->
                 error.localizationKey ==
-                    LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("alignments") == "1-3" &&
-                    error.params.get("switch") == "TV123"
+                    LocalizationKey.of(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected"
+                    ) && error.params.get("alignments") == "1-3" && error.params.get("switch") == "TV123"
             }
         )
         assertFalse(
             errorsWhenDeletingBranchingTrack.any { error ->
                 error.localizationKey ==
-                    LocalizationKey("validation.layout.location-track.switch-linkage.front-joint-not-connected")
+                    LocalizationKey.of("validation.layout.location-track.switch-linkage.front-joint-not-connected")
             }
         )
     }
@@ -596,9 +596,9 @@ constructor(
         assertTrue(
             locationTrackDeletionErrors.any { error ->
                 error.localizationKey ==
-                    LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected") &&
-                    error.params.get("alignments") == "1-5-2" &&
-                    error.params.get("switch") == "TV123"
+                    LocalizationKey.of(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected"
+                    ) && error.params.get("alignments") == "1-5-2" && error.params.get("switch") == "TV123"
             }
         )
         // but it's OK if we link a replacement track
@@ -631,7 +631,7 @@ constructor(
         assertFalse(
             errorsWithReplacementTrackLinked.any { error ->
                 error.localizationKey ==
-                    LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected")
+                    LocalizationKey.of("validation.layout.location-track.switch-linkage.switch-alignment-not-connected")
             }
         )
     }
@@ -651,7 +651,7 @@ constructor(
         assertTrue(
             validation.errors.any {
                 it.type == LayoutValidationIssueType.FATAL &&
-                    it.localizationKey == LocalizationKey("$VALIDATION_GEOCODING.duplicate-km-posts")
+                    it.localizationKey == LocalizationKey.of("$VALIDATION_GEOCODING.duplicate-km-posts")
             }
         )
     }
@@ -666,7 +666,7 @@ constructor(
         assertTrue(
             validation.errors.any {
                 it.type == LayoutValidationIssueType.FATAL &&
-                    it.localizationKey == LocalizationKey("validation.layout.switch.duplicate-name-draft-in-main")
+                    it.localizationKey == LocalizationKey.of("validation.layout.switch.duplicate-name-draft-in-main")
             }
         )
     }
@@ -685,7 +685,8 @@ constructor(
         assertTrue(
             validation.errors.any {
                 it.type == LayoutValidationIssueType.FATAL &&
-                    it.localizationKey == LocalizationKey("validation.layout.track-number.duplicate-name-draft-in-main")
+                    it.localizationKey ==
+                        LocalizationKey.of("validation.layout.track-number.duplicate-name-draft-in-main")
             }
         )
     }
@@ -717,7 +718,7 @@ constructor(
         assertTrue(
             validation.errors.any {
                 it.type == LayoutValidationIssueType.FATAL &&
-                    it.localizationKey == LocalizationKey("$VALIDATION_LOCATION_TRACK.duplicate-name-draft-in-main")
+                    it.localizationKey == LocalizationKey.of("$VALIDATION_LOCATION_TRACK.duplicate-name-draft-in-main")
             }
         )
     }
@@ -748,7 +749,7 @@ constructor(
         val referenceLineIssues = validated.validatedAsPublicationUnit.referenceLines[0].issues
         assertEquals(1, referenceLineIssues.size)
         assertEquals(
-            LocalizationKey("validation.layout.reference-line.points.not-continuous"),
+            LocalizationKey.of("validation.layout.reference-line.points.not-continuous"),
             referenceLineIssues[0].localizationKey,
         )
     }
@@ -1028,7 +1029,10 @@ constructor(
             LayoutValidationIssue(
                 LayoutValidationIssueType.WARNING,
                 "validation.layout.switch.track-linkage.switch-alignment-multiply-connected",
-                mapOf("locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})", "switch" to "TV123"),
+                mapOf(
+                    "locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})",
+                    "switch" to "TV123",
+                ),
             ),
         )
     }
@@ -1103,7 +1107,7 @@ constructor(
             errorsWhenValidatingSwitchWithTracks(trackOn152Alignment, trackOn13Alignment),
             LayoutValidationIssue(
                 LayoutValidationIssueType.WARNING,
-                LocalizationKey("validation.layout.switch.track-linkage.front-joint-not-connected"),
+                LocalizationKey.of("validation.layout.switch.track-linkage.front-joint-not-connected"),
                 LocalizationParams(mapOf("switch" to "TV123")),
             ),
         )
@@ -1255,7 +1259,7 @@ constructor(
             errors,
             LayoutValidationIssue(
                 LayoutValidationIssueType.ERROR,
-                LocalizationKey("validation.layout.split.source-not-deleted"),
+                LocalizationKey.of("validation.layout.split.source-not-deleted"),
                 localizationParams("sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack).name),
             ),
         )
@@ -1278,7 +1282,7 @@ constructor(
             errors,
             LayoutValidationIssue(
                 LayoutValidationIssueType.ERROR,
-                LocalizationKey("validation.layout.split.source-and-target-track-numbers-are-different"),
+                LocalizationKey.of("validation.layout.split.source-and-target-track-numbers-are-different"),
                 localizationParams(
                     "targetName" to startTarget.name,
                     "sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack).name,
@@ -1416,7 +1420,7 @@ constructor(
         val errors = validateLocationTracks(sourceTrackResponse.id, startTargetTrackId, endTargetTrackId)
 
         assertTrue(
-            errors.any { it.localizationKey == LocalizationKey("validation.layout.split.geometry-changed") },
+            errors.any { it.localizationKey == LocalizationKey.of("validation.layout.split.geometry-changed") },
             errors.joinToString { ", " },
         )
     }
@@ -1461,7 +1465,7 @@ constructor(
         )
 
         val errors = validateLocationTracks(sourceTrackResponse.id, startTargetTrackId, endTargetTrackId)
-        assertTrue(errors.any { it.localizationKey == LocalizationKey("validation.layout.split.geometry-changed") })
+        assertTrue(errors.any { it.localizationKey == LocalizationKey.of("validation.layout.split.geometry-changed") })
     }
 
     @Test
@@ -1721,7 +1725,7 @@ constructor(
             listOf(
                 LayoutValidationIssue(
                     localizationKey =
-                        LocalizationKey("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
+                        LocalizationKey.of("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
                     type = LayoutValidationIssueType.WARNING,
                     params = LocalizationParams(mapOf("switch" to "some switch", "alignments" to "1-3")),
                 )
@@ -1732,7 +1736,9 @@ constructor(
             validateCancellation.validatedAsPublicationUnit.locationTracks.find { it.id == branchingTrack }!!.issues,
             LayoutValidationIssue(
                 localizationKey =
-                    LocalizationKey("validation.layout.location-track.switch-linkage.switch-alignment-not-connected"),
+                    LocalizationKey.of(
+                        "validation.layout.location-track.switch-linkage.switch-alignment-not-connected"
+                    ),
                 type = LayoutValidationIssueType.WARNING,
                 params = LocalizationParams(mapOf("switch" to "some switch", "alignments" to "1-3")),
             ),
@@ -1756,7 +1762,7 @@ constructor(
                 .validateSwitches(ValidateTransition(PublicationInMain), listOf(draftSwitch))[0]
                 .errors,
             LayoutValidationIssue(
-                localizationKey = LocalizationKey("validation.layout.switch.duplicate-oid"),
+                localizationKey = LocalizationKey.of("validation.layout.switch.duplicate-oid"),
                 type = LayoutValidationIssueType.ERROR,
                 params = LocalizationParams(mapOf()),
             ),
@@ -1929,7 +1935,7 @@ constructor(
         assertEquals(
             listOf(
                 LayoutValidationIssue(
-                    localizationKey = LocalizationKey("validation.layout.track-number.km-post.reference-deleted"),
+                    localizationKey = LocalizationKey.of("validation.layout.track-number.km-post.reference-deleted"),
                     type = LayoutValidationIssueType.ERROR,
                     params = LocalizationParams(mapOf("kmPosts" to "0001")),
                 )
@@ -1940,7 +1946,7 @@ constructor(
         assertEquals(
             listOf(
                 LayoutValidationIssue(
-                    localizationKey = LocalizationKey("validation.layout.track-number.km-post.reference-deleted"),
+                    localizationKey = LocalizationKey.of("validation.layout.track-number.km-post.reference-deleted"),
                     type = LayoutValidationIssueType.ERROR,
                     params = LocalizationParams(mapOf("kmPosts" to "0001")),
                 )
@@ -1950,7 +1956,7 @@ constructor(
         assertContains(
             validateBoth.validatedAsPublicationUnit.kmPosts[0].issues,
             LayoutValidationIssue(
-                localizationKey = LocalizationKey("validation.layout.km-post.track-number.cancelled"),
+                localizationKey = LocalizationKey.of("validation.layout.km-post.track-number.cancelled"),
                 type = LayoutValidationIssueType.ERROR,
                 params = LocalizationParams(mapOf("trackNumber" to trackNumberNumber.number.toString())),
             ),
@@ -1994,7 +2000,7 @@ constructor(
                 tn.issues,
                 LayoutValidationIssue(
                     type = LayoutValidationIssueType.FATAL,
-                    localizationKey = LocalizationKey("validation.layout.track-number.duplicate-name-official"),
+                    localizationKey = LocalizationKey.of("validation.layout.track-number.duplicate-name-official"),
                     params = LocalizationParams(mapOf("trackNumber" to tn.number.toString())),
                 ),
             )
@@ -2040,7 +2046,7 @@ constructor(
                 kmPost.issues,
                 LayoutValidationIssue(
                     type = LayoutValidationIssueType.FATAL,
-                    localizationKey = LocalizationKey("validation.layout.km-post.duplicate-name-official"),
+                    localizationKey = LocalizationKey.of("validation.layout.km-post.duplicate-name-official"),
                     params =
                         LocalizationParams(
                             mapOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -541,7 +541,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -563,7 +566,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -586,7 +592,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -607,7 +616,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -629,7 +641,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -651,7 +666,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -672,7 +690,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -695,7 +716,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -717,7 +741,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -739,7 +766,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -758,7 +788,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -779,7 +812,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -797,7 +833,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -815,7 +854,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -832,7 +874,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -855,7 +900,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1024,7 +1072,7 @@ class PublicationValidationTest {
 
     private fun assertContainsError(contains: Boolean, errors: List<LayoutValidationIssue>, error: String) {
         val message = "Expected to ${if (contains) "have" else "not have"} error: expected=$error actual=$errors"
-        assertEquals(contains, errors.any { e -> e.localizationKey == LocalizationKey(error) }, message)
+        assertEquals(contains, errors.any { e -> e.localizationKey == LocalizationKey.of(error) }, message)
     }
 
     private fun simpleGeocodingContext(referenceLinePoints: List<SegmentPoint>): GeocodingContext<ReferenceLineM> =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -70,7 +70,7 @@ fun switchStructureYV60_300_1_9(): SwitchStructure {
         version = RowVersion(IntId(55), 1),
         data =
             SwitchStructureData(
-                type = SwitchType("YV60-300-1:9-O"),
+                type = SwitchType.of("YV60-300-1:9-O"),
                 presentationJointNumber = JointNumber(1),
                 joints =
                     setOf(
@@ -107,7 +107,7 @@ fun switchStructureRR54_4x1_9() =
         version = RowVersion(IntId(133), 1),
         data =
             SwitchStructureData(
-                type = SwitchType("RR54-4x1:9"),
+                type = SwitchType.of("RR54-4x1:9"),
                 presentationJointNumber = JointNumber(5),
                 joints =
                     setOf(


### PR DESCRIPTION
Nippu optimointeja julkaisluokille ja ext-api:lle ja vähän muuallekin missä vain tehdään reverse geokoodausta, lokalisaatiota, ja historiallisen kaman käsittelyä. Yksittäin jokainen näistä on hyvinkin pieniä asioita, mutta kokonaisuutena niistä kertyi ihan kohtuullinen määrä. 

Testailin ennenkaikkea tietyllä pitkällä julkaisulokin välillä, jossa näiden kokonaisvaikutus oli hiukan yli puolet:
- Ensimmäinen haku (paljon asioita haettava cacheen): 7.5s -> 3.5s
- Myöhemmät identtiset haut (lähinnä asioiden uudelleenlaskentaa ja julkaisujen sisältöjen haut): 4s -> 1.5s
Tältä pohjalta voitaisiin harkita kasvattaa julkaisulokin maksimiväli 6kk -> 12kk. Yksi vuosi tuntuisi intuitiivisemmalta rajalta kuin puoli vuotta.

Muuttuneita tiedostoja on iso kasa johtuen tiettyjen yleisten funkkareiden käyttötavan muutoksesta, mutta ne on nopea plarata läpi koska identtisiä. Pointtaan ne oleelliset paikat kommenteilla.