### PR TITLE
GVT-3279&GVT-3280 Find revertable publication candidates with fetchCandidateVersions

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostDao.kt
@@ -344,35 +344,6 @@ class LayoutKmPostDao(
         return response
     }
 
-    fun fetchOnlyDraftVersions(
-        branch: LayoutBranch,
-        includeDeleted: Boolean,
-        trackNumberId: IntId<LayoutTrackNumber>? = null,
-    ): List<LayoutRowVersion<LayoutKmPost>> {
-        val sql =
-            """
-            select id, design_id, draft, version
-            from layout.km_post
-            where draft
-              and (:include_deleted or state != 'DELETED')
-              and (:trackNumberId::int is null or track_number_id = :trackNumberId)
-              and design_id is not distinct from :design_id
-        """
-                .trimIndent()
-        return jdbcTemplate
-            .query(
-                sql,
-                mapOf(
-                    "include_deleted" to includeDeleted,
-                    "trackNumberId" to trackNumberId?.intValue,
-                    "design_id" to branch.designId?.intValue,
-                ),
-            ) { rs, _ ->
-                rs.getLayoutRowVersion<LayoutKmPost>("id", "design_id", "draft", "version")
-            }
-            .also { ids -> logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids) }
-    }
-
     fun fetchNextWithLocationAfter(
         layoutContext: LayoutContext,
         trackNumberId: IntId<LayoutTrackNumber>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -531,34 +531,6 @@ class LocationTrackDao(
         return locationTrackOwners
     }
 
-    fun fetchOnlyDraftVersions(
-        branch: LayoutBranch,
-        includeDeleted: Boolean,
-        trackNumberId: IntId<LayoutTrackNumber>? = null,
-    ): List<LayoutRowVersion<LocationTrack>> {
-        val sql =
-            """
-                select id, design_id, draft, version
-                from layout.location_track
-                where draft
-                  and (:includeDeleted or state != 'DELETED')
-                  and (:trackNumberId::int is null or track_number_id = :trackNumberId)
-                  and design_id is not distinct from :design_id
-            """
-                .trimIndent()
-        val params =
-            mapOf(
-                "includeDeleted" to includeDeleted,
-                "trackNumberId" to trackNumberId?.intValue,
-                "design_id" to branch.designId?.intValue,
-            )
-        return jdbcTemplate
-            .query(sql, params) { rs, _ ->
-                rs.getLayoutRowVersion<LocationTrack>("id", "design_id", "draft", "version")
-            }
-            .also { ids -> logger.daoAccess(AccessType.VERSION_FETCH, "fetchOnlyDraftVersions", ids) }
-    }
-
     fun fetchVersionsForPublication(
         target: ValidationTarget,
         trackNumberIds: List<IntId<LayoutTrackNumber>>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -821,6 +821,20 @@ constructor(
     }
 
     @Test
+    fun `getRevertRequestDependencies can see cancelled track numbers`() {
+        val branch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
+        val designOfficialContext = testDBService.testContext(branch, DRAFT)
+        val trackNumber = designOfficialContext.save(trackNumber()).id
+        trackNumberService.cancel(branch, trackNumber)
+        val dependencies =
+            publicationService.getRevertRequestDependencies(
+                branch,
+                publicationRequestIds(trackNumbers = listOf(trackNumber)),
+            )
+        assertEquals(publicationRequestIds(trackNumbers = listOf(trackNumber)), dependencies)
+    }
+
+    @Test
     fun `Publication rejects duplicate track number names`() {
         trackNumberDao.save(trackNumber(number = TrackNumber("TN"), draft = false))
         val draftTrackNumberId = trackNumberDao.save(trackNumber(number = TrackNumber("TN"), draft = true)).id


### PR DESCRIPTION
Tässä funktiossa ei pidä käyttää tavallisia in_layout_context-sääntöjä käyttäviä hakuja, koska ne piilottavat cancelled-tilaiset rivit, ts. suunnitelmien muutosten perumiset. Toisaalta eipä noita fetchOnlyDraftVersions-funktioita myöskään tarvita, koska tämän funktion perffivaatimukset on sen verran olemattomat. Siksi voidaan yhtenäistää kaikki haut fetchCandidateVersions-pohjaisiksi. Pyörittelin myös tämän funktion järjestystä vähän muuten loogisemmaksi.