### PR TITLE
GVT-3259 Allow not finding a reference line in deleteDraftByTrackNumberId

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -127,11 +127,8 @@ class ReferenceLineService(
         branch: LayoutBranch,
         trackNumberId: IntId<LayoutTrackNumber>,
     ): LayoutRowVersion<ReferenceLine>? {
-        val referenceLine =
-            requireNotNull(referenceLineDao.getByTrackNumber(branch.draft, trackNumberId)) {
-                "Found Track Number without Reference Line $trackNumberId"
-            }
-        return if (referenceLine.isDraft) deleteDraft(branch, referenceLine.id as IntId) else null
+        val referenceLine = referenceLineDao.getByTrackNumber(branch.draft, trackNumberId)
+        return if (referenceLine?.isDraft == true) deleteDraft(branch, referenceLine.id as IntId) else null
     }
 
     fun getByTrackNumber(layoutContext: LayoutContext, trackNumberId: IntId<LayoutTrackNumber>): ReferenceLine? {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1841,6 +1841,20 @@ constructor(
         assertPublicationResults(designCreatedResult, designUpdatedResult)
     }
 
+    @Test
+    fun `revert drafted creation of track number and reference line`() {
+        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val referenceLineId =
+            mainDraftContext.save(referenceLine(trackNumberId), alignment(segment(Point(0.0, 0.0), Point(1.0, 0.0)))).id
+        publicationService.revertPublicationCandidates(
+            LayoutBranch.main,
+            publicationRequestIds(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId)),
+        )
+        // the test setup clears the layout tables, so these should just be empty now
+        assertEquals(0, trackNumberDao.list(mainDraftContext.context, false).size)
+        assertEquals(0, referenceLineDao.list(mainDraftContext.context, false).size)
+    }
+
     private fun touchAsDraftAndPublish(
         branch: LayoutBranch,
         trackNumbers: List<IntId<LayoutTrackNumber>> = listOf(),


### PR DESCRIPTION
Funktio salli jo aiemmin sellaisen tapauksen, että pituusmittauslinja löytyy mutta vain virallisesta paikannuspohjasta, joten ajattelin kohtuulliseksi synniksi sallia myös sen, että sitä ei löydy lainkaan: Tällä tavalla pysytään siinä, että ratanumeroilla on vain yksi draftinpoisto-operaatio, ja sillä päästään hyvään tilaan. Ongelma siis oli, että revertPublicationCandidates kaatuu siitä, että se kerkiää ensiksi poistaa pituusmittauslinjan, ja sitten ratanumeroa poistaessaan luulee pystyvänsä poistamaan sen jälleen.