### PR TITLE
GVT-3100: Improve ext-api address point range filter

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackControllerV1.kt
@@ -3,7 +3,6 @@ package fi.fta.geoviite.api.tracklayout.v1
 import fi.fta.geoviite.api.aspects.GeoviiteExtApiController
 import fi.fta.geoviite.api.frameconverter.v1.LOCATION_TRACK_OID_PARAM
 import fi.fta.geoviite.infra.authorization.AUTH_API_GEOMETRY
-import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
@@ -325,12 +324,12 @@ class ExtLocationTrackControllerV1(
         @Parameter(description = EXT_OPENAPI_COORDINATE_SYSTEM, schema = Schema(type = "string", format = "string"))
         @RequestParam(COORDINATE_SYSTEM, required = false)
         coordinateSystem: Srid? = null,
-        @Parameter(description = EXT_OPENAPI_TRACK_KILOMETER_START)
-        @RequestParam(TRACK_KILOMETER_START, required = false)
-        trackKmStart: KmNumber? = null,
-        @Parameter(description = EXT_OPENAPI_TRACK_KILOMETER_END)
-        @RequestParam(TRACK_KILOMETER_END, required = false)
-        trackKmEnd: KmNumber? = null,
+        @Parameter(description = EXT_OPENAPI_ADDRESS_POINT_FILTER_START)
+        @RequestParam(ADDRESS_POINT_FILTER_START, required = false)
+        addressPointFilterStart: ExtMaybeTrackKmOrTrackMeterV1? = null,
+        @Parameter(description = EXT_OPENAPI_ADDRESS_POINT_FILTER_END)
+        @RequestParam(ADDRESS_POINT_FILTER_END, required = false)
+        addressPointFilterEnd: ExtMaybeTrackKmOrTrackMeterV1? = null,
     ): ResponseEntity<ExtLocationTrackGeometryResponseV1> {
         return publicationService
             .getPublicationByUuidOrLatest(LayoutBranchType.MAIN, trackLayoutVersion)
@@ -340,7 +339,7 @@ class ExtLocationTrackControllerV1(
                     publication,
                     extResolution?.toResolution() ?: Resolution.ONE_METER,
                     coordinateSystem ?: LAYOUT_SRID,
-                    ExtTrackKilometerIntervalV1(trackKmStart, trackKmEnd),
+                    ExtTrackKilometerIntervalFilterV1.of(addressPointFilterStart, addressPointFilterEnd),
                 )
             }
             .let(::toResponse)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackGeometryServiceV1.kt
@@ -24,7 +24,7 @@ constructor(
         publication: Publication,
         resolution: Resolution,
         coordinateSystem: Srid,
-        trackIntervalFilter: ExtTrackKilometerIntervalV1,
+        trackIntervalFilter: ExtTrackKilometerIntervalFilterV1,
     ): ExtLocationTrackGeometryResponseV1? {
         val locationTrackId =
             locationTrackDao.lookupByExternalId(oid.toString())?.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -9,8 +9,8 @@ const val LOCATION_TRACK_OID = "sijaintiraide_oid"
 const val LOCATION_TRACK = "sijaintiraide"
 const val LOCATION_TRACK_NAME = "sijaintiraidetunnus"
 const val LOCATION_TRACK_COLLECTION = "sijaintiraiteet"
-const val TRACK_KILOMETER_START = "ratakilometri_alku"
-const val TRACK_KILOMETER_END = "ratakilometri_loppu"
+const val ADDRESS_POINT_FILTER_START = "osoitepistevali_alku"
+const val ADDRESS_POINT_FILTER_END = "osoitepistevali_loppu"
 const val TRACK_NUMBER = "ratanumero"
 const val TRACK_NUMBER_OID = "ratanumero_oid"
 const val TRACK_NUMBER_COLLECTION = "ratanumerot"
@@ -49,17 +49,11 @@ const val EXT_OPENAPI_COORDINATE_SYSTEM =
 const val EXT_OPENAPI_RESOLUTION =
     "Palautettavien osoitepisteiden metriväli. Oletuksena osoitepisteet palautetaan yhden metrin välein."
 
-const val EXT_OPENAPI_TRACK_KILOMETER_START =
-    "Osoitepisteitä haetaan tästä ratakilometristä lähtien. Oletuksena osoitepisteitä haetaan raiteen alusta lähtien."
+const val EXT_OPENAPI_ADDRESS_POINT_FILTER_START =
+    "Osoitepisteitä haetaan tästä ratakilometristä tai rataosoitteesta lähtien. Välin alku käsitellään suljettuna (alku <= osoitepiste). Oletuksena osoitepisteväliä ei rajoiteta alusta."
 
-const val EXT_OPENAPI_TRACK_KILOMETER_END =
-    "Osoitepisteitä haetaan tähän ratakilometriin asti. Oletuksena osoitepisteitä haetaan raiteen loppuun asti."
-
-const val EXT_OPENAPI_REFERENCE_LINE_KILOMETER_START =
-    "Osoitepisteitä haetaan tästä ratakilometristä lähtien. Oletuksena osoitepisteitä haetaan ratanumeron alusta lähtien."
-
-const val EXT_OPENAPI_REFERENCE_LINE_KILOMETER_END =
-    "Osoitepisteitä haetaan tähän ratakilometriin asti. Oletuksena osoitepisteitä haetaan ratanumeron loppuun asti."
+const val EXT_OPENAPI_ADDRESS_POINT_FILTER_END =
+    "Osoitepisteitä haetaan tähän ratakilometriin tai rataosoitteeseen asti. Välin loppu käsitellään suljettuna (osoitepiste <= loppu). Oletuksena osoitepisteväliä ei rajoiteta lopusta."
 
 const val EXT_OPENAPI_LOCATION_TRACK_OR_TRACK_LAYOUT_VERSION_NOT_FOUND =
     "Sijaintiraidetta ei löytynyt OID-tunnuksella tai annettua rataverkon versiota ei ole olemassa."

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -90,13 +90,13 @@ data class ExtCenterLineTrackIntervalV1(
 
 fun <M : AnyM<M>> filteredCenterLineTrackIntervals(
     alignmentAddresses: AlignmentAddresses<M>,
-    trackIntervalFilter: ExtTrackKilometerIntervalV1,
+    trackIntervalFilter: ExtTrackKilometerIntervalFilterV1,
     coordinateSystem: Srid,
 ): List<ExtCenterLineTrackIntervalV1> {
     val extAddressPoints =
         alignmentAddresses.allPoints.mapNotNull { point ->
             point
-                .takeIf { p -> trackIntervalFilter.containsKmEndInclusive(p.address.kmNumber) }
+                .takeIf { p -> trackIntervalFilter.contains(p.address) }
                 ?.let { toExtAddressPoint(point, coordinateSystem) }
         }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberControllerV1.kt
@@ -2,7 +2,6 @@ package fi.fta.geoviite.api.tracklayout.v1
 
 import fi.fta.geoviite.api.aspects.GeoviiteExtApiController
 import fi.fta.geoviite.infra.authorization.AUTH_API_GEOMETRY
-import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
@@ -322,12 +321,12 @@ constructor(
         @Parameter(description = EXT_OPENAPI_COORDINATE_SYSTEM, schema = Schema(type = "string", format = "string"))
         @RequestParam(COORDINATE_SYSTEM, required = false)
         coordinateSystem: Srid? = null,
-        @Parameter(description = EXT_OPENAPI_REFERENCE_LINE_KILOMETER_START)
-        @RequestParam(TRACK_KILOMETER_START, required = false)
-        trackKmStart: KmNumber? = null,
-        @Parameter(description = EXT_OPENAPI_REFERENCE_LINE_KILOMETER_END)
-        @RequestParam(TRACK_KILOMETER_END, required = false)
-        trackKmEnd: KmNumber? = null,
+        @Parameter(description = EXT_OPENAPI_ADDRESS_POINT_FILTER_START)
+        @RequestParam(ADDRESS_POINT_FILTER_START, required = false)
+        addressPointFilterStart: ExtMaybeTrackKmOrTrackMeterV1? = null,
+        @Parameter(description = EXT_OPENAPI_ADDRESS_POINT_FILTER_END)
+        @RequestParam(ADDRESS_POINT_FILTER_END, required = false)
+        addressPointFilterEnd: ExtMaybeTrackKmOrTrackMeterV1? = null,
     ): ResponseEntity<ExtTrackNumberGeometryResponseV1> {
         return publicationService
             .getPublicationByUuidOrLatest(LayoutBranchType.MAIN, trackLayoutVersion)
@@ -337,7 +336,7 @@ constructor(
                     publication,
                     extResolution?.toResolution() ?: Resolution.ONE_METER,
                     coordinateSystem ?: LAYOUT_SRID,
-                    ExtTrackKilometerIntervalV1(trackKmStart, trackKmEnd),
+                    ExtTrackKilometerIntervalFilterV1.of(addressPointFilterStart, addressPointFilterEnd),
                 )
             }
             .let(::toResponse)

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
@@ -23,7 +23,7 @@ constructor(
         publication: Publication,
         resolution: Resolution,
         coordinateSystem: Srid,
-        trackIntervalFilter: ExtTrackKilometerIntervalV1,
+        trackIntervalFilter: ExtTrackKilometerIntervalFilterV1,
     ): ExtTrackNumberGeometryResponseV1? {
         val trackNumberId =
             layoutTrackNumberDao.lookupByExternalId(oid.toString())?.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/WebConfiguration.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
 import fi.fta.geoviite.api.frameconverter.v1.FrameConverterLocationTrackTypeV1
 import fi.fta.geoviite.api.frameconverter.v1.FrameConverterStringV1
+import fi.fta.geoviite.api.tracklayout.v1.ExtMaybeTrackKmOrTrackMeterV1
 import fi.fta.geoviite.api.tracklayout.v1.ExtResolutionV1
 import fi.fta.geoviite.infra.authorization.AuthCode
 import fi.fta.geoviite.infra.authorization.AuthName
@@ -163,11 +164,12 @@ class WebConfig(
         registry.addStringConstructorConverter { enumCaseInsensitive<LocalizationLanguage>(it) }
 
         if (extApiEnabled) {
-            logger.info("Registering frame converter converters")
+            logger.info("Registering ext api converters")
             registry.addStringConstructorConverter(::FrameConverterStringV1)
             registry.addStringConstructorConverter { FrameConverterLocationTrackTypeV1.fromValue(it) }
 
             registry.addStringConstructorConverter { ExtResolutionV1.fromValue(it) }
+            registry.addStringConstructorConverter { ::ExtMaybeTrackKmOrTrackMeterV1 }
         }
     }
 


### PR DESCRIPTION
* Ylläpidetään tuki kilometrien avulla suodattamiselle
* Lisätään tuki rataosoitteiden avulla suodattamiselle
* Ristiinkäyttö on tuettua: 
    * Alun voi rajoittaa kilometrillä ja lopun tarkalla osoitteella tai päinvastoin
    * Alun tai lopun voi jättää määrittämättä ja käyttää ainoastaan toista