### PR TITLE
GVT-3087 Introduce interpolateAngleRads

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/AngleTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/AngleTest.kt
@@ -97,12 +97,21 @@ class AngleTest {
         assertEquals(0.1, angleAvgRads(0.0, 0.2), DOUBLE_CALC_DELTA)
         assertEquals(-0.2, angleAvgRads(-0.1, -0.3), DOUBLE_CALC_DELTA)
         assertEquals(0.0, angleAvgRads(0.4 * PI, -0.4 * PI), DOUBLE_CALC_DELTA)
-        assertEquals(PI, angleAvgRads(0.6 * PI, -0.6 * PI), DOUBLE_CALC_DELTA)
-        assertEquals(PI, angleAvgRads(0.9 * PI, -0.9 * PI), DOUBLE_CALC_DELTA)
-        assertEquals(PI, angleAvgRads(PI, -PI), DOUBLE_CALC_DELTA)
+        assertEquals(-PI, angleAvgRads(0.6 * PI, -0.6 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(-PI, angleAvgRads(0.9 * PI, -0.9 * PI), DOUBLE_CALC_DELTA)
+        assertEquals(-PI, angleAvgRads(PI, -PI), DOUBLE_CALC_DELTA)
         assertEquals(0.8 * PI, angleAvgRads(0.9 * PI, 0.7 * PI), DOUBLE_CALC_DELTA)
         assertEquals(0.9 * PI, angleAvgRads(0.7 * PI, -0.9 * PI), DOUBLE_CALC_DELTA)
         assertEquals(-0.9 * PI, angleAvgRads(0.9 * PI, -0.7 * PI), DOUBLE_CALC_DELTA)
+    }
+
+    @Test
+    fun `interpolateAngleRads works`() {
+        assertEquals(0.05, interpolateAngleRads(0.1, -0.1, 0.25), DOUBLE_CALC_DELTA)
+        assertEquals(-0.05, interpolateAngleRads(0.1, -0.1, 0.75), DOUBLE_CALC_DELTA)
+        assertEquals(PI - 0.05, interpolateAngleRads(PI - 0.1, -PI + 0.1, 0.25), DOUBLE_CALC_DELTA)
+        assertEquals(-PI + 0.05, interpolateAngleRads(PI - 0.1, -PI + 0.1, 0.75), DOUBLE_CALC_DELTA)
+        assertEquals(-PI, interpolateAngleRads(PI - 0.1, -PI + 0.3, 0.25))
     }
 
     @Test


### PR DESCRIPTION
interpolateAngleRads on uuden geokoodauksen kanssa tarvittava funktio. Ajattelin tuoda tämän jo mainiin, vaikka muuten uusi geokoodaus tulee vasta myöhemmin (ehkä paljon myöhemmin), koska tämä yhtenäistää Angle.kt:n funktioita:

- Kun interpolateAngleRads on olemassa, angleAvgRads on selvästikin sen erikoistapaus, ja varmaan ihan perffisyistäkin jees toteuttaa niin (entistoteutuksessa on monta trigonometriafunktiokutsua)
- ... mutta jotta angleAvgRads()ista tulisi yhä tasan oikea tulos, piti korjata normalizeDirectionRads toimimaan tarkemmin juuri speksinsä mukaan
- Ja tämä "tasan" oikea tulos on nyt yhdenmukaisesti niin, että myös angleAvgRads palauttaa tulokset aina juuri jaksolla [-PI,PI).