### PR TITLE
GVT-3133: Add automated tests for ext api location tracks

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -14,10 +14,10 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
-import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.Instant
 
 @GeoviiteService
 class ExtLocationTrackServiceV1
@@ -59,12 +59,11 @@ constructor(
 
     fun createLocationTrackModificationResponse(
         oid: Oid<LocationTrack>,
+        locationTrackId: IntId<LocationTrack>,
         publications: PublicationComparison,
         coordinateSystem: Srid,
     ): ExtModifiedLocationTrackResponseV1? {
-        val locationTrackId =
-            locationTrackDao.lookupByExternalId(oid.toString())?.id
-                ?: throw ExtOidNotFoundExceptionV1("location track lookup failed, oid=$oid")
+
 
         return locationTrackDao
             .fetchOfficialVersionComparison(

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
@@ -57,13 +57,10 @@ constructor(
 
     fun createTrackNumberModificationResponse(
         oid: Oid<LayoutTrackNumber>,
+        trackNumberId: IntId<LayoutTrackNumber>,
         publications: PublicationComparison,
         coordinateSystem: Srid,
     ): ExtModifiedTrackNumberResponseV1? {
-        val trackNumberId =
-            layoutTrackNumberDao.lookupByExternalId(oid.toString())?.id
-                ?: throw ExtOidNotFoundExceptionV1("track number lookup failed, oid=$oid")
-
         return layoutTrackNumberDao
             .fetchOfficialVersionComparison(
                 LayoutBranch.main,

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackTestIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackTestIT.kt
@@ -1,0 +1,255 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+import fi.fta.geoviite.api.ExtApiTestDataServiceV1
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.InfraApplication
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.someOid
+import fi.fta.geoviite.infra.util.FreeText
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+
+@ActiveProfiles("dev", "test", "ext-api")
+@SpringBootTest(classes = [InfraApplication::class])
+@AutoConfigureMockMvc
+class ExtLocationTrackTestIT
+@Autowired
+constructor(
+    mockMvc: MockMvc,
+    private val locationTrackService: LocationTrackService,
+    private val extTestDataService: ExtApiTestDataServiceV1,
+) : DBTestBase() {
+    private val api = ExtTrackLayoutTestApiService(mockMvc)
+
+    @Test
+    fun `Newest official location track is returned by default`() {
+        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
+        val (trackNumberId, referenceLineId, _) =
+            extTestDataService.insertTrackNumberAndReferenceWithOid(
+                mainDraftContext,
+                segments = listOf(segment),
+            )
+
+        val (track, geometry) =
+            mainDraftContext
+                .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
+                .let(locationTrackService::getWithGeometry)
+
+        val oid =
+            someOid<LocationTrack>().also { oid ->
+                locationTrackService.insertExternalId(LayoutBranch.main, track.id as IntId, oid)
+            }
+
+        val publication1 =
+            extTestDataService.publishInMain(
+                trackNumbers = listOf(trackNumberId),
+                referenceLines = listOf(referenceLineId),
+                locationTracks = listOf(track.id as IntId),
+            )
+
+        val modifiedDescription = "modified description after publication=${publication1.uuid}"
+        mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+
+        val responseAfterCreatingDraftTrack = api.locationTracks.get(oid)
+        assertEquals(publication1.uuid.toString(), responseAfterCreatingDraftTrack.rataverkon_versio)
+        assertNotEquals(modifiedDescription, responseAfterCreatingDraftTrack.sijaintiraide.kuvaus)
+
+        val publication2 = extTestDataService.publishInMain(locationTracks = listOf(track.id))
+        val responseAfterPublishingModification = api.locationTracks.get(oid)
+
+        assertEquals(publication2.uuid.toString(), responseAfterPublishingModification.rataverkon_versio)
+        assertEquals(modifiedDescription, responseAfterPublishingModification.sijaintiraide.kuvaus)
+    }
+
+    @Test
+    fun `Location track api respects the track layout version argument`() {
+        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
+        val (trackNumberId, referenceLineId, _) =
+            extTestDataService.insertTrackNumberAndReferenceWithOid(
+                mainDraftContext,
+                segments = listOf(segment),
+            )
+
+        val (track, geometry) =
+            mainDraftContext
+                .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
+                .let(locationTrackService::getWithGeometry)
+
+        val oid =
+            someOid<LocationTrack>().also { oid ->
+                locationTrackService.insertExternalId(LayoutBranch.main, track.id as IntId, oid)
+            }
+
+        val publication1 =
+            extTestDataService.publishInMain(
+                trackNumbers = listOf(trackNumberId),
+                referenceLines = listOf(referenceLineId),
+                locationTracks = listOf(track.id as IntId),
+            )
+
+        val publication2 = extTestDataService.publishInMain()
+
+        val modifiedDescription = "modified description after publication=${publication1.uuid}"
+        mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+
+        val publication3 = extTestDataService.publishInMain(locationTracks = listOf(track.id))
+
+        val responses =
+            listOf(publication1, publication2, publication3).map { publication ->
+                val response = api.locationTracks.get(oid, "rataverkon_versio" to publication.uuid.toString())
+                assertEquals(publication.uuid.toString(), response.rataverkon_versio)
+
+                response
+            }
+
+        assertNotEquals(modifiedDescription, responses[0].sijaintiraide.kuvaus)
+        assertNotEquals(modifiedDescription, responses[1].sijaintiraide.kuvaus)
+        assertEquals(modifiedDescription, responses[2].sijaintiraide.kuvaus)
+    }
+
+    @Test
+    fun `Location track api respects the coordinate system argument`() {
+        val helsinkiRailwayStationTm35Fin = Point(385782.89, 6672277.83)
+        val helsinkiRailwayStationTm35FinPlus10000 = Point(395782.89, 6682277.83)
+
+        val tests =
+            listOf(
+                Triple("EPSG:3067", helsinkiRailwayStationTm35Fin, helsinkiRailwayStationTm35FinPlus10000),
+
+                // EPSG:4326 == WGS84, converted using https://epsg.io/transform
+                Triple("EPSG:4326", Point(24.9414003, 60.1713788), Point(25.1163757, 60.2637958)),
+            )
+
+        val segment = segment(helsinkiRailwayStationTm35Fin, helsinkiRailwayStationTm35FinPlus10000)
+
+        val (trackNumberId, referenceLineId, _) =
+            extTestDataService.insertTrackNumberAndReferenceWithOid(mainDraftContext, segments = listOf(segment))
+
+        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
+        val oid =
+            someOid<LocationTrack>().also { oid ->
+                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
+            }
+
+        extTestDataService.publishInMain(
+            trackNumbers = listOf(trackNumberId),
+            referenceLines = listOf(referenceLineId),
+            locationTracks = listOf(trackId),
+        )
+
+        tests.forEach { (epsgCode, expectedStart, expectedEnd) ->
+            val response = api.locationTracks.get(oid, "koordinaatisto" to epsgCode)
+
+            assertEquals(epsgCode, response.koordinaatisto)
+            assertExtStartAndEnd(expectedStart, expectedEnd, response.sijaintiraide)
+        }
+    }
+
+    @Test
+    fun `Location track api should return track information regardless of its state`() {
+        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
+        val (trackNumberId, referenceLineId, _) =
+            extTestDataService.insertTrackNumberAndReferenceWithOid(mainDraftContext, segments = listOf(segment))
+
+        val tracks =
+            LocationTrackState.entries.map { state ->
+                val trackId =
+                    mainDraftContext
+                        .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
+                        .id
+
+                val trackOid =
+                    someOid<LocationTrack>().also { oid ->
+                        locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
+                    }
+
+                Triple(trackOid, trackId, state)
+            }
+
+        extTestDataService.publishInMain(
+            trackNumbers = listOf(trackNumberId),
+            referenceLines = listOf(referenceLineId),
+            locationTracks = tracks.map { (_, id, _) -> id },
+        )
+
+        tracks.forEach { (oid, _, state) ->
+            val response = api.locationTracks.get(oid)
+
+            assertEquals(oid.toString(), response.sijaintiraide.sijaintiraide_oid)
+            assertExtLocationTrackState(state, response.sijaintiraide.tila)
+        }
+    }
+
+    @Test
+    fun `Location track modifications api should return track information regardless of its state`() {
+        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
+        val (trackNumberId, referenceLineId, _) =
+            extTestDataService.insertTrackNumberAndReferenceWithOid(mainDraftContext, segments = listOf(segment))
+
+        val tracks =
+            LocationTrackState.entries.map { state ->
+                val (track, geometry) =
+                    mainDraftContext
+                        .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
+                        .let(locationTrackService::getWithGeometry)
+
+                val trackOid =
+                    someOid<LocationTrack>().also { oid ->
+                        locationTrackService.insertExternalId(LayoutBranch.main, track.id as IntId, oid)
+                    }
+
+                Triple(trackOid, track, geometry)
+            }
+
+        val publication1 =
+            extTestDataService.publishInMain(
+                trackNumbers = listOf(trackNumberId),
+                referenceLines = listOf(referenceLineId),
+                locationTracks = tracks.map { (_, track, _) -> track.id as IntId },
+            )
+
+        val modifiedDescription = "this is a modified location track after publication=${publication1.uuid}"
+        tracks.forEach { (_, track, geometry) ->
+            mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+        }
+
+        val publication2 =
+            extTestDataService.publishInMain(
+                locationTracks =
+                    tracks.map {
+                        (
+                            _,
+                            track,
+                            _,
+                        ) ->
+                        track.id as IntId
+                    }
+            )
+
+        tracks.forEach { (oid, track, _) ->
+            val response =
+                api.locationTracks.getModified(
+                    oid,
+                    "alkuversio" to publication1.uuid.toString(),
+                    "loppuversio" to publication2.uuid.toString(),
+                )
+
+            assertEquals(oid.toString(), response.sijaintiraide.sijaintiraide_oid)
+            assertEquals(modifiedDescription, response.sijaintiraide.kuvaus)
+            assertExtLocationTrackState(track.state, response.sijaintiraide.tila)
+        }
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutDataV1.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutDataV1.kt
@@ -1,0 +1,71 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+data class ExtTestAddressPointV1(
+    val x: Double,
+    val y: Double,
+    val rataosoite: String?,
+)
+
+data class ExtTestLocationTrackV1(
+    val sijaintiraide_oid: String,
+    val sijaintiraidetunnus: String,
+    val ratanumero: String,
+    val ratanumero_oid: String,
+    val tyyppi: String,
+    val tila: String,
+    val kuvaus: String,
+    val omistaja: String,
+    val alkusijainti: ExtTestAddressPointV1?,
+    val loppusijainti: ExtTestAddressPointV1?,
+)
+
+data class ExtTestLocationTrackResponseV1(
+    val rataverkon_versio: String,
+    val koordinaatisto: String,
+    val sijaintiraide: ExtTestLocationTrackV1,
+)
+
+data class ExtTestLocationTrackGeometryResponseV1(
+    val rataverkon_versio: String,
+    val koordinaatisto: String,
+    val osoitevalit: List<ExtTestGeometryIntervalV1>,
+)
+
+data class ExtTestModifiedLocationTrackGeometryResponseV1(
+    val alkuversio: String,
+    val loppuversio: String,
+    val koordinaatisto: String,
+    val osoitevalit: List<ExtTestGeometryIntervalV1>,
+)
+
+data class ExtTestModifiedLocationTrackResponseV1(
+    val alkuversio: String,
+    val loppuversio: String,
+    val koordinaatisto: String,
+    val sijaintiraide: ExtTestLocationTrackV1,
+)
+
+data class ExtTestLocationTrackCollectionResponseV1(
+    val rataverkon_versio: String,
+    val koordinaatisto: String,
+    val sijaintiraiteet: List<ExtTestLocationTrackV1>,
+)
+
+data class ExtTestModifiedLocationTrackCollectionResponseV1(
+    val alkuversio: String,
+    val loppuversio: String,
+    val koordinaatisto: String,
+    val sijaintiraiteet: List<ExtTestLocationTrackV1>,
+)
+
+data class ExtTestErrorResponseV1(
+    val virheviesti: String,
+    val korrelaatiotunnus: String,
+    val aikaleima: String,
+)
+
+data class ExtTestGeometryIntervalV1(
+    val alku: String,
+    val loppu: String,
+    val pisteet: List<ExtTestAddressPointV1>,
+)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1.kt
@@ -1,39 +1,239 @@
-package fi.fta.geoviite.api.tracklayout.v1
+import fi.fta.geoviite.api.ExtApiTestDataServiceV1
+import fi.fta.geoviite.api.tracklayout.v1.ExtTrackLayoutTestApiService
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.InfraApplication
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.someOid
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
 
-data class ExtTestAddressPointV1(
-    val x: Double,
-    val y: Double,
-    val rataosoite: String?,
-)
+@ActiveProfiles("dev", "test", "ext-api")
+@SpringBootTest(classes = [InfraApplication::class])
+@AutoConfigureMockMvc
+class ExtTestTrackLayoutV1
+@Autowired
+constructor(
+    mockMvc: MockMvc,
+    private val locationTrackService: LocationTrackService,
+    private val extTestDataService: ExtApiTestDataServiceV1,
+    @Autowired private val publicationService: PublicationService,
+    service: PublicationService,
+) : DBTestBase() {
+    private val api = ExtTrackLayoutTestApiService(mockMvc)
 
-data class ExtTestLocationTrackV1(
-    val sijaintiraide_oid: String,
-    val sijaintiraidetunnus: String,
-    val ratanumero: String,
-    val ratanumero_oid: String,
-    val tyyppi: String,
-    val tila: String,
-    val kuvaus: String,
-    val omistaja: String,
-    val alkusijainti: ExtTestAddressPointV1?,
-    val loppusijainti: ExtTestAddressPointV1?,
-)
+    private val errorTests =
+        listOf(
+            ::setupValidLocationTrack to api.locationTracks::getWithExpectedError,
+            ::setupValidLocationTrack to api.locationTracks::getGeometryWithExpectedError,
+        )
 
-data class ExtTestLocationTrackCollectionV1(
-    val rataverkon_versio: String,
-    val koordinaatisto: String,
-    val sijaintiraiteet: List<ExtTestLocationTrackV1>,
-)
+    private val modificationErrorTests =
+        listOf(
+            ::setupValidLocationTrack to api.locationTracks::getModifiedWithExpectedError,
+        )
 
-data class ExtTestModifiedLocationTrackCollectionV1(
-    val alkuversio: String,
-    val loppuversio: String,
-    val koordinaatisto: String,
-    val sijaintiraiteet: List<ExtTestLocationTrackV1>,
-)
+    private val noContentTests =
+        listOf(
+            ::setupValidLocationTrack to api.locationTracks::getWithEmptyBody,
+            ::setupValidLocationTrack to api.locationTracks::getGeometryWithEmptyBody,
+        )
 
-data class ExtTestErrorResponseV1(
-    val virheviesti: String,
-    val korrelaatiotunnus: String,
-    val aikaleima: String,
-)
+    private val noContentModificationTests =
+        listOf(
+            ::setupValidLocationTrack to api.locationTracks::getModifiedWithEmptyBody,
+        )
+
+    private val modificationSuccessTests = listOf(::setupValidLocationTrack to api.locationTracks::getModified)
+
+    @BeforeEach
+    fun cleanup() {
+        testDBService.clearAllTables()
+    }
+
+    @Test
+    fun `Ext api asset endpoints should return HTTP 400 if the OID is invalid format`() {
+        val invalidOid = "asd"
+        val expectedStatus = HttpStatus.BAD_REQUEST
+        val validButEmptyPublication = extTestDataService.publishInMain()
+
+        errorTests.forEach { (_, apiCall) -> apiCall(invalidOid, emptyArray(), expectedStatus) }
+        modificationErrorTests.forEach { (_, apiCall) ->
+            apiCall(invalidOid, arrayOf("alkuversio" to validButEmptyPublication.uuid.toString()), expectedStatus)
+        }
+    }
+
+    @Test
+    fun `Ext api asset endpoints should return HTTP 404 if the OID is not found`() {
+        val expectedStatus = HttpStatus.NOT_FOUND
+        val nonExistingOid = someOid<Nothing>().toString()
+        val validButEmptyPublication = extTestDataService.publishInMain()
+
+        errorTests.forEach { (_, apiCall) -> apiCall(nonExistingOid, emptyArray(), expectedStatus) }
+        modificationErrorTests.forEach { (_, apiCall) ->
+            apiCall(nonExistingOid, arrayOf("alkuversio" to validButEmptyPublication.uuid.toString()), expectedStatus)
+        }
+    }
+
+    @Test
+    fun `Ext api asset endpoints should return HTTP 400 if the track layout version is invalid format`() {
+        val invalidTrackLayoutVersion = "asd"
+        val expectedStatus = HttpStatus.BAD_REQUEST
+
+        errorTests
+            .map { (oidSetup, apiCall) -> oidSetup().toString() to apiCall }
+            .forEach { (oid, apiCall) ->
+                val response = apiCall(oid, arrayOf("rataverkon_versio" to invalidTrackLayoutVersion), expectedStatus)
+            }
+    }
+
+    @Test
+    fun `Ext api asset endpoints return HTTP 404 if the track layout version is not found`() {
+        val validButNonExistingUuid = "00000000-0000-0000-0000-000000000000"
+        val expectedStatus = HttpStatus.NOT_FOUND
+
+        errorTests
+            .map { (oidSetup, apiCall) -> oidSetup().toString() to apiCall }
+            .forEach { (oid, apiCall) ->
+                apiCall(oid, arrayOf("rataverkon_versio" to validButNonExistingUuid), expectedStatus)
+            }
+    }
+
+    @Test
+    fun `Ext api asset modification endpoints should return HTTP 400 if either the start or end track layout version is invalid format`() {
+        val invalidTrackLayoutVersion = "asd"
+        val validButNonExistingUuid = "00000000-0000-0000-0000-000000000000"
+        val expectedStatus = HttpStatus.BAD_REQUEST
+
+        modificationErrorTests.forEach { (oidSetup, apiCall) ->
+            val oid = oidSetup().toString()
+
+            apiCall(oid, arrayOf("alkuversio" to invalidTrackLayoutVersion), expectedStatus)
+            apiCall(
+                oid,
+                arrayOf("alkuversio" to validButNonExistingUuid, "loppuversio" to invalidTrackLayoutVersion),
+                expectedStatus,
+            )
+        }
+    }
+
+    @Test
+    fun `Ext api asset modification endpoints should return HTTP 404 if either the start or end track layout version is not found`() {
+        val emptyButExistingPublication = extTestDataService.publishInMain()
+        val validButNonExistingUuid = "00000000-0000-0000-0000-000000000000"
+
+        val expectedStatus = HttpStatus.NOT_FOUND
+
+        modificationErrorTests.forEach { (oidSetup, apiCall) ->
+            val oid = oidSetup().toString()
+
+            apiCall(oid, arrayOf("alkuversio" to validButNonExistingUuid), expectedStatus)
+            apiCall(
+                oid,
+                arrayOf(
+                    "alkuversio" to emptyButExistingPublication.uuid.toString(),
+                    "loppuversio" to validButNonExistingUuid,
+                ),
+                expectedStatus,
+            )
+        }
+    }
+
+    @Test
+    fun `Ext api asset endpoints should return HTTP 204 when the asset does not exist in the specified track layout version`() {
+        val expectedStatus = HttpStatus.NO_CONTENT
+        val validButEmptyPublication = extTestDataService.publishInMain()
+
+        noContentTests
+            .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
+            .forEach { (oid, apiCall) ->
+                apiCall(oid, arrayOf("rataverkon_versio" to validButEmptyPublication.uuid.toString()), expectedStatus)
+            }
+    }
+
+    @Test
+    fun `Ext api asset modification endpoints should return HTTP 204 when the asset has no modifications`() {
+        val expectedStatus = HttpStatus.NO_CONTENT
+
+        noContentModificationTests
+            .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
+            .forEach { (oid, apiCall) ->
+                val newestPublication =
+                    publicationService.getPublicationByUuidOrLatest(LayoutBranchType.MAIN, publicationUuid = null)
+
+                apiCall(oid, arrayOf("alkuversio" to newestPublication.uuid.toString()), expectedStatus)
+            }
+    }
+
+    @Test
+    fun `Ext api asset modification endpoints should return HTTP 204 when the asset does not exist between track layout versions`() {
+        val expectedStatus = HttpStatus.NO_CONTENT
+        val firstPublication = extTestDataService.publishInMain()
+        val secondPublication = extTestDataService.publishInMain()
+
+        noContentModificationTests
+            .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
+            .forEach { (oid, apiCall) ->
+                // oidSetup call has added the asset and created a new publication: the asset exists, but not within the
+                // publications before it.
+                apiCall(
+                    oid,
+                    arrayOf(
+                        "alkuversio" to firstPublication.uuid.toString(),
+                        "loppuversio" to secondPublication.uuid.toString(),
+                    ),
+                    expectedStatus,
+                )
+            }
+    }
+
+    @Test
+    fun `Ext api asset modification endpoints should return HTTP 200 when the asset has been created after the start track layout version`() {
+        val validButEmptyPublication = extTestDataService.publishInMain()
+
+        modificationSuccessTests
+            .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
+            .forEach { (oid, apiCall) ->
+                val response = apiCall(oid, arrayOf("alkuversio" to validButEmptyPublication.uuid.toString()))
+                assertEquals(oid.toString(), response.sijaintiraide.sijaintiraide_oid)
+            }
+    }
+
+    private fun setupValidLocationTrack(): Oid<LocationTrack> {
+        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
+        val (trackNumberId, referenceLineId, _) =
+            extTestDataService.insertTrackNumberAndReferenceWithOid(
+                mainDraftContext,
+                segments = listOf(segment),
+            )
+
+        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
+
+        val oid =
+            someOid<LocationTrack>().also { oid ->
+                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
+            }
+
+        extTestDataService.publishInMain(
+            trackNumbers = listOf(trackNumberId),
+            referenceLines = listOf(referenceLineId),
+            locationTracks = listOf(trackId),
+        )
+
+        return oid
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutAssertions.kt
@@ -1,0 +1,37 @@
+package fi.fta.geoviite.api.tracklayout.v1
+
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.LocationTrackState
+import org.junit.jupiter.api.Assertions.assertEquals
+
+fun assertExtStartAndEnd(
+    expectedStart: Point,
+    expectedEnd: Point,
+    responseTrack: ExtTestLocationTrackV1,
+) {
+
+    assertEquals(expectedStart.x, requireNotNull(responseTrack.alkusijainti?.x), 0.0001)
+    assertEquals(expectedStart.y, requireNotNull(responseTrack.alkusijainti.y), 0.0001)
+    assertEquals(
+        expectedEnd.x,
+        requireNotNull(responseTrack.loppusijainti?.x),
+        0.0001,
+    )
+    assertEquals(
+        expectedEnd.y,
+        requireNotNull(responseTrack.loppusijainti.y),
+        0.0001,
+    )
+}
+
+fun assertExtLocationTrackState(expectedState: LocationTrackState, stateName: String) {
+    val expectedStateName =
+        when (expectedState) {
+            LocationTrackState.IN_USE -> "käytössä"
+            LocationTrackState.BUILT -> "rakennettu"
+            LocationTrackState.NOT_IN_USE -> "käytöstä poistettu"
+            LocationTrackState.DELETED -> "poistettu"
+        }
+
+    assertEquals(expectedStateName, stateName)
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutTestApiService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutTestApiService.kt
@@ -3,62 +3,169 @@ package fi.fta.geoviite.api.tracklayout.v1
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import fi.fta.geoviite.infra.TestApi
+import fi.fta.geoviite.infra.common.Oid
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.MockMvc
-
-const val LOCATION_TRACK_COLLECTION_URL = "/geoviite/paikannuspohja/v1/sijaintiraiteet"
-const val MODIFIED_LOCATION_TRACK_COLLECTION_URL = "/geoviite/paikannuspohja/v1/sijaintiraiteet/muutokset"
+import kotlin.reflect.KClass
 
 class ExtTrackLayoutTestApiService(mockMvc: MockMvc) {
-    val mapper = jacksonObjectMapper().apply { setSerializationInclusion(JsonInclude.Include.NON_NULL) }
-    val testApi = TestApi(mapper, mockMvc)
+    val testApiMapper = jacksonObjectMapper().apply { setSerializationInclusion(JsonInclude.Include.NON_NULL) }
+    val testApiConnection = TestApi(testApiMapper, mockMvc)
 
-    fun getLocationTrackCollection(
-        vararg params: Pair<String, String>,
-    ): ExtTestLocationTrackCollectionV1 {
-        return get<ExtTestLocationTrackCollectionV1>(LOCATION_TRACK_COLLECTION_URL, params.toMap())
-    }
+    val locationTracks =
+        AssetApi(
+            assetUrl = { oid -> "/geoviite/paikannuspohja/v1/sijaintiraiteet/${oid}" },
+            ExtTestLocationTrackResponseV1::class,
+            modifiedUrl = { oid -> "/geoviite/paikannuspohja/v1/sijaintiraiteet/${oid}/muutokset" },
+            ExtTestModifiedLocationTrackResponseV1::class,
+            geometryUrl = { oid -> "/geoviite/paikannuspohja/v1/sijaintiraiteet/${oid}/geometria" },
+            ExtTestLocationTrackGeometryResponseV1::class,
+        )
 
-    fun getLocationTrackCollectionWithExpectedError(
-        vararg params: Pair<String, String>,
-        httpStatus: HttpStatus,
-    ): ExtTestErrorResponseV1 {
-        return get<ExtTestErrorResponseV1>(LOCATION_TRACK_COLLECTION_URL, params.toMap(), httpStatus)
-    }
+    val locationTrackCollection =
+        AssetCollectionApi(
+            assetCollectionUrl = { "/geoviite/paikannuspohja/v1/sijaintiraiteet" },
+            ExtTestLocationTrackCollectionResponseV1::class,
+            modifiedAssetCollectionUrl = { "/geoviite/paikannuspohja/v1/sijaintiraiteet/muutokset" },
+            ExtTestModifiedLocationTrackCollectionResponseV1::class,
+        )
 
-    fun getModifiedLocationTrackCollection(
-        vararg params: Pair<String, String>,
-    ): ExtTestModifiedLocationTrackCollectionV1 {
-        return get<ExtTestModifiedLocationTrackCollectionV1>(MODIFIED_LOCATION_TRACK_COLLECTION_URL, params.toMap())
-    }
-
-    fun getModifiedLocationTrackCollectionWithExpectedError(
-        vararg params: Pair<String, String>,
-        httpStatus: HttpStatus,
-    ): ExtTestErrorResponseV1 {
-        return get<ExtTestErrorResponseV1>(MODIFIED_LOCATION_TRACK_COLLECTION_URL, params.toMap(), httpStatus)
-    }
-
-    fun getModifiedLocationTrackCollectionWithoutResult(
-        vararg params: Pair<String, String>,
-        httpStatus: HttpStatus,
+    inner class AssetApi<
+        AssetResponse : Any,
+        AssetModificationResponse : Any,
+        AssetGeometryResponse : Any,
+    >(
+        private val assetUrl: (String) -> String,
+        private val assetClazz: KClass<AssetResponse>,
+        private val modifiedUrl: ((String) -> String)? = null,
+        private val modifiedClazz: KClass<AssetModificationResponse>? = null,
+        private val geometryUrl: ((String) -> String)? = null,
+        private val geometryClazz: KClass<AssetGeometryResponse>? = null,
     ) {
-        return getWithoutResult(MODIFIED_LOCATION_TRACK_COLLECTION_URL, params.toMap(), httpStatus)
+        fun get(oid: Oid<*>, vararg params: Pair<String, String>): AssetResponse {
+            return internalGet(assetClazz, assetUrl(oid.toString()), params.toMap())
+        }
+
+        fun getWithExpectedError(
+            oid: String,
+            vararg params: Pair<String, String>,
+            httpStatus: HttpStatus,
+        ): ExtTestErrorResponseV1 {
+            return internalGet(ExtTestErrorResponseV1::class, assetUrl(oid), params.toMap(), httpStatus)
+        }
+
+        fun getWithEmptyBody(oid: Oid<*>, vararg params: Pair<String, String>, httpStatus: HttpStatus) {
+            internalGetWithoutBody(assetUrl(oid.toString()), params.toMap(), httpStatus)
+        }
+
+        fun getModified(oid: Oid<*>, vararg params: Pair<String, String>): AssetModificationResponse {
+            require(modifiedUrl != null) { "Modifications not supported for this asset" }
+            return internalGet(requireNotNull(modifiedClazz), modifiedUrl(oid.toString()), params.toMap())
+        }
+
+        fun getModifiedWithExpectedError(
+            oid: String,
+            vararg params: Pair<String, String>,
+            httpStatus: HttpStatus,
+        ): ExtTestErrorResponseV1 {
+            require(modifiedUrl != null) { "Modifications not supported for this asset type" }
+            return internalGet(ExtTestErrorResponseV1::class, modifiedUrl(oid), params.toMap(), httpStatus)
+        }
+
+        fun getModifiedWithEmptyBody(oid: Oid<*>, vararg params: Pair<String, String>, httpStatus: HttpStatus) {
+            require(modifiedUrl != null) { "Modifications not supported for this asset type" }
+            internalGetWithoutBody(modifiedUrl(oid.toString()), params.toMap(), httpStatus)
+        }
+
+        fun getGeometry(oid: Oid<*>, vararg params: Pair<String, String>): AssetGeometryResponse {
+            require(geometryUrl != null) { "Geometry not supported for this asset type" }
+            return internalGet(requireNotNull(geometryClazz), geometryUrl(oid.toString()), params.toMap())
+        }
+
+        fun getGeometryWithExpectedError(
+            oid: String,
+            vararg params: Pair<String, String>,
+            httpStatus: HttpStatus,
+        ): ExtTestErrorResponseV1 {
+            require(geometryUrl != null) { "Geometry not supported for this asset type" }
+            return internalGet(ExtTestErrorResponseV1::class, geometryUrl(oid), params.toMap(), httpStatus)
+        }
+
+        fun getGeometryWithEmptyBody(oid: Oid<*>, vararg params: Pair<String, String>, httpStatus: HttpStatus) {
+            require(geometryUrl != null) { "Geometry not supported for this asset type" }
+            internalGetWithoutBody(geometryUrl(oid.toString()), params.toMap(), httpStatus)
+        }
     }
 
-    inline fun <reified T> get(
+    inner class AssetCollectionApi<
+        AssetCollectionResponse : Any,
+        ModifiedAssetCollectionResponse : Any,
+    >(
+        private val assetCollectionUrl: () -> String,
+        private val assetCollectionClazz: KClass<AssetCollectionResponse>,
+        private val modifiedAssetCollectionUrl: (() -> String)? = null,
+        private val modifiedAssetCollectionClazz: KClass<ModifiedAssetCollectionResponse>? = null,
+    ) {
+
+        fun get(vararg params: Pair<String, String>): AssetCollectionResponse {
+            return internalGet(assetCollectionClazz, assetCollectionUrl(), params.toMap())
+        }
+
+        fun getWithExpectedError(
+            vararg params: Pair<String, String>,
+            httpStatus: HttpStatus,
+        ): ExtTestErrorResponseV1 {
+            return internalGet(ExtTestErrorResponseV1::class, assetCollectionUrl(), params.toMap(), httpStatus)
+        }
+
+        fun getWithEmptyBody(vararg params: Pair<String, String>, httpStatus: HttpStatus) {
+            internalGetWithoutBody(assetCollectionUrl(), params.toMap(), httpStatus)
+        }
+
+        fun getModified(vararg params: Pair<String, String>): ModifiedAssetCollectionResponse {
+            require(modifiedAssetCollectionUrl != null) { "Modifications not supported for this asset collection type" }
+            return internalGet(
+                requireNotNull(modifiedAssetCollectionClazz),
+                modifiedAssetCollectionUrl(),
+                params.toMap(),
+            )
+        }
+
+        fun getModifiedWithExpectedError(
+            vararg params: Pair<String, String>,
+            httpStatus: HttpStatus,
+        ): ExtTestErrorResponseV1 {
+            require(modifiedAssetCollectionUrl != null) { "Modifications not supported for this asset collection type" }
+            return internalGet(
+                ExtTestErrorResponseV1::class,
+                modifiedAssetCollectionUrl(),
+                params.toMap(),
+                httpStatus,
+            )
+        }
+
+        fun getModifiedWithEmptyBody(vararg params: Pair<String, String>, httpStatus: HttpStatus) {
+            require(modifiedAssetCollectionUrl != null) { "Modifications not supported for this asset collection type" }
+            internalGetWithoutBody(modifiedAssetCollectionUrl(), params.toMap(), httpStatus)
+        }
+    }
+
+    fun <T : Any> internalGet(
+        responseClazz: KClass<T>,
         url: String,
         params: Map<String, String> = emptyMap(),
         httpStatus: HttpStatus = HttpStatus.OK,
     ): T {
-        return testApi.doGetWithParams(url, params, httpStatus).let { body -> mapper.readValue(body, T::class.java) }
+        return testApiConnection.doGetWithParams(url, params, httpStatus).let { body ->
+            testApiMapper.readValue(body, responseClazz.java)
+        }
     }
 
-    fun getWithoutResult(
+    fun internalGetWithoutBody(
         url: String,
         params: Map<String, String> = emptyMap(),
-        httpStatus: HttpStatus = HttpStatus.OK,
+        httpStatus: HttpStatus,
     ) {
-        testApi.doGetWithParamsWithoutResponse(url, params, httpStatus)
+        testApiConnection.doGetWithParamsWithoutBody(url, params, httpStatus)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestApi.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestApi.kt
@@ -43,7 +43,7 @@ class TestApi(val mapper: ObjectMapper, val mockMvc: MockMvc) {
         return doGet(request, expectedStatus)
     }
 
-    fun doGetWithParamsWithoutResponse(
+    fun doGetWithParamsWithoutBody(
         url: String,
         params: Map<String, String>,
         expectedStatus: HttpStatus,


### PR DESCRIPTION
Samalla refakkailtu aika merkittävisti tuota sisäistä rakennetta ext-api kutsuja varten. Sen avulla uusien asset- ja asset-listausten testirajapintoja voi luoda siis varsin yksinkertaisesti verrattuna aiempaan rakenteeseen, jossa 9 funkkaria per rajapintatyyppi (asset/asset-listaus) piti duplikoida. Nyt tarvitsee vain tehdä instanssi sisäluokasta eikä määrittää ainuttakaan uutta funktiota.