### PR TITLE
GVT-3303: Ratko integration should not delete points outside the location track boundaries

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -48,11 +48,11 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)
@@ -602,9 +602,17 @@ constructor(
                 )
             } else {
                 val allKms = addresses.allPoints.asSequence().map { point -> point.address.kmNumber }.toSet()
-                val removedKms = changedKmNumbers.filterNot { changedKm -> changedKm in allKms }.toSet()
+                val minTrackKm = allKms.min()
+                val maxTrackKm = allKms.max()
 
-                deleteLocationTrackPoints(removedKms, locationTrackRatkoOid)
+                // This happens for example when a km-post has been removed in the "middle" of a track.
+                val removedKmsWithinTrackBoundaries =
+                    changedKmNumbers
+                        .filterNot { changedKm -> changedKm in allKms }
+                        .filter { kmNumber -> kmNumber > minTrackKm && kmNumber < maxTrackKm }
+                        .toSet()
+
+                deleteLocationTrackPoints(removedKmsWithinTrackBoundaries, locationTrackRatkoOid)
                 updateLocationTrackGeometry(locationTrackOid = locationTrackRatkoOid, newPoints = changedMidPoints)
             }
 


### PR DESCRIPTION
* Tämänhän voisi siis toteuttaa yhtälailla tyhjällä patch-kutsulla kohdistettuna yhteen kilometriin, jätin selvyyden vuoksi tuon deleten kuitenkin käyttöön.
* KM-pylväiden poisto keskeltä raidetta onnistuu (delete-kutsu lähtee näille kilometreille) (toimi myös aiemmin)
* Raiteen geometrian lyhennys kilometrin alku/loppukohdan "yli" ei aikaansaa enää delete-kutsuja (aiempi bugi)