### PR TITLE
GVT-3173 & GVT-3200: Sijaintiraiteen nimen erotus `LocationTrackName`:ksi ja julkaisuvalidoinnit dynaamiselle sijaintiraidetunnisteelle ja sijaintiraiteen kuvaukselle 

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterDataV1.kt
@@ -10,7 +10,7 @@ import fi.fta.geoviite.api.frameconverter.geojson.GeoJsonFeature
 import fi.fta.geoviite.api.frameconverter.geojson.GeoJsonGeometry
 import fi.fta.geoviite.api.frameconverter.geojson.GeoJsonGeometryPoint
 import fi.fta.geoviite.api.frameconverter.geojson.GeoJsonProperties
-import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -182,7 +182,7 @@ data class ValidCoordinateToTrackAddressRequestV1(
     val trackNumberOid: Oid<LayoutTrackNumber>?,
     val trackNumberName: TrackNumber?,
     val locationTrackOid: Oid<LocationTrack>?,
-    val locationTrackName: AlignmentName?,
+    val locationTrackName: LocationTrackName?,
     val locationTrackType: LocationTrackType?,
 ) : FrameConverterRequestV1()
 
@@ -222,7 +222,7 @@ data class FeatureMatchBasicV1(
 data class FeatureMatchDetailsV1(
     @JsonProperty("ratanumero") val trackNumber: TrackNumber,
     @JsonProperty("ratanumero_oid") val trackNumberOid: String,
-    @JsonProperty("sijaintiraide") val locationTrackName: AlignmentName,
+    @JsonProperty("sijaintiraide") val locationTrackName: LocationTrackName,
     @JsonProperty("sijaintiraide_kuvaus") val locationTrackDescription: FreeText,
     @JsonProperty("sijaintiraide_tyyppi") val translatedLocationTrackType: String,
     @JsonProperty("sijaintiraide_oid") val locationTrackOid: String,
@@ -261,7 +261,7 @@ data class ValidTrackAddressToCoordinateRequestV1(
     val trackNumber: LayoutTrackNumber,
     val trackAddress: TrackMeter,
     val locationTrackOid: Oid<LocationTrack>?,
-    val locationTrackName: AlignmentName?,
+    val locationTrackName: LocationTrackName?,
     val locationTrackType: LocationTrackType?,
 ) : FrameConverterRequestV1()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterRequestDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterRequestDataV1.kt
@@ -1,6 +1,6 @@
 package fi.fta.geoviite.api.frameconverter.v1
 
-import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
@@ -69,11 +69,11 @@ fun createValidTrackNumberNameOrNull(
     }
 }
 
-fun createValidAlignmentNameOrNull(
+fun createValidLocationTrackNameOrNull(
     unvalidatedLocationTrackName: FrameConverterStringV1
-): Pair<AlignmentName?, List<FrameConverterErrorV1>> {
+): Pair<LocationTrackName?, List<FrameConverterErrorV1>> {
     return try {
-        AlignmentName(unvalidatedLocationTrackName.toString()) to emptyList()
+        LocationTrackName(unvalidatedLocationTrackName.toString()) to emptyList()
     } catch (e: InputValidationException) {
         null to listOf(FrameConverterErrorV1.InvalidLocationTrackName)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -3,11 +3,11 @@ package fi.fta.geoviite.api.frameconverter.v1
 import fi.fta.geoviite.api.frameconverter.geojson.GeoJsonFeature
 import fi.fta.geoviite.api.frameconverter.geojson.GeoJsonGeometryPoint
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -370,7 +370,7 @@ constructor(
             request.trackNumberOid?.let(::createValidTrackNumberOidOrNull) ?: (null to emptyList())
 
         val (locationTrackNameOrNull, locationTrackNameErrors) =
-            request.locationTrackName?.let(::createValidAlignmentNameOrNull) ?: (null to emptyList())
+            request.locationTrackName?.let(::createValidLocationTrackNameOrNull) ?: (null to emptyList())
 
         val (locationTrackOidOrNull, locationTrackOidErrors) =
             request.locationTrackOid?.let(::createValidLocationTrackOidOrNull) ?: (null to emptyList())
@@ -471,7 +471,7 @@ constructor(
             request.locationTrackOid?.let(::createValidLocationTrackOidOrNull) ?: (null to emptyList())
 
         val (locationTrackNameOrNull, locationTrackNameErrors) =
-            request.locationTrackName?.let(::createValidAlignmentNameOrNull) ?: (null to emptyList())
+            request.locationTrackName?.let(::createValidLocationTrackNameOrNull) ?: (null to emptyList())
 
         val errors =
             listOf(
@@ -666,7 +666,7 @@ private fun createSimpleFeatureMatchOrNull(
     }
 }
 
-private fun filterByLocationTrackName(locationTrackName: AlignmentName?, locationTrack: LocationTrack): Boolean =
+private fun filterByLocationTrackName(locationTrackName: LocationTrackName?, locationTrack: LocationTrack): Boolean =
     locationTrackName == null || locationTrackName == locationTrack.name
 
 private fun filterByLocationTrackType(locationTrackType: LocationTrackType?, locationTrack: LocationTrack): Boolean {

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -2,10 +2,10 @@ package fi.fta.geoviite.api.tracklayout.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
@@ -23,10 +23,10 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.util.FreeText
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 
 @Schema(name = "Vastaus: Sijaintiraide")
 data class ExtLocationTrackResponseV1(
@@ -46,7 +46,7 @@ data class ExtModifiedLocationTrackResponseV1(
 @Schema(name = "Sijaintiraide")
 data class ExtLocationTrackV1(
     @JsonProperty("sijaintiraide_oid") val locationTrackOid: Oid<LocationTrack>,
-    @JsonProperty("sijaintiraidetunnus") val locationTrackName: AlignmentName,
+    @JsonProperty("sijaintiraidetunnus") val locationTrackName: LocationTrackName,
     @JsonProperty("ratanumero") val trackNumberName: TrackNumber,
     @JsonProperty("ratanumero_oid") val trackNumberOid: Oid<LayoutTrackNumber>,
     @JsonProperty("tyyppi") val locationTrackType: ExtLocationTrackTypeV1,

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -4,7 +4,6 @@ import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
-import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
@@ -15,6 +14,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackV1.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import fi.fta.geoviite.infra.common.AlignmentName
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackNumber
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(name = "Sijaintiraide")
 data class ExtLocationTrackV1(
     @JsonProperty(LOCATION_TRACK_OID) val locationTrackOid: Oid<LocationTrack>,
-    @JsonProperty(LOCATION_TRACK_NAME) val locationTrackName: AlignmentName,
+    @JsonProperty(LOCATION_TRACK_NAME) val locationTrackName: LocationTrackName,
     @JsonProperty(TRACK_NUMBER) val trackNumberName: TrackNumber,
     @JsonProperty(TRACK_NUMBER_OID) val trackNumberOid: Oid<LayoutTrackNumber>,
     @JsonProperty(TYPE) val locationTrackType: ExtLocationTrackTypeV1,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/AlignmentName.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/AlignmentName.kt
@@ -5,12 +5,21 @@ import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.util.StringSanitizer
 
+const val ALLOWED_CHARACTERS = "A-Za-zÄÖÅäöå0-9 \\-_/!?"
+const val ALLOWED_ALIGNMENT_NAME_LENGTH = 50
+const val MAX_SPECIFIER_LENGTH = 5
+const val MAX_LOCATION_TRACK_NAME_WHITESPACE = 2
+const val MAX_LOCATION_TRACK_NAME_LENGTH =
+    ALLOWED_ALIGNMENT_NAME_LENGTH +
+        ALLOWED_TRACK_NUMBER_LENGTH +
+        MAX_SPECIFIER_LENGTH +
+        MAX_LOCATION_TRACK_NAME_WHITESPACE
+
 data class AlignmentName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
     Comparable<AlignmentName>, CharSequence by value {
 
     companion object {
-        const val ALLOWED_CHARACTERS = "A-Za-zÄÖÅäöå0-9 \\-_/!?"
-        val allowedLength = 1..50
+        val allowedLength = 1..ALLOWED_ALIGNMENT_NAME_LENGTH
         val sanitizer = StringSanitizer(AlignmentName::class, ALLOWED_CHARACTERS, allowedLength)
 
         fun ofUnsafe(value: String) = value.trim().let(sanitizer::sanitize).let(::AlignmentName)
@@ -24,4 +33,24 @@ data class AlignmentName @JsonCreator(mode = DELEGATING) constructor(private val
     @JsonValue override fun toString(): String = value
 
     override fun compareTo(other: AlignmentName): Int = value.compareTo(other.value)
+}
+
+data class LocationTrackName @JsonCreator(mode = DELEGATING) constructor(private val value: String) :
+    Comparable<LocationTrackName>, CharSequence by value {
+
+    companion object {
+        val allowedLength = 1..MAX_LOCATION_TRACK_NAME_LENGTH
+        val sanitizer = StringSanitizer(LocationTrackName::class, ALLOWED_CHARACTERS, allowedLength)
+
+        fun of(value: AlignmentName) = LocationTrackName(value.toString())
+    }
+
+    init {
+        sanitizer.assertSanitized(value)
+        sanitizer.assertTrimmed(value)
+    }
+
+    @JsonValue override fun toString(): String = value
+
+    override fun compareTo(other: LocationTrackName): Int = value.compareTo(other.value)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/TrackNumber.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/TrackNumber.kt
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.util.StringSanitizer
 
+const val ALLOWED_TRACK_NUMBER_LENGTH = 30
+
 data class TrackNumber @JsonCreator(mode = DELEGATING) constructor(val value: String) :
     Comparable<TrackNumber>, CharSequence by value {
 
     companion object {
-        val allowedLength = 2..30
+        val allowedLength = 2..ALLOWED_TRACK_NUMBER_LENGTH
         const val ALLOWED_CHARACTERS = "äÄöÖåÅA-Za-z0-9 "
         val sanitizer = StringSanitizer(TrackNumber::class, ALLOWED_CHARACTERS, allowedLength)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -17,6 +17,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.ProjectName
@@ -117,6 +118,7 @@ class WebConfig(
         logger.info("Registering layout name converters")
         registry.addStringConstructorConverter(::TrackNumber)
         registry.addStringConstructorConverter(::AlignmentName)
+        registry.addStringConstructorConverter(::LocationTrackName)
         registry.addStringConstructorConverter(::SwitchName)
         registry.addStringConstructorConverter(::JointNumber)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.infra.error
 
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.inframodel.INFRAMODEL_PARSING_KEY_GENERIC
@@ -9,12 +9,12 @@ import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.util.formatForException
+import kotlin.reflect.KClass
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE
 import org.springframework.http.HttpStatus.UNAUTHORIZED
-import kotlin.reflect.KClass
 
 interface HasLocalizedMessage {
     val localizationKey: LocalizationKey
@@ -163,7 +163,7 @@ class DuplicateNameInPublicationException(
     )
 
 class DuplicateLocationTrackNameInPublicationException(
-    alignmentName: AlignmentName,
+    alignmentName: LocationTrackName,
     trackNumber: TrackNumber,
     cause: Throwable? = null,
 ) :
@@ -175,7 +175,7 @@ class DuplicateLocationTrackNameInPublicationException(
         localizedMessageParams = localizationParams("locationTrack" to alignmentName, "trackNumber" to trackNumber),
     )
 
-class SplitSourceLocationTrackUpdateException(alignmentName: AlignmentName, cause: Throwable? = null) :
+class SplitSourceLocationTrackUpdateException(alignmentName: LocationTrackName, cause: Throwable? = null) :
     ClientException(
         status = BAD_REQUEST,
         message = "Split source location track updates are not allowed",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -163,25 +163,25 @@ class DuplicateNameInPublicationException(
     )
 
 class DuplicateLocationTrackNameInPublicationException(
-    alignmentName: LocationTrackName,
+    locationTrackName: LocationTrackName,
     trackNumber: TrackNumber,
     cause: Throwable? = null,
 ) :
     ClientException(
         status = BAD_REQUEST,
-        message = "Duplicate location track $alignmentName in $trackNumber",
+        message = "Duplicate location track $locationTrackName in $trackNumber",
         cause = cause,
         localizedMessageKey = "error.publication.duplicate-name-on.location-track",
-        localizedMessageParams = localizationParams("locationTrack" to alignmentName, "trackNumber" to trackNumber),
+        localizedMessageParams = localizationParams("locationTrack" to locationTrackName, "trackNumber" to trackNumber),
     )
 
-class SplitSourceLocationTrackUpdateException(alignmentName: LocationTrackName, cause: Throwable? = null) :
+class SplitSourceLocationTrackUpdateException(locationTrackName: LocationTrackName, cause: Throwable? = null) :
     ClientException(
         status = BAD_REQUEST,
         message = "Split source location track updates are not allowed",
         cause = cause,
         localizedMessageKey = "error.split.source-track-update-is-not-allowed",
-        localizedMessageParams = localizationParams("alignmentName" to alignmentName),
+        localizedMessageParams = localizationParams("name" to locationTrackName),
     )
 
 enum class Integration {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/AlignmentHeights.kt
@@ -1,5 +1,6 @@
 package fi.fta.geoviite.infra.geometry
 
+import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.ElevationMeasurementMethod
 import fi.fta.geoviite.infra.common.KmNumber
@@ -33,7 +34,7 @@ data class PlanLinkingSummaryItem<M : AlignmentM<M>>(
     val startM: LineM<M>,
     val endM: LineM<M>,
     val filename: FileName?,
-    val alignmentHeader: AlignmentHeader<GeometryAlignment, LayoutState>?,
+    val alignmentHeader: AlignmentHeader<GeometryAlignment, AlignmentName, LayoutState>?,
     val planId: DomainId<GeometryPlan>?,
     val verticalCoordinateSystem: VerticalCoordinateSystem?,
     val elevationMeasurementMethod: ElevationMeasurementMethod?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/ElementListing.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.common.SwitchName
@@ -27,7 +28,6 @@ import fi.fta.geoviite.infra.tracklayout.LayoutEdge
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
-import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
 import fi.fta.geoviite.infra.util.CsvEntry
@@ -62,7 +62,7 @@ data class ElementListing(
     val trackNumberDescription: PlanElementName?,
     val alignmentId: DomainId<GeometryAlignment>?,
     val alignmentName: AlignmentName?,
-    val locationTrackName: AlignmentName?,
+    val locationTrackName: LocationTrackName?,
     val elementId: DomainId<GeometryElement>?,
     val elementType: TrackGeometryElementType,
     val lengthMeters: BigDecimal,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/VerticalGeometryListing.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.ElevationMeasurementMethod
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.StringId
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -94,7 +95,7 @@ data class VerticalGeometryListing(
     val fileName: FileName?,
     val alignmentId: DomainId<GeometryAlignment>?,
     val alignmentName: AlignmentName?,
-    val locationTrackName: AlignmentName?,
+    val locationTrackName: LocationTrackName?,
     val start: CurvedSectionEndpoint,
     val end: CurvedSectionEndpoint,
     val point: IntersectionPoint,
@@ -279,7 +280,7 @@ private fun toVerticalGeometry(
 fun toVerticalGeometryListing(
     segment: CurvedProfileSegment,
     alignment: GeometryAlignment,
-    locationTrackName: AlignmentName?,
+    locationTrackName: LocationTrackName?,
     coordinateTransform: Transformation?,
     planHeader: GeometryPlanHeader,
     geocodingContext: GeocodingContext<*>?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.map
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.geography.bufferedPolygonForLineStringPoints
 import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.logging.Loggable
@@ -40,16 +41,16 @@ enum class MapAlignmentType {
     REFERENCE_LINE,
 }
 
-sealed class AlignmentHeader<AlignmentType, StateType> {
+sealed class AlignmentHeader<AlignmentType, NameType, StateType> {
     abstract val id: DomainId<AlignmentType>
     abstract val trackNumberId: DomainId<LayoutTrackNumber>?
-    abstract val name: AlignmentName
     abstract val state: StateType
     abstract val alignmentSource: MapAlignmentSource
     abstract val alignmentType: MapAlignmentType
     abstract val length: LineM<*>
     abstract val boundingBox: BoundingBox?
     abstract val segmentCount: Int
+    abstract val name: NameType
 }
 
 data class GeometryAlignmentHeader(
@@ -61,7 +62,7 @@ data class GeometryAlignmentHeader(
     override val length: LineM<PlanLayoutAlignmentM>,
     override val boundingBox: BoundingBox?,
     override val segmentCount: Int,
-) : AlignmentHeader<GeometryAlignment, LayoutState>() {
+) : AlignmentHeader<GeometryAlignment, AlignmentName, LayoutState>() {
     override val alignmentSource = MapAlignmentSource.GEOMETRY
 }
 
@@ -74,7 +75,7 @@ data class ReferenceLineHeader(
     override val length: LineM<ReferenceLineM>,
     override val boundingBox: BoundingBox?,
     override val segmentCount: Int,
-) : AlignmentHeader<ReferenceLine, LayoutState>() {
+) : AlignmentHeader<ReferenceLine, AlignmentName, LayoutState>() {
     override val alignmentSource = MapAlignmentSource.LAYOUT
     override val alignmentType = MapAlignmentType.REFERENCE_LINE
 }
@@ -84,13 +85,13 @@ data class LocationTrackHeader(
     val version: LayoutRowVersion<LocationTrack>,
     override val trackNumberId: IntId<LayoutTrackNumber>,
     val duplicateOf: IntId<LocationTrack>?,
-    override val name: AlignmentName,
+    override val name: LocationTrackName,
     override val state: LocationTrackState,
     val trackType: LocationTrackType,
     override val length: LineM<LocationTrackM>,
     override val boundingBox: BoundingBox?,
     override val segmentCount: Int,
-) : AlignmentHeader<LocationTrack, LocationTrackState>() {
+) : AlignmentHeader<LocationTrack, LocationTrackName, LocationTrackState>() {
     override val alignmentSource = MapAlignmentSource.LAYOUT
     override val alignmentType = MapAlignmentType.LOCATION_TRACK
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
@@ -12,6 +11,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.MeasurementMethod
 import fi.fta.geoviite.infra.common.Oid
@@ -235,7 +235,7 @@ data class PublishedReferenceLine(
 
 data class PublishedLocationTrack(
     val version: LayoutRowVersion<LocationTrack>,
-    val name: AlignmentName,
+    val name: LocationTrackName,
     val trackNumberId: IntId<LayoutTrackNumber>,
     val operation: Operation,
     val changedKmNumbers: Set<KmNumber>,
@@ -571,7 +571,7 @@ data class ReferenceLinePublicationCandidate(
 
 data class LocationTrackPublicationCandidate(
     override val rowVersion: LayoutRowVersion<LocationTrack>,
-    val name: AlignmentName,
+    val name: LocationTrackName,
     val trackNumberId: IntId<LayoutTrackNumber>,
     override val draftChangeTime: Instant,
     val duplicateOf: IntId<LocationTrack>?,
@@ -619,7 +619,7 @@ data class KmPostPublicationCandidate(
 data class SwitchLocationTrack(
     val id: IntId<LocationTrack>,
     val trackNumberId: IntId<LayoutTrackNumber>,
-    val name: AlignmentName,
+    val name: LocationTrackName,
     val joints: List<PublicationSwitchJoint>,
 )
 
@@ -648,7 +648,7 @@ fun <T> Change<T?>.ifHasEndState(): Change<T>? = if (new != null) Change(old, ne
 
 data class LocationTrackChanges(
     val id: IntId<LocationTrack>,
-    val name: Change<AlignmentName>,
+    val name: Change<LocationTrackName>,
     val descriptionBase: Change<LocationTrackDescriptionBase>,
     val descriptionSuffix: Change<LocationTrackDescriptionSuffix>,
     val state: Change<LocationTrackState>,
@@ -678,7 +678,7 @@ data class TrackNumberJointLocationChange(
 
 data class TrackJointChange(
     val id: IntId<LocationTrack>,
-    val name: AlignmentName,
+    val name: LocationTrackName,
     val joints: Change<List<JointNumber>?>,
 )
 
@@ -792,7 +792,7 @@ data class SplitInPublication(
 
 data class SplitTargetInPublication(
     val id: IntId<LocationTrack>,
-    val name: AlignmentName,
+    val name: LocationTrackName,
     val oid: Oid<LocationTrack>?,
     val startAddress: TrackMeter?,
     val endAddress: TrackMeter?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.publication
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
@@ -11,6 +10,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MeasurementMethod
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.SwitchName
@@ -283,7 +283,7 @@ class PublicationDao(
             jdbcTemplate.query(sql, publicationCandidateSqlArguments(transition)) { rs, _ ->
                 LocationTrackPublicationCandidate(
                     rowVersion = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
-                    name = AlignmentName(rs.getString("name")),
+                    name = LocationTrackName(rs.getString("name")),
                     trackNumberId = rs.getIntId("track_number_id"),
                     draftChangeTime = rs.getInstant("change_time"),
                     duplicateOf = rs.getIntIdOrNull("duplicate_of_location_track_id"),
@@ -1046,7 +1046,7 @@ class PublicationDao(
                     LocationTrackChanges(
                         id,
                         trackNumberId = rs.getChange("track_number_id", rs::getIntIdOrNull),
-                        name = rs.getChange("name") { rs.getString(it)?.let(::AlignmentName) },
+                        name = rs.getChange("name") { rs.getString(it)?.let(::LocationTrackName) },
                         descriptionBase =
                             rs.getChange("description_base") { rs.getString(it)?.let(::LocationTrackDescriptionBase) },
                         descriptionSuffix =
@@ -1516,7 +1516,7 @@ class PublicationDao(
                     rs.getListOrNull<Int>("track_track_number_ids")?.map { IntId<LayoutTrackNumber>(it) } ?: emptyList()
                 val trackChangeSides =
                     rs.getStringArrayOrNull("track_change_sides")?.map { enumValueOf<ChangeSide>(it) } ?: emptyList()
-                val trackNames = rs.getStringArrayOrNull("track_names")?.map(::AlignmentName) ?: emptyList()
+                val trackNames = rs.getStringArrayOrNull("track_names")?.map(::LocationTrackName) ?: emptyList()
                 val trackJointNumbers = rs.getListOrNull<Int>("track_joint_numbers")?.map(::JointNumber) ?: emptyList()
                 val trackJointXs = rs.getListOrNull<Double>("track_joint_locations_x") ?: emptyList()
                 val trackJointYs = rs.getListOrNull<Double>("track_joint_locations_y") ?: emptyList()
@@ -2086,11 +2086,10 @@ class PublicationDao(
                 (rs.getIntId<Publication>("publication_id") to rs.getBoolean("direct_change")) to
                     PublishedLocationTrack(
                         version = rs.getLayoutRowVersion("id", "design_id", "draft", "version"),
-                        name = AlignmentName(rs.getString("name")),
+                        name = LocationTrackName(rs.getString("name")),
                         trackNumberId = rs.getIntId("track_number_id"),
                         operation = rs.getEnum("operation"),
-                        changedKmNumbers =
-                            rs.getStringArrayOrNull("changed_km")?.map(::KmNumber)?.toSet() ?: emptySet(),
+                        changedKmNumbers = rs.getStringArrayOrNull("changed_km")?.map(::KmNumber)?.toSet() ?: emptySet(),
                     )
             }
             .let { locationTrackRows ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -1,12 +1,12 @@
 package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
@@ -43,12 +43,12 @@ import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsFirstComparator
 import fi.fta.geoviite.infra.util.printCsv
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.ZoneId
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 
 const val DISTANCE_CHANGE_THRESHOLD = 0.0005
 
@@ -317,7 +317,7 @@ constructor(
     }
 
     @Transactional(readOnly = true)
-    fun getSplitInPublicationCsv(id: IntId<Publication>, lang: LocalizationLanguage): Pair<String, AlignmentName?> {
+    fun getSplitInPublicationCsv(id: IntId<Publication>, lang: LocalizationLanguage): Pair<String, LocationTrackName?> {
         return getSplitInPublication(id).let { splitInPublication ->
             val data = splitInPublication?.targetLocationTracks?.map { lt -> splitInPublication to lt } ?: emptyList()
             printCsv(splitCsvColumns(localizationService.getLocalization(lang)), data) to

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -1,11 +1,11 @@
 package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Uuid
@@ -490,7 +490,7 @@ constructor(
                 if (trackNumberVersion != null) {
                     val trackNumber = trackNumberDao.fetch(trackNumberVersion)
                     throw DuplicateLocationTrackNameInPublicationException(
-                        AlignmentName(nameString),
+                        LocationTrackName(nameString),
                         trackNumber.number,
                         exception,
                     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -564,7 +564,7 @@ constructor(
 
             val startSwitch = track.startSwitchId?.let(validationContext::getSwitch)
             val endSwitch = track.endSwitchId?.let(validationContext::getSwitch)
-            val nameIssues = validateLocationTrackEndSwitchNames(track, startSwitch, endSwitch)
+            val switchNameIssues = validateLocationTrackEndSwitchNames(track, startSwitch, endSwitch)
 
             val tracksWithSameName = validationContext.getLocationTracksByName(track.name)
             val nameDuplicationIssues =
@@ -580,7 +580,7 @@ constructor(
                 duplicateIssues +
                 alignmentIssues +
                 geocodingIssues +
-                nameIssues +
+                switchNameIssues +
                 nameDuplicationIssues +
                 trackNetworkTopologyIssues +
                 switchConnectivityIssues)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -560,8 +560,12 @@ constructor(
                     } ?: listOf(noGeocodingContext(VALIDATION_LOCATION_TRACK))
                 } else listOf()
 
+            val startSwitch = track.startSwitchId?.let(validationContext::getSwitch)
+            val endSwitch = track.endSwitchId?.let(validationContext::getSwitch)
+            val nameIssues = validateLocationTrackEndSwitchNames(track, startSwitch, endSwitch)
+
             val tracksWithSameName = validationContext.getLocationTracksByName(track.name)
-            val duplicateNameIssues =
+            val nameDuplicationIssues =
                 validateLocationTrackNameDuplication(
                     track,
                     trackNumberName,
@@ -574,7 +578,8 @@ constructor(
                 duplicateIssues +
                 alignmentIssues +
                 geocodingIssues +
-                duplicateNameIssues +
+                nameIssues +
+                nameDuplicationIssues +
                 trackNetworkTopologyIssues +
                 switchConnectivityIssues)
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -1,8 +1,8 @@
 package fi.fta.geoviite.infra.publication
 
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackNumber
@@ -126,7 +126,7 @@ class ValidationContext(
     fun getLocationTrack(id: IntId<LocationTrack>): LocationTrack? =
         getObject(target.baseContext, id, publicationSet.locationTracks, locationTrackDao, locationTrackVersionCache)
 
-    fun getLocationTracksByName(name: AlignmentName): List<LocationTrack> =
+    fun getLocationTracksByName(name: LocationTrackName): List<LocationTrack> =
         trackNameCache.get(name).mapNotNull(::getLocationTrack)
 
     fun getDuplicateTrackIds(trackId: IntId<LocationTrack>): List<IntId<LocationTrack>>? =
@@ -321,7 +321,7 @@ class ValidationContext(
     fun preloadLocationTracksByName(trackIds: List<IntId<LocationTrack>>) =
         trackNameCache.preload(trackIds.mapNotNull(::getLocationTrack).map(LocationTrack::name).distinct())
 
-    fun fetchLocationTracksByName(names: List<AlignmentName>): Map<AlignmentName, List<IntId<LocationTrack>>> {
+    fun fetchLocationTracksByName(names: List<LocationTrackName>): Map<LocationTrackName, List<IntId<LocationTrack>>> {
         val baseVersions = locationTrackDao.findNameDuplicates(target.baseContext, names)
         cacheBaseVersions(baseVersions.values.flatten(), locationTrackVersionCache)
         return mapIdsByField(names, { t -> t.name }, publicationSet.locationTracks, baseVersions, locationTrackDao)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.publication.Publication
@@ -161,7 +162,7 @@ data class SplittingInitializationParameters(
 data class SplitDuplicateTrack(
     val id: IntId<LocationTrack>,
     val nameStructure: LocationTrackNameStructure,
-    val name: AlignmentName,
+    val name: LocationTrackName,
     val length: LineM<LocationTrackM>,
     val status: DuplicateStatus,
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.split
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.error.PublicationFailureException
@@ -44,9 +44,9 @@ import fi.fta.geoviite.infra.tracklayout.TopologicalConnectivityType
 import fi.fta.geoviite.infra.tracklayout.topologicalConnectivityTypeOf
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.produceIf
+import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @GeoviiteService
 class SplitService(
@@ -679,7 +679,7 @@ private fun createSplitTarget(
             descriptionStructure = request.descriptionStructure,
 
             // These will be automatically recalculated upon saving
-            name = AlignmentName("?"),
+            name = LocationTrackName("?"),
             description = FreeText("?"),
 
             // After split, tracks are not duplicates

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/GeometryPlanLayout.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -56,7 +57,7 @@ data class GeometryPlanLayout(
 }
 
 data class PlanLayoutAlignment(
-    val header: AlignmentHeader<GeometryAlignment, LayoutState>,
+    val header: AlignmentHeader<GeometryAlignment, AlignmentName, LayoutState>,
     @JsonIgnore override val segments: List<PlanLayoutSegment>,
     @JsonIgnore val staStart: Double,
     val polyLine: AlignmentPolyLine<GeometryAlignment, PlanLayoutAlignmentM>? = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -7,12 +7,12 @@ import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
 import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
@@ -264,7 +264,7 @@ class LocationTrackController(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @PathVariable("trackNumberId") trackNumberId: IntId<LayoutTrackNumber>,
-        @RequestParam("locationTrackNames") names: List<AlignmentName>,
+        @RequestParam("locationTrackNames") names: List<LocationTrackName>,
         @RequestParam("includeDeleted") includeDeleted: Boolean = true,
     ): List<LocationTrack> {
         val context = LayoutContext.of(layoutBranch, publicationState)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.configuration.CACHE_COMMON_LOCATION_TRACK_OWNER
 import fi.fta.geoviite.infra.geometry.MetaDataName
@@ -30,14 +31,14 @@ import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setForceCustomPlan
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.sql.Timestamp
-import java.time.Instant
 
 const val LOCATIONTRACK_CACHE_SIZE = 10000L
 
@@ -102,8 +103,8 @@ class LocationTrackDao(
 
     fun findNameDuplicates(
         context: LayoutContext,
-        names: List<AlignmentName>,
-    ): Map<AlignmentName, List<LayoutRowVersion<LocationTrack>>> {
+        names: List<LocationTrackName>,
+    ): Map<LocationTrackName, List<LayoutRowVersion<LocationTrack>>> {
         return if (names.isEmpty()) {
             emptyMap()
         } else {
@@ -122,9 +123,9 @@ class LocationTrackDao(
                     "design_id" to context.branch.designId?.intValue,
                 )
             val found =
-                jdbcTemplate.query<Pair<AlignmentName, LayoutRowVersion<LocationTrack>>>(sql, params) { rs, _ ->
+                jdbcTemplate.query<Pair<LocationTrackName, LayoutRowVersion<LocationTrack>>>(sql, params) { rs, _ ->
                     val daoResponse = rs.getLayoutRowVersion<LocationTrack>("id", "design_id", "draft", "version")
-                    val name = rs.getString("name").let(::AlignmentName)
+                    val name = rs.getString("name").let(::LocationTrackName)
                     name to daoResponse
                 }
             // Ensure that the result contains all asked-for names, even if there are no matches
@@ -253,7 +254,7 @@ class LocationTrackDao(
         LocationTrack(
             sourceId = null,
             trackNumberId = rs.getIntId("track_number_id"),
-            name = rs.getString("name").let(::AlignmentName),
+            name = rs.getString("name").let(::LocationTrackName),
             nameStructure =
                 LocationTrackNameStructure.of(
                     scheme = rs.getEnum("naming_scheme"),
@@ -412,14 +413,14 @@ class LocationTrackDao(
         layoutContext: LayoutContext,
         includeDeleted: Boolean,
         trackNumberId: IntId<LayoutTrackNumber>? = null,
-        names: List<AlignmentName> = emptyList(),
+        names: List<LocationTrackName> = emptyList(),
     ) = fetchVersions(layoutContext, includeDeleted, trackNumberId, names).let(::fetchMany)
 
     fun fetchVersions(
         layoutContext: LayoutContext,
         includeDeleted: Boolean,
         trackNumberId: IntId<LayoutTrackNumber>? = null,
-        names: List<AlignmentName> = emptyList(),
+        names: List<LocationTrackName> = emptyList(),
     ): List<LayoutRowVersion<LocationTrack>> {
         val sql =
             """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -1,13 +1,13 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.error.NoSuchEntityException
@@ -46,11 +46,11 @@ import fi.fta.geoviite.infra.tracklayout.DuplicateEndPointType.START
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.processFlattened
+import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
 
 const val TRACK_SEARCH_AREA_SIZE = 2.0
 const val OPERATING_POINT_AROUND_SWITCH_SEARCH_AREA_SIZE = 1000.0
@@ -117,7 +117,7 @@ class LocationTrackService(
         } catch (dataIntegrityException: DataIntegrityViolationException) {
             throw if (isSplitSourceReferenceError(dataIntegrityException)) {
                 SplitSourceLocationTrackUpdateException(
-                    AlignmentName(request.nameFreeText?.toString() ?: ""),
+                    LocationTrackName(request.nameFreeText?.toString() ?: ""),
                     dataIntegrityException,
                 )
             } else {
@@ -247,7 +247,7 @@ class LocationTrackService(
         layoutContext: LayoutContext,
         includeDeleted: Boolean,
         trackNumberId: IntId<LayoutTrackNumber>,
-        names: List<AlignmentName>,
+        names: List<LocationTrackName>,
     ): List<LocationTrack> {
         return dao.list(layoutContext, includeDeleted, trackNumberId, names)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentController.kt
@@ -4,9 +4,11 @@ import fi.fta.geoviite.infra.aspects.GeoviiteController
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
 import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
+import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.map.AlignmentHeader
 import fi.fta.geoviite.infra.map.AlignmentPolyLine
@@ -65,7 +67,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<LocationTrack>>,
-    ): List<AlignmentHeader<LocationTrack, LocationTrackState>> {
+    ): List<AlignmentHeader<LocationTrack, LocationTrackName, LocationTrackState>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getLocationTrackHeaders(layoutContext, ids)
     }
@@ -76,7 +78,7 @@ class MapAlignmentController(private val mapAlignmentService: MapAlignmentServic
         @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
         @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
         @RequestParam("ids") ids: List<IntId<ReferenceLine>>,
-    ): List<AlignmentHeader<ReferenceLine, LayoutState>> {
+    ): List<AlignmentHeader<ReferenceLine, AlignmentName, LayoutState>> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return mapAlignmentService.getReferenceLineHeaders(layoutContext, ids)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/MapAlignmentService.kt
@@ -1,9 +1,11 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.map.AlignmentHeader
 import fi.fta.geoviite.infra.map.AlignmentPolyLine
 import fi.fta.geoviite.infra.map.MapAlignmentType
@@ -122,7 +124,7 @@ class MapAlignmentService(
     fun getReferenceLineHeaders(
         layoutContext: LayoutContext,
         referenceLineIds: List<IntId<ReferenceLine>>,
-    ): List<AlignmentHeader<ReferenceLine, LayoutState>> {
+    ): List<AlignmentHeader<ReferenceLine, AlignmentName, LayoutState>> {
         val referenceLines = referenceLineService.getManyWithAlignments(layoutContext, referenceLineIds)
         val trackNumbers =
             trackNumberService
@@ -140,7 +142,7 @@ class MapAlignmentService(
     fun getLocationTrackHeaders(
         layoutContext: LayoutContext,
         locationTrackIds: List<IntId<LocationTrack>>,
-    ): List<AlignmentHeader<LocationTrack, LocationTrackState>> {
+    ): List<AlignmentHeader<LocationTrack, LocationTrackName, LocationTrackState>> {
         return locationTrackService.getManyWithGeometries(layoutContext, locationTrackIds).map { (track, geometry) ->
             toAlignmentHeader(track, geometry)
         }

--- a/infra/src/main/resources/db/migration/prod/V127__lengthen_location_track_name.sql
+++ b/infra/src/main/resources/db/migration/prod/V127__lengthen_location_track_name.sql
@@ -1,0 +1,16 @@
+alter table layout.location_track
+  disable trigger version_update_trigger;
+alter table layout.location_track
+  disable trigger version_row_trigger;
+
+drop view if exists layout.location_track_change_view;
+
+alter table layout.location_track
+  alter column name type varchar(87);
+alter table layout.location_track_version
+  alter column name type varchar(87);
+
+alter table layout.location_track
+  enable trigger version_update_trigger;
+alter table layout.location_track
+  enable trigger version_row_trigger;

--- a/infra/src/main/resources/db/migration/repeatable/R__03.11_layout_location_track_change_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__03.11_layout_location_track_change_view.sql
@@ -1,4 +1,4 @@
--- increment to force a rerun: 2
+-- increment to force a rerun: 3
 
 drop view if exists layout.location_track_change_view;
 create view layout.location_track_change_view as
@@ -15,13 +15,13 @@ select
   old.state as old_state
   from layout.location_track_version
     left join lateral (
-      select state
+    select state
       from layout.location_track_version old
       where old.id = location_track_version.id
         and old.layout_context_id = location_track_version.layout_context_id
         and old.version < location_track_version.version
       order by old.version desc
       limit 1
-      ) old on (true)
+    ) old on (true)
   where not draft
-);
+    );

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1646,7 +1646,12 @@
                     "alignment-not-continuous": "Sijaintiraide on kytketty vaihteelle {{switch}} useammasta kuin yhdestä kohtaa",
                     "joint-location-mismatch": "Sijaintiraiteen ja vaihteen {{switch}} vaihdepisteiden sijainnit eivät vastaa toisiaan",
                     "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{switchJoints}}) vaihteella {{switch}} ({{switchType}}) eivät vastaa vaihderakenteen linjoja",
-                    "wrong-links": "Vaihteen {{switch}} linkitys on vajavainen ja se täytyy linkittää uudelleen"
+                    "wrong-links": "Vaihteen {{switch}} linkitys on puutteellinen ja se täytyy linkittää uudelleen",
+                    "missing-both-switches-name": "Sijaintiraidetunnusta ei voi muodostaa oikein, sillä raiteen molemmissa päissä ei ole vaihdetta",
+                    "unshortenable-name": "Vaihteen {{switchName}} nimi ei ole määrämuotoinen, eikä sitä voida käyttää sijaintiraidetunnuksessa tai raiteen kuvauksessa",
+                    "too-many-switches": "Raiteen kuvausta ei voi muodostaa oikein, sillä raide yhdistyy vaihteisiin molemmista päistä",
+                    "missing-one-switch": "Raiteen kuvausta ei voi muodostaa oikein, sillä raiteen kummassakaan päässä ei ole vaihdetta",
+                    "missing-both-switches-description": "Raiteen kuvausta ei voi muodostaa oikein, sillä raiteen molemmissa päissä ei ole vaihdetta"
                 },
                 "switch-linkage": {
                     "front-joint-not-connected": "Vaihteen {{switch}} etujatkokselta ei jatku raidetta",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1649,11 +1649,11 @@
                     "joint-location-mismatch": "Sijaintiraiteen ja vaihteen {{switch}} vaihdepisteiden sijainnit eivät vastaa toisiaan",
                     "wrong-joint-sequence": "Sijaintiraiteen vaihdepisteet ({{switchJoints}}) vaihteella {{switch}} ({{switchType}}) eivät vastaa vaihderakenteen linjoja",
                     "wrong-links": "Vaihteen {{switch}} linkitys on puutteellinen ja se täytyy linkittää uudelleen",
-                    "missing-both-switches-name": "Sijaintiraidetunnusta ei voi muodostaa oikein, sillä raiteen molemmissa päissä ei ole vaihdetta",
+                    "missing-both-switches-name": "Sijaintiraidetunnusta ei voida muodostaa oikein, sillä raiteen molemmissa päissä ei ole vaihdetta",
                     "unshortenable-name": "Vaihteen {{switchName}} nimi ei ole määrämuotoinen, eikä sitä voida käyttää sijaintiraidetunnuksessa tai raiteen kuvauksessa",
-                    "too-many-switches": "Raiteen kuvausta ei voi muodostaa oikein, sillä raide yhdistyy vaihteisiin molemmista päistä",
-                    "missing-one-switch": "Raiteen kuvausta ei voi muodostaa oikein, sillä raiteen kummassakaan päässä ei ole vaihdetta",
-                    "missing-both-switches-description": "Raiteen kuvausta ei voi muodostaa oikein, sillä raiteen molemmissa päissä ei ole vaihdetta"
+                    "too-many-switches": "Raiteen kuvausta ei voida muodostaa oikein, sillä raide yhdistyy vaihteisiin molemmista päistä",
+                    "missing-one-switch": "Raiteen kuvausta ei voida muodostaa oikein, sillä raiteen kummassakaan päässä ei ole vaihdetta",
+                    "missing-both-switches-description": "Raiteen kuvausta ei voida muodostaa oikein, sillä raiteen molemmissa päissä ei ole vaihdetta"
                 },
                 "switch-linkage": {
                     "front-joint-not-connected": "Vaihteen {{switch}} etujatkokselta ei jatku raidetta",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -65,7 +65,7 @@
         },
         "split": {
             "source-track-state-not-in-use": "Jakamista ei voitu suorittaa, koska jaettava raide ei ole \"Käytössä\"-tilassa",
-            "source-track-update-is-not-allowed": "Raide {{alignmentName}} on jaettu, eikä sen muokkaaminen ole enää mahdollista",
+            "source-track-update-is-not-allowed": "Raide {{name}} on jaettu, eikä sen muokkaaminen ole enää mahdollista",
             "segment-allocation-failed": "Jakamista ei voitu suorittaa, koska katkaisukohtien määritys epäonnistui",
             "switch-segment-mapping-failed": "Raidetta ei voitu jakaa vaihteen {{switchName}} kohdalta, koska sen uudelleenlinkitys epäonnistui",
             "switch-linking-failed": "Jakamista ei voitu suorittaa, koska vaihteiden uudelleenlinkitys epäonnistui",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTest.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.linking.switches
 
 import fi.fta.geoviite.infra.asSwitchStructure
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.lineLength
@@ -42,7 +42,7 @@ data class TrackForSwitchFitting(
         // must fake a stored asset ID because the switch linking code implements its own version-based locking
         val contextData =
             MainOfficialContextData(StoredAssetId(LayoutRowVersion(LayoutRowId(newId, LayoutBranch.main.official), 1)))
-        return copy(locationTrack = locationTrack.copy(contextData = contextData, name = AlignmentName(name)))
+        return copy(locationTrack = locationTrack.copy(contextData = contextData, name = LocationTrackName(name)))
     }
 
     fun startPoint(): IPoint {
@@ -110,11 +110,12 @@ data class TrackForSwitchFitting(
                     val (edge, mRange) = geometry.getEdgeAtMOrThrow(mOnTrack)
                     val edgeIndex = geometry.edges.indexOf(edge)
                     val mOnEdge = mOnTrack - mRange.min
-                    edgeIndex to SwitchLinkingJoint(
-                        mOnEdge.castToDifferentM(),
-                        joint.jointNumber,
-                        edge.getPointAtM(mOnEdge.castToDifferentM())!!.toPoint()
-                    )
+                    edgeIndex to
+                        SwitchLinkingJoint(
+                            mOnEdge.castToDifferentM(),
+                            joint.jointNumber,
+                            edge.getPointAtM(mOnEdge.castToDifferentM())!!.toPoint(),
+                        )
                 }
                 .groupBy({ it.first }, { it.second })
         val newEdges =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingTest.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.linking.switches
 
 import fi.fta.geoviite.infra.asSwitchStructure
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoints
@@ -27,10 +27,10 @@ import fi.fta.geoviite.infra.tracklayout.segmentPoint
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class SwitchLinkingTest {
 
@@ -607,9 +607,27 @@ class SwitchLinkingTest {
         val linkedTracks = directlyApplyFittedSwitchChangesToTracks(switchId, fittedSwitch, nearbyTracks)
 
         // validate
-        assertInnerSwitchNodeExists(linkedTracks, trackA.locationTrackId, switchId = switchId, joint = 1, mValue = LineM(0.0))
-        assertInnerSwitchNodeExists(linkedTracks, trackA.locationTrackId, switchId = switchId, joint = 5, mValue = LineM(16.0))
-        assertInnerSwitchNodeExists(linkedTracks, trackA.locationTrackId, switchId = switchId, joint = 2, mValue = LineM(30.0))
+        assertInnerSwitchNodeExists(
+            linkedTracks,
+            trackA.locationTrackId,
+            switchId = switchId,
+            joint = 1,
+            mValue = LineM(0.0),
+        )
+        assertInnerSwitchNodeExists(
+            linkedTracks,
+            trackA.locationTrackId,
+            switchId = switchId,
+            joint = 5,
+            mValue = LineM(16.0),
+        )
+        assertInnerSwitchNodeExists(
+            linkedTracks,
+            trackA.locationTrackId,
+            switchId = switchId,
+            joint = 2,
+            mValue = LineM(30.0),
+        )
         assertJointsOnSequentialEdges(
             linkedTracks,
             trackA.locationTrackId,
@@ -617,13 +635,19 @@ class SwitchLinkingTest {
             joints = listOf(1, 5, 2),
         )
 
-        assertInnerSwitchNodeExists(linkedTracks, trackB.locationTrackId, switchId = switchId, joint = 1, mValue = LineM(0.0))
+        assertInnerSwitchNodeExists(
+            linkedTracks,
+            trackB.locationTrackId,
+            switchId = switchId,
+            joint = 1,
+            mValue = LineM(0.0),
+        )
         assertInnerSwitchNodeExists(
             linkedTracks,
             trackB.locationTrackId,
             switchId = switchId,
             joint = 3,
-            mValue = LineM(32.567,)
+            mValue = LineM(32.567),
         )
         assertJointsOnSequentialEdges(linkedTracks, trackB.locationTrackId, switchId = switchId, joints = listOf(1, 3))
     }
@@ -1119,14 +1143,14 @@ fun assertTrackAndGeometry(
 
 fun assertTrackAndGeometry(
     tracks: List<Pair<LocationTrack, LocationTrackGeometry>>,
-    name: AlignmentName,
+    name: LocationTrackName,
 ): Pair<LocationTrack, LocationTrackGeometry> {
     val trackAndGeometry = tracks.firstOrNull { (locationTrack, _) -> locationTrack.name == name }
     assertNotNull(trackAndGeometry, "Tracks do not contain location track '$name'")
     return trackAndGeometry
 }
 
-fun assertTracksExists(tracks: List<Pair<LocationTrack, LocationTrackGeometry>>, vararg trackNames: AlignmentName) {
+fun assertTracksExists(tracks: List<Pair<LocationTrack, LocationTrackGeometry>>, vararg trackNames: LocationTrackName) {
     trackNames.forEach { name -> assertTrackAndGeometry(tracks, name) }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.infra.publication
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.TEST_USER
 import fi.fta.geoviite.infra.authorization.UserName
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
@@ -11,6 +10,7 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
@@ -108,7 +108,7 @@ constructor(
     @Test
     fun locationTrackPublicationCandidatesAreFound() {
         val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (_, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        val (_, draft) = insertAndCheck(asMainDraft(track).copy(name = LocationTrackName("${track.name} DRAFT")))
         val candidates = publicationDao.fetchLocationTrackPublicationCandidates(PublicationInMain)
         assertEquals(1, candidates.size)
         assertEquals(track.id, candidates.first().id)
@@ -142,12 +142,12 @@ constructor(
     @Test
     fun modifyOperationIsInferredCorrectly() {
         val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = LocationTrackName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
             LayoutBranch.main,
             locationTrackService.getOrThrow(MainLayoutContext.official, draft.id as IntId).let { lt ->
-                lt.copy(name = AlignmentName("${lt.name} TEST"))
+                lt.copy(name = LocationTrackName("${lt.name} TEST"))
             },
             TmpLocationTrackGeometry.empty,
         )
@@ -160,7 +160,7 @@ constructor(
     @Test
     fun deleteOperationIsInferredCorrectly() {
         val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
-        val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT")))
+        val (version, draft) = insertAndCheck(asMainDraft(track).copy(name = LocationTrackName("${track.name} DRAFT")))
         publishAndCheck(version)
         locationTrackService.saveDraft(
             LayoutBranch.main,
@@ -180,7 +180,8 @@ constructor(
         val (_, track) = insertAndCheck(locationTrack(mainOfficialContext.createLayoutTrackNumber().id, draft = false))
         val (version, draft) =
             insertAndCheck(
-                asMainDraft(track).copy(name = AlignmentName("${track.name} DRAFT"), state = LocationTrackState.DELETED)
+                asMainDraft(track)
+                    .copy(name = LocationTrackName("${track.name} DRAFT"), state = LocationTrackState.DELETED)
             )
         publishAndCheck(version)
         locationTrackService.saveDraft(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
@@ -72,6 +73,12 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.tracklayout.trackNumberSaveRequest
 import fi.fta.geoviite.infra.util.SortOrder
+import java.sql.Timestamp
+import java.time.Instant
+import kotlin.math.absoluteValue
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -80,12 +87,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import publicationRequest
 import publish
-import java.sql.Timestamp
-import java.time.Instant
-import kotlin.math.absoluteValue
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1437,7 +1438,7 @@ constructor(
             alignment(segment(Point(1.0, 0.0), Point(1.0, 10.0))),
         )
         mainOfficialContext.fetchWithGeometry(locationTrack.id)!!.let { (t, g) ->
-            locationTrackService.saveDraft(designBranch, t.copy(name = AlignmentName("edited in design")), g)
+            locationTrackService.saveDraft(designBranch, t.copy(name = LocationTrackName("edited in design")), g)
         }
         switchService.saveDraft(
             designBranch,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1,7 +1,6 @@
 package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
@@ -9,6 +8,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
@@ -864,7 +864,7 @@ constructor(
         val lt1OriginalVersion = locationTrackDao.save(lt1, someGeometry)
         val lt1RenamedDraft =
             locationTrackDao.save(
-                asMainDraft(locationTrackDao.fetch(lt1OriginalVersion).copy(name = AlignmentName("LT2"))),
+                asMainDraft(locationTrackDao.fetch(lt1OriginalVersion).copy(name = LocationTrackName("LT2"))),
                 someGeometry,
             )
 
@@ -872,7 +872,7 @@ constructor(
         val lt2OriginalVersion = locationTrackDao.save(lt2, someGeometry)
         val lt2RenamedDraft =
             locationTrackDao.save(
-                asMainDraft(locationTrackDao.fetch(lt2OriginalVersion).copy(name = AlignmentName("LT1"))),
+                asMainDraft(locationTrackDao.fetch(lt2OriginalVersion).copy(name = LocationTrackName("LT1"))),
                 someGeometry,
             )
 
@@ -1017,7 +1017,7 @@ constructor(
         )
         testDraftContext.save(
             asDesignDraft(
-                mainOfficialContext.fetch(locationTrack)!!.copy(name = AlignmentName("edited")),
+                mainOfficialContext.fetch(locationTrack)!!.copy(name = LocationTrackName("edited")),
                 testBranch.designId,
             )
         )
@@ -1363,7 +1363,7 @@ constructor(
             )
         locationTrackService.saveDraft(
             LayoutBranch.main,
-            targetTrackToModify.copy(name = AlignmentName("Some other draft name")),
+            targetTrackToModify.copy(name = LocationTrackName("Some other draft name")),
             targetAlignment,
         )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -6,6 +6,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
@@ -62,6 +63,7 @@ import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -75,7 +77,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import publicationRequest
 import publish
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -239,11 +240,11 @@ constructor(
                 LayoutValidationIssue(
                     LayoutValidationIssueType.FATAL,
                     "validation.layout.location-track.duplicate-name-draft",
-                    mapOf("locationTrack" to AlignmentName("NLT"), "trackNumber" to TrackNumber("TN")),
+                    mapOf("locationTrack" to LocationTrackName("NLT"), "trackNumber" to TrackNumber("TN")),
                 )
             },
             validation.validatedAsPublicationUnit.locationTracks
-                .filter { lt -> lt.name == AlignmentName("NLT") }
+                .filter { lt -> lt.name == LocationTrackName("NLT") }
                 .flatMap { it.issues },
         )
 
@@ -1029,10 +1030,7 @@ constructor(
             LayoutValidationIssue(
                 LayoutValidationIssueType.WARNING,
                 "validation.layout.switch.track-linkage.switch-alignment-multiply-connected",
-                mapOf(
-                    "locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})",
-                    "switch" to "TV123",
-                ),
+                mapOf("locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})", "switch" to "TV123"),
             ),
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -1,13 +1,13 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.MeasurementMethod
 import fi.fta.geoviite.infra.common.Oid
@@ -201,7 +201,7 @@ constructor(
         locationTrackDao.insertExternalId(official.id, LayoutBranch.main, oid)
         val draft =
             locationTrackService.getOrThrow(MainLayoutContext.draft, official.id).let { orig ->
-                orig.copy(name = AlignmentName("${orig.name}-draft"))
+                orig.copy(name = LocationTrackName("${orig.name}-draft"))
             }
         locationTrackService.saveDraft(LayoutBranch.main, draft, locationTrackGeometry)
         fakeRatko.hasLocationTrack(ratkoLocationTrack(id = oid.toString()))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -1,9 +1,9 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -16,10 +16,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -129,7 +125,8 @@ constructor(
             )
         val mainDraftLocationTrack =
             mainDraftContext.save(
-                asMainDraft(mainOfficialContext.fetch(locationTrackId)!!).copy(name = AlignmentName("edited in main"))
+                asMainDraft(mainOfficialContext.fetch(locationTrackId)!!)
+                    .copy(name = LocationTrackName("edited in main"))
             )
         val mainDraftSwitch =
             mainDraftContext.save(
@@ -161,7 +158,7 @@ constructor(
         designOfficialContext.moveFrom(
             designDraftContext.save(
                 asDesignDraft(
-                    mainOfficialContext.fetch(locationTrackId)!!.copy(name = AlignmentName("edited in design")),
+                    mainOfficialContext.fetch(locationTrackId)!!.copy(name = LocationTrackName("edited in design")),
                     someDesignBranch.designId,
                 )
             )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextDataIT.kt
@@ -1,10 +1,10 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.math.Point
@@ -265,7 +265,8 @@ constructor(
             lineAndAlignment.second
 
     private fun alterTrack(trackAndGeometry: Pair<LocationTrack, LocationTrackGeometry>) =
-        trackAndGeometry.first.copy(name = AlignmentName("${trackAndGeometry.first.name}-D")) to trackAndGeometry.second
+        trackAndGeometry.first.copy(name = LocationTrackName("${trackAndGeometry.first.name}-D")) to
+            trackAndGeometry.second
 
     private fun alter(switch: LayoutSwitch): LayoutSwitch = switch.copy(name = SwitchName("${switch.name}-D"))
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -1,12 +1,12 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
-import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.DesignLayoutContext
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
@@ -18,6 +18,9 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackType.MAIN
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType.SIDE
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.queryOne
+import kotlin.random.Random
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -26,9 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.random.Random
-import kotlin.test.assertContains
-import kotlin.test.assertFalse
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -125,7 +125,7 @@ constructor(
         assertEquals(insertVersion, locationTrackDao.fetchVersion(MainLayoutContext.draft, id))
         assertMatches(tempGeometry, alignmentDao.fetch(insertVersion))
 
-        val tempDraft1 = asMainDraft(inserted).copy(name = AlignmentName("test2"))
+        val tempDraft1 = asMainDraft(inserted).copy(name = LocationTrackName("test2"))
         val draftVersion1 = locationTrackDao.save(tempDraft1, tempGeometry)
         val draftId1 = draftVersion1.id
         val draft1 = locationTrackDao.fetch(draftVersion1)
@@ -361,11 +361,14 @@ constructor(
         val officialVersion =
             locationTrackDao.save(locationTrack(tnId, name = "official", draft = false), TmpLocationTrackGeometry.empty)
         val official = locationTrackDao.fetch(officialVersion)
-        locationTrackDao.save(asMainDraft(official.copy(name = AlignmentName("draft"))), TmpLocationTrackGeometry.empty)
+        locationTrackDao.save(
+            asMainDraft(official.copy(name = LocationTrackName("draft"))),
+            TmpLocationTrackGeometry.empty,
+        )
         val bothDesign = layoutDesignDao.insert(layoutDesign("both"))
         val bothDesignInitialDesignDraftFromOfficial =
             locationTrackDao.save(
-                asDesignDraft(official.copy(name = AlignmentName("design-official both")), bothDesign),
+                asDesignDraft(official.copy(name = LocationTrackName("design-official both")), bothDesign),
                 TmpLocationTrackGeometry.empty,
             )
         val updatedToDesignOfficial =
@@ -376,14 +379,14 @@ constructor(
         val bothDesignDesignDraftVersion =
             locationTrackDao.save(
                 asDesignDraft(
-                    locationTrackDao.fetch(updatedToDesignOfficial).copy(name = AlignmentName("design-draft both")),
+                    locationTrackDao.fetch(updatedToDesignOfficial).copy(name = LocationTrackName("design-draft both")),
                     bothDesign,
                 ),
                 TmpLocationTrackGeometry.empty,
             )
         val onlyDraftDesign = layoutDesignDao.insert(layoutDesign("onlyDraft"))
         locationTrackDao.save(
-            asDesignDraft(official.copy(name = AlignmentName("design-draft onlyDraft")), onlyDraftDesign),
+            asDesignDraft(official.copy(name = LocationTrackName("design-draft onlyDraft")), onlyDraftDesign),
             TmpLocationTrackGeometry.empty,
         )
 
@@ -434,7 +437,7 @@ constructor(
         val lastDesignDraftVersion =
             locationTrackDao.save(
                 asDesignDraft(
-                    locationTrackDao.fetch(bothDesignNowOfficial).copy(name = AlignmentName("design-draft")),
+                    locationTrackDao.fetch(bothDesignNowOfficial).copy(name = LocationTrackName("design-draft")),
                     bothDesign,
                 ),
                 TmpLocationTrackGeometry.empty,
@@ -518,7 +521,7 @@ constructor(
         val designDraftVersion =
             locationTrackDao.save(
                 asDesignDraft(
-                    locationTrackDao.fetch(official).copy(name = AlignmentName("design-official")),
+                    locationTrackDao.fetch(official).copy(name = LocationTrackName("design-official")),
                     someDesignId,
                 ),
                 TmpLocationTrackGeometry.empty,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
+import fi.fta.geoviite.infra.common.LocationTrackName
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.StringId
@@ -432,6 +433,8 @@ fun locationTrack(
     duplicateOf: IntId<LocationTrack>? = null,
     ownerId: IntId<LocationTrackOwner> = IntId(1),
     contextData: LayoutContextData<LocationTrack> = createMainContext(id, draft),
+    startSwitch: IntId<LayoutSwitch>? = null,
+    endSwitch: IntId<LayoutSwitch>? = null,
 ) =
     locationTrack(
         trackNumberId = trackNumberId,
@@ -446,6 +449,8 @@ fun locationTrack(
         topologicalConnectivity = topologicalConnectivity,
         duplicateOf = duplicateOf,
         ownerId = ownerId,
+        startSwitch = startSwitch,
+        endSwitch = endSwitch,
     )
 
 fun trackDescriptionStructure(
@@ -473,9 +478,11 @@ fun locationTrack(
     topologicalConnectivity: TopologicalConnectivityType = TopologicalConnectivityType.NONE,
     duplicateOf: IntId<LocationTrack>? = null,
     ownerId: IntId<LocationTrackOwner> = IntId(1),
+    startSwitch: IntId<LayoutSwitch>? = null,
+    endSwitch: IntId<LayoutSwitch>? = null,
 ) =
     LocationTrack(
-        name = AlignmentName(name),
+        name = LocationTrackName(name),
         nameStructure = nameStructure,
         description = FreeText(description),
         descriptionStructure = descriptionStructure,
@@ -486,8 +493,8 @@ fun locationTrack(
         boundingBox = geometry.boundingBox,
         segmentCount = geometry.segments.size,
         length = geometry.length,
-        startSwitchId = null,
-        endSwitchId = null,
+        startSwitchId = startSwitch,
+        endSwitchId = endSwitch,
         duplicateOf = duplicateOf,
         topologicalConnectivity = topologicalConnectivity,
         ownerId = ownerId,

--- a/ui/src/tool-panel/track-number/dialog/track-number-edit-store.ts
+++ b/ui/src/tool-panel/track-number/dialog/track-number-edit-store.ts
@@ -16,7 +16,7 @@ import { ZERO_TRACK_METER } from 'common/common-model';
 import { formatTrackMeter } from 'utils/geography-utils';
 import { ALIGNMENT_DESCRIPTION_REGEX } from 'tool-panel/location-track/dialog/location-track-validation';
 
-const TRACK_NUMBER_REGEX = /^[äÄöÖåÅA-Za-z0-9 ]{2,20}$/g;
+const TRACK_NUMBER_REGEX = /^[äÄöÖåÅA-Za-z0-9 ]{2,30}$/g;
 export const ADDRESS_REGEX = /^\d{1,4}[A-Z]{0,2}(\+\d{1,4}(\.\d{1,3})?)?$/g;
 type RegexValidation = {
     field: keyof TrackNumberSaveRequest;


### PR DESCRIPTION
Tikettien pihvinä oli lisätä validointeja dynaamiselle sijaintiraidetunnukselle ja sijaintiraiteen kuvaukselle ja estää ???-merkkijonot julkaistavissa sijaintiraiteissa ja kuvauksissa. Nämä toteutettu pääasiassa julkaisuvalidointipuolelle.

Näiden lisäksi tiketillä oltiin mainittu nimien pituusrajojen pöyhäiseminen. Tämä päätyi lopulta käytännössä pakolliseksi, ja johti siihen että sijaintiraiteen nimi piti erottaa omaksi tietotyypikseen bäkkärillä. Tästä johtuu reviewin massiivinen tiedostomäärä. Sortsi siit.

Pariinkin otteeseen puhuttu "Sijaintiraide"-termin typistys "Raide"-termiksi validaatiovirheissä tulee omalla pullarillaan myöhemmin.