### PR TITLE
GVT-3219 Elide switch name-related validations on deleted location tracks

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -562,9 +562,12 @@ constructor(
                     } ?: listOf(noGeocodingContext(VALIDATION_LOCATION_TRACK))
                 } else listOf()
 
-            val startSwitch = track.startSwitchId?.let(validationContext::getSwitch)
-            val endSwitch = track.endSwitchId?.let(validationContext::getSwitch)
-            val switchNameIssues = validateLocationTrackEndSwitchNames(track, startSwitch, endSwitch)
+            val switchNameIssues =
+                if (track.exists) {
+                    val startSwitch = track.startSwitchId?.let(validationContext::getSwitch)
+                    val endSwitch = track.endSwitchId?.let(validationContext::getSwitch)
+                    validateLocationTrackEndSwitchNames(track, startSwitch, endSwitch)
+                } else listOf()
 
             val tracksWithSameName = validationContext.getLocationTracksByName(track.name)
             val nameDuplicationIssues =


### PR DESCRIPTION
Taski oli huomio siitä, että validaatioissa pitää ottaa huomioon se, että nyt kun raiteen poisto ei enää poista sen vaihdelinkkejä, raiteen validaantion pitää olla sallivampi. No, paljoa sallivampi ei tarvinnut olla: Koodia kaivelemalla ainoa selkeä tapaus, johon piti ottaa kantaa, oli tämä että validaatio välittää yhä siitä, että saa rakennettua nätin raiteen nimen, vaikka eihän sillä kai ole poiston jälkeen väliä.

Muuten olemassaoleva koodi osaakin jo välttää raiteen poiston jälkeen tarpeettomien asioiden validoinnin.