### PR TITLE
GVT-3285 Raidegeometrian tallentamisen optimointeja

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -314,53 +314,85 @@ class LayoutAlignmentDao(
         return createEdges(edges, nodes, geometries).associateBy { e -> e.id }
     }
 
+    private fun saveEdges(
+        edges: List<TmpLayoutEdge>,
+        savedNodes: Map<NodeHash, IntId<LayoutNode>>,
+        savedGeometries: Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>>,
+    ): List<IntId<LayoutEdge>> {
+        val startNodeIds =
+            edges.map { edge ->
+                (edge.startNode.node as? DbLayoutNode)?.id
+                    ?: requireNotNull(savedNodes[edge.startNode.node.contentHash])
+            }
+        val endNodeIds =
+            edges.map { edge ->
+                (edge.endNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.endNode.node.contentHash])
+            }
+        val sql =
+            """
+            select * from layout.get_or_insert_edges(
+              :insert_edge_ids,
+              :start_node_ids,
+              :start_node_ports::layout.node_port_type[],
+              :end_node_ids,
+              :end_node_ports::layout.node_port_type[],
+              :geometry_alignment_idss,
+              :geometry_element_indicess,
+              :start_m_valuess,
+              :source_start_m_valuess,
+              :sourcess::layout.geometry_source[],
+              :geometry_idss,
+              (select array_agg(postgis.st_polygonfromtext(polygon_string, 3067)) from unnest(:polygon_strings) ps(polygon_string)),
+              :segment_index_range_starts,
+              :segment_index_range_ends
+            )
+        """
+        val segmentIndexRangeEndpoints = edges.map { it.segments.size }.scan(0) { a, b -> a + b }
+        val params =
+            mapOf(
+                "insert_edge_ids" to edges.indices.toList().toTypedArray(),
+                "start_node_ids" to startNodeIds.map { it.intValue }.toTypedArray(),
+                "start_node_ports" to edges.map { it.startNode.portConnection.name }.toTypedArray(),
+                "end_node_ids" to endNodeIds.map { it.intValue }.toTypedArray(),
+                "end_node_ports" to edges.map { it.endNode.portConnection.name }.toTypedArray(),
+                "geometry_alignment_idss" to
+                    edges.flatMap { edge -> edge.segments.map { s -> s.sourceId?.parentId } }.toTypedArray(),
+                "geometry_element_indicess" to
+                    edges.flatMap { edge -> edge.segments.map { s -> s.sourceId?.index } }.toTypedArray(),
+                "start_m_valuess" to
+                    edges
+                        .flatMap { edge -> edge.segmentMValues.map { m -> roundTo6Decimals(m.min.distance) } }
+                        .toTypedArray(),
+                "source_start_m_valuess" to
+                    edges.flatMap { edge -> edge.segments.map { s -> s.sourceStartM } }.toTypedArray(),
+                "sourcess" to edges.flatMap { edge -> edge.segments.map { s -> s.source.name } }.toTypedArray(),
+                "geometry_idss" to
+                    edges
+                        .flatMap { edge ->
+                            edge.segments.map { s ->
+                                (s.geometry.id as? IntId ?: requireNotNull(savedGeometries[s.geometry.id])).intValue
+                            }
+                        }
+                        .toTypedArray(),
+                "polygon_strings" to edges.map { edge -> edge.boundingBox.polygonFromCorners.toWkt() }.toTypedArray(),
+                "segment_index_range_starts" to
+                    segmentIndexRangeEndpoints.let { it.subList(0, it.size - 1) }.toTypedArray(),
+                "segment_index_range_ends" to
+                    segmentIndexRangeEndpoints.let { it.subList(1, it.size) }.map { it - 1 }.toTypedArray(),
+            )
+
+        val results =
+            jdbcTemplate.query(sql, params) { rs, _ ->
+                rs.getInt("insert_edge_id") to rs.getIntId<LayoutEdge>("edge_id")
+            }
+        return results.sortedBy { it.first }.map { it.second }
+    }
+
     private fun saveEdge(
         content: TmpLayoutEdge,
         savedNodes: Map<NodeHash, IntId<LayoutNode>>,
         savedGeometries: Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>>,
-    ): IntId<LayoutEdge> {
-        val startNodeId =
-            (content.startNode.node as? DbLayoutNode)?.id
-                ?: requireNotNull(savedNodes[content.startNode.node.contentHash])
-        val endNodeId =
-            (content.endNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[content.endNode.node.contentHash])
-        val sql =
-            """
-            select layout.get_or_insert_edge(
-              :start_node_id,
-              :start_node_port::layout.node_port_type,
-              :end_node_id,
-              :end_node_port::layout.node_port_type,
-              :geometry_alignment_ids,
-              :geometry_element_indices,
-              :start_m_values,
-              :source_start_m_values,
-              :sources,
-              :geometry_ids,
-               postgis.st_polygonfromtext(:polygon_string, 3067)
-            ) as id
-        """
-        val params =
-            mapOf(
-                "start_node_id" to startNodeId.intValue,
-                "start_node_port" to content.startNode.portConnection.name,
-                "end_node_id" to endNodeId.intValue,
-                "end_node_port" to content.endNode.portConnection.name,
-                "geometry_alignment_ids" to content.segments.map { s -> s.sourceId?.parentId }.toTypedArray(),
-                "geometry_element_indices" to content.segments.map { s -> s.sourceId?.index }.toTypedArray(),
-                "start_m_values" to content.segmentMValues.map { m -> roundTo6Decimals(m.min.distance) }.toTypedArray(),
-                "source_start_m_values" to content.segments.map { s -> s.sourceStartM }.toTypedArray(),
-                "sources" to content.segments.map { s -> s.source.name }.toTypedArray(),
-                "geometry_ids" to
-                    content.segments
-                        .map { s ->
-                            (s.geometry.id as? IntId ?: requireNotNull(savedGeometries[s.geometry.id])).intValue
-                        }
-                        .toTypedArray(),
-                "polygon_string" to content.boundingBox.polygonFromCorners.toWkt(),
-            )
-        return jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId<LayoutEdge>("id") }.single()
-    }
+    ): IntId<LayoutEdge> = saveEdges(listOf(content), savedNodes, savedGeometries)[0]
 
     fun fetch(trackVersion: LayoutRowVersion<LocationTrack>): DbLocationTrackGeometry =
         locationTrackGeometryCache.get(trackVersion) { version ->
@@ -431,7 +463,11 @@ class LayoutAlignmentDao(
             tmpEdges
                 .flatMap { e -> e.segments.mapNotNull { s -> if (s.geometry.id is StringId) s.geometry else null } }
                 .let { insertSegmentGeometries(it) }
-        val savedEdges = tmpEdges.associate { e -> e.contentHash to saveEdge(e, savedNodes, savedGeometries) }
+
+        val savedEdges = tmpEdges.associateBy { it.contentHash }.entries.let { edgesByHash ->
+            val saved = saveEdges(edgesByHash.map { it.value }, savedNodes, savedGeometries)
+            edgesByHash.map { it.key }.zip(saved).associate { it}
+        }
 
         val sql =
             """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -81,8 +81,7 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
             if (i == edges.lastIndex) {
                 listOf(
                     e.startNode.node to e.firstSegmentStart.toAlignmentPoint(m.min),
-                    e.endNode.node to
-                        e.lastSegmentEnd.toAlignmentPoint(e.segmentMValues.last().min.toAlignmentM(m.min)),
+                    e.endNode.node to e.lastSegmentEnd.toAlignmentPoint(e.segmentMValues.last().min.toAlignmentM(m.min)),
                 )
             } else {
                 listOf(e.startNode.node to e.firstSegmentStart.toAlignmentPoint(m.min))
@@ -621,6 +620,15 @@ sealed class LayoutNode {
         ports.any { port -> (port as? SwitchLink)?.matches(switchId, joint) ?: false }
 
     fun containsBoundary(boundary: TrackBoundary): Boolean = ports.any { port -> port == boundary }
+
+    fun forEachPort(onPort: (port: NodePort, type: NodePortType) -> Unit) {
+        onPort(portA, A)
+        if (type == SWITCH && portB == null) {
+            onPort(EmptyPort, B)
+        } else {
+            portB?.let { b -> onPort(b, B) }
+        }
+    }
 
     abstract val type: LayoutNodeType
 

--- a/infra/src/main/resources/db/migration/repeatable/R__10.01_layout_node_insert.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__10.01_layout_node_insert.sql
@@ -1,100 +1,125 @@
 drop function if exists layout.get_or_insert_node;
-create function layout.get_or_insert_node(
+drop function if exists layout.get_or_insert_nodes;
+drop type if exists layout.node_insert_result;
+
+create type layout.node_insert_result as
+(
+  insert_node_id int,
+  node_id        int
+);
+
+create function layout.get_or_insert_nodes(
+  insert_node_ids int[],
+  ports layout.node_port_type[],
   switch_ids int[],
   switch_joint_numbers int[],
   switch_joint_roles common.switch_joint_role[],
   boundary_track_ids int[],
   boundary_types layout.boundary_type[]
-) returns int as
+) returns setof layout.node_insert_result as
 $$
-declare
-  node_hash uuid;
-  node_type layout.node_type :=
-    case
-      when cardinality(switch_ids) > 0 and cardinality(boundary_track_ids) = 0 then 'SWITCH'
-      when cardinality(switch_ids) = 0 and cardinality(boundary_track_ids) > 0 then 'TRACK_BOUNDARY'
-      else 'invalid' -- if neither applies, the type is incorrect -> break the variable assignment
-    end;
-  result_id int;
-begin
-  if node_type is null
-  then
-    raise exception
-      'Node type is inconclusive due to conflicting content: switch_ids=% boundary_track_ids=% type=%', switch_ids, boundary_track_ids, node_type;
-  end if;
-  -- Node contents must be in a consistent order for correct port resolution
-  if array [switch_ids[1], switch_joint_numbers[1], boundary_track_ids[1]] >
-     array [switch_ids[2], switch_joint_numbers[2], boundary_track_ids[2]]
-  then
-    raise exception
-      'Node ports in incorrect order or duplicated: switch_ids=[%] switch_joints=[%] boundary_track_ids[%]',
-      switch_ids, switch_joint_numbers, boundary_track_ids;
-  end if;
-
-  drop table if exists port_tmp;
-  create temporary table port_tmp as
-  select *,
-    layout.calculate_node_port_hash(
-        node_type,
-        switch_id,
-        switch_joint_number,
-        switch_joint_role,
-        boundary_location_track_id,
-        boundary_type
-    ) as hash
-    from (
-      select
-        unnest(array ['A', 'B'])::layout.node_port_type as port,
-        unnest(switch_ids) as switch_id,
-        unnest(switch_joint_numbers) as switch_joint_number,
-        unnest(switch_joint_roles)::common.switch_joint_role as switch_joint_role,
-        unnest(boundary_track_ids) as boundary_location_track_id,
-        unnest(boundary_types)::layout.boundary_type as boundary_type
-    ) tmp
-    -- For switches, both ports must be linkable, even if B has no switch-joint
-    where node_type = 'SWITCH' or boundary_location_track_id is not null;
-  alter table port_tmp
-    add primary key (port),
-    alter column port set not null,
-    alter column hash set not null;
-
+with port as (
   select
-    layout.calculate_node_hash(
-        (select hash from port_tmp where port = 'A'),
-        (select hash from port_tmp where port = 'B')
-    ),
-    (select node_type from port_tmp where port = 'A')
-    into node_hash, node_type;
-
-  -- Try inserting node: if it already exists, the key will conflict
-  insert into layout.node
-    (type, hash)
-    values
-      (node_type, node_hash)
-  on conflict (hash) do nothing
-    returning id into result_id;
-
-  -- If the row was inserted (no conflict) then the id is not null
-  if result_id is not null then
-    insert into layout.node_port
-      (node_id, port, hash, switch_id, switch_joint_number, switch_joint_role, boundary_location_track_id,
-       boundary_type)
+    unnest(insert_node_ids) as insert_node_id,
+    unnest(ports)::layout.node_port_type as port_type,
+    unnest(switch_ids) as switch_id,
+    unnest(switch_joint_numbers) as switch_joint_number,
+    unnest(switch_joint_roles)::common.switch_joint_role as switch_joint_role,
+    unnest(boundary_track_ids) as boundary_track_id,
+    unnest(boundary_types)::layout.boundary_type as boundary_type
+),
+  -- (insert_node_id, node_type), row per distinct insert_node_id
+  node_type as (
     select
-      result_id,
-      port_tmp.port,
-      port_tmp.hash,
-      port_tmp.switch_id,
-      port_tmp.switch_joint_number,
-      port_tmp.switch_joint_role,
-      port_tmp.boundary_location_track_id,
-      port_tmp.boundary_type
-      from port_tmp;
-    drop table port_tmp;
-    return result_id;
-  else -- Insert yielded nothing, so the node already exists
-    select id from layout.node where hash = node_hash into result_id;
-    drop table port_tmp;
-    return result_id;
-  end if;
-end;
-$$ language plpgsql volatile;
+      insert_node_id,
+      case
+        when
+              count(*) filter (where switch_id is not null) > 0 and
+              count(*) filter (where boundary_track_id is not null) = 0 then 'SWITCH'
+        when
+              count(*) filter (where switch_id is not null) = 0 and
+              count(*) filter (where boundary_track_id is not null) > 0 then 'TRACK_BOUNDARY'
+      end::layout.node_type as type
+      from port
+      group by insert_node_id
+  ),
+  -- (insert_node_id, port_type, hash), row per distinct (insert_node_id, port_type)
+  port_hash as (
+    select
+      insert_node_id,
+      port.port_type,
+      layout.calculate_node_port_hash(
+          node_type.type,
+          switch_id,
+          switch_joint_number,
+          switch_joint_role,
+          boundary_track_id,
+          boundary_type
+      ) as hash
+      from port
+        join node_type using (insert_node_id)
+  ),
+  -- (insert_node_id, hash), row per distinct insert_node_id
+  node_hash as (
+    select insert_node_id, layout.calculate_node_hash(port_a.hash, port_b.hash) as hash
+      from node_type
+        join (
+        select *
+          from port_hash
+          where port_type = 'A'
+      ) port_a using (insert_node_id)
+        left join (
+        select *
+          from port_hash
+          where port_type = 'B'
+      ) port_b using (insert_node_id)
+  ),
+  -- (insert_node_id, hash), row per distinct hash
+  distinct_node_hash as (
+    select distinct on (hash) insert_node_id, hash
+      from node_hash
+  ),
+  -- (id, hash), row per inserted node
+  inserted_node as (
+    insert into layout.node (type, hash)
+      (
+        select type, hash
+          from node_type
+            join distinct_node_hash using (insert_node_id)
+      )
+      on conflict do nothing
+      returning id, hash
+  ),
+  inserted_port as (
+    insert into layout.node_port
+      (node_id, port, hash,
+       switch_id, switch_joint_number, switch_joint_role,
+       boundary_location_track_id, boundary_type)
+      (
+        select
+          inserted_node.id,
+          port.port_type,
+          port_hash.hash,
+          switch_id,
+          switch_joint_number,
+          switch_joint_role,
+          boundary_track_id,
+          boundary_type
+          from inserted_node
+            join distinct_node_hash using (hash)
+            join node_type using (insert_node_id)
+            join port_hash using (insert_node_id)
+            join port using (insert_node_id, port_type)
+          where node_type.type = 'SWITCH' or boundary_track_id is not null
+      )
+  )
+select insert_node_id, node_id.id as node_id
+  from node_hash
+    join (
+    select hash, id
+      from inserted_node
+    union all
+    select hash, id
+      from layout.node
+  ) node_id using (hash)
+$$ language sql volatile;

--- a/infra/src/main/resources/db/migration/repeatable/R__10.02_layout_edge_insert.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__10.02_layout_edge_insert.sql
@@ -1,121 +1,183 @@
 drop function if exists layout.get_or_insert_edge;
-create function layout.get_or_insert_edge(
-  start_node_id int,
-  start_node_port layout.node_port_type,
-  end_node_id int,
-  end_node_port layout.node_port_type,
-  geometry_alignment_ids int[],
-  geometry_element_indices int[],
-  start_m_values decimal(13, 6)[],
-  source_start_m_values decimal(13, 6)[],
-  sources varchar[],
-  geometry_ids int[],
-  edge_bbox postgis.geometry(polygon, 3067)
-) returns int as
+drop function if exists layout.get_or_insert_edges;
+drop type if exists layout.edge_insert_result;
+
+create type layout.edge_insert_result as
+(
+  insert_edge_id int,
+  edge_id        int
+);
+
+create function layout.get_or_insert_edges(
+  insert_edge_ids int[],
+  start_node_ids int[],
+  start_node_ports layout.node_port_type[],
+  end_node_ids int[],
+  end_node_ports layout.node_port_type[],
+  geometry_alignment_idss int[],
+  geometry_element_indicess int[],
+  start_m_valuess decimal(13, 6)[],
+  source_start_m_valuess decimal(13, 6)[],
+  sourcess layout.geometry_source[],
+  geometry_idss int[],
+  edge_bboxes postgis.geometry(polygon, 3067)[],
+  segment_index_range_starts int[],
+  segment_index_range_ends int[])
+  returns setof layout.edge_insert_result as
 $$
-declare
-  edge_hash   uuid;
-  edge_length decimal(13, 6);
-  result_id   int;
 begin
-  drop table if exists segment_tmp;
-  create temporary table segment_tmp as
-  select
-    row_number() over (order by tmp.start_m) - 1 as segment_index,
-    tmp.*,
-    layout.calculate_segment_hash(
-        geometry_alignment_id,
-        geometry_element_index,
-        source_start_m,
-        source,
-        geometry_id
-    ) as hash,
-    sg.geometry
-    from (
-      select
-        unnest(geometry_alignment_ids) as geometry_alignment_id,
-        unnest(geometry_element_indices) as geometry_element_index,
-        unnest(start_m_values) as start_m,
-        unnest(source_start_m_values) as source_start_m,
-        unnest(sources)::layout.geometry_source as source,
-        unnest(geometry_ids) as geometry_id
-    ) tmp
-      left join layout.segment_geometry sg on tmp.geometry_id = sg.id;
-  alter table segment_tmp
-    add primary key (segment_index),
-    alter column start_m set not null,
-    alter column source set not null,
-    alter column geometry_id set not null,
-    alter column segment_index set not null,
-    alter column geometry set not null;
+  -- one row per insert_edge_id, with segment info in arrays
+  create temporary table edge_content on commit drop as (
+    select te.*
+      from (
+        select
+          unnest(segment_index_range_starts) + 1 as segment_ix_start,
+          unnest(segment_index_range_ends) + 1 as segment_ix_end,
+          generate_series(1, cardinality(insert_edge_ids)) as ix
+      ) ixr,
+        lateral (
+          select
+            insert_edge_ids[ix] as insert_edge_id,
+            start_node_ids[ix] as start_node_id,
+            start_node_ports[ix] as start_node_port,
+            end_node_ids[ix] as end_node_id,
+            end_node_ports[ix] as end_node_port,
+            geometry_alignment_idss[segment_ix_start : segment_ix_end] as geometry_alignment_ids,
+            geometry_element_indicess[segment_ix_start : segment_ix_end] as geometry_element_indices,
+            start_m_valuess[segment_ix_start : segment_ix_end] as start_m_values,
+            source_start_m_valuess[segment_ix_start : segment_ix_end] as source_start_m_values,
+            sourcess[segment_ix_start : segment_ix_end] as sources,
+            geometry_idss[segment_ix_start : segment_ix_end] as geometry_ids,
+            edge_bboxes[ix] as edge_bbox
+          ) te
+  );
+  create index on edge_content (insert_edge_id);
 
-  select
-    layout.calculate_edge_hash(
-        start_node_id,
-        start_node_port,
-        end_node_id,
-        end_node_port,
-        array_agg(segment_tmp.hash)
-    ),
-    sum(postgis.st_m(postgis.st_endpoint(segment_tmp.geometry)))
-    into edge_hash, edge_length
-    from segment_tmp;
-
-  -- Try inserting edge: if it already exists, the hash will conflict
-  insert into layout.edge
-    (start_node_id,
-     start_node_port,
-     end_node_id,
-     end_node_port,
-     bounding_box,
-     start_location,
-     end_location,
-     segment_count,
-     length,
-     hash)
-    values
-      (start_node_id,
-       start_node_port,
-       end_node_id,
-       end_node_port,
-       edge_bbox,
-       (
-         select postgis.st_force2d(postgis.st_startpoint(geometry))
-           from layout.segment_geometry
-           where id = geometry_ids[1]
-       ),
-       (
-         select postgis.st_force2d(postgis.st_endpoint(geometry))
-           from layout.segment_geometry
-           where id = geometry_ids[array_length(geometry_ids, 1)]
-       ),
-       array_length(geometry_ids, 1),
-       edge_length,
-       edge_hash)
-  on conflict do nothing
-    returning id into result_id;
-
-  -- If the row was inserted (no conflict) then the id is not null -> insert the rest of the data
-  if result_id is not null then
-    insert into layout.edge_segment
-      (edge_id, segment_index, geometry_alignment_id, geometry_element_index, start_m, source_start_m, source, geometry_id, hash)
+  -- one row per segment, identified by (insert_edge_id, segment_index)
+  create temporary table segment on commit drop as (
     select
-      result_id as edge_id,
-      segment_tmp.segment_index,
-      segment_tmp.geometry_alignment_id,
-      segment_tmp.geometry_element_index,
-      segment_tmp.start_m,
-      segment_tmp.source_start_m,
-      segment_tmp.source,
-      segment_tmp.geometry_id,
-      segment_tmp.hash
-      from segment_tmp;
-    drop table segment_tmp;
-    return result_id;
-  else -- Insert yielded nothing, so the edge already exists
-    select id from layout.edge where hash = edge_hash into result_id;
-    drop table segment_tmp;
-    return result_id;
-  end if;
+          row_number()
+          over (partition by start_node_id, start_node_port, end_node_id, end_node_port order by start_m) -
+          1 as segment_index,
+      layout.calculate_segment_hash(
+          geometry_alignment_id,
+          geometry_element_index,
+          source_start_m,
+          source,
+          geometry_id
+      ) as hash,
+      segment_content.*,
+      postgis.st_m(postgis.st_endpoint(sg.geometry)) as segment_length
+      from (
+        select
+          insert_edge_id,
+          start_node_id,
+          start_node_port,
+          end_node_id,
+          end_node_port,
+          unnest(start_m_values) as start_m,
+          unnest(geometry_alignment_ids) as geometry_alignment_id,
+          unnest(geometry_element_indices) as geometry_element_index,
+          unnest(source_start_m_values) as source_start_m,
+          unnest(sources) as source,
+          unnest(geometry_ids) as geometry_id
+          from edge_content
+      ) segment_content
+        left join layout.segment_geometry sg on segment_content.geometry_id = sg.id
+  );
+
+  create index on segment(insert_edge_id);
+
+  return query
+    -- one row per insert_edge_id
+    with edge_hash as (
+      select
+        insert_edge_id,
+        layout.calculate_edge_hash(
+            start_node_id,
+            start_node_port,
+            end_node_id,
+            end_node_port,
+            array_agg(segment.hash order by segment_index)
+        ) as hash,
+        sum(segment_length) as edge_length
+        from segment
+        group by insert_edge_id, start_node_id, start_node_port, end_node_id, end_node_port
+    ),
+      -- one row per distinct hash
+      distinct_edge_hash as (
+        select distinct on (hash) *
+          from edge_hash
+      ),
+      inserted_edge as (
+        insert into layout.edge
+          (start_node_id,
+           start_node_port,
+           end_node_id,
+           end_node_port,
+           bounding_box,
+           start_location,
+           end_location,
+           segment_count,
+           length,
+           hash)
+          (
+            select
+              start_node_id,
+              start_node_port,
+              end_node_id,
+              end_node_port,
+              edge_bbox,
+              postgis.st_force2d(postgis.st_startpoint(start_segment_geometry.geometry)),
+              postgis.st_force2d(postgis.st_endpoint(end_segment_geometry.geometry)),
+              array_length(geometry_ids, 1),
+              edge_length,
+              distinct_edge_hash.hash
+              from edge_content
+                join distinct_edge_hash using (insert_edge_id)
+                join layout.segment_geometry start_segment_geometry
+                     on start_segment_geometry.id = geometry_ids[1]
+                join layout.segment_geometry end_segment_geometry
+                     on end_segment_geometry.id = geometry_ids[array_length(geometry_ids, 1)]
+          )
+          on conflict do nothing
+          returning id, hash
+      ),
+      inserted_segment as (
+        insert into layout.edge_segment
+          (edge_id, segment_index, geometry_alignment_id, geometry_element_index, start_m, source_start_m,
+           source,
+           geometry_id, hash)
+          (
+            select
+              inserted_edge.id as edge_id,
+              segment_index,
+              geometry_alignment_id,
+              geometry_element_index,
+              start_m,
+              source_start_m,
+              source,
+              geometry_id,
+              segment.hash
+              from inserted_edge
+                join distinct_edge_hash using (hash)
+                join segment using (insert_edge_id)
+          )
+      )
+    select insert_edge_id, id
+      from edge_hash
+        join (
+        select hash, id
+          from inserted_edge
+        union all
+        select hash, id
+          from layout.edge
+      ) e using (hash);
+
+  drop table edge_content;
+  drop table segment;
 end;
-$$ language plpgsql volatile;
+
+$$
+  language plpgsql
+  volatile;


### PR DESCRIPTION
Postgressi ei ole kovin hyvä käsittelemään isoja määriä temppitauluja, joten hillitään niiden käyttöä. Varsinainen asioita kaatava ongelma oli, että jos samassa transaktiossa tallennetaan riittävä määrä riittävän pitkiä raidegeometrioita (eli uusia noodeja ja edgejä), postgres luo temppitaulujen käsittelyjä varten niin määrättömästi lukkoja, että se alkaa paukkua muistirajoitteisiin.

Tosin toisin kuin alkuun suunnittelin, tässä ratkaisussa ei poisteta temppitauluja ihan kokonaan, koska en saanut paria vaihtoehtoa pyörittelemälläkään aikaan hyvää perffiä saveEdgesistä ilman että segmentit viedään omaan indeksoituun tauluunsa. Mutta tässäkin varmaan useimmissa tapauksissa on aika iso voitto, että temppitauluja luodaan kaksi per raide, eikä yksi per edge.

Eli perusajatus: Tehdään raidegeometrioiden tallentaminen niin, että kaikki nodet tallennetaan yhdessä pompsissa, sitten kaikki edget toisessa, raidekohtaisesti (SQL-funktiot sinällään pystyisivät selviämään useammankin raiteen tallentamisesta kerrallaan, mutta sen eteen pitäisi muuten tehdä aivan liian isoja muutoksia LocationTrackServiceen asti)

Hyviä SQL-asioita tietää kommittien lukua varten:
- `select unnest(a), unnest(b)` missä a ja b ovat taulukoita zippaa ne yhteen indekseittäin. Tämä on postgressissä nykyään käsittääkseni luotettavasti toimiva ominaisuus: https://www.postgresql.org/docs/current/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET ("If there is more than one set-returning function in the query's select list...")
- Yksittäisessä WITH-lauseessa pystyy periaatteessa tekemään muutoksia rajattomaan määrään tauluja, mutta lukuoperaatiot näkevät vain tilan ennen muutoksia: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-MODIFYING
- JDBC:n kautta ei pysty viemään lainkaan rakenteellisia olioita, eikä ainakaan minun kokeilun perusteella moniulotteisia taulukoita; ja moniulotteisen taulukon unnest() litistää kerralla pois kaikki ulottuvuudet. Niin ja postgressissä moniulotteisen taulukon koon pitää olla yhtenäinen, eli jos on taulukko `foo[][]`, niin `foo[1][:]`:n pitää olla yhtä iso taulukko kuin `foo[2][:]`:n. Näistä syistä piti saveEdges()issä litistää segmenttitiedot yksiulotteiseen taulukkoon ja viedä erikseen sen indeksirajat.