### PR TITLE
GVT-3237: Tietotuotteiden haku ei löydä aiemmin valittuna olevaa raidetta++

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1831,7 +1831,7 @@
         "designs-latest": "Viimeisimmät suunnitelmajulkaisut",
         "designs-no-publications": "Ei suunnitelmajulkaisuja.",
         "missing-design-name": "???",
-        "log-link": "Hae julkaisuja",
+        "log-link": "Avaa julkaisuloki",
         "no-publications": "Ei julkaisuja.",
         "show-more": "Näytä lisää",
         "publication-status": "Raiteiden ja vaihteiden vienti",

--- a/ui/src/data-products/data-products-utils.ts
+++ b/ui/src/data-products/data-products-utils.ts
@@ -45,17 +45,12 @@ export const debouncedGetGeometryPlanHeaders = debounceAsync(searchGeometryPlanH
 
 export const debouncedSearchTracks = debounceAsync(getLocationTracksBySearchTerm, 250);
 
-export const getLocationTrackOptions = (
-    tracks: LayoutLocationTrack[],
-    selectedTrack: LayoutLocationTrack | undefined,
-) =>
-    tracks
-        .filter((lt) => !selectedTrack || lt.id !== selectedTrack.id)
-        .map((lt) => ({
-            name: `${lt.name}, ${lt.description}`,
-            value: lt,
-            qaId: `location-track-${lt.id}`,
-        }));
+export const getLocationTrackOptions = (tracks: LayoutLocationTrack[]) =>
+    tracks.map((lt) => ({
+        name: `${lt.name}, ${lt.description}`,
+        value: lt,
+        qaId: `location-track-${lt.id}`,
+    }));
 
 export type ElementHeading = {
     name: string;

--- a/ui/src/data-products/element-list/location-track-element-listing-search.tsx
+++ b/ui/src/data-products/element-list/location-track-element-listing-search.tsx
@@ -48,8 +48,7 @@ const LocationTrackElementListingSearch = ({
     const getLocationTracks = React.useCallback(
         (searchTerm: string) =>
             debouncedSearchTracks(searchTerm, officialMainLayoutContext(), 10).then(
-                (locationTracks) =>
-                    getLocationTrackOptions(locationTracks, state.searchParameters.locationTrack),
+                (locationTracks) => getLocationTrackOptions(locationTracks),
             ),
         [state.searchParameters.locationTrack],
     );

--- a/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
+++ b/ui/src/data-products/vertical-geometry/location-track-vertical-geometry-search.tsx
@@ -45,8 +45,7 @@ export const LocationTrackVerticalGeometrySearch: React.FC<
     const getLocationTracks = React.useCallback(
         (searchTerm: string) =>
             debouncedSearchTracks(searchTerm, officialMainLayoutContext(), 10).then(
-                (locationTracks) =>
-                    getLocationTrackOptions(locationTracks, state.searchParameters.locationTrack),
+                (locationTracks) => getLocationTrackOptions(locationTracks),
             ),
         [state.searchParameters.locationTrack],
     );


### PR DESCRIPTION
Syystä tai toisesta kyseessä oli toiminnallisuus joka oli ihan koodattuna hakuun, ei mikään bugi 🤷 Syytä tuolle en tiedä, mutta nyt se on yhtenäistetty muiden Geoviitteen hakujen kanssa samanlaiseksi.

Samalla muutettu etusivun julkaisulokilinkki muotoon "Avaa julkaisuloki"