### PR TITLE
GVT-3067 Remove duplicate-switch-linking validation...

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1625,7 +1625,6 @@
                 "deleted-duplicated-by-existing": "Poistettavaan raiteeseen viittaa edelleen duplikaattiraiteita: {{duplicates}}",
                 "empty-segments": "Raiteella ei ole geometriaa",
                 "too-short": "Raiteen pituus on vain {{length}}m. Alle {{minLength}}m pitkille raiteelle ei voida laskea reititystietoja.",
-                "duplicate-switch": "Vaihde {{switch}} on linkitetty raiteelle useampaan eri kohtaan",
                 "edge-switch-partial": "Vaihteen {{switch}} linkitys raiteella on puutteellinen ja se on linkitettävä uudelleen",
                 "points": {
                     "not-continuous": "Raiteen pisteet eivät ole jatkuvia (kulma on liian suuri pisteiden välillä)"
@@ -1646,7 +1645,7 @@
                     "state-category": {
                         "NOT_EXISTING": "Raide viittaa vaihteeseen {{switch}}, joka on tilakategoriassa \"Poistunut kohde\""
                     },
-                    "alignment-not-continuous": "Raide on kytketty vaihteelle {{switch}} useammasta kuin yhdestä kohtaa",
+                    "alignment-not-continuous": "Raide on kytketty vaihteelle {{switch}} useammasta kuin yhdestä kohdasta",
                     "joint-location-mismatch": "Raiteen ja vaihteen {{switch}} vaihdepisteiden sijainnit eivät vastaa toisiaan",
                     "wrong-joint-sequence": "Raiteen vaihdepisteet ({{switchJoints}}) vaihteella {{switch}} ({{switchType}}) eivät vastaa vaihderakenteen linjoja",
                     "wrong-links": "Vaihteen {{switch}} linkitys on puutteellinen ja se täytyy linkittää uudelleen",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -46,7 +46,6 @@ import fi.fta.geoviite.infra.tracklayout.TopologicalConnectivityType
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLink
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType
 import fi.fta.geoviite.infra.tracklayout.alignment
-import fi.fta.geoviite.infra.tracklayout.combineEdges
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
@@ -68,12 +67,12 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNameStructure
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import kotlin.math.PI
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.math.PI
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 
 class PublicationValidationTest {
 
@@ -838,7 +837,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -860,7 +862,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -883,7 +888,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -904,7 +912,10 @@ class PublicationValidationTest {
                     edge(
                         endInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -926,7 +937,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -948,7 +962,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -969,7 +986,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -992,7 +1012,10 @@ class PublicationValidationTest {
                     edge(
                         startInnerSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1014,7 +1037,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1036,7 +1062,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1055,7 +1084,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1076,7 +1108,10 @@ class PublicationValidationTest {
                     edge(
                         endOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1094,7 +1129,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1112,7 +1150,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1129,7 +1170,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1152,7 +1196,10 @@ class PublicationValidationTest {
                     edge(
                         startOuterSwitch = switchLinkYV(IntId(100), 1),
                         segments =
-                            listOf(segment(Point(0.0, 0.0), Point(0.0, 1.0)), segment(Point(0.0, 1.0), Point(0.0, 2.0))),
+                            listOf(
+                                segment(Point(0.0, 0.0), Point(0.0, 1.0)),
+                                segment(Point(0.0, 1.0), Point(0.0, 2.0)),
+                            ),
                     )
                 ),
             )
@@ -1224,43 +1271,6 @@ class PublicationValidationTest {
                             listOf(segment(Point(0.0, 0.0), Point(0.0, 2.0))),
                             startInnerSwitch = switchLinkYV(IntId(1), 1),
                             endInnerSwitch = switchLinkYV(IntId(1), 2),
-                        )
-                    ),
-                getSwitchName = { id -> SwitchName("$id") },
-            ),
-        )
-    }
-
-    @Test
-    fun `should give validation error for double-linked switch`() {
-        assertEquals(
-            listOf(
-                validationError(
-                    "validation.layout.location-track.duplicate-switch",
-                    localizationParams("switch" to IntId<LayoutSwitch>(1)),
-                )
-            ),
-            validateEdges(
-                geometry =
-                    trackGeometry(
-                        combineEdges(
-                            listOf(
-                                edge(
-                                    listOf(segment(Point(0.0, 0.0), Point(0.0, 2.0))),
-                                    startInnerSwitch = switchLinkYV(IntId(1), 1),
-                                    endInnerSwitch = switchLinkYV(IntId(1), 5),
-                                ),
-                                edge(
-                                    listOf(segment(Point(2.0, 0.0), Point(0.0, 4.0))),
-                                    startInnerSwitch = switchLinkYV(IntId(2), 1),
-                                    endInnerSwitch = switchLinkYV(IntId(2), 2),
-                                ),
-                                edge(
-                                    listOf(segment(Point(4.0, 0.0), Point(0.0, 6.0))),
-                                    startInnerSwitch = switchLinkYV(IntId(1), 5),
-                                    endInnerSwitch = switchLinkYV(IntId(1), 2),
-                                ),
-                            )
                         )
                     ),
                 getSwitchName = { id -> SwitchName("$id") },


### PR DESCRIPTION
, as it already exists in switch-alignment validations