### PR TITLE
Ad-hoc: Placeholderit puuttuville muutosajoille

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -936,7 +936,8 @@
             "copy-success": "OID {{oid}} kopioitu leikepöydälle",
             "copy-failed": "OID:n kopiointi leikepöydälle epäonnistui"
         },
-        "show-in-publication-log": "Avaa julkaisuloki"
+        "show-in-publication-log": "Avaa julkaisuloki",
+        "unmodified-in-geoviite": "Ei muokattu Geoviitteessä"
     },
     "data-products": {
         "search": {

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -341,8 +341,9 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                             <InfoboxField
                                 label={t('tool-panel.changed')}
                                 value={
-                                    kmPostCreatedAndChangedTime.changed &&
-                                    formatDateShort(kmPostCreatedAndChangedTime.changed)
+                                    kmPostCreatedAndChangedTime.changed
+                                        ? formatDateShort(kmPostCreatedAndChangedTime.changed)
+                                        : t('tool-panel.unmodified-in-geoviite')
                                 }
                             />
                             <Button

--- a/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
@@ -67,8 +67,9 @@ export const LocationTrackChangeInfoInfobox: React.FC<LocationTrackChangeInfoInf
                         qaId="location-track-changed-date"
                         label={t('tool-panel.changed')}
                         value={
-                            locationTrackChangeInfo.changed &&
-                            formatDateShort(locationTrackChangeInfo.changed)
+                            locationTrackChangeInfo.changed
+                                ? formatDateShort(locationTrackChangeInfo.changed)
+                                : t('tool-panel.unmodified-in-geoviite')
                         }
                     />
                     <div>

--- a/ui/src/tool-panel/switch/switch-change-info-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-change-info-infobox.tsx
@@ -62,7 +62,9 @@ export const SwitchChangeInfoInfobox: React.FC<SwitchChangeInfoInfoboxProps> = (
                         qaId="switch-changed-date"
                         label={t('tool-panel.changed')}
                         value={
-                            switchChangeInfo.changed && formatDateShort(switchChangeInfo.changed)
+                            switchChangeInfo.changed
+                                ? formatDateShort(switchChangeInfo.changed)
+                                : t('tool-panel.unmodified-in-geoviite')
                         }
                     />
                     <div>

--- a/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
@@ -77,7 +77,11 @@ export const TrackNumberChangeInfoInfobox: React.FC<TrackNumberChangeInfoInfobox
                     <InfoboxField
                         qaId="TrackNumber-changed-date"
                         label={t('tool-panel.changed')}
-                        value={changedTime === undefined ? '' : formatDateShort(changedTime)}
+                        value={
+                            changedTime === undefined
+                                ? t('tool-panel.unmodified-in-geoviite')
+                                : formatDateShort(changedTime)
+                        }
                     />
                     <div>
                         <Button


### PR DESCRIPTION
Geoviitteessä näkyy välillä assetteja, joilla on luontiaika mutta ei muutosaikaa. Nämä ovat seurausta alkuimportista. Lisätty placeholderit näille