### PR TITLE
GVT-3301 Only display location track duplicates when extra info loading is ready

### DIFF
--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -172,25 +172,27 @@ const LocationTrackBasicInfoInfoboxM: React.FC<LocationTrackBasicInfoInfoboxProp
                     value={<TrackNumberLinkContainer trackNumberId={trackNumber?.id} />}
                 />
                 <InfoboxText value={trackNumber?.description} />
-                <InfoboxField
-                    label={
-                        locationTrack.duplicateOf
-                            ? t('tool-panel.location-track.duplicate-of')
-                            : (extraInfo?.duplicates?.length ?? 0 > 0)
-                              ? t('tool-panel.location-track.has-duplicates')
-                              : t('tool-panel.location-track.not-a-duplicate')
-                    }
-                    value={
-                        <LocationTrackInfoboxDuplicateOf
-                            targetLocationTrack={locationTrack}
-                            existingDuplicate={extraInfo?.duplicateOf}
-                            duplicatesOfLocationTrack={extraInfo?.duplicates ?? []}
-                            layoutContext={layoutContext}
-                            changeTime={changeTimes.layoutLocationTrack}
-                            currentTrackNumberId={trackNumber?.id}
-                        />
-                    }
-                />
+                {extraInfoLoadingStatus === LoaderStatus.Ready && (
+                    <InfoboxField
+                        label={
+                            locationTrack.duplicateOf
+                                ? t('tool-panel.location-track.duplicate-of')
+                                : (extraInfo?.duplicates?.length ?? 0 > 0)
+                                  ? t('tool-panel.location-track.has-duplicates')
+                                  : t('tool-panel.location-track.not-a-duplicate')
+                        }
+                        value={
+                            <LocationTrackInfoboxDuplicateOf
+                                targetLocationTrack={locationTrack}
+                                existingDuplicate={extraInfo?.duplicateOf}
+                                duplicatesOfLocationTrack={extraInfo?.duplicates ?? []}
+                                layoutContext={layoutContext}
+                                changeTime={changeTimes.layoutLocationTrack}
+                                currentTrackNumberId={trackNumber?.id}
+                            />
+                        }
+                    />
+                )}
                 <InfoboxField
                     label={t('tool-panel.location-track.topological-connectivity')}
                     value={


### PR DESCRIPTION
Tämä aiheutti ikävää välkkymistä, koska saattoi keretä väliin renderi, jossa uuden raiteen perustiedot on jo ladattu (ja koko LocationTrackInfobox näytetään vasta, kun se on tehty) mutta extrainfoa ei -> duplikaattivalidaatiot lasketaan yhä vanhojen ekstrainfojen perusteella, ja niistähän jokainen on sitten jonkin muun raiteen duplikaatti, eli jokaisesta tulee punakolmiolla varoitusta että eihän tässä voi olla mitään järkeä.

Ei siis muuta muutosta kuin tuo extraInfoLoadingStatus-tarkistus.