### PR TITLE
GVT-3262 Hide sr-only weekday names in datepicker

### DIFF
--- a/ui/src/vayla-design-lib/datepicker/datepicker.scss
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.scss
@@ -125,4 +125,16 @@
             outline: 1px solid colors.$color-blue-default;
         }
     }
+
+    &__sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
 }


### PR DESCRIPTION
React-datepickeriin on lisätty ruudunlukuohjelmille tarkoitetut pitemmät viikonpäivien nimet, jotka sitten piilotetaan selaimilta CSS:llä, mutta koska meillä käytetään ihan omaa kustomia CSS:ää, piilotus ei tapahtunut. Kopioidaan piilotus-CSS:ät siis sieltä (taitaa olla tehty näin aiemminkin, ylempänä oleva aria-live-määritys näyttää myös copypastetetulta).