### PR TITLE
GVT-3206 Ei lähetetä vaihdepisteitä poistetuille raiteille Ratko-integraatiossa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -2009,7 +2009,8 @@ class PublicationDao(
                   location_track_id,
                   location_track_external_id, 
                   track_number_id,
-                  track_number_external_id)
+                  track_number_external_id,
+                  location_track_deleted)
                 values (
                   :publication_id,
                   :switch_id,
@@ -2020,7 +2021,8 @@ class PublicationDao(
                   :location_track_id,
                   :location_track_external_id,
                   :track_number_id,
-                  :track_number_external_id
+                  :track_number_external_id,
+                  :location_track_deleted
                 )
             """
                 .trimIndent(),
@@ -2039,6 +2041,7 @@ class PublicationDao(
                             "location_track_external_id" to cj.locationTrackExternalId,
                             "track_number_id" to cj.trackNumberId.intValue,
                             "track_number_external_id" to cj.trackNumberExternalId,
+                            "location_track_deleted" to cj.locationTrackDeleted,
                         )
                     }
                 }
@@ -2252,7 +2255,8 @@ class PublicationDao(
                   location_track_id,
                   location_track_external_id,
                   track_number_id,
-                  track_number_external_id
+                  track_number_external_id,
+                  location_track_deleted
                 from publication.switch_joint
                 where publication_id = any(array[:publication_ids]::int[])
             """
@@ -2270,6 +2274,7 @@ class PublicationDao(
                         locationTrackExternalId = rs.getOidOrNull("location_track_external_id"),
                         trackNumberId = rs.getIntId("track_number_id"),
                         trackNumberExternalId = rs.getOidOrNull("track_number_external_id"),
+                        locationTrackDeleted = rs.getBoolean("location_track_deleted"),
                     )
             }
             .groupBy({ it.first.first }, { it.first.second to it.second })

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
@@ -27,9 +27,9 @@ import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)
@@ -301,10 +301,13 @@ constructor(
         jointChanges: List<SwitchJointChange>,
         switchStructure: SwitchStructure,
     ): List<RatkoAssetLocation> {
-        val changedJointsOnly = jointChanges.filterNot { it.isRemoved }
+        val changedJointsOnExistingTracksOnly = jointChanges.filterNot { it.isRemoved || it.locationTrackDeleted }
 
         val assetLocations =
-            convertToRatkoAssetLocations(jointChanges = changedJointsOnly, switchType = switchStructure.baseType)
+            convertToRatkoAssetLocations(
+                    jointChanges = changedJointsOnExistingTracksOnly,
+                    switchType = switchStructure.baseType,
+                )
                 .sortedBy(::sortJointAToTop)
                 .mapIndexed { index, ratkoAssetLocation -> ratkoAssetLocation.copy(priority = index + 1) }
         return assetLocations

--- a/infra/src/main/resources/db/migration/prod/V126__add_location_track_deleted_to_publication_switch_joint.sql
+++ b/infra/src/main/resources/db/migration/prod/V126__add_location_track_deleted_to_publication_switch_joint.sql
@@ -1,0 +1,4 @@
+alter table publication.switch_joint
+  add column location_track_deleted boolean not null default false;
+alter table publication.switch_joint
+  alter column location_track_deleted drop default;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -1124,6 +1124,7 @@ constructor(
                 Oid("1.2.3.4.5"),
                 trackNumber,
                 Oid("3.4.5.6.7"),
+                locationTrackDeleted = false,
             )
         assertEquals(listOf(SwitchChange(switch, listOf(expectedSwitchJointChange))), changes.switchChanges)
     }
@@ -1186,6 +1187,7 @@ constructor(
                 Oid("1.2.3.4.5"),
                 trackNumber,
                 Oid("3.4.5.6.7"),
+                locationTrackDeleted = false,
             )
         assertEquals(listOf(SwitchChange(switch, listOf(expectedSwitchJointChange))), changes.switchChanges)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -213,6 +213,7 @@ constructor(
                 Oid("123.456.789"),
                 trackNumberVersion.id,
                 Oid("1.234.567"),
+                locationTrackDeleted = false,
             )
 
         val changes =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -265,8 +265,9 @@ class FakeRatko(port: Int) {
             .forEach { km -> delete("/api/infra/v1.0/points/${locationTrackAsset.id}/${km}").respond(ok()) }
     }
 
-    fun hasSwitch(switchAsset: InterfaceRatkoSwitch) {
-        get("/api/assets/v1.2/${switchAsset.id}").respond(okJson(switchAsset))
+    fun hasSwitch(switchAsset: InterfaceRatkoSwitch, locations: List<RatkoAssetLocation>? = null) {
+        val pushedSwitch = if (locations == null) switchAsset else switchAsset.copy(locations = locations)
+        get("/api/assets/v1.2/${switchAsset.id}").respond(okJson(pushedSwitch))
         put("/api/assets/v1.2/${switchAsset.id}/properties").respond(ok())
         put("/api/assets/v1.2/${switchAsset.id}/locations").respond(ok())
         put("/api/assets/v1.2/${switchAsset.id}/geoms").respond(ok())
@@ -392,7 +393,8 @@ class FakeRatko(port: Int) {
             .lastOrNull()
             ?.bodyAsString
 
-    fun hostPushedSwitch(oid: String) = hasSwitch(getLastPushedSwitch(oid)!!)
+    fun hostPushedSwitch(oid: String) =
+        hasSwitch(getLastPushedSwitch(oid)!!, getPushedSwitchLocations(oid).lastOrNull())
 
     fun getLastPushedSwitch(oid: String): InterfaceRatkoSwitch? = lastPushedSwitchBody(oid)?.let(jsonMapper::readValue)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoConversionTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoConversionTest.kt
@@ -57,6 +57,7 @@ class RatkoConversionTest {
                     point = Point(0.0, 2.0),
                     trackNumberExternalId = Oid("00.00000.0000"),
                     trackNumberId = IntId(0),
+                    locationTrackDeleted = false,
                 ),
                 SwitchJointChange(
                     number = JointNumber(5),
@@ -67,6 +68,7 @@ class RatkoConversionTest {
                     point = Point(0.0, 1.0),
                     trackNumberExternalId = Oid("00.00000.0000"),
                     trackNumberId = IntId(0),
+                    locationTrackDeleted = false,
                 ),
                 SwitchJointChange(
                     number = JointNumber(2),
@@ -77,6 +79,7 @@ class RatkoConversionTest {
                     point = Point(0.0, 0.0),
                     trackNumberExternalId = Oid("00.00000.0000"),
                     trackNumberId = IntId(0),
+                    locationTrackDeleted = false,
                 ),
                 SwitchJointChange(
                     number = JointNumber(5),
@@ -87,6 +90,7 @@ class RatkoConversionTest {
                     point = Point(0.0, 1.0),
                     trackNumberExternalId = Oid("00.00000.0000"),
                     trackNumberId = IntId(0),
+                    locationTrackDeleted = false,
                 ),
             )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -824,13 +824,14 @@ constructor(
         val updatePush = switchLocations.last().let(::sortRatkoSwitchLocationsByTrack)
 
         // switch was originally after kmPost2, but it got removed and then we pushed again. kmPost2 was at m=4, while
-        // throughTrack's non-math joints are at 0 and 9.5, branchingTrack's at 0 and 7.5.
+        // throughTrack's non-math joints are at 0 and 9.5, branchingTrack's at 0 and 7.5. Existing unchanged locations
+        // at 0 get re-pushed.
         assertEquals(
             listOf(listOf("0000+0000", "0002+0005.5"), listOf("0000+0000", "0002+0003.5")),
             createPush.map { track -> track.nodecollection.nodes.map { joint -> joint.point.kmM.toString() } },
         )
         assertEquals(
-            listOf(listOf("0001+0007.5"), listOf("0001+0005.5")),
+            listOf(listOf("0000+0000"), listOf("0001+0007.5"), listOf("0000+0000"), listOf("0001+0005.5")),
             updatePush.map { track -> track.nodecollection.nodes.map { joint -> joint.point.kmM.toString() } },
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.MainLayoutContext.Companion.draft
 import fi.fta.geoviite.infra.common.MeasurementMethod
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
@@ -863,13 +864,7 @@ constructor(
             kmPosts = listOf(kmPost1.id, kmPost2.id),
         )
         listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
-        val officialThroughTrackVersion =
-            locationTrackDao.fetchVersionOrThrow(MainLayoutContext.official, throughTrack.id)
-        locationTrackService.saveDraft(
-            LayoutBranch.main,
-            locationTrackDao.fetch(officialThroughTrackVersion).copy(state = LocationTrackState.DELETED),
-            alignmentDao.fetch(officialThroughTrackVersion),
-        )
+        locationTrackService.updateState(LayoutBranch.main, throughTrack.id, LocationTrackState.DELETED)
         publishAndPush(locationTracks = listOf(throughTrack.id))
         val pushedSwitchLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7")
 
@@ -880,11 +875,7 @@ constructor(
             createPush.map { track -> track.nodecollection.nodes.map { node -> node.nodeType.name } },
         )
         val updatePush = pushedSwitchLocations.last()
-        assertEquals(1, updatePush.size)
-        assertEquals(
-            listOf("JOINT_A", "JOINT_B"),
-            updatePush[0].nodecollection.nodes.map { node -> node.nodeType.name },
-        )
+        assertEquals(0, updatePush.size)
     }
 
     @Test
@@ -2145,6 +2136,93 @@ constructor(
 
         ratkoService.pushChangesToRatko(LayoutBranch.main)
         assertEquals(splitService.get(split.id)?.bulkTransferState, BulkTransferState.DONE)
+    }
+
+    @Test
+    fun `switch creation doesn't send locations on removed location tracks`() {
+        val trackNumber = establishedTrackNumber()
+
+        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+
+        listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
+        fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
+        locationTrackService.updateState(LayoutBranch.main, throughTrack.id, LocationTrackState.DELETED)
+        publishAndPush(locationTracks = listOf(throughTrack.id, branchingTrack.id), switches = listOf(switch.id))
+        val lastPushLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7").last()
+        assertEquals(
+            listOf("2.3.4.5.6", "2.3.4.5.6"),
+            lastPushLocations.flatMap { location ->
+                location.nodecollection.nodes.map { node -> node.point.locationtrack!!.toString() }
+            },
+        )
+    }
+
+    @Test
+    fun `switch update doesn't send locations on removed location tracks`() {
+        val trackNumber = establishedTrackNumber()
+
+        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+
+        listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
+        fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
+
+        publishAndPush(locationTracks = listOf(throughTrack.id, branchingTrack.id), switches = listOf(switch.id))
+        fakeRatko.hostPushedSwitch("3.4.5.6.7")
+        listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
+
+        locationTrackService.updateState(LayoutBranch.main, throughTrack.id, LocationTrackState.DELETED)
+        switchService.saveDraft(LayoutBranch.main, switchService.getOrThrow(mainOfficialContext.context, switch.id))
+        publishAndPush(locationTracks = listOf(throughTrack.id), switches = listOf(switch.id))
+
+        val lastPushLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7").last()
+        assertEquals(
+            listOf("2.3.4.5.6", "2.3.4.5.6"),
+            lastPushLocations.flatMap { location ->
+                location.nodecollection.nodes.map { node -> node.point.locationtrack!!.toString() }
+            },
+        )
+    }
+
+    @Test
+    fun `switch update doesn't send locations on removed location tracks, even if joint was changed`() {
+        val trackNumber = establishedTrackNumber()
+
+        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+
+        listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::acceptsNewLocationTrackGivingItOid)
+        fakeRatko.acceptsNewSwitchGivingItOid("3.4.5.6.7")
+
+        publishAndPush(locationTracks = listOf(throughTrack.id, branchingTrack.id), switches = listOf(switch.id))
+        fakeRatko.hostPushedSwitch("3.4.5.6.7")
+        listOf("1.2.3.4.5", "2.3.4.5.6").forEach(fakeRatko::hostPushedLocationTrack)
+
+        // link point for switch on through track gets moved 0.1 m east (to x=5.1)
+        locationTrackService.saveDraft(
+            LayoutBranch.main,
+            locationTrackService.getOrThrow(mainOfficialContext.context, throughTrack.id),
+            trackGeometry(
+                edge(
+                    startInnerSwitch = switchLinkYV(switch.id, 1),
+                    endInnerSwitch = switchLinkYV(switch.id, 5),
+                    segments = listOf(segment(Point(0.0, 0.0), Point(5.1, 0.0))),
+                ),
+                edge(
+                    startInnerSwitch = switchLinkYV(switch.id, 5),
+                    endInnerSwitch = switchLinkYV(switch.id, 2),
+                    segments = listOf(segment(Point(5.1, 0.0), Point(9.5, 0.0))),
+                ),
+            ),
+        )
+        locationTrackService.updateState(LayoutBranch.main, throughTrack.id, LocationTrackState.DELETED)
+        switchService.saveDraft(LayoutBranch.main, switchService.getOrThrow(mainOfficialContext.context, switch.id))
+        publishAndPush(locationTracks = listOf(throughTrack.id), switches = listOf(switch.id))
+        val lastPushLocations = fakeRatko.getPushedSwitchLocations("3.4.5.6.7").last()
+        assertEquals(
+            listOf("2.3.4.5.6", "2.3.4.5.6"),
+            lastPushLocations.flatMap { location ->
+                location.nodecollection.nodes.map { node -> node.point.locationtrack!!.toString() }
+            },
+        )
     }
 
     private fun insertReferenceLineFor(


### PR DESCRIPTION
Tein pullarin GVT-3067:n päälle, koska molemmat koskee Ratko-integraatioon ja sen testeihin sen verran, että näytti siltä, että tällä pääsee vähemmillä merge-hähmillä.

Tässä tehdyt Ratko-oletukset:

- `assets/v1.2/{id}/locations`iin pusketut sijainnit yhdistyvät Ratkossa myöhemmin palautettavaan asset-olioon. FakeRatko ei tätä aiemmin tehnyt, mutta meidän toteutus näytti olettavan toimivan niin, joten päivitin FakeRatkon toimimaan samoin
- sijaintilistan rakenteessa ei ole oleellista, tuleeko se useampana RatkoAssetLocationina vai yksittäisinä RatkoAssetLocationeina, joissa useampi RatkoNode (integraatio toimii näin jo nykyään, mutta nyt tämä näkyy testeissä paremmin)
- vaihteille ei haluta jättää sijainteja roikkumaan millään tavalla, vaan niille pusketaan tyhjiä sijaintilistoja surutta

Varsinainen tieto siitä, että vaihteen julkaisuhetkellä raide oli poistettu-tilassa, näytti luonteeltaan sellaiselta että hyvähän sen on olla laskettu julkaisun yhteydessä ja sitten suoraan käsillä Ratko-integraatiossa => tallennetaan siis kantaan.