### PR TITLE
GVT-3291 avoid saving unchanged tracks in switch linking (bulk & single)

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -402,9 +402,13 @@ class LocationTrackDao(
 
         jdbcTemplate.setUser()
         val response: LayoutRowVersion<LocationTrack> =
-            jdbcTemplate.queryForObject(sql, params) { rs, _ ->
-                rs.getLayoutRowVersion("id", "design_id", "draft", "version")
-            } ?: throw IllegalStateException("Failed to save Location Track")
+            requireNotNull(
+                jdbcTemplate.queryForObject(sql, params) { rs, _ ->
+                    rs.getLayoutRowVersion("id", "design_id", "draft", "version")
+                }
+            ) {
+                "Failed to save Location Track: ${item.toLog()}"
+            }
         logger.daoAccess(AccessType.INSERT, LocationTrack::class, response)
         alignmentDao.saveLocationTrackGeometry(response, geometry)
         return response


### PR DESCRIPTION
Palautetaan vaihdelinkityksen lopussa raiteille DB-versiot muokatuista noodeista ja vertaillaan muutos vasta sen jälkeen. Vedetään myös yhteen raiteiden tallennuslogiikka yhden vaihteen ja kaikkien vaihteiden uudelleenlinkityksestä jotta fix pätee molempiin caseihin. 

Tällä saavutetaan 2 etua:
- Node/Edge hash cachejen poiston myötä pitkien raiteiden linkitys hidastui merkittävästi koska noodeja/edgejä koitetaan tallentaa turhaan vaikka ne ovat jo kannassa. Nyt tuolta vältytään kun tallennettaville raiteille palautuu ennen tallennusta db-versiot niistä noodeista/edgeistä jotka ei oikeasti muuttuneet mitenkään.
- Koska normalisointi parantaa raiteen muutoksen vertailua, muuttumattomista raiteista ei myöskään enää synny muutosriviä julkaistavaksi (esikatseluun), joten samalla vältytään turhilta raiteen 0-julkaisuilta.