### PR TITLE
GVT-3270: Add initial automated tests for ext-api track numbers

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutDataV1.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutDataV1.kt
@@ -58,6 +58,34 @@ data class ExtTestModifiedLocationTrackCollectionResponseV1(
     val sijaintiraiteet: List<ExtTestLocationTrackV1>,
 )
 
+data class ExtTestTrackNumberV1(
+    val ratanumero_oid: String,
+    val ratanumero: String,
+    val kuvaus: String,
+    val tila: String,
+    val alkusijainti: ExtTestAddressPointV1?,
+    val loppusijainti: ExtTestAddressPointV1?,
+)
+
+data class ExtTestTrackNumberResponseV1(
+    val rataverkon_versio: String,
+    val koordinaatisto: String,
+    val ratanumero: ExtTestTrackNumberV1,
+)
+
+data class ExtTestModifiedTrackNumberResponseV1(
+    val alkuversio: String,
+    val loppuversio: String,
+    val koordinaatisto: String,
+    val ratanumero: ExtTestTrackNumberV1,
+)
+
+data class ExtTestTrackNumberGeometryResponseV1(
+    val rataverkon_versio: String,
+    val koordinaatisto: String,
+    val osoitevalit: List<ExtTestGeometryIntervalV1>,
+)
+
 data class ExtTestErrorResponseV1(
     val virheviesti: String,
     val korrelaatiotunnus: String,

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutTestApiService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutTestApiService.kt
@@ -22,6 +22,16 @@ class ExtTrackLayoutTestApiService(mockMvc: MockMvc) {
             ExtTestLocationTrackGeometryResponseV1::class,
         )
 
+    val trackNumbers =
+        AssetApi(
+            assetUrl = { oid -> "/geoviite/paikannuspohja/v1/ratanumerot/${oid}" },
+            ExtTestTrackNumberResponseV1::class,
+            modifiedUrl = { oid -> "/geoviite/paikannuspohja/v1/ratanumerot/${oid}/muutokset" },
+            ExtTestModifiedTrackNumberResponseV1::class,
+            geometryUrl = { oid -> "/geoviite/paikannuspohja/v1/ratanumerot/${oid}/geometria" },
+            ExtTestTrackNumberGeometryResponseV1::class,
+        )
+
     val locationTrackCollection =
         AssetCollectionApi(
             assetCollectionUrl = { "/geoviite/paikannuspohja/v1/sijaintiraiteet" },


### PR DESCRIPTION
Nyt kun soveltuvia testirakenteita on määritelty (aiempi pullari) niin uusien testien lisääminen asseteille on melko yksinkertaista.

Lisää ratanumerokohtaisia testejä luvassa myöhemmin, ja samoin pitää yleistää osa niistä collection-testeistä...