### PR TITLE
GVT-3298 Test-based fixes

### DIFF
--- a/ui/src/publication/log/publication-log.tsx
+++ b/ui/src/publication/log/publication-log.tsx
@@ -3,7 +3,6 @@ import styles from './publication-log.scss';
 import { useTranslation } from 'react-i18next';
 import { DatePicker, END_OF_CENTURY, START_OF_2022 } from 'vayla-design-lib/datepicker/datepicker';
 import { daysBetween, parseISOOrUndefined } from 'utils/date-utils';
-import { endOfDay } from 'date-fns';
 import {
     getPublicationsAsTableItems,
     getPublicationsCsvUri,
@@ -37,6 +36,7 @@ import { LayoutTrackNumber } from 'track-layout/track-layout-model';
 import { useTrackNumbersIncludingDeleted } from 'track-layout/track-layout-react-utils';
 import { TFunction } from 'i18next';
 import { useMemoizedDate, useRateLimitedTwoPartEffect } from 'utils/react-utils';
+import { endOfDay, startOfDay } from 'date-fns';
 
 const MAX_SEARCH_DAYS = 180;
 
@@ -189,8 +189,8 @@ function usePublicationLogSearch(
                     return undefined;
                 } else {
                     return getPublicationsAsTableItems(
-                        startDate,
-                        endDate,
+                        startDate && startOfDay(startDate),
+                        endDate && endOfDay(endDate),
                         specificItem === undefined
                             ? undefined
                             : searchableItemIdAndType(specificItem),


### PR DESCRIPTION
Kaksi testien löytämää bugia, molemmat todellisia, tosin toinen hyvin pieni:

- Normaalitavan mukaan hakuvälin loppupäivän julkaisut tulee hakuun mukaan, koska muu maailma ei ole vielä kuullut Dijkstran hyvää sanomaa
- Vaikka (aiemmassa pullarissa mainitusti) epäsuora reagointi kenttien muutoksiin aiheuttaa vähän ylimääräisiä rendereitä, niin eihän se tarkoita, ettei loading-spinneriä pysty heittämään jo heti ensimmäisellä renderillä päälle. Tällöin testeissäkään ei tarvitse sitten säätää odotusaikoja että no tuliko se spinneri jo näkyviin vai missattiinko se kokonaan vai mitä.