### PR TITLE
GVT-3258 Make all dynamic location track descriptions consistent

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -204,13 +204,13 @@ data class LocationTrackDescriptionStructure(
                 LocationTrackDescriptionSuffix.NONE -> base.toString()
 
                 LocationTrackDescriptionSuffix.SWITCH_TO_BUFFER ->
-                    "$base ${getShortName(startSwitch ?: endSwitch)} - ${translation.t(BUFFER_LOCALIZATION_KEY)}"
+                    "$base ${getShortNumber(startSwitch ?: endSwitch)} - ${translation.t(BUFFER_LOCALIZATION_KEY)}"
 
                 LocationTrackDescriptionSuffix.SWITCH_TO_OWNERSHIP_BOUNDARY ->
-                    "$base ${getShortName(startSwitch ?: endSwitch)} - ${translation.t(OWNERSHIP_BOUNDARY_LOCALIZATION_KEY)}"
+                    "$base ${getShortNumber(startSwitch ?: endSwitch)} - ${translation.t(OWNERSHIP_BOUNDARY_LOCALIZATION_KEY)}"
 
                 LocationTrackDescriptionSuffix.SWITCH_TO_SWITCH ->
-                    "$base ${getShortName(startSwitch)} - ${getShortName(endSwitch)}"
+                    "$base ${getShortNumber(startSwitch)} - ${getShortNumber(endSwitch)}"
             }
         )
 }

--- a/infra/src/main/resources/db/migration/prod/V122_03__restore_precalculated_location_track_description.sql
+++ b/infra/src/main/resources/db/migration/prod/V122_03__restore_precalculated_location_track_description.sql
@@ -10,7 +10,7 @@ alter table layout.location_track
 create function v122__parse_switch_name(name varchar)
   returns table
           (
-            station       text,
+            station      text,
             short_number text
           )
 as
@@ -47,7 +47,7 @@ $$
 
 create function v122__switch_short_number(name varchar) returns text as
 $$
-select short_number
+select case when short_number = '' then '???' else short_number end
   from v122__parse_switch_name(name) p
 $$ language sql;
 
@@ -60,13 +60,13 @@ set
         description_base
       when description_suffix = 'SWITCH_TO_BUFFER' then
         description_base || ' ' ||
-        v122__switch_short_number(coalesce(t.start_switch_name, t.end_switch_name, '???')) || ' - Puskin'
+        v122__switch_short_number(coalesce(t.start_switch_name, t.end_switch_name)) || ' - Puskin'
       when description_suffix = 'SWITCH_TO_OWNERSHIP_BOUNDARY' then
         description_base || ' ' ||
-        v122__switch_short_number(coalesce(t.start_switch_name, t.end_switch_name, '???')) || ' - Omistusraja'
+        v122__switch_short_number(coalesce(t.start_switch_name, t.end_switch_name)) || ' - Omistusraja'
       when description_suffix = 'SWITCH_TO_SWITCH' then
-        description_base || ' ' || v122__switch_short_number(coalesce(t.start_switch_name, '???')) || ' - ' ||
-        v122__switch_short_number(coalesce(t.end_switch_name, '???'))
+        description_base || ' ' || v122__switch_short_number(t.start_switch_name) || ' - ' ||
+        v122__switch_short_number(t.end_switch_name)
     end
   from (
     select

--- a/infra/src/main/resources/db/migration/prod/V122_03__restore_precalculated_location_track_description.sql
+++ b/infra/src/main/resources/db/migration/prod/V122_03__restore_precalculated_location_track_description.sql
@@ -7,6 +7,50 @@ alter table layout.location_track_version
 alter table layout.location_track
   add column description varchar(256) not null default '';
 
+create function v122__parse_switch_name(name varchar)
+  returns table
+          (
+            station       text,
+            short_number text
+          )
+as
+$$
+select station_and_body[1] as station, coalesce(trimmed_parts, '') as short_number
+  from regexp_split_to_array(name, '[\s_]+') as station_and_body,
+    lateral regexp_split_to_array(station_and_body[2], '/') body_parts,
+    lateral (
+             select
+               string_agg((
+                            select trimmed_name
+                              from (
+                                select
+                                  case
+                                    when body_part like 'V%' then substring(body_part from 2)
+                                    else body_part
+                                  end as number_part
+                              ) np,
+                                lateral (select length(regexp_substr(number_part, '^[0-9]+')) as number_length) npl,
+                                lateral (select
+                                           coalesce(substring(number_part for number_length), '') as numeric_number_part,
+                                           coalesce(substring(number_part from number_length + 1), '') as number_part_postfix) nnp,
+                                lateral (select ltrim(numeric_number_part, '0') as trimmed_numeric_number_part) tnnp,
+                                lateral (select greatest(3, length(trimmed_numeric_number_part)) as pad_length) tl,
+                                lateral (select
+                                           'V' || lpad(trimmed_numeric_number_part, pad_length, '0') ||
+                                           number_part_postfix as trimmed_name)
+                          ), '/') as trimmed_parts
+               from unnest(body_parts) body_part
+      )
+
+$$
+  language sql immutable;
+
+create function v122__switch_short_number(name varchar) returns text as
+$$
+select short_number
+  from v122__parse_switch_name(name) p
+$$ language sql;
+
 -- Note: we only handle main-branch here, as there are no designs yet to worry about
 update layout.location_track_version lt
 set
@@ -15,11 +59,14 @@ set
       when description_suffix = 'NONE' then
         description_base
       when description_suffix = 'SWITCH_TO_BUFFER' then
-        description_base || ' ' || coalesce(t.start_switch_name, t.end_switch_name, '???') || ' - Puskin'
+        description_base || ' ' ||
+        v122__switch_short_number(coalesce(t.start_switch_name, t.end_switch_name, '???')) || ' - Puskin'
       when description_suffix = 'SWITCH_TO_OWNERSHIP_BOUNDARY' then
-        description_base || ' ' || coalesce(t.start_switch_name, t.end_switch_name, '???') || ' - Omistusraja'
+        description_base || ' ' ||
+        v122__switch_short_number(coalesce(t.start_switch_name, t.end_switch_name, '???')) || ' - Omistusraja'
       when description_suffix = 'SWITCH_TO_SWITCH' then
-        description_base || ' ' || coalesce(t.start_switch_name, '???') || ' - ' || coalesce(t.end_switch_name, '???')
+        description_base || ' ' || v122__switch_short_number(coalesce(t.start_switch_name, '???')) || ' - ' ||
+        v122__switch_short_number(coalesce(t.end_switch_name, '???'))
     end
   from (
     select
@@ -47,6 +94,9 @@ set
   where t.id = lt.id
     and t.layout_context_id = lt.layout_context_id
     and t.version = lt.version;
+
+drop function v122__parse_switch_name(varchar);
+drop function v122__switch_short_number(varchar);
 
 update layout.location_track t
 set description = v.description

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -1094,7 +1094,7 @@ constructor(
         }
         getDraftDescriptionAndStructure(trackId).let { (description, structure) ->
             assertEquals(LocationTrackDescriptionSuffix.SWITCH_TO_SWITCH, structure.suffix)
-            assertEquals(FreeText("New description ABC V001 - ABC V002"), description)
+            assertEquals(FreeText("New description V001 - V002"), description)
         }
 
         // Changing the switch linkings should update the name and description
@@ -1115,7 +1115,7 @@ constructor(
         }
         getDraftDescriptionAndStructure(trackId).let { (description, structure) ->
             assertEquals(LocationTrackDescriptionSuffix.SWITCH_TO_SWITCH, structure.suffix)
-            assertEquals(FreeText("New description ABC V001 - ABC V003"), description)
+            assertEquals(FreeText("New description V001 - V003"), description)
         }
 
         // Changing the switch names should update the name and description
@@ -1130,7 +1130,7 @@ constructor(
         }
         getDraftDescriptionAndStructure(trackId).let { (description, structure) ->
             assertEquals(LocationTrackDescriptionSuffix.SWITCH_TO_SWITCH, structure.suffix)
-            assertEquals(FreeText("New description ABC V999 - ABC V003"), description)
+            assertEquals(FreeText("New description V999 - V003"), description)
         }
         // Make sure that switch draft revert also reverts the track name
         switchService.deleteDraft(LayoutBranch.main, switch1Id)
@@ -1141,7 +1141,7 @@ constructor(
         }
         getDraftDescriptionAndStructure(trackId).let { (description, structure) ->
             assertEquals(LocationTrackDescriptionSuffix.SWITCH_TO_SWITCH, structure.suffix)
-            assertEquals(FreeText("New description ABC V001 - ABC V003"), description)
+            assertEquals(FreeText("New description V001 - V003"), description)
         }
 
         // Finally, verify that chord-style naming also works

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -605,11 +605,11 @@ export function formatTrackDescription(
         case 'NONE':
             return descriptionBase;
         case 'SWITCH_TO_BUFFER':
-            return `${descriptionBase} ${getShortName(startSwitch ?? endSwitch)} - ${t('location-track-dialog.buffer')}`;
+            return `${descriptionBase} ${getShortNumber(startSwitch ?? endSwitch)} - ${t('location-track-dialog.buffer')}`;
         case 'SWITCH_TO_OWNERSHIP_BOUNDARY':
-            return `${descriptionBase} ${getShortName(startSwitch ?? endSwitch)} - ${t('location-track-dialog.ownership-boundary')}`;
+            return `${descriptionBase} ${getShortNumber(startSwitch ?? endSwitch)} - ${t('location-track-dialog.ownership-boundary')}`;
         case 'SWITCH_TO_SWITCH':
-            return `${descriptionBase} ${getShortName(startSwitch)} - ${getShortName(endSwitch)}`;
+            return `${descriptionBase} ${getShortNumber(startSwitch)} - ${getShortNumber(endSwitch)}`;
         default:
             return exhaustiveMatchingGuard(descriptionSuffix);
     }


### PR DESCRIPTION
Heitto. Epäilen vähän että tuleekohan tämäkään nyt olemaan lopullinen totuus, mutta onpahan nyt ainakin tässä haarassa kaikki tapaukset samassa paikassa. Tämä siis uusimman Karin sanoman mukaan, että "liikennepaikat tulevat tosiaan vapaatekstiosaan".

Migra on luonteeltaan tosin vähän tämänhetkistä SwitchName-parseria sallivampi, koska se ottaa mahdolliset vaihdenumeroiden jälkeiset merkkijonot vaan orjallisesti mukaan.