### PR TITLE
GVT-3256: Add external track number APIs

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -27,10 +27,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 
-const val EXT_TRACK_LAYOUT_BASE_PATH = "/geoviite"
-
-const val EXT_LOCATION_TRACK_TAG_V1 = "Sijaintiraide"
-const val EXT_LOCATION_TRACK_COLLECTION_TAG_V1 = "Sijaintiraidekokoelma"
+private const val EXT_LOCATION_TRACK_TAG_V1 = "Sijaintiraide"
+private const val EXT_LOCATION_TRACK_COLLECTION_TAG_V1 = "Sijaintiraidekokoelma"
 
 @PreAuthorize(AUTH_API_GEOMETRY)
 @GeoviiteExtApiController(

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -137,7 +137,7 @@ class ExtLocationTrackControllerV1(
                 trackLayoutVersion = trackLayoutVersion,
                 coordinateSystem = coordinateSystem ?: LAYOUT_SRID,
             )
-            ?.let { modifiedResponse -> ResponseEntity.ok(modifiedResponse) } ?: ResponseEntity.noContent().build()
+            .let(::toResponse)
     }
 
     @GetMapping("/sijaintiraiteet/{$LOCATION_TRACK_OID_PARAM}")

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
@@ -7,10 +7,8 @@ import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
-import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.Uuid
 import fi.fta.geoviite.infra.error.TrackLayoutVersionNotFound
-import fi.fta.geoviite.infra.geocoding.AlignmentEndPoint
 import fi.fta.geoviite.infra.geocoding.GeocodingDao
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
@@ -38,21 +36,6 @@ data class ExtLocationTrackModifiedGeometryResponseV1(
     @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
     @JsonProperty(LOCATION_TRACK_OID_PARAM) val locationTrackOid: Oid<LocationTrack>,
     @JsonProperty("osoitevalit") val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
-)
-
-@Schema(name = "Osoitepiste")
-data class ExtAddressPointV1(val x: Double, val y: Double, @JsonProperty("rataosoite") val trackAddress: String?) {
-
-    constructor(x: Double, y: Double, address: TrackMeter?) : this(x, y, address?.formatFixedDecimals(3))
-
-    constructor(point: AlignmentEndPoint) : this(point.point.x, point.point.y, point.address)
-}
-
-@Schema(name = "Osoiteväli")
-data class ExtCenterLineTrackIntervalV1(
-    @JsonProperty("alku") val startAddress: String,
-    @JsonProperty("loppu") val endAddress: String,
-    @JsonProperty("pisteet") val addressPoints: List<ExtAddressPointV1>,
 )
 
 data class ExtTrackKilometerIntervalV1(val start: KmNumber?, val inclusiveEnd: KmNumber?) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -10,6 +10,7 @@ const val LOCATION_TRACK_COLLECTION = "sijaintiraiteet"
 const val TRACK_KILOMETER_START_PARAM = "ratakilometri_alku"
 const val TRACK_KILOMETER_END_PARAM = "ratakilometri_loppu"
 const val TRACK_NUMBER_PARAM = "ratanumero"
+const val TRACK_NUMBER_OID_PARAM = "ratanumero_oid"
 const val TRACK_NUMBER_COLLECTION = "ratanumerot"
 const val COORDINATE_SYSTEM_PARAM = "koordinaatisto"
 const val ADDRESS_POINT_RESOLUTION = "osoitepistevali"
@@ -25,6 +26,7 @@ const val EXT_OPENAPI_TRACK_LAYOUT_VERSION_TO =
 const val EXT_OPENAPI_NO_MODIFICATIONS_BETWEEN_VERSIONS =
     "Muutoksia vertailtavien rataverkon versioiden välillä ei ole."
 const val EXT_OPENAPI_LOCATION_TRACK_OID_DESCRIPTION = "Sijaintiraiteen OID-tunnus."
+const val EXT_OPENAPI_TRACK_NUMBER_OID_DESCRIPTION = "Ratanumeron OID-tunnus."
 const val EXT_OPENAPI_COORDINATE_SYSTEM =
     "Hyödynnettävän koordinaattijärjestelmän EPSG-tunnus. Oletuksena käytetään paikannuspohjan koordinaatistoa EPSG:3067 (ETRS-TM35FIN)."
 const val EXT_OPENAPI_RESOLUTION =

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -1,5 +1,7 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
+const val EXT_TRACK_LAYOUT_BASE_PATH = "/geoviite"
+
 const val MODIFICATIONS_FROM_VERSION = "muutokset_versiosta"
 const val TRACK_LAYOUT_VERSION = "rataverkon_versio"
 const val LOCATION_TRACK_OID_PARAM = "sijaintiraide_oid"
@@ -7,6 +9,8 @@ const val LOCATION_TRACK_PARAM = "sijaintiraide"
 const val LOCATION_TRACK_COLLECTION = "sijaintiraiteet"
 const val TRACK_KILOMETER_START_PARAM = "ratakilometri_alku"
 const val TRACK_KILOMETER_END_PARAM = "ratakilometri_loppu"
+const val TRACK_NUMBER_PARAM = "ratanumero"
+const val TRACK_NUMBER_COLLECTION = "ratanumerot"
 const val COORDINATE_SYSTEM_PARAM = "koordinaatisto"
 const val ADDRESS_POINT_RESOLUTION = "osoitepistevali"
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutRequestDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutRequestDataV1.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
 import com.fasterxml.jackson.annotation.JsonValue
+import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.geocoding.Resolution
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -26,5 +27,14 @@ enum class ExtResolutionV1(@JsonValue val value: String) {
             QUARTER_METER -> Resolution.QUARTER_METER
             ONE_METER -> Resolution.ONE_METER
         }
+    }
+}
+
+data class ExtTrackKilometerIntervalV1(val start: KmNumber?, val inclusiveEnd: KmNumber?) {
+    fun containsKmEndInclusive(kmNumber: KmNumber): Boolean {
+        val startsAfterStartKmFilter = start == null || kmNumber >= start
+        val endsBeforeEndKmFilter = inclusiveEnd == null || kmNumber <= inclusiveEnd
+
+        return startsAfterStartKmFilter && endsBeforeEndKmFilter
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
 import com.fasterxml.jackson.annotation.JsonValue
+import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import io.swagger.v3.oas.annotations.media.Schema
@@ -42,6 +43,25 @@ enum class ExtLocationTrackStateV1(val value: String) {
                 LocationTrackState.IN_USE -> IN_USE
                 LocationTrackState.NOT_IN_USE -> NOT_IN_USE
                 LocationTrackState.DELETED -> DELETED
+            }
+        }
+    }
+}
+
+@Schema(name = "Ratanumeron tila", type = "string")
+enum class ExtTrackNumberStateV1(val value: String) {
+    IN_USE("käytössä"),
+    NOT_IN_USE("käytöstä poistettu"),
+    DELETED("poistettu");
+
+    @JsonValue override fun toString() = value
+
+    companion object {
+        fun of(trackNumberState: LayoutState): ExtTrackNumberStateV1 {
+            return when (trackNumberState) {
+                LayoutState.IN_USE -> IN_USE
+                LayoutState.NOT_IN_USE -> NOT_IN_USE
+                LayoutState.DELETED -> DELETED
             }
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -1,6 +1,9 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.geocoding.AlignmentEndPoint
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
@@ -66,3 +69,18 @@ enum class ExtTrackNumberStateV1(val value: String) {
         }
     }
 }
+
+@Schema(name = "Osoitepiste")
+data class ExtAddressPointV1(val x: Double, val y: Double, @JsonProperty("rataosoite") val trackAddress: String?) {
+
+    constructor(x: Double, y: Double, address: TrackMeter?) : this(x, y, address?.formatFixedDecimals(3))
+
+    constructor(point: AlignmentEndPoint) : this(point.point.x, point.point.y, point.address)
+}
+
+@Schema(name = "Osoiteväli")
+data class ExtCenterLineTrackIntervalV1(
+    @JsonProperty("alku") val startAddress: String,
+    @JsonProperty("loppu") val endAddress: String,
+    @JsonProperty("pisteet") val addressPoints: List<ExtAddressPointV1>,
+)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionServiceV1.kt
@@ -1,0 +1,185 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+import ExtTrackNumberV1
+import com.fasterxml.jackson.annotation.JsonProperty
+import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.MainLayoutContext
+import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.common.Uuid
+import fi.fta.geoviite.infra.error.TrackLayoutVersionNotFound
+import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.publication.PublicationDao
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
+import io.swagger.v3.oas.annotations.media.Schema
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
+
+@Schema(name = "Vastaus: Ratanumerokokoelma")
+data class ExtTrackNumberCollectionResponseV1(
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
+    @JsonProperty(COORDINATE_SYSTEM_PARAM) val coordinateSystem: Srid,
+    @JsonProperty(TRACK_NUMBER_COLLECTION) val trackNumberCollection: List<ExtTrackNumberV1>,
+)
+
+@Schema(name = "Vastaus: Muutettu sijaintiraidekokoelma")
+data class ExtModifiedTrackNumberCollectionResponseV1(
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
+    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(COORDINATE_SYSTEM_PARAM) val coordinateSystem: Srid,
+    @JsonProperty(TRACK_NUMBER_COLLECTION) val trackNumberCollection: List<ExtTrackNumberV1>,
+)
+
+@GeoviiteService
+class ExtTrackNumberCollectionServiceV1
+@Autowired
+constructor(
+    private val layoutTrackNumberDao: LayoutTrackNumberDao,
+    private val publicationDao: PublicationDao,
+    private val publicationService: PublicationService,
+    private val referenceLineService: ReferenceLineService,
+) {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    fun createTrackNumberCollectionResponse(
+        trackLayoutVersion: Uuid<Publication>?,
+        coordinateSystem: Srid,
+    ): ExtTrackNumberCollectionResponseV1 {
+        val layoutContext = MainLayoutContext.official
+
+        val (publication, locationTracks) =
+            when (trackLayoutVersion) {
+                null -> {
+                    publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single().let {
+                        newestPublication ->
+                        newestPublication to layoutTrackNumberDao.list(layoutContext, includeDeleted = false)
+                    }
+                }
+                else -> {
+                    trackLayoutVersion
+                        .let { uuid -> publicationDao.fetchPublicationByUuid(uuid) }
+                        ?.let { specifiedPublication ->
+                            specifiedPublication to
+                                layoutTrackNumberDao.listPublishedLayoutTrackNumbersAtMoment(
+                                    specifiedPublication.publicationTime
+                                )
+                        } ?: throw TrackLayoutVersionNotFound("trackLayoutVersion=${trackLayoutVersion}")
+                }
+            }
+
+        return ExtTrackNumberCollectionResponseV1(
+            trackLayoutVersion = publication.uuid,
+            coordinateSystem = coordinateSystem,
+            trackNumberCollection =
+                extGetTrackNumberCollection(
+                    layoutContext,
+                    locationTracks,
+                    coordinateSystem,
+                    publication.publicationTime,
+                ),
+        )
+    }
+
+    fun createTrackNumberCollectionModificationResponse(
+        modificationsFromVersion: Uuid<Publication>,
+        trackLayoutVersion: Uuid<Publication>?,
+        coordinateSystem: Srid,
+    ): ExtModifiedTrackNumberCollectionResponseV1? {
+        val layoutContext = MainLayoutContext.official
+
+        val (fromPublication, toPublication) =
+            publicationService.getPublicationsToCompare(modificationsFromVersion, trackLayoutVersion)
+
+        return if (fromPublication == toPublication) {
+            logger.info(
+                "there cannot be any differences if the requested publication ids are the same, publicationId=${fromPublication.id}"
+            )
+            null
+        } else {
+            val changedIds =
+                publicationDao.fetchPublishedTrackNumbersAfterMoment(
+                    fromPublication.publicationTime,
+                    toPublication.publicationTime,
+                )
+
+            val modifiedTrackNumbers =
+                layoutTrackNumberDao.getManyOfficialAtMoment(
+                    layoutContext.branch,
+                    changedIds,
+                    toPublication.publicationTime,
+                )
+
+            if (modifiedTrackNumbers.isEmpty()) {
+                logger.info(
+                    "There were no modified track numbers between publications ${fromPublication.id} -> ${toPublication.id}"
+                )
+                null
+            } else {
+                ExtModifiedTrackNumberCollectionResponseV1(
+                    modificationsFromVersion = modificationsFromVersion,
+                    trackLayoutVersion = toPublication.uuid,
+                    coordinateSystem = coordinateSystem,
+                    trackNumberCollection =
+                        extGetTrackNumberCollection(
+                            layoutContext,
+                            modifiedTrackNumbers,
+                            coordinateSystem,
+                            toPublication.publicationTime,
+                        ),
+                )
+            }
+        }
+    }
+
+    fun extGetTrackNumberCollection(
+        layoutContext: LayoutContext,
+        trackNumbers: List<LayoutTrackNumber>,
+        coordinateSystem: Srid,
+        moment: Instant,
+    ): List<ExtTrackNumberV1> {
+        val trackNumberIds = trackNumbers.map { trackNumber -> trackNumber.id as IntId }
+
+        val referenceLineStartsAndEnds =
+            referenceLineService
+                .getStartAndEndAtMoment(
+                    layoutContext,
+                    trackNumbers.mapNotNull { trackNumber -> trackNumber.referenceLineId },
+                    moment,
+                )
+                .associateBy { it.id }
+
+        val externalTrackNumberIds = layoutTrackNumberDao.fetchExternalIds(layoutContext.branch, trackNumberIds)
+
+        return trackNumbers.map { trackNumber ->
+            val (startLocation, endLocation) =
+                referenceLineStartsAndEnds[trackNumber.referenceLineId]?.let { startAndEnd ->
+                    layoutAlignmentStartAndEndToCoordinateSystem(coordinateSystem, startAndEnd).let {
+                        convertedStartAndEnd ->
+                        convertedStartAndEnd.start to convertedStartAndEnd.end
+                    }
+                } ?: (null to null)
+
+            val trackNumberOid =
+                externalTrackNumberIds[trackNumber.id]?.oid
+                    ?: throw ExtOidNotFoundExceptionV1(
+                        "track number oid not found, layoutTrackNumberId=${trackNumber.id}"
+                    )
+
+            ExtTrackNumberV1(
+                trackNumberOid = trackNumberOid,
+                trackNumber = trackNumber.number,
+                trackNumberDescription = trackNumber.description,
+                trackNumberState = ExtTrackNumberStateV1.of(trackNumber.state),
+                startLocation = startLocation?.let(::ExtAddressPointV1),
+                endLocation = endLocation?.let(::ExtAddressPointV1),
+            )
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionServiceV1.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import ExtTrackNumberV1
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
@@ -176,7 +175,7 @@ constructor(
                 trackNumberOid = trackNumberOid,
                 trackNumber = trackNumber.number,
                 trackNumberDescription = trackNumber.description,
-                trackNumberState = ExtTrackNumberStateV1.of(trackNumber.state),
+                trackNumberState = trackNumber.state.let(ExtTrackNumberStateV1::of),
                 startLocation = startLocation?.let(::ExtAddressPointV1),
                 endLocation = endLocation?.let(::ExtAddressPointV1),
             )

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
@@ -1,0 +1,133 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+import fi.fta.geoviite.api.aspects.GeoviiteExtApiController
+import fi.fta.geoviite.infra.authorization.AUTH_API_GEOMETRY
+import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.common.Uuid
+import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+private const val EXT_TRACK_NUMBER_TAG_V1 = "Ratanumero"
+private const val EXT_TRACK_NUMBER_COLLECTION_TAG_V1 = "Ratanumerokokoelma"
+
+@PreAuthorize(AUTH_API_GEOMETRY)
+@GeoviiteExtApiController(
+    ["$EXT_TRACK_LAYOUT_BASE_PATH/paikannuspohja/v1", "$EXT_TRACK_LAYOUT_BASE_PATH/dev/paikannuspohja/v1"]
+)
+class ExtTrackNumberControllerV1
+@Autowired
+constructor(private val extTrackNumberCollectionService: ExtTrackNumberCollectionServiceV1) {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @GetMapping("/ratanumerot")
+    @Tag(name = EXT_TRACK_NUMBER_COLLECTION_TAG_V1)
+    @Operation(summary = "Ratanumerokokoelman haku")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(responseCode = "200", description = "Ratanumerokokoelman haku onnistui."),
+                ApiResponse(
+                    responseCode = "400",
+                    description = EXT_OPENAPI_INVALID_ARGUMENTS,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "Annettua rataverkon versiota ei ole olemassa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "500",
+                    description = EXT_OPENAPI_SERVER_ERROR,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+            ]
+    )
+    fun extGetTrackNumberCollection(
+        @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION, schema = Schema(type = "string", format = "uuid"))
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
+        trackLayoutVersion: Uuid<Publication>?,
+        @Parameter(description = EXT_OPENAPI_COORDINATE_SYSTEM, schema = Schema(type = "string", format = "string"))
+        @RequestParam(COORDINATE_SYSTEM_PARAM, required = false)
+        coordinateSystem: Srid?,
+    ): ExtTrackNumberCollectionResponseV1 {
+        return extTrackNumberCollectionService.createTrackNumberCollectionResponse(
+            trackLayoutVersion = trackLayoutVersion,
+            coordinateSystem = coordinateSystem ?: LAYOUT_SRID,
+        )
+    }
+
+    @GetMapping("/ratanumerot/muutokset", params = [MODIFICATIONS_FROM_VERSION])
+    @Tag(name = EXT_TRACK_NUMBER_COLLECTION_TAG_V1)
+    @Operation(summary = "Ratanumerokokoelman muutosten haku")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(
+                    responseCode = "200",
+                    description =
+                        "Ratanumerokokoelman muutokset haettiin onnistuneesti kahden rataverkon version välillä.",
+                ),
+                ApiResponse(
+                    responseCode = "204",
+                    description = EXT_OPENAPI_NO_MODIFICATIONS_BETWEEN_VERSIONS,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = EXT_OPENAPI_INVALID_ARGUMENTS,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "Yhtä tai useampaa rataverkon versiota ei ole olemassa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "500",
+                    description = EXT_OPENAPI_SERVER_ERROR,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+            ]
+    )
+    fun extGetTrackNumberCollectionModifications(
+        @Parameter(
+            description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_FROM,
+            schema = Schema(type = "string", format = "uuid"),
+        )
+        @RequestParam(MODIFICATIONS_FROM_VERSION, required = true)
+        modificationsFromVersion: Uuid<Publication>,
+        @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_TO, schema = Schema(type = "string", format = "uuid"))
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
+        trackLayoutVersion: Uuid<Publication>?,
+        @Parameter(
+            name = COORDINATE_SYSTEM_PARAM,
+            description = EXT_OPENAPI_COORDINATE_SYSTEM,
+            schema = Schema(type = "string", format = "string"),
+        )
+        @RequestParam(COORDINATE_SYSTEM_PARAM, required = false)
+        coordinateSystem: Srid?,
+    ): ResponseEntity<ExtModifiedTrackNumberCollectionResponseV1> {
+        return extTrackNumberCollectionService
+            .createTrackNumberCollectionModificationResponse(
+                modificationsFromVersion = modificationsFromVersion,
+                trackLayoutVersion = trackLayoutVersion,
+                coordinateSystem = coordinateSystem ?: LAYOUT_SRID,
+            )
+            ?.let { modifiedResponse -> ResponseEntity.ok(modifiedResponse) } ?: ResponseEntity.noContent().build()
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
@@ -2,9 +2,11 @@ package fi.fta.geoviite.api.tracklayout.v1
 
 import fi.fta.geoviite.api.aspects.GeoviiteExtApiController
 import fi.fta.geoviite.infra.authorization.AUTH_API_GEOMETRY
+import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.Uuid
+import fi.fta.geoviite.infra.geocoding.Resolution
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
@@ -35,8 +37,9 @@ private const val EXT_TRACK_NUMBER_COLLECTION_TAG_V1 = "Ratanumerokokoelma"
 class ExtTrackNumberControllerV1
 @Autowired
 constructor(
-    private val extTrackNumberCollectionService: ExtTrackNumberCollectionServiceV1,
     private val extTrackNumberService: ExtTrackNumberServiceV1,
+    private val extTrackNumberGeometryService: ExtTrackNumberGeometryServiceV1,
+    private val extTrackNumberCollectionService: ExtTrackNumberCollectionServiceV1,
 ) {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -253,6 +256,68 @@ constructor(
                 modificationsFromVersion,
                 trackLayoutVersion,
                 coordinateSystem ?: LAYOUT_SRID,
+            )
+            .let(::toResponse)
+    }
+
+    @GetMapping("/ratanumerot/{${TRACK_NUMBER_OID_PARAM}}/geometria")
+    @Tag(name = EXT_TRACK_NUMBER_TAG_V1)
+    @Operation(summary = "Yksittäisen ratanumeron geometrian haku OID-tunnuksella")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(responseCode = "200", description = "Ratanumeron geometrian haku onnistui."),
+                ApiResponse(
+                    responseCode = "204",
+                    description =
+                        "Ratanumeron OID-tunnus löytyi, muttei sille ole olemassa geometriaa annetussa rataverkon versiossa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "400",
+                    description = EXT_OPENAPI_INVALID_ARGUMENTS,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "404",
+                    description =
+                        "Ratanumeroa ei löytynyt OID-tunnuksella tai annettua rataverkon versiota ei ole olemassa.",
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+                ApiResponse(
+                    responseCode = "500",
+                    description = EXT_OPENAPI_SERVER_ERROR,
+                    content = [Content(schema = Schema(hidden = true))],
+                ),
+            ]
+    )
+    fun extGetTrackNumberGeometry(
+        @Parameter(description = EXT_OPENAPI_TRACK_NUMBER_OID_DESCRIPTION)
+        @PathVariable(TRACK_NUMBER_OID_PARAM)
+        oid: Oid<LayoutTrackNumber>,
+        @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION, schema = Schema(type = "string", format = "uuid"))
+        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
+        trackLayoutVersion: Uuid<Publication>? = null,
+        @Parameter(description = EXT_OPENAPI_RESOLUTION)
+        @RequestParam(ADDRESS_POINT_RESOLUTION, required = false)
+        extResolution: ExtResolutionV1? = null,
+        @Parameter(description = EXT_OPENAPI_COORDINATE_SYSTEM, schema = Schema(type = "string", format = "string"))
+        @RequestParam(COORDINATE_SYSTEM_PARAM, required = false)
+        coordinateSystem: Srid? = null,
+        @Parameter(description = EXT_OPENAPI_TRACK_KILOMETER_START)
+        @RequestParam(TRACK_KILOMETER_START_PARAM, required = false)
+        trackKmStart: KmNumber? = null,
+        @Parameter(description = EXT_OPENAPI_TRACK_KILOMETER_END)
+        @RequestParam(TRACK_KILOMETER_END_PARAM, required = false)
+        trackKmEnd: KmNumber? = null,
+    ): ResponseEntity<ExtTrackNumberGeometryResponseV1> {
+        return extTrackNumberGeometryService
+            .createGeometryResponse(
+                oid,
+                trackLayoutVersion,
+                extResolution?.toResolution() ?: Resolution.ONE_METER,
+                coordinateSystem ?: LAYOUT_SRID,
+                ExtTrackKilometerIntervalV1(trackKmStart, trackKmEnd),
             )
             .let(::toResponse)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
@@ -2,6 +2,8 @@ package fi.fta.geoviite.api.tracklayout.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
@@ -10,51 +12,50 @@ import fi.fta.geoviite.infra.common.Uuid
 import fi.fta.geoviite.infra.error.TrackLayoutVersionNotFound
 import fi.fta.geoviite.infra.geocoding.GeocodingDao
 import fi.fta.geoviite.infra.geocoding.GeocodingService
-import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.geocoding.Resolution
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationDao
-import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
-import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import io.swagger.v3.oas.annotations.media.Schema
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
 
-@Schema(name = "Vastaus: Sijaintiraidegeometria")
-data class ExtLocationTrackGeometryResponseV1(
+@Schema(name = "Vastaus: Ratanumerogeometria")
+data class ExtTrackNumberGeometryResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(LOCATION_TRACK_OID_PARAM) val locationTrackOid: Oid<LocationTrack>,
+    @JsonProperty(TRACK_NUMBER_OID_PARAM) val trackNumberOid: Oid<LayoutTrackNumber>,
     @JsonProperty("osoitevalit") val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
 )
 
-@Schema(name = "Vastaus: Muutettu sijaintiraidegeometria")
-data class ExtLocationTrackModifiedGeometryResponseV1(
+@Schema(name = "Vastaus: Muutettu ratanumerogeometrika")
+data class ExtTrackNumberkModifiedGeometryResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
     @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
-    @JsonProperty(LOCATION_TRACK_OID_PARAM) val locationTrackOid: Oid<LocationTrack>,
+    @JsonProperty(TRACK_NUMBER_OID_PARAM) val trackNumberOid: Oid<LayoutTrackNumber>,
     @JsonProperty("osoitevalit") val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
 )
 
 @GeoviiteService
-class ExtLocationTrackGeometryServiceV1
+class ExtTrackNumberGeometryServiceV1
 @Autowired
 constructor(
     private val geocodingService: GeocodingService,
     private val geocodingDao: GeocodingDao,
-    private val locationTrackDao: LocationTrackDao,
+    private val layoutTrackNumberDao: LayoutTrackNumberDao,
     private val publicationDao: PublicationDao,
 ) {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     fun createGeometryResponse(
-        oid: Oid<LocationTrack>,
+        oid: Oid<LayoutTrackNumber>,
         trackLayoutVersion: Uuid<Publication>?,
         resolution: Resolution,
         coordinateSystem: Srid,
         trackIntervalFilter: ExtTrackKilometerIntervalV1,
-    ): ExtLocationTrackGeometryResponseV1? {
+    ): ExtTrackNumberGeometryResponseV1? {
         val layoutContext = MainLayoutContext.official
 
         val publication =
@@ -63,46 +64,43 @@ constructor(
                     ?: throw TrackLayoutVersionNotFound("trackLayoutVersion=${trackLayoutVersion}")
             } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
 
-        val locationTrackId =
-            locationTrackDao.lookupByExternalId(oid.toString())?.id
-                ?: throw ExtOidNotFoundExceptionV1("location track lookup failed for oid=$oid")
+        val trackNumberId =
+            layoutTrackNumberDao.lookupByExternalId(oid.toString())?.id
+                ?: throw ExtOidNotFoundExceptionV1("track number lookup failed for oid=$oid")
 
-        return locationTrackDao
-            .fetchOfficialVersionAtMoment(layoutContext.branch, locationTrackId, publication.publicationTime)
-            ?.let(locationTrackDao::fetch)
-            ?.let { locationTrack ->
-                val geocodingContextCacheKey =
-                    geocodingDao.getLayoutGeocodingContextCacheKey(
-                        layoutContext.branch,
-                        locationTrack.trackNumberId,
-                        publication.publicationTime,
-                    ) ?: throw ExtGeocodingFailedV1("could not get geocoding context cache key")
-
-                ExtLocationTrackGeometryResponseV1(
+        return layoutTrackNumberDao
+            .fetchOfficialVersionAtMoment(layoutContext.branch, trackNumberId, publication.publicationTime)
+            ?.let(layoutTrackNumberDao::fetch)
+            ?.let { trackNumber ->
+                ExtTrackNumberGeometryResponseV1(
                     trackLayoutVersion = publication.uuid,
-                    locationTrackOid = oid,
+                    trackNumberOid = oid,
                     trackIntervals =
-                        getExtLocationTrackGeometry(
-                            locationTrack.getVersionOrThrow(),
-                            geocodingContextCacheKey,
+                        getExtTrackNumberGeometry(
+                            layoutContext.branch,
+                            trackNumber,
                             trackIntervalFilter,
                             resolution,
                             coordinateSystem,
+                            publication.publicationTime,
                         ),
                 )
             }
     }
 
-    private fun getExtLocationTrackGeometry(
-        locationTrackVersion: LayoutRowVersion<LocationTrack>,
-        geocodingContextCacheKey: LayoutGeocodingContextCacheKey,
+    private fun getExtTrackNumberGeometry(
+        branch: LayoutBranch,
+        trackNumber: LayoutTrackNumber,
         trackIntervalFilter: ExtTrackKilometerIntervalV1,
         resolution: Resolution,
         coordinateSystem: Srid,
+        moment: Instant,
     ): List<ExtCenterLineTrackIntervalV1> {
         val alignmentAddresses =
-            geocodingService.getAddressPoints(geocodingContextCacheKey, locationTrackVersion, resolution)
-                ?: throw ExtGeocodingFailedV1("could not get address points")
+            geocodingService
+                .getGeocodingContextAtMoment(branch, trackNumber.id as IntId, moment)
+                ?.getReferenceLineAddressesWithResolution(resolution)
+                ?: throw ExtGeocodingFailedV1("could not get reference line address points")
 
         val extAddressPoints =
             alignmentAddresses.allPoints.mapNotNull { point ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
@@ -1,0 +1,40 @@
+import com.fasterxml.jackson.annotation.JsonProperty
+import fi.fta.geoviite.api.tracklayout.v1.COORDINATE_SYSTEM_PARAM
+import fi.fta.geoviite.api.tracklayout.v1.ExtAddressPointV1
+import fi.fta.geoviite.api.tracklayout.v1.ExtTrackNumberStateV1
+import fi.fta.geoviite.api.tracklayout.v1.MODIFICATIONS_FROM_VERSION
+import fi.fta.geoviite.api.tracklayout.v1.TRACK_LAYOUT_VERSION
+import fi.fta.geoviite.api.tracklayout.v1.TRACK_NUMBER_PARAM
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.common.TrackNumber
+import fi.fta.geoviite.infra.common.TrackNumberDescription
+import fi.fta.geoviite.infra.common.Uuid
+import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "Vastaus: Ratanumero")
+data class ExtTrackNumberResponseV1(
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
+    @JsonProperty(COORDINATE_SYSTEM_PARAM) val coordinateSystem: Srid,
+    @JsonProperty(TRACK_NUMBER_PARAM) val trackNumber: ExtTrackNumberV1,
+)
+
+@Schema(name = "Vastaus: Muutettu ratanumero")
+data class ExtModifiedTrackNumberResponseV1(
+    @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
+    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(COORDINATE_SYSTEM_PARAM) val coordinateSystem: Srid,
+    @JsonProperty(TRACK_NUMBER_PARAM) val trackNumber: ExtTrackNumberV1,
+)
+
+@Schema(name = "Ratanumero")
+data class ExtTrackNumberV1(
+    @JsonProperty("ratanumero_oid") val trackNumberOid: Oid<LayoutTrackNumber>,
+    @JsonProperty("ratanumero") val trackNumber: TrackNumber,
+    @JsonProperty("kuvaus") val trackNumberDescription: TrackNumberDescription,
+    @JsonProperty("tila") val trackNumberState: ExtTrackNumberStateV1,
+    @JsonProperty("alkusijainti") val startLocation: ExtAddressPointV1?,
+    @JsonProperty("loppusijainti") val endLocation: ExtAddressPointV1?,
+)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
@@ -1,18 +1,28 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
 import com.fasterxml.jackson.annotation.JsonProperty
-import fi.fta.geoviite.api.tracklayout.v1.COORDINATE_SYSTEM_PARAM
-import fi.fta.geoviite.api.tracklayout.v1.ExtAddressPointV1
-import fi.fta.geoviite.api.tracklayout.v1.ExtTrackNumberStateV1
-import fi.fta.geoviite.api.tracklayout.v1.MODIFICATIONS_FROM_VERSION
-import fi.fta.geoviite.api.tracklayout.v1.TRACK_LAYOUT_VERSION
-import fi.fta.geoviite.api.tracklayout.v1.TRACK_NUMBER_PARAM
+import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import fi.fta.geoviite.infra.common.Uuid
+import fi.fta.geoviite.infra.error.TrackLayoutVersionNotFound
 import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.publication.PublicationDao
+import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
 import io.swagger.v3.oas.annotations.media.Schema
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
 
 @Schema(name = "Vastaus: Ratanumero")
 data class ExtTrackNumberResponseV1(
@@ -38,3 +48,137 @@ data class ExtTrackNumberV1(
     @JsonProperty("alkusijainti") val startLocation: ExtAddressPointV1?,
     @JsonProperty("loppusijainti") val endLocation: ExtAddressPointV1?,
 )
+
+@GeoviiteService
+class ExtTrackNumberServiceV1
+@Autowired
+constructor(
+    private val publicationDao: PublicationDao,
+    private val publicationService: PublicationService,
+    private val layoutTrackNumberDao: LayoutTrackNumberDao,
+    private val referenceLineService: ReferenceLineService,
+) {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    fun createTrackNumberResponse(
+        oid: Oid<LayoutTrackNumber>,
+        trackLayoutVersion: Uuid<Publication>?,
+        coordinateSystem: Srid,
+    ): ExtTrackNumberResponseV1? {
+        val layoutContext = MainLayoutContext.official
+
+        val publication =
+            trackLayoutVersion?.let { uuid ->
+                publicationDao.fetchPublicationByUuid(uuid)
+                    ?: throw TrackLayoutVersionNotFound("trackLayoutVersion=${trackLayoutVersion}")
+            } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()
+
+        val trackNumberId =
+            layoutTrackNumberDao.lookupByExternalId(oid.toString())?.id
+                ?: throw ExtOidNotFoundExceptionV1("track number lookup failed for oid=$oid")
+
+        return layoutTrackNumberDao
+            .fetchOfficialVersionAtMoment(layoutContext.branch, trackNumberId, publication.publicationTime)
+            ?.let(layoutTrackNumberDao::fetch)
+            ?.let { trackNumber ->
+                ExtTrackNumberResponseV1(
+                    trackLayoutVersion = publication.uuid,
+                    coordinateSystem = coordinateSystem,
+                    trackNumber =
+                        getExtTrackNumber(
+                            oid,
+                            trackNumber,
+                            layoutContext,
+                            publication.publicationTime,
+                            coordinateSystem,
+                        ),
+                )
+            }
+    }
+
+    fun createTrackNumberModificationResponse(
+        oid: Oid<LayoutTrackNumber>,
+        modificationsFromVersion: Uuid<Publication>,
+        trackLayoutVersion: Uuid<Publication>?,
+        coordinateSystem: Srid,
+    ): ExtModifiedTrackNumberResponseV1? {
+        val layoutContext = MainLayoutContext.official
+
+        val (fromPublication, toPublication) =
+            publicationService.getPublicationsToCompare(modificationsFromVersion, trackLayoutVersion)
+
+        return if (fromPublication == toPublication) {
+            logger.info(
+                "there cannot be any differences if the requested publication ids are the same publication=${fromPublication.id}"
+            )
+            null
+        } else {
+            val trackNumberId =
+                layoutTrackNumberDao.lookupByExternalId(oid.toString())?.id
+                    ?: throw ExtOidNotFoundExceptionV1("track number lookup failed, oid=$oid")
+
+            val fromTrackNumberVersion =
+                layoutTrackNumberDao.fetchOfficialVersionAtMoment(
+                    layoutContext.branch,
+                    trackNumberId,
+                    fromPublication.publicationTime,
+                )
+
+            val toTrackNumberVersion =
+                layoutTrackNumberDao.fetchOfficialVersionAtMoment(
+                    layoutContext.branch,
+                    trackNumberId,
+                    toPublication.publicationTime,
+                )
+
+            return if (fromTrackNumberVersion == toTrackNumberVersion) {
+                logger.info(
+                    "track number version was the same for trackNumberId=$trackNumberId, earlierPublication=${fromPublication.id}, laterPublication=${toPublication.id}"
+                )
+                null
+            } else {
+                checkNotNull(toTrackNumberVersion) {
+                    "It should not be possible for the fromTrackNumberVersion to be non-null, while the toTrackNumberVersion is null."
+                }
+
+                ExtModifiedTrackNumberResponseV1(
+                    modificationsFromVersion = modificationsFromVersion,
+                    trackLayoutVersion = toPublication.uuid,
+                    coordinateSystem = coordinateSystem,
+                    trackNumber =
+                        getExtTrackNumber(
+                            oid,
+                            layoutTrackNumberDao.fetch(toTrackNumberVersion),
+                            MainLayoutContext.official,
+                            toPublication.publicationTime,
+                            coordinateSystem,
+                        ),
+                )
+            }
+        }
+    }
+
+    fun getExtTrackNumber(
+        oid: Oid<LayoutTrackNumber>,
+        trackNumber: LayoutTrackNumber,
+        layoutContext: LayoutContext,
+        moment: Instant,
+        coordinateSystem: Srid,
+    ): ExtTrackNumberV1 {
+        val (startLocation, endLocation) =
+            referenceLineService
+                .getStartAndEndAtMoment(layoutContext, listOf(trackNumber.referenceLineId as IntId), moment)
+                .firstOrNull()
+                ?.let { startAndEnd -> layoutAlignmentStartAndEndToCoordinateSystem(coordinateSystem, startAndEnd) }
+                ?.let { startAndEnd -> startAndEnd.start to startAndEnd.end } ?: (null to null)
+
+        return ExtTrackNumberV1(
+            trackNumberOid = oid,
+            trackNumber = trackNumber.number,
+            trackNumberDescription = trackNumber.description,
+            trackNumberState = trackNumber.state.let(ExtTrackNumberStateV1::of),
+            startLocation = startLocation?.let(::ExtAddressPointV1),
+            endLocation = endLocation?.let(::ExtAddressPointV1),
+        )
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -479,6 +479,10 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
 
     val referenceLineAddresses by lazy { getAddressPoints(referenceLineGeometry) }
 
+    fun getReferenceLineAddressesWithResolution(resolution: Resolution): AlignmentAddresses<M>? {
+        return getAddressPoints(referenceLineGeometry, resolution)
+    }
+
     fun <TargetM : AnyM<TargetM>> toAddressPoint(
         point: AlignmentPoint<TargetM>,
         decimals: Int = DEFAULT_TRACK_METER_DECIMALS,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -88,11 +88,11 @@ import fi.fta.geoviite.infra.util.getTrackNumberOrNull
 import fi.fta.geoviite.infra.util.getUuid
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
-import java.sql.Timestamp
-import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -2384,6 +2384,26 @@ class PublicationDao(
                 "end_time" to Timestamp.from(inclusiveEndMoment),
             )
         return jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId("location_track_id") }
+    }
+
+    fun fetchPublishedTrackNumbersAfterMoment(
+        exclusiveStartMoment: Instant,
+        inclusiveEndMoment: Instant,
+    ): List<IntId<LayoutTrackNumber>> {
+        val sql =
+            """
+            select distinct ptn.id as track_number_id
+            from publication.track_number ptn
+              join publication.publication publication on ptn.publication_id = publication.id
+            where publication.publication_time > :start_time and publication.publication_time <= :end_time;
+        """
+
+        val params =
+            mapOf(
+                "start_time" to Timestamp.from(exclusiveStartMoment),
+                "end_time" to Timestamp.from(inclusiveEndMoment),
+            )
+        return jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId("track_number_id") }
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -26,6 +26,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
 
 const val TRACK_NUMBER_CACHE_SIZE = 1000L
 
@@ -63,12 +65,12 @@ class LayoutTrackNumberDao(
     ): List<LayoutRowVersion<LayoutTrackNumber>> {
         val sql =
             """
-            select id, design_id, draft, version
-            from layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id)
-            where (:number::varchar is null or :number = number)
-              and (:include_deleted = true or state != 'DELETED')
-            order by number
-        """
+                select id, design_id, draft, version
+                from layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id)
+                where (:number::varchar is null or :number = number)
+                  and (:include_deleted = true or state != 'DELETED')
+                order by number
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -88,28 +90,28 @@ class LayoutTrackNumberDao(
         if (versions.isEmpty()) return emptyMap()
         val sql =
             """
-            select
-              tn.id,
-              tn.version,
-              tn.design_id,
-              tn.draft,
-              tn.design_asset_state,
-              tn.number,
-              tn.description,
-              tn.state,
-              -- Track number reference line identity never changes, so any instance whatsoever is fine
-              (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
-              tn.origin_design_id
-            from layout.track_number_version tn
-              inner join lateral
-                (
-                  select
-                    unnest(:ids) id,
-                    unnest(:layout_context_ids) layout_context_id,
-                    unnest(:versions) version
-                ) args on args.id = tn.id and args.layout_context_id = tn.layout_context_id and args.version = tn.version
-              where tn.deleted = false
-        """
+                select
+                  tn.id,
+                  tn.version,
+                  tn.design_id,
+                  tn.draft,
+                  tn.design_asset_state,
+                  tn.number,
+                  tn.description,
+                  tn.state,
+                  -- Track number reference line identity never changes, so any instance whatsoever is fine
+                  (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
+                  tn.origin_design_id
+                from layout.track_number_version tn
+                  inner join lateral
+                    (
+                      select
+                        unnest(:ids) id,
+                        unnest(:layout_context_ids) layout_context_id,
+                        unnest(:versions) version
+                    ) args on args.id = tn.id and args.layout_context_id = tn.layout_context_id and args.version = tn.version
+                  where tn.deleted = false
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -126,21 +128,21 @@ class LayoutTrackNumberDao(
     override fun preloadCache(): Int {
         val sql =
             """
-            select
-              tn.id,
-              tn.version,
-              tn.design_id,
-              tn.draft,
-              tn.number, 
-              tn.description,
-              tn.state,
-              tn.design_asset_state,
-              -- Track number reference line identity never changes, so any instance whatsoever is fine
-              (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
-              tn.origin_design_id
-            from layout.track_number tn
-            order by tn.id
-        """
+                select
+                  tn.id,
+                  tn.version,
+                  tn.design_id,
+                  tn.draft,
+                  tn.number, 
+                  tn.description,
+                  tn.state,
+                  tn.design_asset_state,
+                  -- Track number reference line identity never changes, so any instance whatsoever is fine
+                  (select id from layout.reference_line_version rl where rl.track_number_id = tn.id limit 1) reference_line_id,
+                  tn.origin_design_id
+                from layout.track_number tn
+                order by tn.id
+            """
                 .trimIndent()
 
         val trackNumbers =
@@ -165,7 +167,14 @@ class LayoutTrackNumberDao(
             // There, they are save always as one, all the way from DAO.save
             referenceLineId = rs.getIntIdOrNull("reference_line_id"),
             contextData =
-                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
+                rs.getLayoutContextData(
+                    "id",
+                    "design_id",
+                    "draft",
+                    "version",
+                    "design_asset_state",
+                    "origin_design_id",
+                ),
         )
 
     @Transactional
@@ -178,33 +187,33 @@ class LayoutTrackNumberDao(
         // language=sql
         val sql =
             """
-            insert into layout.track_number(layout_context_id,
-                                            id,
-                                            number,
-                                            description,
-                                            state,
-                                            draft,
-                                            design_asset_state,
-                                            design_id,
-                                            origin_design_id)
-              values
-                (:layout_context_id,
-                 :id,
-                 :number,
-                 :description,
-                 :state::layout.state,
-                 :draft,
-                 :design_asset_state::layout.design_asset_state,
-                 :design_id,
-                 :origin_design_id)
-              on conflict (id, layout_context_id) do update
-                set number = excluded.number,
-                    description = excluded.description,
-                    state = excluded.state,
-                    design_asset_state = excluded.design_asset_state,
-                    origin_design_id = excluded.origin_design_id
-              returning id, design_id, draft, version;
-        """
+                insert into layout.track_number(layout_context_id,
+                                                id,
+                                                number,
+                                                description,
+                                                state,
+                                                draft,
+                                                design_asset_state,
+                                                design_id,
+                                                origin_design_id)
+                  values
+                    (:layout_context_id,
+                     :id,
+                     :number,
+                     :description,
+                     :state::layout.state,
+                     :draft,
+                     :design_asset_state::layout.design_asset_state,
+                     :design_id,
+                     :origin_design_id)
+                  on conflict (id, layout_context_id) do update
+                    set number = excluded.number,
+                        description = excluded.description,
+                        state = excluded.state,
+                        design_asset_state = excluded.design_asset_state,
+                        origin_design_id = excluded.origin_design_id
+                  returning id, design_id, draft, version;
+            """
                 .trimIndent()
         val params =
             mapOf(
@@ -230,11 +239,11 @@ class LayoutTrackNumberDao(
     fun fetchTrackNumberNames(): List<TrackNumberAndChangeTime> {
         val sql =
             """
-            select tn.id, tn.number, tn.change_time
-            from layout.track_number_version tn
-            where tn.draft = false
-            order by tn.change_time
-        """
+                select tn.id, tn.number, tn.change_time
+                from layout.track_number_version tn
+                where tn.draft = false
+                order by tn.change_time
+            """
                 .trimIndent()
 
         return jdbcTemplate
@@ -253,10 +262,10 @@ class LayoutTrackNumberDao(
         } else {
             val sql =
                 """
-                select id, design_id, draft, version, number
-                from layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id)
-                where number in (:numbers)
-            """
+                    select id, design_id, draft, version, number
+                    from layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id)
+                    where number in (:numbers)
+                """
                     .trimIndent()
             val params =
                 mapOf(
@@ -273,6 +282,27 @@ class LayoutTrackNumberDao(
             // Ensure that the result contains all asked-for numbers, even if there are no matches
             numbers.associateWith { n -> found.filter { (number, _) -> number == n }.map { (_, v) -> v } }
         }
+    }
+
+    fun listPublishedLayoutTrackNumbersAtMoment(moment: Instant): List<LayoutTrackNumber> {
+        val sql =
+            """
+                  select distinct on (id) id, design_id, draft, version
+                  from layout.track_number_version
+                  where change_time <= :change_time
+                    and not deleted
+                    and not draft
+                    and design_id is null
+                  order by id, change_time desc
+            """
+                .trimIndent()
+
+        return jdbcTemplate
+            .query(sql, mapOf("change_time" to Timestamp.from(moment))) { rs, _ ->
+                rs.getLayoutRowVersion<LayoutTrackNumber>("id", "design_id", "draft", "version")
+            }
+            .map(::fetch)
+            .also { logger.daoAccess(AccessType.FETCH, LayoutTrackNumber::class, moment) }
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -47,6 +47,7 @@ class LayoutTrackNumberService(
     dao: LayoutTrackNumberDao,
     private val referenceLineService: ReferenceLineService,
     private val geocodingService: GeocodingService,
+    private val alignmentDao: LayoutAlignmentDao,
     private val alignmentService: LayoutAlignmentService,
     private val localizationService: LocalizationService,
     private val geographyService: GeographyService,


### PR DESCRIPTION
The following APIs are included:
* Track number collection listing
* Modifications to the track number collection between two track layout versions
* Single track number metadata api
* Modifications to a single track number between two track layout versions (no field-level comparisons)
* Single track number (reference line) geometry api