### PR TITLE
GVT-3216: Pituusmittauslinjan käsittely ratanumeron julkaisulokinäkymässä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -300,34 +300,35 @@ enum class PublishableObjectType {
     KM_POST,
 }
 
-data class PublishableObjectIdAndType(val id: IntId<*>, val type: PublishableObjectType) {
+enum class PublicationLogAssetType(val publishableObjectType: PublishableObjectType) {
+    TRACK_NUMBER(PublishableObjectType.TRACK_NUMBER),
+    LOCATION_TRACK(PublishableObjectType.LOCATION_TRACK),
+    SWITCH(PublishableObjectType.SWITCH),
+    KM_POST(PublishableObjectType.KM_POST),
+}
+
+data class PublicationLogAsset(val id: IntId<*>, val type: PublicationLogAssetType) {
     companion object {
-        fun trackNumber(id: IntId<LayoutTrackNumber>) =
-            PublishableObjectIdAndType(id, PublishableObjectType.TRACK_NUMBER)
+        fun trackNumber(id: IntId<LayoutTrackNumber>) = PublicationLogAsset(id, PublicationLogAssetType.TRACK_NUMBER)
 
         fun locationTrack(id: IntId<LayoutTrackNumber>) =
-            PublishableObjectIdAndType(id, PublishableObjectType.LOCATION_TRACK)
+            PublicationLogAsset(id, PublicationLogAssetType.LOCATION_TRACK)
 
-        fun referenceLine(id: IntId<LayoutTrackNumber>) =
-            PublishableObjectIdAndType(id, PublishableObjectType.REFERENCE_LINE)
+        fun switch(id: IntId<LayoutTrackNumber>) = PublicationLogAsset(id, PublicationLogAssetType.SWITCH)
 
-        fun switch(id: IntId<LayoutTrackNumber>) = PublishableObjectIdAndType(id, PublishableObjectType.SWITCH)
-
-        fun kmPost(id: IntId<LayoutTrackNumber>) = PublishableObjectIdAndType(id, PublishableObjectType.KM_POST)
+        fun kmPost(id: IntId<LayoutTrackNumber>) = PublicationLogAsset(id, PublicationLogAssetType.KM_POST)
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun locationTrackId() = if (type != PublishableObjectType.LOCATION_TRACK) null else id as IntId<LocationTrack>
+    fun locationTrackId() = if (type != PublicationLogAssetType.LOCATION_TRACK) null else id as IntId<LocationTrack>
 
-    fun isTrackNumber(other: IntId<LayoutTrackNumber>) = type == PublishableObjectType.TRACK_NUMBER && id == other
+    fun isTrackNumber(other: IntId<LayoutTrackNumber>) = type == PublicationLogAssetType.TRACK_NUMBER && id == other
 
-    fun isLocationTrack(other: IntId<LocationTrack>) = type == PublishableObjectType.LOCATION_TRACK && id == other
+    fun isLocationTrack(other: IntId<LocationTrack>) = type == PublicationLogAssetType.LOCATION_TRACK && id == other
 
-    fun isReferenceLine(other: IntId<ReferenceLine>) = type == PublishableObjectType.REFERENCE_LINE && id == other
+    fun isSwitch(other: IntId<LayoutSwitch>) = type == PublicationLogAssetType.SWITCH && id == other
 
-    fun isSwitch(other: IntId<LayoutSwitch>) = type == PublishableObjectType.SWITCH && id == other
-
-    fun isKmPost(other: IntId<LayoutKmPost>) = type == PublishableObjectType.KM_POST && id == other
+    fun isKmPost(other: IntId<LayoutKmPost>) = type == PublicationLogAssetType.KM_POST && id == other
 }
 
 enum class Operation(val priority: Int) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationController.kt
@@ -176,19 +176,19 @@ constructor(
         @RequestParam("order", required = false) order: SortOrder?,
         @RequestParam("timeZone") timeZone: ZoneId?,
         @RequestParam("lang") lang: LocalizationLanguage,
-        @RequestParam("type", required = false) type: PublishableObjectType?,
+        @RequestParam("type", required = false) type: PublicationLogAssetType?,
         @RequestParam("id", required = false) id: IntId<*>?,
         @RequestParam("filenameObjectPart", required = false) filenameObjectPart: FileName?,
     ): ResponseEntity<ByteArray> {
         val translation = localizationService.getLocalization(lang)
-        val specificId = getSpecificObjectId(type, id)
+        val publicationLogAsset = getPublicationLogAssetOrNull(type, id)
 
         val publicationsAsCsv =
             publicationLogService.fetchPublicationsAsCsv(
                 layoutBranch ?: LayoutBranch.main,
                 from,
                 to,
-                specificId = specificId,
+                publicationLogAsset,
                 sortBy,
                 order,
                 timeZone,
@@ -212,20 +212,20 @@ constructor(
         @RequestParam("layoutBranch", required = false) layoutBranch: LayoutBranch?,
         @RequestParam("from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) from: Instant?,
         @RequestParam("to", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) to: Instant?,
-        @RequestParam("type", required = false) type: PublishableObjectType?,
+        @RequestParam("type", required = false) type: PublicationLogAssetType?,
         @RequestParam("id", required = false) id: IntId<*>?,
         @RequestParam("sortBy", required = false) sortBy: PublicationTableColumn?,
         @RequestParam("order", required = false) order: SortOrder?,
         @RequestParam("lang") lang: LocalizationLanguage,
     ): Page<PublicationTableItem> {
-        val specificId = getSpecificObjectId(type, id)
+        val publicationLogAsset = getPublicationLogAssetOrNull(type, id)
 
         val publications =
             publicationLogService.fetchPublicationDetails(
                 layoutBranch = layoutBranch ?: LayoutBranch.main,
                 from = from,
                 to = to,
-                specificId = specificId,
+                publicationLogAsset = publicationLogAsset,
                 sortBy = sortBy,
                 order = order,
                 translation = localizationService.getLocalization(lang),
@@ -273,8 +273,8 @@ constructor(
         }
     }
 
-    private fun getSpecificObjectId(type: PublishableObjectType?, id: IntId<*>?): PublishableObjectIdAndType? {
+    private fun getPublicationLogAssetOrNull(type: PublicationLogAssetType?, id: IntId<*>?): PublicationLogAsset? {
         require((type == null) == (id == null)) { "Must provide either both or neither of id and type" }
-        return if (type != null) PublishableObjectIdAndType(requireNotNull(id), type) else null
+        return if (type != null) PublicationLogAsset(requireNotNull(id), type) else null
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -871,7 +871,7 @@ class PublicationDao(
         layoutBranch: LayoutBranch?,
         from: Instant?,
         to: Instant?,
-        specificObjectId: PublishableObjectIdAndType?,
+        specificObjectId: PublicationLogAsset?,
     ): Map<IntId<Publication>, Map<IntId<LocationTrack>, LocationTrackPublicationSwitchLinkChanges>> {
         require((layoutBranch != null) != (publicationId != null)) {
             """

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -799,7 +799,11 @@ constructor(
         type: PublishableObjectType,
     ) =
         if (specificObject == null) false
-        else
+        else if (
+            specificObject.type == PublishableObjectType.TRACK_NUMBER && type == PublishableObjectType.REFERENCE_LINE
+        ) {
+            publication.referenceLines.none { rl -> specificObject.isTrackNumber(rl.trackNumberId) }
+        } else
             type != specificObject.type ||
                 when (specificObject.type) {
                     PublishableObjectType.TRACK_NUMBER ->
@@ -850,7 +854,9 @@ constructor(
             publication.trackNumbers.filter { tn -> specificObjectId == null || specificObjectId.isTrackNumber(tn.id) }
         val referenceLinesToDiff =
             publication.referenceLines.filter { rl ->
-                specificObjectId == null || specificObjectId.isReferenceLine(rl.id)
+                specificObjectId == null ||
+                    specificObjectId.isReferenceLine(rl.id) ||
+                    specificObjectId.isTrackNumber(rl.trackNumberId)
             }
         val kmPostsToDiff =
             publication.kmPosts.filter { kp -> specificObjectId == null || specificObjectId.isKmPost(kp.id) }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -1202,6 +1202,33 @@ constructor(
     }
 
     @Test
+    fun `should also fetch reference line's publication log rows when fetching track number`() {
+        val trackNumberId = mainDraftContext.getOrCreateLayoutTrackNumber(TrackNumber("1234")).id as IntId
+        val referenceLineId =
+            referenceLineService
+                .saveDraft(
+                    LayoutBranch.main,
+                    referenceLine(trackNumberId, draft = true),
+                    alignment(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+                )
+                .id
+
+        publish(publicationService, trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+
+        val rows =
+            publicationLogService.fetchPublicationDetails(
+                LayoutBranch.main,
+                sortBy = PublicationTableColumn.NAME,
+                translation = localizationService.getLocalization(LocalizationLanguage.FI),
+                publicationLogAsset = PublicationLogAsset(trackNumberId, PublicationLogAssetType.TRACK_NUMBER),
+            )
+
+        assertEquals(2, rows.size)
+        assertTrue { rows.any { it.name.contains("1234") && it.asset.type == PublishableObjectType.TRACK_NUMBER } }
+        assertTrue { rows.any { it.name.contains("1234") && it.asset.type == PublishableObjectType.REFERENCE_LINE } }
+    }
+
+    @Test
     fun `switch diff consistently uses segment point for joint location`() {
         val trackNumber = TrackNumber("1234")
         val trackNumberId = mainOfficialContext.getOrCreateLayoutTrackNumber(trackNumber).id as IntId


### PR DESCRIPTION
Täällä toteutettuna käytännössä tiketin varsinaiset pihvijutut. Ideana siis se, että julkaisulokin assettikohtainen haku on nyt muutettu palauttamaan ratanumerolla haettaessa myös pituusmittauslinjan rivit. Tämän lisäksi mahdollisuus ylipäätään hakea pelkän pituusmittauslinjan lokirivejä on poistettu. Näistä tosiaan aiheutui jonkin verran tyyppimuutoksia ja rename-tarpeita, joten vaikka uudet toiminnallisuudet ovatkin suht. simppeleitä, niin muutoksia on melko paljon. Näistä lisää kommenteissa ka. tiedostoissa.

Frontti jätetty ennalleen vielä tällä pullarilla. Aion tosin tehdä sinnekin vielä jonkinasteisia paranteluja (mm. linkit assettikohtaiseen julkaisulokiin myös pituusmittauslinjoille, joilta ne nyt vielä puuttuvat.) Nämä tosiaan tulevat myöhemmin omalla pullarillaan.