### PR TITLE
GVT-3216 Part 2: KM-pylväät haettaviksi, pituusmittauslinjoille ja km-pylväille linkit assettikohtaiseen julkaisulokiin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -10,8 +10,11 @@ import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.linking.LayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.pageToList
 import org.springframework.transaction.annotation.Transactional
+
+const val KM_POST_SEARCH_TERM_MIN_LENGTH = 4
 
 @GeoviiteService
 class LayoutKmPostService(
@@ -127,6 +130,20 @@ class LayoutKmPostService(
     @Transactional
     fun saveDraft(branch: LayoutBranch, draftAsset: LayoutKmPost): LayoutRowVersion<LayoutKmPost> =
         saveDraftInternal(branch, draftAsset, NoParams.instance)
+
+    override fun contentMatches(term: String, item: LayoutKmPost): Boolean =
+        item.exists &&
+            term.length >= KM_POST_SEARCH_TERM_MIN_LENGTH &&
+            item.kmNumber.toString().contains(term.trim(), ignoreCase = true)
+
+    fun idMatches(
+        layoutContext: LayoutContext,
+        searchTerm: FreeText,
+        onlyIds: Collection<IntId<LayoutKmPost>>? = null,
+    ): ((term: String, item: LayoutKmPost) -> Boolean) = { term, item ->
+        (onlyIds == null || onlyIds.contains(item.id)) &&
+            (item.id.toString() == term.trim() || item.kmNumber.toString() == term.trim())
+    }
 }
 
 fun associateByDistance(kmPost: LayoutKmPost, comparisonPoint: Point): Pair<LayoutKmPost, Double?> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostService.kt
@@ -10,7 +10,6 @@ import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.linking.LayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.pageToList
 import org.springframework.transaction.annotation.Transactional
 
@@ -136,14 +135,11 @@ class LayoutKmPostService(
             term.length >= KM_POST_SEARCH_TERM_MIN_LENGTH &&
             item.kmNumber.toString().contains(term.trim(), ignoreCase = true)
 
-    fun idMatches(
-        layoutContext: LayoutContext,
-        searchTerm: FreeText,
-        onlyIds: Collection<IntId<LayoutKmPost>>? = null,
-    ): ((term: String, item: LayoutKmPost) -> Boolean) = { term, item ->
-        (onlyIds == null || onlyIds.contains(item.id)) &&
-            (item.id.toString() == term.trim() || item.kmNumber.toString() == term.trim())
-    }
+    fun idMatches(onlyIds: Collection<IntId<LayoutKmPost>>? = null): ((term: String, item: LayoutKmPost) -> Boolean) =
+        { term, item ->
+            (onlyIds == null || onlyIds.contains(item.id)) &&
+                (item.id.toString() == term.trim() || item.kmNumber.toString() == term.trim())
+        }
 }
 
 fun associateByDistance(kmPost: LayoutKmPost, comparisonPoint: Point): Pair<LayoutKmPost, Double?> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -19,6 +19,7 @@ data class TrackLayoutSearchResult(
     val locationTracks: List<LocationTrack>,
     val switches: List<LayoutSwitch>,
     val trackNumbers: List<LayoutTrackNumber>,
+    val kmPosts: List<LayoutKmPost>,
     val operatingPoints: List<RatkoOperatingPoint>,
 )
 
@@ -27,6 +28,7 @@ enum class TrackLayoutSearchedAssetType {
     SWITCH,
     TRACK_NUMBER,
     OPERATING_POINT,
+    KM_POST,
 }
 
 @GeoviiteController("/track-layout/search")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchService.kt
@@ -76,21 +76,12 @@ constructor(
             .take(limit)
     }
 
-    fun searchAllKmPosts(layoutContext: LayoutContext, searchTerm: FreeText, limit: Int): List<LayoutKmPost> {
-        val posts =
-            kmPostService
-                .list(layoutContext, true)
-                .let { list ->
-                    kmPostService.filterBySearchTerm(
-                        list,
-                        searchTerm,
-                        kmPostService.idMatches(layoutContext, searchTerm),
-                    )
-                }
-                .sortedBy(LayoutKmPost::kmNumber)
-                .take(limit)
-        return posts
-    }
+    fun searchAllKmPosts(layoutContext: LayoutContext, searchTerm: FreeText, limit: Int): List<LayoutKmPost> =
+        kmPostService
+            .list(layoutContext, true)
+            .let { list -> kmPostService.filterBySearchTerm(list, searchTerm, kmPostService.idMatches()) }
+            .sortedBy(LayoutKmPost::kmNumber)
+            .take(limit)
 
     private fun searchFromEntireRailwayNetwork(
         layoutContext: LayoutContext,
@@ -145,7 +136,7 @@ constructor(
         val ltIdMatch = locationTrackService.idMatches(layoutContext, searchTerm, locationTracks.map { it.id as IntId })
         val trackNumberIdMatch =
             trackNumberService.idMatches(layoutContext, searchTerm, trackNumbers.map { it.id as IntId })
-        val kmPostIdMatch = kmPostService.idMatches(layoutContext, searchTerm, kmPosts.map { it.id as IntId })
+        val kmPostIdMatch = kmPostService.idMatches(kmPosts.map { it.id as IntId })
 
         return TrackLayoutSearchResult(
             switches =

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -183,7 +183,8 @@
         "copy-details-to-clipboard": "Kopioi tiedot leikepöydälle",
         "expected-non-null": "Pyyntö palautti null-arvon",
         "file-size-limit-exceeded": "Tiedosto ylittää suurimman sallitun koon",
-        "request-timed-out": "Pyyntö katkaistiin, koska se kesti liian kauan"
+        "request-timed-out": "Pyyntö katkaistiin, koska se kesti liian kauan",
+        "unsupported-result-type": "Tyyppi {{type}} ei ole tuettu"
     },
     "unauthorized-request": {
         "title": "Istunto on vanhentunut.",
@@ -1452,8 +1453,7 @@
         "invalid-track-meter": "Tarkista ratakilometrin muoto",
         "end-before-start": "Ratakilometrin loppu on ennen alkua",
         "outside-track-number-range": "Ratakilometri ei osu ratanumeron alueelle ({{start}}-{{end}})",
-        "outside-location-track-range": "Ratakilometri ei osu raiteen alueelle ({{start}}-{{end}})",
-        "unsupported-result-type": "Tyyppi {{type}} ei ole tuettu"
+        "outside-location-track-range": "Ratakilometri ei osu raiteen alueelle ({{start}}-{{end}})"
     },
     "preview-view": {
         "unstaged-changes-title": "Muutokset ({{amount}} kpl)",
@@ -2160,6 +2160,9 @@
         "unselected": "Ei valittu",
         "no-options": "Ei vaihtoehtoja",
         "loading": "Ladataan"
+    },
+    "asset-search": {
+        "km-post-on-track-number": "{{kmPost}}, ratanumerolla {{trackNumber}}"
     },
     "privilege": {
         "view-basic": "Geoviitteen käyttö",

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -9,7 +9,7 @@ import { AppBar } from 'app-bar/app-bar';
 import { GeoviiteLibDemo } from 'geoviite-design-lib/demo/demo';
 import { VersionHolderView } from 'version-holder/version-holder-view';
 import { useCommonDataAppSelector, useTrackLayoutAppSelector } from 'store/hooks';
-import { LayoutMode } from 'common/common-model';
+import { LayoutMode, officialMainLayoutContext } from 'common/common-model';
 import { PreviewContainer } from 'preview/preview-container';
 import { FrontpageContainer } from 'frontpage/frontpage-container';
 import { EnvRestricted } from 'environment/env-restricted';
@@ -52,10 +52,17 @@ const Main: React.FC<MainProps> = (props: MainProps) => {
             <div className={styles.main__content} qa-id="main-content-container">
                 <Routes>
                     <Route path="/" element={<FrontpageContainer />} />
-                    <Route path={'/publications'} element={<PublicationLog />} />
+                    <Route
+                        path={'/publications'}
+                        element={<PublicationLog layoutContext={officialMainLayoutContext()} />}
+                    />
                     <Route
                         path={'/publications/:publicationId'}
-                        element={<PublicationDetailsContainer />}
+                        element={
+                            <PublicationDetailsContainer
+                                layoutContext={officialMainLayoutContext()}
+                            />
+                        }
                     />
                     <Route
                         path="/track-layout"

--- a/ui/src/map/plan-download/plan-download-area-section.tsx
+++ b/ui/src/map/plan-download/plan-download-area-section.tsx
@@ -129,7 +129,8 @@ export const PlanDownloadAreaSection: React.FC<{
                 });
             case SearchItemType.SWITCH:
             case SearchItemType.OPERATING_POINT:
-                return error(t('plan-download.unsupported-result-type', { type: item.type }));
+            case SearchItemType.KM_POST:
+                return error(t('unsupported-result-type', { type: item.type }));
             default:
                 return exhaustiveMatchingGuard(item);
         }
@@ -156,6 +157,7 @@ export const PlanDownloadAreaSection: React.FC<{
                 return item.locationTrack.name;
             case SearchItemType.SWITCH:
             case SearchItemType.OPERATING_POINT:
+            case SearchItemType.KM_POST:
                 console.error('Unsupported item type', item.type);
                 return '';
             default:

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -40,6 +40,9 @@ import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 import { SearchDropdown, SearchItemType, SearchItemValue } from 'tool-bar/search-dropdown';
 import { LayoutContext, officialMainLayoutContext } from 'common/common-model';
 import { DropdownSize } from 'vayla-design-lib/dropdown/dropdown';
+import { LayoutTrackNumber } from 'track-layout/track-layout-model';
+import { useTrackNumbersIncludingDeleted } from 'track-layout/track-layout-react-utils';
+import { TFunction } from 'i18next';
 
 const MAX_SEARCH_DAYS = 180;
 
@@ -114,7 +117,8 @@ const PublicationLogTableHeading: React.FC<PublicationLogTableHeadingProps> = ({
 export type SearchablePublicationLogItem =
     | SearchItemType.LOCATION_TRACK
     | SearchItemType.TRACK_NUMBER
-    | SearchItemType.SWITCH;
+    | SearchItemType.SWITCH
+    | SearchItemType.KM_POST;
 
 function searchableItemIdAndType(
     item: SearchItemValue<SearchablePublicationLogItem>,
@@ -126,12 +130,18 @@ function searchableItemIdAndType(
             return { type: item.type, id: item.trackNumber.id };
         case SearchItemType.SWITCH:
             return { type: item.type, id: item.layoutSwitch.id };
+        case SearchItemType.KM_POST:
+            return { type: item.type, id: item.kmPost.id };
         default:
             return exhaustiveMatchingGuard(item);
     }
 }
 
-function getSearchableItemName(item: SearchItemValue<SearchablePublicationLogItem>): string {
+function getSearchableItemName(
+    item: SearchItemValue<SearchablePublicationLogItem>,
+    trackNumbers: LayoutTrackNumber[],
+    t: TFunction<'translation', undefined>,
+): string {
     switch (item.type) {
         case SearchItemType.LOCATION_TRACK:
             return item.locationTrack.name;
@@ -139,6 +149,11 @@ function getSearchableItemName(item: SearchItemValue<SearchablePublicationLogIte
             return item.trackNumber.number;
         case SearchItemType.SWITCH:
             return item.layoutSwitch.name;
+        case SearchItemType.KM_POST:
+            return t('asset-search.km-post-on-track-number', {
+                kmPost: item.kmPost.kmNumber,
+                trackNumber: trackNumbers.find((tn) => tn.id === item.kmPost.trackNumberId)?.number,
+            });
         default:
             return exhaustiveMatchingGuard(item);
     }
@@ -151,6 +166,7 @@ type PublicationLogProps = {
 const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
+    const trackNumbers = useTrackNumbersIncludingDeleted(layoutContext) ?? [];
 
     const selectedPublicationSearch = useTrackLayoutAppSelector(
         (state) => state.selection.publicationSearch,
@@ -350,13 +366,14 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                                 placeholder={t('publication-log.search-specific-object')}
                                 onItemSelected={setSpecificItem}
                                 value={storedSpecificItem}
-                                getName={getSearchableItemName}
+                                getName={(name) => getSearchableItemName(name, trackNumbers, t)}
                                 disabled={false}
                                 size={DropdownSize.LARGE}
                                 searchTypes={[
                                     SearchItemType.LOCATION_TRACK,
                                     SearchItemType.SWITCH,
                                     SearchItemType.TRACK_NUMBER,
+                                    SearchItemType.KM_POST,
                                 ]}
                                 wide={false}
                                 useAnchorElementWidth={true}
@@ -385,7 +402,11 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                                             : {
                                                   idAndType:
                                                       searchableItemIdAndType(storedSpecificItem),
-                                                  name: getSearchableItemName(storedSpecificItem),
+                                                  name: getSearchableItemName(
+                                                      storedSpecificItem,
+                                                      trackNumbers,
+                                                      t,
+                                                  ),
                                               },
                                         sortInfo?.propName,
                                         sortInfo?.direction,

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -38,7 +38,7 @@ import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { SortDirection, TableSorting } from 'utils/table-utils';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 import { SearchDropdown, SearchItemType, SearchItemValue } from 'tool-bar/search-dropdown';
-import { officialMainLayoutContext } from 'common/common-model';
+import { LayoutContext, officialMainLayoutContext } from 'common/common-model';
 import { DropdownSize } from 'vayla-design-lib/dropdown/dropdown';
 
 const MAX_SEARCH_DAYS = 180;
@@ -144,7 +144,11 @@ function getSearchableItemName(item: SearchItemValue<SearchablePublicationLogIte
     }
 }
 
-const PublicationLog: React.FC = () => {
+type PublicationLogProps = {
+    layoutContext: LayoutContext;
+};
+
+const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
 
@@ -408,6 +412,7 @@ const PublicationLog: React.FC = () => {
                     )}
                 </div>
                 <PublicationTable
+                    layoutContext={layoutContext}
                     isLoading={isLoading}
                     items={pagedPublications?.items || []}
                     sortInfo={sortInfo}

--- a/ui/src/publication/publication-details-container.tsx
+++ b/ui/src/publication/publication-details-container.tsx
@@ -7,8 +7,15 @@ import React from 'react';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { PublicationId } from 'publication/publication-model';
+import { LayoutContext } from 'common/common-model';
 
-export const PublicationDetailsContainer: React.FC = () => {
+type PublicationDetailsContainerProps = {
+    layoutContext: LayoutContext;
+};
+
+export const PublicationDetailsContainer: React.FC<PublicationDetailsContainerProps> = ({
+    layoutContext,
+}) => {
     const trackLayoutActionDelegates = React.useMemo(
         () => createDelegates(trackLayoutActionCreators),
         [],
@@ -30,6 +37,7 @@ export const PublicationDetailsContainer: React.FC = () => {
 
     return (
         <PublicationDetailsView
+            layoutContext={layoutContext}
             publication={publication}
             setSelectedPublicationId={trackLayoutActionDelegates.setSelectedPublicationId}
             changeTime={publicationChangeTime}

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { formatDateFull } from 'utils/date-utils';
 import { ratkoPushFailed } from 'ratko/ratko-model';
 import { getPublicationAsTableItems } from 'publication/publication-api';
-import { TimeStamp } from 'common/common-model';
+import { LayoutContext, TimeStamp } from 'common/common-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { useAppNavigate } from 'common/navigate';
 import {
@@ -27,12 +27,14 @@ import { START_OF_2022 } from 'vayla-design-lib/datepicker/datepicker';
 import { TableSorting } from 'utils/table-utils';
 
 export type PublicationDetailsViewProps = {
+    layoutContext: LayoutContext;
     publication: PublicationDetails;
     setSelectedPublicationId: (publicationId: PublicationId | undefined) => void;
     changeTime: TimeStamp;
 };
 
 const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
+    layoutContext,
     publication,
     setSelectedPublicationId,
     changeTime,
@@ -102,6 +104,7 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
                     )}
                 </div>
                 <PublicationTable
+                    layoutContext={layoutContext}
                     isLoading={isLoading}
                     items={publicationItems}
                     sortInfo={sortInfo}

--- a/ui/src/publication/table/publication-table-row.tsx
+++ b/ui/src/publication/table/publication-table-row.tsx
@@ -14,6 +14,7 @@ import { SearchItemType, SearchItemValue } from 'tool-bar/search-dropdown';
 import { SearchablePublicationLogItem } from 'publication/log/publication-log';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 import { PublishedAsset } from 'publication/publication-api';
+import { LayoutTrackNumber } from 'track-layout/track-layout-model';
 
 type PublicationTableRowProps = {
     propChanges: PublicationChange[];
@@ -21,14 +22,32 @@ type PublicationTableRowProps = {
     detailsVisibleToggle: (id: PublicationId) => void;
     displaySinglePublication: (id: PublicationId) => void;
     displayItemHistory: (item: SearchItemValue<SearchablePublicationLogItem>) => void;
+    allLayoutTrackNumbers: LayoutTrackNumber[];
 } & PublicationTableItem;
+
+const getTrackNumberForReferenceLine = (
+    asset: PublishedAsset,
+    trackNumbers: LayoutTrackNumber[],
+): SearchItemValue<SearchablePublicationLogItem> | undefined => {
+    if (asset.type !== 'REFERENCE_LINE') {
+        return undefined;
+    } else {
+        const trackNumber = trackNumbers.find((tn) => tn.id === asset.asset.trackNumberId);
+        console.log(asset, trackNumbers);
+
+        return trackNumber ? { trackNumber, type: SearchItemType.TRACK_NUMBER } : undefined;
+    }
+};
 
 const assetToSearchItem = (
     asset: PublishedAsset,
+    trackNumbers: LayoutTrackNumber[],
 ): SearchItemValue<SearchablePublicationLogItem> | undefined => {
     switch (asset.type) {
         case 'TRACK_NUMBER':
             return { trackNumber: asset.asset, type: SearchItemType.TRACK_NUMBER };
+        case 'REFERENCE_LINE':
+            return getTrackNumberForReferenceLine(asset, trackNumbers);
         case 'LOCATION_TRACK':
             return { locationTrack: asset.asset, type: SearchItemType.LOCATION_TRACK };
         case 'SWITCH':
@@ -46,6 +65,7 @@ const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
     trackNumbers,
     changedKmNumbers,
     operation,
+    allLayoutTrackNumbers,
     publicationTime,
     publicationUser,
     message,
@@ -62,7 +82,7 @@ const PublicationTableRow: React.FC<PublicationTableRowProps> = ({
         detailsVisible && styles['publication-table__row--details-are-visible'],
     );
 
-    const assetAsSearchItem = assetToSearchItem(asset);
+    const assetAsSearchItem = assetToSearchItem(asset, allLayoutTrackNumbers);
     const displaySingleItem =
         assetAsSearchItem === undefined
             ? undefined

--- a/ui/src/publication/table/publication-table-row.tsx
+++ b/ui/src/publication/table/publication-table-row.tsx
@@ -33,7 +33,6 @@ const getTrackNumberForReferenceLine = (
         return undefined;
     } else {
         const trackNumber = trackNumbers.find((tn) => tn.id === asset.asset.trackNumberId);
-        console.log(asset, trackNumbers);
 
         return trackNumber ? { trackNumber, type: SearchItemType.TRACK_NUMBER } : undefined;
     }
@@ -52,6 +51,8 @@ const assetToSearchItem = (
             return { locationTrack: asset.asset, type: SearchItemType.LOCATION_TRACK };
         case 'SWITCH':
             return { layoutSwitch: asset.asset, type: SearchItemType.SWITCH };
+        case 'KM_POST':
+            return { kmPost: asset.asset, type: SearchItemType.KM_POST };
         default:
             return undefined;
     }

--- a/ui/src/publication/table/publication-table.tsx
+++ b/ui/src/publication/table/publication-table.tsx
@@ -14,8 +14,11 @@ import { useAppNavigate } from 'common/navigate';
 import { SearchablePublicationLogItem } from 'publication/log/publication-log';
 import { SearchItemValue } from 'tool-bar/search-dropdown';
 import { SortableTableHeader } from 'vayla-design-lib/table/sortable-table-header';
+import { useTrackNumbersIncludingDeleted } from 'track-layout/track-layout-react-utils';
+import { LayoutContext } from 'common/common-model';
 
 export type PublicationTableProps = {
+    layoutContext: LayoutContext;
     items: PublicationTableItem[];
     sortInfo: TableSorting<SortablePublicationTableProps>;
     onSortChange: (sortInfo: TableSorting<SortablePublicationTableProps>) => void;
@@ -26,6 +29,7 @@ export type PublicationTableProps = {
 };
 
 const PublicationTable: React.FC<PublicationTableProps> = ({
+    layoutContext,
     items,
     onSortChange,
     sortInfo,
@@ -78,6 +82,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
         },
         [delegates],
     );
+    const trackNumbers = useTrackNumbersIncludingDeleted(layoutContext) ?? [];
 
     return (
         <div className={styles['publication-table']}>
@@ -164,6 +169,7 @@ const PublicationTable: React.FC<PublicationTableProps> = ({
                             changedKmNumbers={entry.changedKmNumbers}
                             message={entry.message}
                             propChanges={entry.propChanges}
+                            allLayoutTrackNumbers={trackNumbers}
                             detailsVisible={itemDetailsVisible.includes(entry.id)}
                             detailsVisibleToggle={publicationItemDetailsVisibilityToggle}
                             displayItemHistory={displaySingleItemHistory}

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -59,6 +59,7 @@ import { WorkspaceDialog } from 'tool-bar/workspace-dialog';
 import { WorkspaceDeleteConfirmDialog } from 'tool-bar/workspace-delete-confirm-dialog';
 import { SearchDropdown, SearchItemType, SearchItemValue } from 'tool-bar/search-dropdown';
 import { ToolPanelAsset } from 'tool-panel/tool-panel';
+import { error } from 'geoviite-design-lib/snackbar/snackbar';
 
 const DESIGN_SELECT_POPUP_MARGIN_WHEN_SELECTED = 6;
 const DESIGN_SELECT_POPUP_MARGIN_WHEN_NOT_SELECTED = 3;
@@ -229,6 +230,9 @@ export const ToolBar: React.FC<ToolbarParams> = ({
                     switches: [],
                 });
                 setToolPanelTab({ id: item.trackNumber.id, type: 'TRACK_NUMBER' });
+                break;
+            case SearchItemType.KM_POST:
+                error(t('unsupported-result-type', { type: item.type }));
                 break;
 
             default:

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -41,6 +41,8 @@ import styles from './km-post-infobox.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 import { GK_FIN_COORDINATE_SYSTEMS } from 'tool-panel/km-post/dialog/km-post-edit-store';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
+import { SearchItemType } from 'tool-bar/search-dropdown';
+import { useAppNavigate } from 'common/navigate';
 
 type KmPostInfoboxProps = {
     layoutContext: LayoutContext;
@@ -100,6 +102,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     changeTimes,
 }: KmPostInfoboxProps) => {
     const { t } = useTranslation();
+    const navigate = useAppNavigate();
     const kmPostCreatedAndChangedTime = useKmPostChangeTimes(kmPost.id, layoutContext);
 
     const [showEditDialog, setShowEditDialog] = React.useState(false);
@@ -152,12 +155,26 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
         onUnselect,
     );
 
+    const openPublicationLog = React.useCallback(() => {
+        if (kmPostCreatedAndChangedTime) {
+            delegates.setSelectedPublicationSearchStartDate(kmPostCreatedAndChangedTime.created);
+            if (kmPostCreatedAndChangedTime.changed) {
+                delegates.setSelectedPublicationSearchEndDate(kmPostCreatedAndChangedTime.changed);
+            }
+            delegates.setSelectedPublicationSearchSearchableItem({
+                type: SearchItemType.KM_POST,
+                kmPost,
+            });
+            navigate('publication-search');
+        }
+    }, [kmPost, kmPostChangeTime, kmPostCreatedAndChangedTime]);
+
     const kmPostLengthText =
         infoboxExtras?.kmLength === undefined
             ? t('tool-panel.km-post.layout.no-kilometer-length')
             : infoboxExtras.kmLength < 0
-            ? t('tool-panel.km-post.layout.negative-kilometer-length')
-            : `${roundToPrecision(infoboxExtras.kmLength, 3)} m`;
+              ? t('tool-panel.km-post.layout.negative-kilometer-length')
+              : `${roundToPrecision(infoboxExtras.kmLength, 3)} m`;
 
     return (
         <React.Fragment>
@@ -328,6 +345,12 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                     formatDateShort(kmPostCreatedAndChangedTime.changed)
                                 }
                             />
+                            <Button
+                                size={ButtonSize.SMALL}
+                                variant={ButtonVariant.SECONDARY}
+                                onClick={openPublicationLog}>
+                                {t('tool-panel.show-in-publication-log')}
+                            </Button>
                         </React.Fragment>
                     )}
                 </InfoboxContent>

--- a/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
@@ -48,7 +48,6 @@ export const TrackNumberChangeInfoInfobox: React.FC<TrackNumberChangeInfoInfobox
     const navigate = useAppNavigate();
 
     const openPublicationLog = React.useCallback(() => {
-        console.log({ createdTime, changedTime });
         if (createdTime) {
             delegates.setSelectedPublicationSearchStartDate(createdTime);
         }

--- a/ui/src/track-layout/track-layout-search-api.ts
+++ b/ui/src/track-layout/track-layout-search-api.ts
@@ -1,4 +1,5 @@
 import {
+    LayoutKmPost,
     LayoutLocationTrack,
     LayoutSwitch,
     LayoutTrackNumber,
@@ -14,6 +15,7 @@ export interface LayoutSearchResult {
     switches: LayoutSwitch[];
     locationTracks: LayoutLocationTrack[];
     trackNumbers: LayoutTrackNumber[];
+    kmPosts: LayoutKmPost[];
     operatingPoints: OperatingPoint[];
 }
 


### PR DESCRIPTION
Alkuperäisenä lisäkeideana part 1:n pihvin rinnalle oli lisätä pituusmittauslinjojen julkaisulokiriveille linkit ratanumerojen julkaisulokiin. Tämän myötä lähdin miettimään että oikeastaan kilometripylväillekin voisi sellaiset lisätä samaan rahaan, ja sen jälkeen totesin että niistä kannattaisi tehdä myös haettavia. Näistä viimeinen päätyikin olemaan aika paljon isompi eskalaatio kuin alunperin uskoinkaan. 