### PR TITLE
GVT-3298 Separate out single-item search date ranges in publication log

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1818,6 +1818,8 @@
         "start-date": "Alkupvm.",
         "end-date": "Loppupvm.",
         "specific-object": "Muutoskohde",
+        "start-date-with-specific-object": "Alkupvm. (muutoskohde)",
+        "end-date-with-specific-object": "Loppupvm. (muutoskohde)",
         "search-specific-object": "Hae...",
         "export-csv": "Lataa CSV",
         "end-before-start": "Loppupäivämäärä on ennen alkupäivämäärää",

--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
 import styles from './publication-log.scss';
 import { useTranslation } from 'react-i18next';
-import {
-    DatePicker,
-    DatePickerDateSource,
-    END_OF_CENTURY,
-    START_OF_2022,
-} from 'vayla-design-lib/datepicker/datepicker';
+import { DatePicker, END_OF_CENTURY, START_OF_2022 } from 'vayla-design-lib/datepicker/datepicker';
 import { daysBetween, parseISOOrUndefined } from 'utils/date-utils';
-import { endOfDay, startOfDay } from 'date-fns';
+import { endOfDay } from 'date-fns';
 import {
     getPublicationsAsTableItems,
     getPublicationsCsvUri,
@@ -30,12 +25,10 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { useTrackLayoutAppSelector } from 'store/hooks';
 import { useAppNavigate } from 'common/navigate';
-import { defaultPublicationSearch } from 'publication/publication-utils';
 import { DOWNLOAD_PUBLICATION } from 'user/user-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
-import { debounceAsync } from 'utils/async-utils';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
-import { SortDirection, TableSorting } from 'utils/table-utils';
+import { TableSorting } from 'utils/table-utils';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 import { SearchDropdown, SearchItemType, SearchItemValue } from 'tool-bar/search-dropdown';
 import { LayoutContext, officialMainLayoutContext } from 'common/common-model';
@@ -43,36 +36,9 @@ import { DropdownSize } from 'vayla-design-lib/dropdown/dropdown';
 import { LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { useTrackNumbersIncludingDeleted } from 'track-layout/track-layout-react-utils';
 import { TFunction } from 'i18next';
+import { useMemoizedDate, useRateLimitedTwoPartEffect } from 'utils/react-utils';
 
 const MAX_SEARCH_DAYS = 180;
-
-type TableFetchFn = (
-    from?: Date,
-    to?: Date,
-    specificItem?: PublishableObjectIdAndType,
-    sortBy?: keyof SortablePublicationTableProps,
-    order?: SortDirection,
-) => Promise<Page<PublicationTableItem>>;
-
-let fetchId = 0;
-const debouncedGetPublicationsAsTableItems = debounceAsync(getPublicationsAsTableItems, 500);
-
-type DataSourceChangeMethod = DatePickerDateSource | 'SORTING_CHANGED';
-
-const publicationTableFetchFunctionByChangeMethod = (
-    changeMethod: DataSourceChangeMethod,
-): TableFetchFn => {
-    switch (changeMethod) {
-        case 'TEXT':
-            return debouncedGetPublicationsAsTableItems;
-        case 'PICKER':
-            return getPublicationsAsTableItems;
-        case 'SORTING_CHANGED':
-            return getPublicationsAsTableItems;
-        default:
-            return exhaustiveMatchingGuard(changeMethod);
-    }
-};
 
 type PublicationLogTableHeadingProps = {
     isLoading: boolean;
@@ -159,10 +125,84 @@ function getSearchableItemName(
     }
 }
 
+const isValidPublicationLogSearchRange = (
+    specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
+    start: Date | undefined,
+    end: Date | undefined,
+): boolean => {
+    return (
+        specificItem !== undefined || // go nuts with single-item searches, they're cheap
+        (start !== undefined && daysBetween(start, end ?? new Date()) < MAX_SEARCH_DAYS)
+    );
+};
+
+function usePublicationLogSearch(
+    startDate: Date | undefined,
+    endDate: Date | undefined,
+    specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
+    sortInfo: TableSorting<SortablePublicationTableProps>,
+): { pagedPublications: Page<PublicationTableItem> | undefined; isLoading: boolean } {
+    const [isLoading, setIsLoading] = React.useState(false);
+    const [pagedPublications, setPagedPublications] = React.useState<Page<PublicationTableItem>>();
+    const displayedSearchResultParams = React.useRef<
+        | {
+              startDate: Date | undefined;
+              endDate: Date | undefined;
+              specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined;
+              sortInfo: TableSorting<SortablePublicationTableProps>;
+          }
+        | undefined
+    >(undefined);
+
+    const clearPublicationsTable = () => {
+        setPagedPublications({
+            totalCount: 0,
+            items: [],
+            start: 0,
+        });
+    };
+
+    useRateLimitedTwoPartEffect(
+        () => {
+            const lastSearch = displayedSearchResultParams.current;
+            if (!isValidPublicationLogSearchRange(specificItem, startDate, endDate)) {
+                clearPublicationsTable();
+                return undefined;
+            } else if (
+                lastSearch !== undefined &&
+                lastSearch.startDate === startDate &&
+                lastSearch.endDate === endDate &&
+                lastSearch.specificItem === specificItem &&
+                (pagedPublications?.items.length ?? 0) < MAX_RETURNED_PUBLICATION_LOG_ROWS
+            ) {
+                // only sort order changed, but we're displaying every displayable row: elide search call
+                return undefined;
+            } else {
+                setIsLoading(true);
+                return getPublicationsAsTableItems(
+                    startDate,
+                    endDate,
+                    specificItem === undefined ? undefined : searchableItemIdAndType(specificItem),
+                    sortInfo.propName,
+                    sortInfo.direction,
+                );
+            }
+        },
+        (results) => {
+            setPagedPublications(results);
+            setIsLoading(false);
+            displayedSearchResultParams.current = { startDate, endDate, specificItem, sortInfo };
+        },
+        500,
+        [startDate, endDate, specificItem, sortInfo],
+    );
+
+    return { isLoading, pagedPublications };
+}
+
 type PublicationLogProps = {
     layoutContext: LayoutContext;
 };
-
 const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
@@ -177,140 +217,46 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
         [],
     );
 
-    const storedStartDate = parseISOOrUndefined(selectedPublicationSearch?.startDate);
-    const storedEndDate = parseISOOrUndefined(selectedPublicationSearch?.endDate);
-    const storedSpecificItem = selectedPublicationSearch?.specificItem;
+    const specificItem = selectedPublicationSearch?.specificItem;
+    const startDate = useMemoizedDate(
+        parseISOOrUndefined(
+            specificItem === undefined
+                ? selectedPublicationSearch?.globalStartDate
+                : selectedPublicationSearch?.specificItemStartDate,
+        ),
+    );
+    const endDate = useMemoizedDate(
+        parseISOOrUndefined(
+            specificItem === undefined
+                ? selectedPublicationSearch?.globalEndDate
+                : selectedPublicationSearch?.specificItemEndDate,
+        ),
+    );
 
     const [sortInfo, setSortInfo] =
         React.useState<TableSorting<SortablePublicationTableProps>>(SortedByTimeDesc);
-    const [isLoading, setIsLoading] = React.useState(false);
-    const [pagedPublications, setPagedPublications] = React.useState<Page<PublicationTableItem>>();
 
-    React.useEffect(() => {
-        if (!selectedPublicationSearch) {
-            trackLayoutActionDelegates.setSelectedPublicationSearch(defaultPublicationSearch);
-        }
+    const { isLoading, pagedPublications } = usePublicationLogSearch(
+        startDate,
+        endDate,
+        specificItem,
+        sortInfo,
+    );
 
-        updatePublicationsTable(
-            storedStartDate ?? parseISOOrUndefined(defaultPublicationSearch.startDate),
-            storedEndDate ?? parseISOOrUndefined(defaultPublicationSearch.endDate),
-            storedSpecificItem,
-            sortInfo,
-            getPublicationsAsTableItems,
-        );
-    }, []);
-
-    const updateTableSorting = (updatedSort: TableSorting<SortablePublicationTableProps>) => {
-        if (pagedPublications?.items.length === MAX_RETURNED_PUBLICATION_LOG_ROWS) {
-            updatePublicationsTable(
-                storedStartDate,
-                storedEndDate,
-                storedSpecificItem,
-                updatedSort,
-                publicationTableFetchFunctionByChangeMethod('SORTING_CHANGED'),
-            ).then(() => setSortInfo(updatedSort));
-        } else {
-            setSortInfo(updatedSort);
-        }
-    };
-
-    const setSpecificItem = (
-        newSpecificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
-    ) => {
-        trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem(newSpecificItem);
-        updatePublicationsTable(
-            storedStartDate,
-            storedEndDate,
-            newSpecificItem,
-            sortInfo,
-            publicationTableFetchFunctionByChangeMethod('PICKER'),
-        );
-    };
-
-    const setStartDate = (newStartDate: Date | undefined, source: DataSourceChangeMethod) => {
+    const setStartDate = (newStartDate: Date | undefined) => {
         trackLayoutActionDelegates.setSelectedPublicationSearchStartDate(
             newStartDate?.toISOString(),
         );
-        updatePublicationsTable(
-            newStartDate,
-            storedEndDate,
-            storedSpecificItem,
-            sortInfo,
-            publicationTableFetchFunctionByChangeMethod(source),
-        );
     };
 
-    const setEndDate = (newEndDate: Date | undefined, source: DataSourceChangeMethod) => {
+    const setEndDate = (newEndDate: Date | undefined) => {
         trackLayoutActionDelegates.setSelectedPublicationSearchEndDate(newEndDate?.toISOString());
-        updatePublicationsTable(
-            storedStartDate,
-            newEndDate,
-            storedSpecificItem,
-            sortInfo,
-            publicationTableFetchFunctionByChangeMethod(source),
-        );
     };
 
-    const isValidPublicationLogSearchRange = (
-        specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
-        start: Date | undefined,
-        end: Date | undefined,
-    ): boolean => {
-        return (
-            specificItem !== undefined || // go nuts with single-item searches, they're cheap
-            (start !== undefined && end !== undefined && daysBetween(start, end) < MAX_SEARCH_DAYS)
-        );
-    };
-
-    const isStoredSearchRangeValid = isValidPublicationLogSearchRange(
-        storedSpecificItem,
-        storedStartDate,
-        storedEndDate,
-    );
-
-    const updatePublicationsTable = (
-        startDate: Date | undefined,
-        endDate: Date | undefined,
-        specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined,
-        sortInfo: TableSorting<SortablePublicationTableProps>,
-        fetchFn: TableFetchFn,
-    ): Promise<Page<PublicationTableItem> | undefined> => {
-        if (!isValidPublicationLogSearchRange(specificItem, startDate, endDate)) {
-            clearPublicationsTable();
-            return Promise.resolve(undefined);
-        }
-
-        setIsLoading(true);
-        const currentFetchId = ++fetchId;
-
-        return fetchFn(
-            startDate && startOfDay(startDate),
-            endDate && endOfDay(endDate),
-            specificItem === undefined ? undefined : searchableItemIdAndType(specificItem),
-            sortInfo.propName,
-            sortInfo.direction,
-        ).then((r) => {
-            if (fetchId === currentFetchId) {
-                r && setPagedPublications(r);
-                setIsLoading(false);
-            }
-
-            return r;
-        });
-    };
-
-    const clearPublicationsTable = () => {
-        setPagedPublications({
-            totalCount: 0,
-            items: [],
-            start: 0,
-        });
-    };
+    const isSearchRangeValid = isValidPublicationLogSearchRange(specificItem, startDate, endDate);
 
     const endDateErrors =
-        storedStartDate && storedEndDate && storedStartDate > storedEndDate
-            ? [t('publication-log.end-before-start')]
-            : [];
+        startDate && endDate && startDate > endDate ? [t('publication-log.end-before-start')] : [];
 
     const isTruncated =
         pagedPublications !== undefined &&
@@ -333,26 +279,36 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
             <div className={styles['publication-log__content']}>
                 <div className={styles['publication-log__actions']}>
                     <FieldLayout
-                        label={t('publication-log.start-date')}
+                        label={
+                            specificItem === undefined
+                                ? t('publication-log.start-date')
+                                : t('publication-log.start-date-with-specific-object')
+                        }
                         value={
                             <DatePicker
-                                value={storedStartDate}
-                                onChange={(date, source) => setStartDate(date, source)}
+                                value={startDate}
+                                onChange={setStartDate}
                                 minDate={START_OF_2022}
                                 maxDate={END_OF_CENTURY}
                                 qa-id={'publication-log-start-date-input'}
+                                isClearable
                             />
                         }
                     />
                     <FieldLayout
-                        label={t('publication-log.end-date')}
+                        label={
+                            specificItem === undefined
+                                ? t('publication-log.end-date')
+                                : t('publication-log.end-date-with-specific-object')
+                        }
                         value={
                             <DatePicker
-                                value={storedEndDate}
-                                onChange={(date, source) => setEndDate(date, source)}
+                                value={endDate}
+                                onChange={setEndDate}
                                 minDate={START_OF_2022}
                                 maxDate={END_OF_CENTURY}
                                 qa-id={'publication-log-end-date-input'}
+                                isClearable
                             />
                         }
                         errors={endDateErrors}
@@ -364,8 +320,10 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                                 layoutContext={officialMainLayoutContext()}
                                 splittingState={undefined}
                                 placeholder={t('publication-log.search-specific-object')}
-                                onItemSelected={setSpecificItem}
-                                value={storedSpecificItem}
+                                onItemSelected={
+                                    trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem
+                                }
+                                value={specificItem}
                                 getName={(name) => getSearchableItemName(name, trackNumbers, t)}
                                 disabled={false}
                                 size={DropdownSize.LARGE}
@@ -385,9 +343,9 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                         <div className={styles['publication-log__export_button']}>
                             <Button
                                 icon={Icons.Download}
-                                disabled={!isStoredSearchRangeValid}
+                                disabled={!isSearchRangeValid}
                                 title={
-                                    isStoredSearchRangeValid
+                                    isSearchRangeValid
                                         ? undefined
                                         : t('publication-log.search-range-too-long', {
                                               maxDays: MAX_SEARCH_DAYS,
@@ -395,15 +353,14 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                                 }
                                 onClick={() =>
                                     (location.href = getPublicationsCsvUri(
-                                        storedStartDate,
-                                        storedEndDate && endOfDay(storedEndDate),
-                                        storedSpecificItem === undefined
+                                        startDate,
+                                        endDate && endOfDay(endDate),
+                                        specificItem === undefined
                                             ? undefined
                                             : {
-                                                  idAndType:
-                                                      searchableItemIdAndType(storedSpecificItem),
+                                                  idAndType: searchableItemIdAndType(specificItem),
                                                   name: getSearchableItemName(
-                                                      storedSpecificItem,
+                                                      specificItem,
                                                       trackNumbers,
                                                       t,
                                                   ),
@@ -418,7 +375,7 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                     </PrivilegeRequired>
                 </div>
                 <div className={styles['publication-log__count-header']}>
-                    {isStoredSearchRangeValid ? (
+                    {isSearchRangeValid ? (
                         <PublicationLogTableHeading
                             isLoading={isLoading}
                             isTruncated={isTruncated}
@@ -437,8 +394,10 @@ const PublicationLog: React.FC<PublicationLogProps> = ({ layoutContext }) => {
                     isLoading={isLoading}
                     items={pagedPublications?.items || []}
                     sortInfo={sortInfo}
-                    onSortChange={updateTableSorting}
-                    displaySingleItemHistory={setSpecificItem}
+                    onSortChange={setSortInfo}
+                    displaySingleItemHistory={
+                        trackLayoutActionDelegates.startFreshSpecificItemPublicationLogSearch
+                    }
                 />
             </div>
         </div>

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -395,8 +395,10 @@ export type PublicationTableItem = {
 };
 
 export type PublicationSearch = {
-    startDate: TimeStamp | undefined;
-    endDate: TimeStamp | undefined;
+    globalStartDate: TimeStamp | undefined;
+    globalEndDate: TimeStamp | undefined;
+    specificItemStartDate: TimeStamp | undefined;
+    specificItemEndDate: TimeStamp | undefined;
     specificItem: SearchItemValue<SearchablePublicationLogItem> | undefined;
 };
 

--- a/ui/src/publication/publication-utils.ts
+++ b/ui/src/publication/publication-utils.ts
@@ -16,8 +16,10 @@ import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { mapLazy } from 'utils/array-utils';
 
 export const defaultPublicationSearch: PublicationSearch = {
-    startDate: subMonths(currentDay, 1).toISOString(),
-    endDate: currentDay.toISOString(),
+    globalStartDate: subMonths(currentDay, 1).toISOString(),
+    globalEndDate: currentDay.toISOString(),
+    specificItemStartDate: undefined,
+    specificItemEndDate: undefined,
     specificItem: undefined,
 };
 

--- a/ui/src/publication/publication.tsx
+++ b/ui/src/publication/publication.tsx
@@ -23,7 +23,6 @@ import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators } from 'track-layout/track-layout-slice';
 import { SearchItemValue } from 'tool-bar/search-dropdown';
 import { SearchablePublicationLogItem } from 'publication/log/publication-log';
-import { START_OF_2022 } from 'vayla-design-lib/datepicker/datepicker';
 import { TableSorting } from 'utils/table-utils';
 
 export type PublicationDetailsViewProps = {
@@ -65,11 +64,7 @@ const PublicationDetailsView: React.FC<PublicationDetailsViewProps> = ({
     const displaySingleItemHistory = (
         item: SearchItemValue<SearchablePublicationLogItem> | undefined,
     ) => {
-        trackLayoutActionDelegates.setSelectedPublicationSearchStartDate(
-            START_OF_2022.toISOString(),
-        );
-        trackLayoutActionDelegates.setSelectedPublicationSearchEndDate(new Date().toISOString());
-        trackLayoutActionDelegates.setSelectedPublicationSearchSearchableItem(item);
+        trackLayoutActionDelegates.startFreshSpecificItemPublicationLogSearch(item);
         navigate('publication-search');
     };
 

--- a/ui/src/selection/selection-store.ts
+++ b/ui/src/selection/selection-store.ts
@@ -301,7 +301,6 @@ export const selectionReducers = {
         { payload: publicationId }: PayloadAction<PublicationId | undefined>,
     ) => {
         state.publicationId = publicationId;
-        state.publicationSearch = undefined;
     },
     setSelectedPublicationSearch: (
         state: Selection,
@@ -317,7 +316,11 @@ export const selectionReducers = {
         if (!state.publicationSearch) {
             state.publicationSearch = { ...defaultPublicationSearch };
         }
-        state.publicationSearch.startDate = newStartDate;
+        if (state.publicationSearch.specificItem === undefined) {
+            state.publicationSearch.globalStartDate = newStartDate;
+        } else {
+            state.publicationSearch.specificItemStartDate = newStartDate;
+        }
     },
     setSelectedPublicationSearchEndDate: (
         state: Selection,
@@ -326,7 +329,24 @@ export const selectionReducers = {
         if (!state.publicationSearch) {
             state.publicationSearch = { ...defaultPublicationSearch };
         }
-        state.publicationSearch.endDate = newEndDate;
+        if (state.publicationSearch.specificItem === undefined) {
+            state.publicationSearch.globalEndDate = newEndDate;
+        } else {
+            state.publicationSearch.specificItemEndDate = newEndDate;
+        }
+    },
+    startFreshSpecificItemPublicationLogSearch: (
+        state: Selection,
+        {
+            payload: newSearchItem,
+        }: PayloadAction<SearchItemValue<SearchablePublicationLogItem> | undefined>,
+    ) => {
+        if (!state.publicationSearch) {
+            state.publicationSearch = { ...defaultPublicationSearch };
+        }
+        state.publicationSearch.specificItemStartDate = undefined;
+        state.publicationSearch.specificItemEndDate = undefined;
+        state.publicationSearch.specificItem = newSearchItem;
     },
     setSelectedPublicationSearchSearchableItem: (
         state: Selection,
@@ -336,6 +356,10 @@ export const selectionReducers = {
     ) => {
         if (!state.publicationSearch) {
             state.publicationSearch = { ...defaultPublicationSearch };
+        }
+        if (state.publicationSearch.specificItem === undefined && newSearchItem !== undefined) {
+            state.publicationSearch.specificItemStartDate = undefined;
+            state.publicationSearch.specificItemEndDate = undefined;
         }
         state.publicationSearch.specificItem = newSearchItem;
     },

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -156,17 +156,11 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     );
 
     const openPublicationLog = React.useCallback(() => {
-        if (kmPostCreatedAndChangedTime) {
-            delegates.setSelectedPublicationSearchStartDate(kmPostCreatedAndChangedTime.created);
-            if (kmPostCreatedAndChangedTime.changed) {
-                delegates.setSelectedPublicationSearchEndDate(kmPostCreatedAndChangedTime.changed);
-            }
-            delegates.setSelectedPublicationSearchSearchableItem({
-                type: SearchItemType.KM_POST,
-                kmPost,
-            });
-            navigate('publication-search');
-        }
+        delegates.startFreshSpecificItemPublicationLogSearch({
+            type: SearchItemType.KM_POST,
+            kmPost,
+        });
+        navigate('publication-search');
     }, [kmPost, kmPostChangeTime, kmPostCreatedAndChangedTime]);
 
     const kmPostLengthText =

--- a/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-change-info-infobox.tsx
@@ -37,13 +37,7 @@ export const LocationTrackChangeInfoInfobox: React.FC<LocationTrackChangeInfoInf
     const navigate = useAppNavigate();
 
     const openPublicationLog = React.useCallback(() => {
-        if (locationTrackChangeInfo?.created) {
-            delegates.setSelectedPublicationSearchStartDate(locationTrackChangeInfo.created);
-        }
-        if (locationTrackChangeInfo?.changed) {
-            delegates.setSelectedPublicationSearchEndDate(locationTrackChangeInfo.changed);
-        }
-        delegates.setSelectedPublicationSearchSearchableItem({
+        delegates.startFreshSpecificItemPublicationLogSearch({
             type: SearchItemType.LOCATION_TRACK,
             locationTrack,
         });

--- a/ui/src/tool-panel/switch/switch-change-info-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-change-info-infobox.tsx
@@ -34,15 +34,11 @@ export const SwitchChangeInfoInfobox: React.FC<SwitchChangeInfoInfoboxProps> = (
     const navigate = useAppNavigate();
 
     const openPublicationLog = React.useCallback(() => {
-        if (switchChangeInfo) {
-            delegates.setSelectedPublicationSearchStartDate(switchChangeInfo.created);
-            delegates.setSelectedPublicationSearchEndDate(switchChangeInfo.changed);
-            delegates.setSelectedPublicationSearchSearchableItem({
-                type: SearchItemType.SWITCH,
-                layoutSwitch,
-            });
-            navigate('publication-search');
-        }
+        delegates.startFreshSpecificItemPublicationLogSearch({
+            type: SearchItemType.SWITCH,
+            layoutSwitch,
+        });
+        navigate('publication-search');
     }, [layoutSwitch, switchChangeInfo]);
 
     return (

--- a/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-change-info-infobox.tsx
@@ -48,13 +48,7 @@ export const TrackNumberChangeInfoInfobox: React.FC<TrackNumberChangeInfoInfobox
     const navigate = useAppNavigate();
 
     const openPublicationLog = React.useCallback(() => {
-        if (createdTime) {
-            delegates.setSelectedPublicationSearchStartDate(createdTime);
-        }
-        if (changedTime) {
-            delegates.setSelectedPublicationSearchEndDate(changedTime);
-        }
-        delegates.setSelectedPublicationSearchSearchableItem({
+        delegates.startFreshSpecificItemPublicationLogSearch({
             type: SearchItemType.TRACK_NUMBER,
             trackNumber,
         });

--- a/ui/src/utils/react-utils.tsx
+++ b/ui/src/utils/react-utils.tsx
@@ -448,6 +448,20 @@ export function dispatchPrevIfObjectsEqual<T>(next: T) {
 
 type PropsType = Record<string, unknown>;
 
+function useMemoBy<T>(value: T, same: (a: T, b: T) => boolean): T {
+    const store = useRef(value);
+    if (same(store.current, value)) {
+        return store.current;
+    } else {
+        store.current = value;
+        return value;
+    }
+}
+
+export function useMemoizedDate(value: Date | undefined) {
+    return useMemoBy(value, (a, b) => a?.getTime() === b?.getTime());
+}
+
 export function useTraceProps(componentName: string, props: PropsType) {
     const prev = useRef(props);
 

--- a/ui/src/vayla-design-lib/datepicker/datepicker.tsx
+++ b/ui/src/vayla-design-lib/datepicker/datepicker.tsx
@@ -18,6 +18,7 @@ type DatePickerProps = {
     wide?: boolean;
     minDate?: Date;
     maxDate?: Date;
+    isClearable?: boolean;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
 
 type DatePickerInputProps = {
@@ -27,6 +28,7 @@ type DatePickerInputProps = {
     wide: boolean | undefined;
     minDate?: Date;
     maxDate?: Date;
+    isClearable: boolean;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'>;
 
 const DATE_FORMAT = 'dd.MM.yyyy';
@@ -47,7 +49,7 @@ const clampDateToRange = (date: Date, minDate?: Date, maxDate?: Date): Date => {
 };
 
 const DatePickerInput = React.forwardRef<HTMLInputElement, DatePickerInputProps>(
-    ({ openDatePicker, date, setDate, wide, minDate, maxDate, ...props }, ref) => {
+    ({ openDatePicker, date, setDate, wide, minDate, maxDate, isClearable, ...props }, ref) => {
         const [value, setValue] = React.useState<string>('');
         const localRef = useCloneRef<HTMLInputElement>(ref);
         React.useEffect(() => {
@@ -66,13 +68,18 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, DatePickerInputProps>
         }
 
         function setDateOrResetIfInvalid(e: React.FocusEvent<HTMLInputElement>): void {
-            const newDate = parse(e.target.value, DATE_FORMAT, new Date());
-            if (!isValid(newDate)) {
-                setValue(date ? formatDateShort(date) : '');
-            } else if (!date || !isSameDay(date, newDate)) {
-                const clampedDate = clampDateToRange(newDate, minDate, maxDate);
-                setValue(formatDateShort(clampedDate));
-                setDate(clampedDate);
+            if (e.target.value === '' && isClearable) {
+                setValue('');
+                setDate(undefined);
+            } else {
+                const newDate = parse(e.target.value, DATE_FORMAT, new Date());
+                if (!isValid(newDate)) {
+                    setValue(date ? formatDateShort(date) : '');
+                } else if (!date || !isSameDay(date, newDate)) {
+                    const clampedDate = clampDateToRange(newDate, minDate, maxDate);
+                    setValue(formatDateShort(clampedDate));
+                    setDate(clampedDate);
+                }
             }
         }
 
@@ -140,7 +147,13 @@ function getHeaderElement({
     );
 }
 
-export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, ...props }) => {
+export const DatePicker: React.FC<DatePickerProps> = ({
+    onChange,
+    value,
+    wide,
+    isClearable,
+    ...props
+}) => {
     const [open, setOpen] = React.useState(false);
     const ref = React.useRef<HTMLInputElement>(null);
     const iconRef = React.useRef<SVGSVGElement>(null);
@@ -154,6 +167,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                 setDate={(date) => onChange(date, 'TEXT')}
                 wide={wide}
                 ref={ref}
+                isClearable={isClearable ?? false}
                 {...props}
             />
             {open && (
@@ -187,6 +201,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({ onChange, value, wide, .
                                 }),
                             },
                         ]}
+                        {...{ isClearable }}
                     />
                 </CloseableModal>
             )}


### PR DESCRIPTION
Hieman heitto, ja niin paljon asiaa muuttava kommitti että ehdottomasti mainin päälle: Jos tällaisia lähdetään yrittämään hotfix-haaraan, 1.19 julkaistaan vuonna 2027.

Nyt:

- globalStartDate/globalEndDate ja specificItemStartDate/specificItemEndDate ovat erillisiä tietoja
- molemmissa saa olla tyhjää ainakin jonkin verran. Jos haetaan yksittäisen olion muutoshistoriaa, molemmat saa olla tyhjiä. Pienenä adhoccina jos haun loppupäivä on tyhjä, se tulkitaan koko julkaisulokinkin puolella käytännössä vaan nykypäiväksi
- Kenttien tyhjentäminen itsessään onnistuu tällä hetkellä tosin ainoastaan tyhjentämällä teksti-inputti: En lisännyt tyhjentämisrukseja, koska näyttää kuitenkin vähän siltä, että tuskinpa niitä paljoa tarvitaan
- Useimmissa kohdissa, missä valitaan yksittäisen kohteen muutoshistoria, nollataan aina specificItemStartDate/specificItemEndDate-tiedot: Jokainen haku lähtee ilman aikarajoitetta. Poikkeuksena jos ollaan jo julkaisulokissa, ja katsomassa jo yksittäisen kohteen muutoshistoriaa, ja hakuboksista valitaankin jokin muu yksittäinen kohde, aikaraja säilyy.

Refaktoroin julkaisulokin päivitykset vähän epäpuhtaampaan mutta paremmin yleiseen rakenteeseen sopivaan muotoon. Aiemminhan se toimi puhdasoppisesti niin, että haut lähtivät suoraan tapahtumahändlereistä. Mutta koska nyt reducereissa on enemmän kuin nollamäärä logiikkaa, siirryin siihen, että komponentti reagoi Reduxin tilasta tulleiden asioiden muutoksiin useEffect()illä. Eli periaatteessa tästä tulee hieman ylimääräisiä rendereitä. Mutta toisaalta pääsipä tällä eroon hyvästä määrästä kodia.