### PR TITLE
GVT-3076 Topologiamallin uudet julkaisuvalidoinnit

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutCache.kt
@@ -183,7 +183,7 @@ class PlanLayoutCache(
             planCsName == null -> cs.name
             cs.aliases.contains(planCsName) -> planCsName
             else -> cs.name
-        }.also { println("name resolution: srid=${units.coordinateSystemSrid} planName=$planCsName cs=$cs -> $it") }
+        }
     }
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -19,6 +19,7 @@ import fi.fta.geoviite.infra.math.IntersectType.WITHIN
 import fi.fta.geoviite.infra.math.angleDiffRads
 import fi.fta.geoviite.infra.math.directionBetweenPoints
 import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.math.roundTo3Decimals
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.FATAL
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.WARNING
@@ -918,7 +919,10 @@ fun validateLocationTrackGeometry(geometry: LocationTrackGeometry): List<LayoutV
         listOfNotNull(
             validateWithParams(geometry.length.distance > TOPOLOGY_CALC_DISTANCE) {
                 "$VALIDATION_LOCATION_TRACK.too-short" to
-                    localizationParams("minLength" to TOPOLOGY_CALC_DISTANCE.toString())
+                    localizationParams(
+                        "minLength" to TOPOLOGY_CALC_DISTANCE.toString(),
+                        "length" to roundTo3Decimals(geometry.length.distance),
+                    )
             },
         )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -966,10 +966,7 @@ private fun collectDuplicatedSwitches(geometry: LocationTrackGeometry): Set<IntI
 
 fun validateEdge(edge: LayoutEdge, getSwitchName: (IntId<LayoutSwitch>) -> SwitchName): List<LayoutValidationIssue> =
     getEdgePartialSwitchIds(edge).map { partial ->
-        validationError(
-            "$VALIDATION_LOCATION_TRACK.edge-switch-partial",
-            "switch" to getSwitchName(requireNotNull(edge.startNode.switchIn ?: edge.endNode.switchIn).id),
-        )
+        validationError("$VALIDATION_LOCATION_TRACK.edge-switch-partial", "switch" to getSwitchName(partial))
     }
 
 fun getEdgePartialSwitchIds(edge: LayoutEdge): List<IntId<LayoutSwitch>> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -154,9 +154,7 @@ constructor(
         validationContext.preloadSwitchTrackLinks(switchIds)
         validationContext.preloadSwitchesByName(switchIds)
 
-        return switchIds.mapNotNull { id ->
-            validateSwitch(id, validationContext)?.let { issues -> ValidatedAsset(id, issues) }
-        }
+        return switchIds.map { id -> ValidatedAsset(id, validateSwitch(id, validationContext)) }
     }
 
     @Transactional(readOnly = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -552,7 +552,11 @@ constructor(
                     duplicatesAfterPublication,
                 )
 
-            val alignmentIssues = if (track.exists) validateLocationTrackGeometry(geometry) else listOf()
+            val alignmentIssues =
+                if (track.exists) {
+                    validateLocationTrackGeometry(geometry) +
+                        validateEdges(geometry) { id -> requireNotNull(validationContext.getSwitch(id)).name }
+                } else listOf()
             val geocodingIssues =
                 if (track.exists && trackNumber != null) {
                     validationContext.getGeocodingContextCacheKey(track.trackNumberId)?.let { key ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -81,7 +81,8 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
             if (i == edges.lastIndex) {
                 listOf(
                     e.startNode.node to e.firstSegmentStart.toAlignmentPoint(m.min),
-                    e.endNode.node to e.lastSegmentEnd.toAlignmentPoint(e.segmentMValues.last().min.toAlignmentM(m.min)),
+                    e.endNode.node to
+                        e.lastSegmentEnd.toAlignmentPoint(e.segmentMValues.last().min.toAlignmentM(m.min)),
                 )
             } else {
                 listOf(e.startNode.node to e.firstSegmentStart.toAlignmentPoint(m.min))
@@ -259,6 +260,17 @@ fun verifyTrackGeometry(trackId: IntId<LocationTrack>?, edges: List<LayoutEdge>)
             "Track geometry end node must have the correct track ID: trackId=$trackId trackBoundary=$boundary"
         }
     }
+    val nodes = mutableSetOf<NodeHash>()
+    edges
+        .asSequence()
+        .flatMapIndexed { i, edge -> listOfNotNull(edge.startNode.node.takeIf { i == 0 }, edge.endNode.node) }
+        .filter { node -> node !is PlaceholderNode }
+        .forEach { node ->
+            require(!nodes.contains(node.contentHash)) {
+                "Track geometry cannot contain the same node twice: trackId=$trackId node=$node"
+            }
+            nodes.add(node.contentHash)
+        }
 }
 
 data class TmpLocationTrackGeometry

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -408,6 +408,8 @@ sealed class LayoutEdge : IAlignment<EdgeM> {
 
     fun withEndNode(newEndNode: LayoutNode) = withEndNode(reconnectNode(endNode, newEndNode))
 
+    fun containsSwitch(id: IntId<LayoutSwitch>) = startNode.containsSwitch(id) || endNode.containsSwitch(id)
+
     fun withoutSwitch(switchId: IntId<LayoutSwitch>): LayoutEdge {
         val start = startNode.withoutSwitch(switchId)
         val end = endNode.withoutSwitch(switchId)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1624,7 +1624,7 @@
                 },
                 "deleted-duplicated-by-existing": "Poistettavaan raiteeseen viittaa edelleen duplikaattiraiteita: {{duplicates}}",
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
-                "too-short": "Sijaintiraiteen pituus on vain {{length}}m. Liian lyhyille raiteelle ei voida laskea reititystietoja.",
+                "too-short": "Sijaintiraiteen pituus on vain {{length}}m. Alle {{minLength}}m pitkille raiteelle ei voida laskea reititystietoja.",
                 "duplicate-switch": "Vaihde {{switch}} on linkitetty raiteelle useampaan eri kohtaan",
                 "edge-switch-partial": "Vaihteen {{switch}} linkitys raiteella on puutteellinen ja se on linkitettävä uudelleen",
                 "points": {
@@ -1679,7 +1679,7 @@
                     "not-continuous": "Sama raide ({{locationTracks}}) on kytketty vaihteeseen eri kohdista",
                     "joint-location-mismatch": "Vaihteen ja sijaintiraiteen vaihdepisteiden sijainnit eivät kohtaa: {{locationTracks}}",
                     "wrong-joint-sequence": "Kaikki vaihteeseen kytketyt raiteet ({{locationTracks}}) eivät vastaa vaihderakenteen linjoja",
-                    "partial-linking-edge": "Raiteen ({{locationTracks}}) ja vaihteen linkitys on puutteellinen ja vaihde täytyy linkittää uudelleen"
+                    "partial-linking-edge": "Vaihteen linkitys raiteisiin on puutteellinen ja se täytyy linkittää uudelleen"
                 },
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1624,6 +1624,9 @@
                 },
                 "deleted-duplicated-by-existing": "Poistettavaan raiteeseen viittaa edelleen duplikaattiraiteita: {{duplicates}}",
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
+                "too-short": "Sijaintiraiteen pituus on vain {{length}}m (<{{minLength}}m), joten sille ei voida laskea topologialinkkejä",
+                "duplicate-switch": "Vaihde {{switch}} on linkitetty raiteelle useampaan eri kohtaan",
+                "edge-switch-partial": "Vaihteen {{switch}} linkitys raiteella on vaillinainen ja se on linkitettävä uudelleen",
                 "points": {
                     "not-continuous": "Sijaintiraiteen pisteet eivät ole jatkuvia (kulma on liian suuri pisteiden välillä)"
                 },

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1624,9 +1624,9 @@
                 },
                 "deleted-duplicated-by-existing": "Poistettavaan raiteeseen viittaa edelleen duplikaattiraiteita: {{duplicates}}",
                 "empty-segments": "Sijaintiraiteella ei ole geometriaa",
-                "too-short": "Sijaintiraiteen pituus on vain {{length}}m (<{{minLength}}m), joten sille ei voida laskea topologialinkkejä",
+                "too-short": "Sijaintiraiteen pituus on vain {{length}}m. Liian lyhyille raiteelle ei voida laskea reititystietoja.",
                 "duplicate-switch": "Vaihde {{switch}} on linkitetty raiteelle useampaan eri kohtaan",
-                "edge-switch-partial": "Vaihteen {{switch}} linkitys raiteella on vaillinainen ja se on linkitettävä uudelleen",
+                "edge-switch-partial": "Vaihteen {{switch}} linkitys raiteella on puutteellinen ja se on linkitettävä uudelleen",
                 "points": {
                     "not-continuous": "Sijaintiraiteen pisteet eivät ole jatkuvia (kulma on liian suuri pisteiden välillä)"
                 },
@@ -1678,7 +1678,8 @@
                     "not-published": "Vaihteeseen liittyvä sijaintiraide ei ole mukana julkaisussa: {{locationTrack}}",
                     "not-continuous": "Sama raide ({{locationTracks}}) on kytketty vaihteeseen eri kohdista",
                     "joint-location-mismatch": "Vaihteen ja sijaintiraiteen vaihdepisteiden sijainnit eivät kohtaa: {{locationTracks}}",
-                    "wrong-joint-sequence": "Kaikki vaihteeseen kytketyt raiteet ({{locationTracks}}) eivät vastaa vaihderakenteen linjoja"
+                    "wrong-joint-sequence": "Kaikki vaihteeseen kytketyt raiteet ({{locationTracks}}) eivät vastaa vaihderakenteen linjoja",
+                    "partial-linking-edge": "Raiteen ({{locationTracks}}) ja vaihteen linkitys on puutteellinen ja vaihde täytyy linkittää uudelleen"
                 },
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1679,7 +1679,7 @@
                     "not-continuous": "Sama raide ({{locationTracks}}) on kytketty vaihteeseen eri kohdista",
                     "joint-location-mismatch": "Vaihteen ja sijaintiraiteen vaihdepisteiden sijainnit eivät kohtaa: {{locationTracks}}",
                     "wrong-joint-sequence": "Kaikki vaihteeseen kytketyt raiteet ({{locationTracks}}) eivät vastaa vaihderakenteen linjoja",
-                    "partial-linking-edge": "Vaihteen linkitys raiteisiin on puutteellinen ja se täytyy linkittää uudelleen"
+                    "partial-linking-edge": "Vaihteen linkitys raiteisiin on puutteellinen ja se on linkitettävä uudelleen"
                 },
                 "duplicate-name-official": "Vaihteen nimi {{switch}} on jo käytössä jollain toisella paikannuspohjan vaihteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta vaihdetta nimellä {{switch}}",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
@@ -49,9 +49,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.queryOne
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -59,6 +56,9 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -247,7 +247,11 @@ constructor(
                 .save(
                     switch(
                         draftOid = Oid("1.2.3.4.5"),
-                        joints = listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(0.0, 1.0), null)),
+                        joints =
+                            listOf(
+                                LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(0.0, 1.0), null),
+                                LayoutSwitchJoint(JointNumber(3), SwitchJointRole.MAIN, Point(0.0, 10.0), null),
+                            ),
                     )
                 )
                 .id
@@ -262,6 +266,7 @@ constructor(
                         ),
                         edge(
                             startInnerSwitch = switchLinkYV(switch, 1),
+                            endInnerSwitch = switchLinkYV(switch, 3),
                             segments = listOf(segment(Point(1.0, 0.0), Point(10.0, 0.0))),
                         ),
                     ),
@@ -307,7 +312,11 @@ constructor(
             mainOfficialContext
                 .save(
                     switch(
-                        joints = listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(4.0, 0.0), null))
+                        joints =
+                            listOf(
+                                LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(4.0, 0.0), null),
+                                LayoutSwitchJoint(JointNumber(3), SwitchJointRole.MAIN, Point(8.0, 0.0), null),
+                            )
                     )
                 )
                 .id
@@ -322,6 +331,7 @@ constructor(
                         ),
                         edge(
                             startInnerSwitch = switchLinkYV(switch, 1),
+                            endInnerSwitch = switchLinkYV(switch, 3),
                             segments = listOf(segment(Point(4.0, 0.0), Point(8.0, 0.0))),
                         ),
                     ),
@@ -365,7 +375,7 @@ constructor(
 
         // currently calculated change publications don't record their cause (GVT-2979), but they do
         // simply just occur right next after their cause
-        val mergeCompletionPublicationId = mergePublicationResult.publicationId!!.intValue + 1
+        val mergeCompletionPublicationId = mergePublicationResult.publicationId.intValue + 1
 
         assertEquals(MainLayoutContext.official, designDraftContext.fetchVersion(trackNumber)!!.context)
         assertEquals(MainLayoutContext.official, designDraftContext.fetchVersion(referenceLine)!!.context)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -75,8 +75,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.LayoutAssetTable
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
-import java.math.BigDecimal
-import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -92,6 +90,8 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import publicationRequest
 import publish
+import java.math.BigDecimal
+import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1629,7 +1629,7 @@ constructor(
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
 
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        val segment = segment(Point(0.0, 0.0), Point(0.0, 1.0))
+        val segment = segment(Point(0.0, 0.0), Point(0.0, 2.0))
         mainOfficialContext
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment(segment))
             .id
@@ -1657,7 +1657,7 @@ constructor(
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
 
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        val segment = segment(Point(0.0, 0.0), Point(0.0, 1.0))
+        val segment = segment(Point(0.0, 0.0), Point(0.0, 2.0))
         mainOfficialContext
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment(segment))
             .id
@@ -1686,7 +1686,7 @@ constructor(
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
 
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        val segment = segment(Point(0.0, 0.0), Point(0.0, 1.0))
+        val segment = segment(Point(0.0, 0.0), Point(0.0, 2.0))
         mainOfficialContext
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment(segment))
             .id
@@ -1715,7 +1715,7 @@ constructor(
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
 
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        val segment = segment(Point(0.0, 0.0), Point(0.0, 1.0))
+        val segment = segment(Point(0.0, 0.0), Point(0.0, 2.0))
         mainOfficialContext
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), alignment(segment))
             .id
@@ -1926,10 +1926,10 @@ constructor(
     ): Set<Change<LayoutRowVersion<T>>> {
         val sql =
             """
-            select id, layout_context_id, version, base_layout_context_id, base_version
-            from publication.${table.dbTable.table}
-            where publication_id = :publication_id
-        """
+                select id, layout_context_id, version, base_layout_context_id, base_version
+                from publication.${table.dbTable.table}
+                where publication_id = :publication_id
+            """
                 .trimIndent()
         return jdbc
             .query(sql, mapOf("publication_id" to id.intValue)) { rs, _ ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -66,7 +66,6 @@ import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
-import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
@@ -81,7 +80,6 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
-import fi.fta.geoviite.infra.tracklayout.SwitchJointRole
 import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.alignment
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
@@ -101,10 +99,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNameStructure
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.queryOne
-import java.time.Instant
-import java.time.LocalDate
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -113,6 +107,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1590,7 +1588,10 @@ constructor(
         val designDraft = testDBService.testContext(design, PublicationState.DRAFT)
 
         val trackNumber = establishedTrackNumber("1.1.1.1.1")
-        val switch = designDraft.save(switch(joints = listOf(switchJoint(1, Point(1.0, 0.0))))).id
+        val switch =
+            designDraft
+                .save(switch(joints = listOf(switchJoint(1, Point(1.0, 0.0)), switchJoint(3, Point(10.0, 0.0)))))
+                .id
         val locationTrack =
             designDraft
                 .save(
@@ -1602,6 +1603,7 @@ constructor(
                         ),
                         edge(
                             startInnerSwitch = switchLinkYV(switch, 1),
+                            endInnerSwitch = switchLinkYV(switch, 3),
                             segments = listOf(segment(Point(1.0, 0.0), Point(10.0, 0.0))),
                         ),
                     ),
@@ -1648,12 +1650,8 @@ constructor(
                 switch(
                     joints =
                         listOf(
-                            LayoutSwitchJoint(
-                                number = JointNumber(1),
-                                role = SwitchJointRole.MAIN,
-                                location = Point(4.0, 0.0),
-                                locationAccuracy = null,
-                            )
+                            switchJoint(1, Point(4.0, 0.0)),
+                            switchJoint(3, Point(8.0, 0.0)),
                         )
                 )
             )
@@ -1667,6 +1665,7 @@ constructor(
                     ),
                     edge(
                         startInnerSwitch = switchLinkYV(switch.id, 1),
+                        endInnerSwitch = switchLinkYV(switch.id, 3),
                         segments = listOf(segment(Point(4.0, 0.0), Point(8.0, 0.0))),
                     ),
                 ),
@@ -1728,17 +1727,7 @@ constructor(
             )
         val switch =
             designDraftContext.save(
-                switch(
-                    joints =
-                        listOf(
-                            LayoutSwitchJoint(
-                                number = JointNumber(1),
-                                role = SwitchJointRole.MAIN,
-                                location = Point(4.0, 0.0),
-                                locationAccuracy = null,
-                            )
-                        )
-                )
+                switch(joints = listOf(switchJoint(1, Point(4.0, 0.0)), switchJoint(3, Point(8.0, 0.0))))
             )
         val locationTrack =
             designDraftContext.save(
@@ -1750,6 +1739,7 @@ constructor(
                     ),
                     edge(
                         startInnerSwitch = switchLinkYV(switch.id, 1),
+                        endInnerSwitch = switchLinkYV(switch.id, 3),
                         segments = listOf(segment(Point(4.0, 0.0), Point(8.0, 0.0))),
                     ),
                 ),
@@ -1812,17 +1802,7 @@ constructor(
         val trackNumber = establishedTrackNumber("1.1.1.1.1")
         val switch =
             mainOfficialContext.save(
-                switch(
-                    joints =
-                        listOf(
-                            LayoutSwitchJoint(
-                                number = JointNumber(1),
-                                role = SwitchJointRole.MAIN,
-                                location = Point(4.0, 0.0),
-                                locationAccuracy = null,
-                            )
-                        )
-                )
+                switch(joints = listOf(switchJoint(1, Point(4.0, 0.0)), switchJoint(3, Point(8.0, 0.0))))
             )
         switchDao.insertExternalId(switch.id, LayoutBranch.main, Oid("1.1.1.2.1"))
         fakeRatko.hasSwitch(ratkoSwitch("1.1.1.2.1"))
@@ -1836,6 +1816,7 @@ constructor(
                     ),
                     edge(
                         startInnerSwitch = switchLinkYV(switch.id, 1),
+                        endInnerSwitch = switchLinkYV(switch.id, 3),
                         segments = listOf(segment(Point(4.0, 0.0), Point(8.0, 0.0))),
                     ),
                 ),


### PR DESCRIPTION
Lisätty 3 uutta julkaisuvalidointia uuden malliselle raidegeometrialle:
- Jos edge on sisä-linkillä kiinni vaihteessa, toisenkin pään sisä-linkin täytyy olla kiinni samassa vaihteessa. Tämä oli alunperin init-tason validointi, mutta näitä on sekä historiadatassa että uudelleenlinkityksen välitiloissa (draftissa täytyy olla sallittu)
- Sama vaihde ei saa esiintyä useammassa eri kohdassa raidetta. Tämä olisi käytännössä tilanne jossa vaihteen osuuden keskellä on kohta joka ei liitykään vaihteeseen tai jossa sama vaihde olisi tupla-linkitettynä eri osiin raidetta. Tätä ei pysty nykyversiolla tuottamaan käyttöliittymältä
- WARN-tasolla: varoitetaan alle 1m raiteista, sillä niille ei voi laskea topologialinkkejä

Lisäksi raidegeometrian init-tason validointina nämä, eli tällaisia virheitä ei ole mahdollista edes luoda. Ei ole olemassaolevassa datassa
- Sama noodi ei saa esiintyä montaa kertaa yhden raiteen matkalla (loop)

Setistä puuttuu vielä pari juttua jotka olin aikanaan kirjannut tiketille. Näiden toteuttaminen on vähän hankalaa koska tarvitsee keräillä tietoja koko rataverkolta eikä vain jostain validoitavasta setistä, joten mietin niitä vielä vähän lisää. Ehkä omana tiksunaan, tai ehkä vain luovun ajatuksesta:
- Yksi vaihdepiste saisi olla määriteltynä vain yhden aktiivisen noodin kautta. Tämä toisaalta toteutuu enimmäkseen nykyisen vaihdepistevalidoinninkin kautta, mutta ei ihan sellaisenaan.
- Noodiparin välillä pitäisi olla vain yksi aktiivinen edge (oleellinen kai lähinnä duplikaattiraiteissa)