### PR TITLE
GVT-3267: Refactor track layout api parameter naming to reference start/end versions

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionServiceV1.kt
@@ -62,7 +62,7 @@ constructor(
             .takeIf { modifiedLocationTracks -> modifiedLocationTracks.isNotEmpty() }
             ?.let { modifiedLocationTracks ->
                 ExtModifiedLocationTrackCollectionResponseV1(
-                    modificationsFromVersion = publications.from.uuid,
+                    trackLayoutVersionFrom = publications.from.uuid,
                     trackLayoutVersion = publications.to.uuid,
                     coordinateSystem = coordinateSystem,
                     locationTrackCollection =

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -86,7 +86,7 @@ class ExtLocationTrackControllerV1(
         }
     }
 
-    @GetMapping("/sijaintiraiteet/muutokset", params = [MODIFICATIONS_FROM_VERSION])
+    @GetMapping("/sijaintiraiteet/muutokset", params = [TRACK_LAYOUT_VERSION_FROM])
     @Tag(name = EXT_LOCATION_TRACK_COLLECTION_TAG_V1)
     @Operation(summary = "Sijaintiraidekokoelman muutosten haku")
     @ApiResponses(
@@ -124,11 +124,11 @@ class ExtLocationTrackControllerV1(
             description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_FROM,
             schema = Schema(type = "string", format = "uuid"),
         )
-        @RequestParam(MODIFICATIONS_FROM_VERSION, required = true)
-        modificationsFromVersion: Uuid<Publication>,
+        @RequestParam(TRACK_LAYOUT_VERSION_FROM, required = true)
+        trackLayoutVersionFrom: Uuid<Publication>,
         @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_TO, schema = Schema(type = "string", format = "uuid"))
-        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
-        trackLayoutVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION_TO, required = false)
+        trackLayoutVersionTo: Uuid<Publication>?,
         @Parameter(
             name = COORDINATE_SYSTEM,
             description = EXT_OPENAPI_COORDINATE_SYSTEM,
@@ -138,7 +138,7 @@ class ExtLocationTrackControllerV1(
         coordinateSystem: Srid?,
     ): ResponseEntity<ExtModifiedLocationTrackCollectionResponseV1> {
         return publicationService
-            .getPublicationsToCompare(modificationsFromVersion, trackLayoutVersion)
+            .getPublicationsToCompare(trackLayoutVersionFrom, trackLayoutVersionTo)
             .let { publications ->
                 if (publications.areDifferent()) {
                     extLocationTrackCollectionService.createLocationTrackCollectionModificationResponse(
@@ -146,7 +146,7 @@ class ExtLocationTrackControllerV1(
                         coordinateSystem = coordinateSystem ?: LAYOUT_SRID,
                     )
                 } else {
-                    publicationsAreTheSame(modificationsFromVersion)
+                    publicationsAreTheSame(trackLayoutVersionFrom)
                 }
             }
             .let(::toResponse)
@@ -205,7 +205,7 @@ class ExtLocationTrackControllerV1(
             .let(::toResponse)
     }
 
-    @GetMapping("/sijaintiraiteet/{$LOCATION_TRACK_OID_PARAM}/muutokset", params = [MODIFICATIONS_FROM_VERSION])
+    @GetMapping("/sijaintiraiteet/{$LOCATION_TRACK_OID_PARAM}/muutokset", params = [TRACK_LAYOUT_VERSION_FROM])
     @Tag(name = EXT_LOCATION_TRACK_TAG_V1)
     @Operation(
         summary = "Yksittäisen sijaintiraiteen muutosten haku OID-tunnuksella",
@@ -257,17 +257,17 @@ class ExtLocationTrackControllerV1(
             description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_FROM,
             schema = Schema(type = "string", format = "uuid"),
         )
-        @RequestParam(MODIFICATIONS_FROM_VERSION, required = true)
-        modificationsFromVersion: Uuid<Publication>,
+        @RequestParam(TRACK_LAYOUT_VERSION_FROM, required = true)
+        trackLayoutVersionFrom: Uuid<Publication>,
         @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_TO, schema = Schema(type = "string", format = "uuid"))
-        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
-        trackLayoutVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION_TO, required = false)
+        trackLayoutVersionTo: Uuid<Publication>?,
         @Parameter(description = EXT_OPENAPI_COORDINATE_SYSTEM, schema = Schema(type = "string", format = "string"))
         @RequestParam(COORDINATE_SYSTEM, required = false)
         coordinateSystem: Srid?,
     ): ResponseEntity<ExtModifiedLocationTrackResponseV1> {
         return publicationService
-            .getPublicationsToCompare(modificationsFromVersion, trackLayoutVersion)
+            .getPublicationsToCompare(trackLayoutVersionFrom, trackLayoutVersionTo)
             .let { publications ->
                 if (publications.areDifferent()) {
                     extLocationTrackService.createLocationTrackModificationResponse(
@@ -276,7 +276,7 @@ class ExtLocationTrackControllerV1(
                         coordinateSystem ?: LAYOUT_SRID,
                     )
                 } else {
-                    publicationsAreTheSame(modificationsFromVersion)
+                    publicationsAreTheSame(trackLayoutVersionFrom)
                 }
             }
             .let(::toResponse)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -76,7 +76,7 @@ constructor(
             .takeIf { assetVersions -> assetVersions.areDifferent() }
             ?.let { assetVersions ->
                 ExtModifiedLocationTrackResponseV1(
-                    modificationsFromVersion = publications.from.uuid,
+                    trackLayoutVersionFrom = publications.from.uuid,
                     trackLayoutVersion = publications.to.uuid,
                     coordinateSystem = coordinateSystem,
                     locationTrack =

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackV1.kt
@@ -37,7 +37,7 @@ data class ExtLocationTrackResponseV1(
 @Schema(name = "Vastaus: Muutettu sijaintiraide")
 data class ExtModifiedLocationTrackResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION_FROM) val trackLayoutVersionFrom: Uuid<Publication>,
     @JsonProperty(COORDINATE_SYSTEM) val coordinateSystem: Srid,
     @JsonProperty(LOCATION_TRACK) val locationTrack: ExtLocationTrackV1,
 )
@@ -52,7 +52,7 @@ data class ExtLocationTrackGeometryResponseV1(
 @Schema(name = "Vastaus: Muutettu sijaintiraidegeometria")
 data class ExtLocationTrackModifiedGeometryResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION_FROM) val trackLayoutVersionFrom: Uuid<Publication>,
     @JsonProperty(LOCATION_TRACK_OID) val locationTrackOid: Oid<LocationTrack>,
     @JsonProperty(TRACK_INTERVALS) val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
 )
@@ -67,7 +67,7 @@ data class ExtLocationTrackCollectionResponseV1(
 @Schema(name = "Vastaus: Muutettu sijaintiraidekokoelma")
 data class ExtModifiedLocationTrackCollectionResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION_FROM) val trackLayoutVersionFrom: Uuid<Publication>,
     @JsonProperty(COORDINATE_SYSTEM) val coordinateSystem: Srid,
     @JsonProperty(LOCATION_TRACK_COLLECTION) val locationTrackCollection: List<ExtLocationTrackV1>,
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -2,7 +2,8 @@ package fi.fta.geoviite.api.tracklayout.v1
 
 const val EXT_TRACK_LAYOUT_BASE_PATH = "/geoviite"
 
-const val MODIFICATIONS_FROM_VERSION = "muutokset_versiosta"
+const val TRACK_LAYOUT_VERSION_FROM = "alkuversio"
+const val TRACK_LAYOUT_VERSION_TO = "loppuversio"
 const val TRACK_LAYOUT_VERSION = "rataverkon_versio"
 const val LOCATION_TRACK_OID = "sijaintiraide_oid"
 const val LOCATION_TRACK = "sijaintiraide"

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutLoggingV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutLoggingV1.kt
@@ -19,7 +19,7 @@ inline fun <reified T : LayoutAsset<T>> layoutAssetVersionsAreTheSame(
     publications: PublicationComparison,
 ): Nothing? {
     logger.info(
-        "The versions used for comparing ${T::class.simpleName} were the same: assetId=${assetId}, fromPublication: ${publications.to.id} -> toPublication: ${publications.from.id}"
+        "The versions used for comparing ${T::class.simpleName} were the same: assetId=${assetId}, fromPublication: ${publications.from.id} -> toPublication: ${publications.to.id}"
     )
     return null
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionServiceV1.kt
@@ -63,7 +63,7 @@ constructor(
             .takeIf { modifiedTrackNumbers -> modifiedTrackNumbers.isNotEmpty() }
             ?.let { modifiedTrackNumbers ->
                 ExtModifiedTrackNumberCollectionResponseV1(
-                    modificationsFromVersion = publications.from.uuid,
+                    trackLayoutVersionFrom = publications.from.uuid,
                     trackLayoutVersion = publications.to.uuid,
                     coordinateSystem = coordinateSystem,
                     trackNumberCollection =

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
@@ -87,7 +87,7 @@ constructor(
         }
     }
 
-    @GetMapping("/ratanumerot/muutokset", params = [MODIFICATIONS_FROM_VERSION])
+    @GetMapping("/ratanumerot/muutokset", params = [TRACK_LAYOUT_VERSION_FROM])
     @Tag(name = EXT_TRACK_NUMBER_COLLECTION_TAG_V1)
     @Operation(summary = "Ratanumerokokoelman muutosten haku")
     @ApiResponses(
@@ -125,11 +125,11 @@ constructor(
             description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_FROM,
             schema = Schema(type = "string", format = "uuid"),
         )
-        @RequestParam(MODIFICATIONS_FROM_VERSION, required = true)
-        modificationsFromVersion: Uuid<Publication>,
+        @RequestParam(TRACK_LAYOUT_VERSION_FROM, required = true)
+        trackLayoutVersionFrom: Uuid<Publication>,
         @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_TO, schema = Schema(type = "string", format = "uuid"))
-        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
-        trackLayoutVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION_TO, required = false)
+        trackLayoutVersionTo: Uuid<Publication>?,
         @Parameter(
             name = COORDINATE_SYSTEM,
             description = EXT_OPENAPI_COORDINATE_SYSTEM,
@@ -139,7 +139,7 @@ constructor(
         coordinateSystem: Srid?,
     ): ResponseEntity<ExtModifiedTrackNumberCollectionResponseV1> {
         return publicationService
-            .getPublicationsToCompare(modificationsFromVersion, trackLayoutVersion)
+            .getPublicationsToCompare(trackLayoutVersionFrom, trackLayoutVersionTo)
             .let { publications ->
                 if (publications.areDifferent()) {
                     extTrackNumberCollectionService.createTrackNumberCollectionModificationResponse(
@@ -147,7 +147,7 @@ constructor(
                         coordinateSystem ?: LAYOUT_SRID,
                     )
                 } else {
-                    publicationsAreTheSame(modificationsFromVersion)
+                    publicationsAreTheSame(trackLayoutVersionFrom)
                 }
             }
             .let(::toResponse)
@@ -202,7 +202,7 @@ constructor(
             .let(::toResponse)
     }
 
-    @GetMapping("/ratanumerot/{${TRACK_NUMBER_OID}}/muutokset", params = [MODIFICATIONS_FROM_VERSION])
+    @GetMapping("/ratanumerot/{${TRACK_NUMBER_OID}}/muutokset", params = [TRACK_LAYOUT_VERSION_FROM])
     @Tag(name = EXT_TRACK_NUMBER_TAG_V1)
     @Operation(
         summary = "Yksittäisen ratanumeron muutosten haku OID-tunnuksella",
@@ -254,17 +254,17 @@ constructor(
             description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_FROM,
             schema = Schema(type = "string", format = "uuid"),
         )
-        @RequestParam(MODIFICATIONS_FROM_VERSION, required = true)
-        modificationsFromVersion: Uuid<Publication>,
+        @RequestParam(TRACK_LAYOUT_VERSION_FROM, required = true)
+        trackLayoutVersionFrom: Uuid<Publication>,
         @Parameter(description = EXT_OPENAPI_TRACK_LAYOUT_VERSION_TO, schema = Schema(type = "string", format = "uuid"))
-        @RequestParam(TRACK_LAYOUT_VERSION, required = false)
-        trackLayoutVersion: Uuid<Publication>?,
+        @RequestParam(TRACK_LAYOUT_VERSION_TO, required = false)
+        trackLayoutVersionTo: Uuid<Publication>?,
         @Parameter(description = EXT_OPENAPI_COORDINATE_SYSTEM, schema = Schema(type = "string", format = "string"))
         @RequestParam(COORDINATE_SYSTEM, required = false)
         coordinateSystem: Srid?,
     ): ResponseEntity<ExtModifiedTrackNumberResponseV1> {
         return publicationService
-            .getPublicationsToCompare(modificationsFromVersion, trackLayoutVersion)
+            .getPublicationsToCompare(trackLayoutVersionFrom, trackLayoutVersionTo)
             .let { publications ->
                 if (publications.areDifferent()) {
                     extTrackNumberService.createTrackNumberModificationResponse(
@@ -273,7 +273,7 @@ constructor(
                         coordinateSystem ?: LAYOUT_SRID,
                     )
                 } else {
-                    publicationsAreTheSame(modificationsFromVersion)
+                    publicationsAreTheSame(trackLayoutVersionFrom)
                 }
             }
             .let(::toResponse)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
@@ -74,7 +74,7 @@ constructor(
             .takeIf { assetVersions -> assetVersions.areDifferent() }
             ?.let { assetVersions ->
                 ExtModifiedTrackNumberResponseV1(
-                    modificationsFromVersion = publications.from.uuid,
+                    trackLayoutVersionFrom = publications.from.uuid,
                     trackLayoutVersion = publications.to.uuid,
                     coordinateSystem = coordinateSystem,
                     trackNumber =

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberV1.kt
@@ -30,7 +30,7 @@ data class ExtTrackNumberResponseV1(
 @Schema(name = "Vastaus: Muutettu ratanumero")
 data class ExtModifiedTrackNumberResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION_FROM) val trackLayoutVersionFrom: Uuid<Publication>,
     @JsonProperty(COORDINATE_SYSTEM) val coordinateSystem: Srid,
     @JsonProperty(TRACK_NUMBER) val trackNumber: ExtTrackNumberV1,
 )
@@ -45,7 +45,7 @@ data class ExtTrackNumberGeometryResponseV1(
 @Schema(name = "Vastaus: Muutettu ratanumerogeometria")
 data class ExtTrackNumberkModifiedGeometryResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION_FROM) val trackLayoutVersionFrom: Uuid<Publication>,
     @JsonProperty(TRACK_NUMBER_OID) val trackNumberOid: Oid<LayoutTrackNumber>,
     @JsonProperty(TRACK_INTERVALS) val trackIntervals: List<ExtCenterLineTrackIntervalV1>,
 )
@@ -60,7 +60,7 @@ data class ExtTrackNumberCollectionResponseV1(
 @Schema(name = "Vastaus: Muutettu ratanumerokokoelma")
 data class ExtModifiedTrackNumberCollectionResponseV1(
     @JsonProperty(TRACK_LAYOUT_VERSION) val trackLayoutVersion: Uuid<Publication>,
-    @JsonProperty(MODIFICATIONS_FROM_VERSION) val modificationsFromVersion: Uuid<Publication>,
+    @JsonProperty(TRACK_LAYOUT_VERSION_FROM) val trackLayoutVersionFrom: Uuid<Publication>,
     @JsonProperty(COORDINATE_SYSTEM) val coordinateSystem: Srid,
     @JsonProperty(TRACK_NUMBER_COLLECTION) val trackNumberCollection: List<ExtTrackNumberV1>,
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -2375,7 +2375,7 @@ class PublicationDao(
             select distinct plt.id as location_track_id
             from publication.location_track plt
               join publication.publication publication on plt.publication_id = publication.id
-            where design_id = null 
+            where design_id is null 
               and publication.publication_time > :start_time 
               and publication.publication_time <= :end_time;
         """
@@ -2397,7 +2397,7 @@ class PublicationDao(
             select distinct ptn.id as track_number_id
             from publication.track_number ptn
               join publication.publication publication on ptn.publication_id = publication.id
-            where design_id = null 
+            where design_id is null 
               and publication.publication_time > :start_time 
               and publication.publication_time <= :end_time;
         """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -520,15 +520,15 @@ constructor(
     }
 
     fun getPublicationsToCompare(
-        modificationsFromVersion: Uuid<Publication>,
-        trackLayoutVersion: Uuid<Publication>?,
+        trackLayoutVersionFrom: Uuid<Publication>,
+        trackLayoutVersionTo: Uuid<Publication>?,
     ): PublicationComparison {
         val fromPublication =
-            publicationDao.fetchPublicationByUuid(modificationsFromVersion)
-                ?: throw TrackLayoutVersionNotFound("modificationsFromVersion=${modificationsFromVersion}")
+            publicationDao.fetchPublicationByUuid(trackLayoutVersionFrom)
+                ?: throw TrackLayoutVersionNotFound("trackLayoutVersionFrom=${trackLayoutVersionFrom}")
 
         val toPublication =
-            trackLayoutVersion?.let { uuid ->
+            trackLayoutVersionTo?.let { uuid ->
                 publicationDao.fetchPublicationByUuid(uuid)
                     ?: throw TrackLayoutVersionNotFound("trackLayoutVersion=${uuid}")
             } ?: publicationDao.fetchLatestPublications(LayoutBranchType.MAIN, count = 1).single()


### PR DESCRIPTION
Näiden kenttien käyttö koettiin hankaliksi käyttäjille, ja niiden uudelleennimeäminen on tässä vaiheessa vielä yksinkertaista.

Pari bugikorjausta ohessa, kommentoitu erikseen