### PR TITLE
GVT-2838 & GVT-3225: Wire support email addresses dynamically from the runtime environment

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/openapi/OpenApiConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/openapi/OpenApiConfiguration.kt
@@ -1,22 +1,24 @@
 package fi.fta.geoviite.api.openapi
 
-import fi.fta.geoviite.api.aspects.GeoviiteExtApiController
+import fi.fta.geoviite.infra.environmentInfo.EnvironmentInfo
 import io.swagger.v3.oas.models.Paths
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 
 // Due to the unfortunate nature of the dev-env redirect, some of the mappings are duplicated.
 @Configuration
 @Profile("ext-api")
-class OpenApiConfig {
+class OpenApiConfig
+@Autowired
+constructor(
+    private val environmentInfo: EnvironmentInfo,
+) {
 
     @Bean
     fun geoviiteApi(): GroupedOpenApi {
@@ -46,7 +48,11 @@ class OpenApiConfig {
                     .title("Geoviite")
                     .description("Geoviitteen ulkoiset rajapinnat")
                     .version("1.0.0")
-                    .contact(Contact().name("TODO_NAME").email("TODO_EMAIL"))
+                    .contact(
+                        Contact()
+                            .name(environmentInfo.geoviiteSupportEmailAddress)
+                            .email(environmentInfo.geoviiteSupportEmailAddress)
+                    )
             )
 
             // Alphabetically sort paths & components for user friendliness.
@@ -57,23 +63,5 @@ class OpenApiConfig {
 
             openApi.components?.schemas = openApi.components?.schemas?.toSortedMap()
         }
-    }
-}
-
-@GeoviiteExtApiController(["/rata-vkm/v3/api-docs"])
-class StaticRataVkmApiController {
-    @GetMapping
-    fun getRataVkm(): ResponseEntity<String> {
-        val staticOpenApiJson = javaClass.getResource("/static/openapi-rata-vkm-v1.yml")?.readText() ?: "{}"
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(staticOpenApiJson)
-    }
-}
-
-@GeoviiteExtApiController(["/rata-vkm/dev/v3/api-docs"])
-class StaticRataVkmDevApiController {
-    @GetMapping
-    fun getRataVkmDev(): ResponseEntity<String> {
-        val staticOpenApiJson = javaClass.getResource("/static/openapi-rata-vkm-v1-dev.yml")?.readText() ?: "{}"
-        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(staticOpenApiJson)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/openapi/SwaggerController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/openapi/SwaggerController.kt
@@ -4,9 +4,11 @@ import fi.fta.geoviite.api.aspects.GeoviiteExtApiController
 import fi.fta.geoviite.infra.authorization.AUTH_API_FRAME_CONVERTER
 import fi.fta.geoviite.infra.authorization.AUTH_API_GEOMETRY
 import fi.fta.geoviite.infra.authorization.AUTH_API_SWAGGER
+import fi.fta.geoviite.infra.environmentInfo.EnvironmentInfo
 import io.swagger.v3.oas.annotations.Hidden
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Profile
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,7 +27,11 @@ val allowedApiDefinitionPaths =
 
 @GeoviiteExtApiController([])
 @Hidden // These controller paths are hidden from the dynamically generated OpenApi definitions.
-class SwaggerController {
+class SwaggerController
+@Autowired
+constructor(
+    private val environmentInfo: EnvironmentInfo,
+) {
 
     @PreAuthorize(AUTH_API_GEOMETRY)
     @GetMapping(
@@ -90,7 +96,7 @@ class SwaggerController {
         @PathVariable prefix: String,
         @PathVariable path: String,
     ) {
-        swaggerResourceRequest("/$prefix", request, response)
+        swaggerResourceRequest("/$prefix", request, response, environmentInfo)
     }
 
     @Profile("ext-api-dev-swagger")
@@ -102,7 +108,7 @@ class SwaggerController {
         @PathVariable prefix: String,
         @PathVariable path: String,
     ) {
-        swaggerResourceRequest("/$prefix/dev", request, response)
+        swaggerResourceRequest("/$prefix/dev", request, response, environmentInfo)
     }
 }
 
@@ -110,6 +116,7 @@ private fun swaggerResourceRequest(
     prefixWithLeadingSlash: String,
     request: HttpServletRequest,
     response: HttpServletResponse,
+    environmentInfo: EnvironmentInfo,
 ) {
     val resourcePrefixOk = allowedResourcePrefixes.contains(prefixWithLeadingSlash)
     val apiDefinitionPathOk = request.getParameter("url")?.let(allowedApiDefinitionPaths::contains) ?: true

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/openapi/YamlPlaceholderTransformer.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/openapi/YamlPlaceholderTransformer.kt
@@ -1,0 +1,28 @@
+package fi.fta.geoviite.api.openapi
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.io.Resource
+import org.springframework.web.servlet.resource.ResourceTransformer
+import org.springframework.web.servlet.resource.ResourceTransformerChain
+import org.springframework.web.servlet.resource.TransformedResource
+
+class YamlPlaceholderTransformer(private val replacements: Map<String, String>) : ResourceTransformer {
+    override fun transform(
+        request: HttpServletRequest,
+        resource: Resource,
+        transformerChain: ResourceTransformerChain,
+    ): Resource {
+        val transformed = transformerChain.transform(request, resource)
+
+        val filename = transformed.filename
+        val isYaml = filename != null && (filename.endsWith(".yml") || filename.endsWith(".yaml"))
+        if (isYaml) {
+            val content = transformed.inputStream.bufferedReader().readText()
+            val replaced = replacements.entries.fold(content) { acc, (key, value) -> acc.replace("{$key}", value) }
+
+            return TransformedResource(transformed, replaced.toByteArray())
+        } else {
+            return transformed
+        }
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/environmentInfo/EnvironmentInfo.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/environmentInfo/EnvironmentInfo.kt
@@ -6,10 +6,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
+const val GEOVIITE_SUPPORT_EMAIL = "GEOVIITE_SUPPORT_EMAIL"
+
 @Component
 data class EnvironmentInfo(
     @Value("\${RELEASE_VERSION:Geoviite}") val releaseVersion: String,
     @Value("\${RELEASE_ENVIRONMENT:local}") val environmentName: String,
+    @Value("\${${GEOVIITE_SUPPORT_EMAIL}:local-geoviite-support@example.com}") val geoviiteSupportEmailAddress: String,
+    @Value("\${RATKO_SUPPORT_EMAIL:local-ratko-support@example.com}") val ratkoSupportEmailAddress: String,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)

--- a/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1-dev.yml
+++ b/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1-dev.yml
@@ -6,7 +6,7 @@ info:
 
     Geoviitteen yhtenäisen rataverkon vastaavuutta maastoon rakennettuun rataverkkoon ei voida taata, joten viitekehysmuuntimen palauttamia tietoa ei tule käyttää suurta tarkkuutta vaativiin tehtäviin, esim. uusien suunnitelmien pohjatiedoksi.
 
-    Ongelmatilanteessa ota yhteys ylläpitoon: geoviite.support@solita.fi
+    Ongelmatilanteessa ota yhteys ylläpitoon: {GEOVIITE_SUPPORT_EMAIL}
   version: 1.0.0
 
 servers:

--- a/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1.yml
+++ b/infra/src/main/resources/static/frameconverter/openapi-rata-vkm-v1.yml
@@ -6,7 +6,7 @@ info:
 
     Geoviitteen yhtenäisen rataverkon vastaavuutta maastoon rakennettuun rataverkkoon ei voida taata, joten viitekehysmuuntimen palauttamia tietoa ei tule käyttää suurta tarkkuutta vaativiin tehtäviin, esim. uusien suunnitelmien pohjatiedoksi.
 
-    Ongelmatilanteessa ota yhteys ylläpitoon: geoviite.support@solita.fi
+    Ongelmatilanteessa ota yhteys ylläpitoon: {GEOVIITE_SUPPORT_EMAIL}
   version: 1.0.0
 
 servers:

--- a/ui/src/environment/environment-info.ts
+++ b/ui/src/environment/environment-info.ts
@@ -5,6 +5,8 @@ import { asyncCache } from 'cache/cache';
 export type EnvironmentInfo = {
     releaseVersion: string;
     environmentName: Environment;
+    geoviiteSupportEmailAddress: string;
+    ratkoSupportEmailAddress: string;
 };
 
 export type Environment = 'local' | 'dev' | 'test' | 'prod';

--- a/ui/src/publication/card/main-publication-card.tsx
+++ b/ui/src/publication/card/main-publication-card.tsx
@@ -24,6 +24,7 @@ import PublicationCard, {
     PublicationCardSection,
     ShowMorePublicationsLink,
 } from 'publication/card/publication-card';
+import { useEnvironmentInfo } from 'environment/environment-info';
 
 type MainPublicationCardProps = {
     publicationChangeTime: TimeStamp;
@@ -31,9 +32,6 @@ type MainPublicationCardProps = {
     splitChangeTime: TimeStamp;
     ratkoStatus: RatkoStatus | undefined;
 };
-
-const RATKO_SUPPORT_EMAIL = 'vayla.asiakkaat.fi@cgi.com';
-export const GEOVIITE_SUPPORT_EMAIL = 'geoviite.support@solita.fi';
 
 type RatkoConnectionErrorProps = {
     errorType: string;
@@ -79,13 +77,15 @@ const RatkoConnectionError: React.FC<RatkoConnectionErrorProps> = ({
     contact,
 }) => {
     const { t } = useTranslation();
+    const environmentInfo = useEnvironmentInfo();
+
     return (
         <span>
             {t(`error-in-ratko-connection.${errorType}`, { code: ratkoStatusCode })}
             <br />
             {t(`error-in-ratko-connection.${contact}`, {
-                geoviiteSupportEmail: GEOVIITE_SUPPORT_EMAIL,
-                ratkoSupportEmail: RATKO_SUPPORT_EMAIL,
+                geoviiteSupportEmail: environmentInfo?.geoviiteSupportEmailAddress,
+                ratkoSupportEmail: environmentInfo?.ratkoSupportEmailAddress,
             })}
         </span>
     );

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -8,7 +8,7 @@ import { RatkoAssetType, RatkoPushErrorAsset } from 'ratko/ratko-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { useLayoutDesign } from 'track-layout/track-layout-react-utils';
 import { getChangeTimes } from 'common/change-time-api';
-import { GEOVIITE_SUPPORT_EMAIL } from 'publication/card/main-publication-card';
+import { useEnvironmentInfo } from 'environment/environment-info';
 
 type RatkoPushErrorDetailsProps = {
     failedPublication: PublicationDetails;
@@ -43,6 +43,7 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
     failedPublication,
 }) => {
     const { t } = useTranslation();
+    const environmentInfo = useEnvironmentInfo();
     const error = useLoader(() => getRatkoPushError(failedPublication.id), [failedPublication]);
 
     const design = useLayoutDesign(
@@ -76,7 +77,7 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
         errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
         name: assetNameByType(error),
         operation: t(`enum.RatkoPushErrorOperation.${error.operation}`),
-        geoviiteSupportEmail: GEOVIITE_SUPPORT_EMAIL,
+        geoviiteSupportEmail: environmentInfo?.environmentName,
     });
 
     const pushErrorString = (): string => {


### PR DESCRIPTION
* Poistettu staattiset sähköpostimäärittelyt, nämä päätyvät nyt suoritusympäristöstä niin bäkkärin kuin myös frontin käyttöön asti.
* Muodostettu aiempia staattisia rata-vkm openapin yaml-filuja varten template-korvausrakenne.