### PR TITLE
GVT-3299 Add new switch validation

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -121,6 +121,10 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
         }
     }
 
+    @get:JsonIgnore
+    val nodeConnections: List<NodeConnection>
+        get() = edges.flatMap { listOf(it.startNode, it.endNode) }
+
     fun getSwitchLocation(switchId: IntId<LayoutSwitch>, jointNumber: JointNumber) =
         trackSwitchLinks.firstOrNull { tsl -> tsl.link.matches(switchId, jointNumber) }?.location
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1652,7 +1652,8 @@
                     "switch-alignment-not-connected": "Joitakin vaihteen {{switch}} linjoja ei ole liitetty raiteelle: {{alignments}}",
                     "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen {{switch}} linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
                     "switch-alignment-partially-connected": "Jotkin vaihteen {{switch}} linjoista on liitetty raiteelle vain yhdellä vaihdepisteellä: {{locationTracks}}",
-                    "switch-alignment-multiply-connected": "Jotkin vaihteen {{switch}} linjoista on liitetty useammalle kuin yhdelle raiteelle: {{locationTracks}}"
+                    "switch-alignment-multiply-connected": "Jotkin vaihteen {{switch}} linjoista on liitetty useammalle kuin yhdelle raiteelle: {{locationTracks}}",
+                    "multiple-outer-without-inner-links": "Vaihteen {{switch}} pisteeltä {{joint}} jatkuu enemmän kuin yksi raide, ilman omaa risteyskohdan vaihdetta: {{locationTracks}}"
                 },
                 "duplicate-name-official": "Raiteen nimi {{locationTrack}} on jo käytössä toisella ratanumeron {{trackNumber}} raiteella",
                 "duplicate-name-draft": "Muutosjoukossa on monta raidetta nimellä {{locationTrack}} ratanumerolla {{trackNumber}}",
@@ -1687,6 +1688,7 @@
                     "switch-alignment-only-connected-to-duplicate": "Joitakin vaihteen linjoja on liitetty ainoastaan duplikaatiksi merkityille raiteille: {{locationTracks}}",
                     "switch-alignment-partially-connected": "Jotkin vaihteen linjoista on liitetty raiteelle vain yhdellä vaihdepisteellä: {{locationTracks}}",
                     "switch-alignment-multiply-connected": "Jotkin vaihteen linjoista on liitetty useammalle kuin yhdelle raiteelle: {{locationTracks}}",
+                    "multiple-outer-without-inner-links": "Vaihteen pisteeltä {{joint}} jatkuu enemmän kuin yksi raide, ilman omaa risteyskohdan vaihdetta: {{locationTracks}}",
                     "relinking-failed": "Vaihteen {{switch}} uudelleenlinkitys epäonnistui"
                 }
             },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -532,6 +532,52 @@ fun trackGeometryOfSegments(segments: List<LayoutSegment>): TmpLocationTrackGeom
             )
         )
 
+class BuildTrackTopology {
+    constructor() {
+        edges = listOf()
+    }
+
+    private constructor(edges: List<BuildTrackTopologyEdge>) {
+        this.edges = edges
+    }
+
+    private val edges: List<BuildTrackTopologyEdge>
+
+    fun edge(
+        startInnerSwitch: SwitchLink? = null,
+        startOuterSwitch: SwitchLink? = null,
+        endInnerSwitch: SwitchLink? = null,
+        endOuterSwitch: SwitchLink? = null,
+    ) =
+        BuildTrackTopology(
+            edges = edges + BuildTrackTopologyEdge(startInnerSwitch, startOuterSwitch, endInnerSwitch, endOuterSwitch)
+        )
+
+    fun build(trackId: IntId<LocationTrack>? = null): TmpLocationTrackGeometry {
+        var x = 0.0
+        return TmpLocationTrackGeometry.of(
+            edges.map { edgeInfo ->
+                x += 2.0
+                edge(
+                    listOf(segment(Point(x, 0.0), Point(x + 2.0, 0.0))),
+                    edgeInfo.startInnerSwitch,
+                    edgeInfo.startOuterSwitch,
+                    edgeInfo.endInnerSwitch,
+                    edgeInfo.endOuterSwitch,
+                )
+            },
+            trackId,
+        )
+    }
+}
+
+private data class BuildTrackTopologyEdge(
+    val startInnerSwitch: SwitchLink?,
+    val startOuterSwitch: SwitchLink?,
+    val endInnerSwitch: SwitchLink?,
+    val endOuterSwitch: SwitchLink?,
+)
+
 fun trackGeometry(vararg edges: LayoutEdge, trackId: IntId<LocationTrack>? = null): TmpLocationTrackGeometry =
     trackGeometry(edges.toList(), trackId)
 


### PR DESCRIPTION
Tarkistetaan, että vaihteen kullakin pisteellä on kiinni enintään yksi sellainen outer-linkki, jossa samassa edgen päässä ei ole myös inner-linkkiä; paitsi jos kyseinen raide on joko merkitty duplikaatiksi, tai on duplikaattilinkitetty myös vaihteen geometrian sisällä (koska tällöin siitä tulee valitusta jo olemassaolevasta duplikaattivalidaatiosta -> vältetään noisea vaihteilla, joista näkee jo että joo siitä pitää fiksata duplikaattiraiteet pois).

Tein alkuaan tämän vaihdetta OL V0271 varten (missä raidegeometria haarautuu vaihteen kolmospisteestä ilman omaa vaihdettaan), mutta kyllä tämä löytää myös muita duplikaattihähmiä kuten HA V0002 (missä kaksi raidetta tulee vaihteen läpi ja jatkuu sen etujatkosta puskimeen asti). Tosin siis useimmissa tapauksissa tämä vain laajentaa sitä vaihteiden joukkoa, mihin kukin duplikaattiraide aiheuttaa validaatiohuomioita, mutta tekeepä niistäkin selkeämpiä.