### PR TITLE
GVT-3091: Use newer Ratko api for location track point updates

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -601,7 +601,10 @@ constructor(
                     endAddress = endAddress,
                 )
             } else {
-                deleteLocationTrackPoints(changedKmNumbers, locationTrackRatkoOid)
+                val allKms = addresses.allPoints.asSequence().map { point -> point.address.kmNumber }.toSet()
+                val removedKms = changedKmNumbers.filterNot { changedKm -> changedKm in allKms }.toSet()
+
+                deleteLocationTrackPoints(removedKms, locationTrackRatkoOid)
                 updateLocationTrackGeometry(locationTrackOid = locationTrackRatkoOid, newPoints = changedMidPoints)
             }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -115,7 +115,7 @@ class FakeRatko(port: Int) {
             get("/api/locations/v1.1/locationtracks/${oid}").respond(okJson(listOf(ratkoTrack)))
         }
         post("/api/infra/v1.0/points/${oid}").respond(ok())
-        patch("/api/infra/v1.0/points/${oid}").respond(ok())
+        patch("/api/infra/v1.1/points/${oid}").respond(ok())
         post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
         post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
@@ -139,7 +139,7 @@ class FakeRatko(port: Int) {
             .respond(okJson(mapOf("id" to oid)))
 
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
-        patch("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
+        patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
         post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
@@ -162,7 +162,7 @@ class FakeRatko(port: Int) {
             )
             .respond(ok())
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
-        patch("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
+        patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
         post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
@@ -192,7 +192,7 @@ class FakeRatko(port: Int) {
                 queryParams = mapOf("locationtrackOIDOfGeometry" to locationTrackOidOfGeometry),
             )
             .respond(ok())
-        patch("/api/infra/v1.0/points/${oid}").respond(ok())
+        patch("/api/infra/v1.1/points/${oid}").respond(ok())
         post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
@@ -202,7 +202,7 @@ class FakeRatko(port: Int) {
         states: List<RatkoLocationTrackState>,
     ) {
         get("/api/locations/v1.1/locationtracks/${locationTrackAsset.id}").respond(okJson(listOf(locationTrackAsset)))
-        patch("/api/infra/v1.0/points/${locationTrackAsset.id}").respond(ok())
+        patch("/api/infra/v1.1/points/${locationTrackAsset.id}").respond(ok())
         locationTrackAsset.nodecollection.nodes
             .map { node -> node.point.km }
             .distinct()
@@ -225,7 +225,7 @@ class FakeRatko(port: Int) {
         put("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(ok())
         get("/api/locations/v1.1/locationtracks/${oid}", Times.once()).respond(okJson(listOf<Unit>()))
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
-        patch("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
+        patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
         post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
         post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
@@ -258,7 +258,7 @@ class FakeRatko(port: Int) {
     fun hasLocationTrack(locationTrackAsset: InterfaceRatkoLocationTrack) {
         put("/api/infra/v1.0/locationtracks", mapOf("id" to locationTrackAsset.id)).respond(ok())
         get("/api/locations/v1.1/locationtracks/${locationTrackAsset.id}").respond(okJson(listOf(locationTrackAsset)))
-        patch("/api/infra/v1.0/points/${locationTrackAsset.id}").respond(ok())
+        patch("/api/infra/v1.1/points/${locationTrackAsset.id}").respond(ok())
         locationTrackAsset.nodecollection.nodes
             .map { node -> node.point.km }
             .distinct()
@@ -339,7 +339,7 @@ class FakeRatko(port: Int) {
 
     fun getCreatedLocationTrackPoints(oid: String) = getPointUpdates(oid, "infra/v1.0/points", "POST")
 
-    fun getUpdatedLocationTrackPoints(oid: String) = getPointUpdates(oid, "infra/v1.0/points", "PATCH")
+    fun getUpdatedLocationTrackPoints(oid: String) = getPointUpdates(oid, "infra/v1.1/points", "PATCH")
 
     private fun metadataFilterOn(pointField: String, oid: String) =
         mapOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -112,10 +112,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.tracklayout.verticalEdge
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.queryOne
-import java.time.Instant
-import java.time.LocalDate
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -124,6 +120,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -402,12 +402,10 @@ constructor(
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         val createdPoints = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
         val updatedPoints = fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6")
-        val deletedPoints = fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6")
         assertEquals(1, createdPoints.size)
         assertEquals(1, createdPoints[0].size)
         assertEquals(5, createdPoints[0][0].kmM.meters.intValueExact())
         assertEquals((3..7).toList(), updatedPoints[0].map { p -> p.kmM.meters.intValueExact() })
-        assertEquals(listOf("0000"), deletedPoints)
     }
 
     @Test
@@ -441,12 +439,10 @@ constructor(
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         val createdPoints = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
         val updatedPoints = fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6")
-        val deletedPoints = fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6")
         assertEquals(1, updatedPoints.size)
         assertEquals(1, updatedPoints[0].size)
         assertEquals(5, updatedPoints[0][0].kmM.meters.intValueExact())
         assertEquals((3..7).toList(), createdPoints[0].map { p -> p.kmM.meters.intValueExact() })
-        assertEquals(listOf("0000"), deletedPoints)
     }
 
     @Test
@@ -482,7 +478,6 @@ constructor(
         publishAndPush(locationTracks = listOf(locationTrackOriginal.id))
         val createdPoints = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
         val updatedPoints = fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6")
-        val deletedPoints = fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6")
         assertEquals(1, updatedPoints.size)
         assertEquals(9, createdPoints[0].size)
         assertEquals(9, updatedPoints[0].size)
@@ -495,7 +490,6 @@ constructor(
         }
         assertTrue(createdPoints[0].subList(1, 8).all { p -> p.geometry!!.coordinates[1] > 0.0 })
         assertEquals(List(9) { 0.0 }, updatedPoints[0].map { p -> p.geometry!!.coordinates[1] })
-        assertEquals(listOf("0000"), deletedPoints)
     }
 
     @Test
@@ -728,7 +722,6 @@ constructor(
             // geometry change
             referenceLines = listOf(originalReferenceLineDaoResponse.id)
         )
-        val deletedOnTrack = fakeRatko.getLocationTrackPointDeletions("2.3.4.5.6")
         val updatedOnTrack = fakeRatko.getUpdatedLocationTrackPoints("2.3.4.5.6")
         val createdOnTrack = fakeRatko.getCreatedLocationTrackPoints("2.3.4.5.6")
         // bump in reference line was after 10 m, so the addresses of the first 9 points (separate
@@ -746,7 +739,6 @@ constructor(
                 updatedOnTrack[0][i].geometry?.coordinates?.get(0),
             )
         }
-        assertEquals(listOf("0000"), deletedOnTrack)
     }
 
     @Test


### PR DESCRIPTION
* Location track points are no longer always deleted. Only track kilometers which no longer contain any points are deleted.

* Point updates are no longer chunked, all points for a given track kilometer are sent in a single request.