### PR TITLE
GVT-3297 (Part 3): Assettihaun parametrien dataclassifiointi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchController.kt
@@ -45,14 +45,14 @@ class LayoutSearchController(private val searchService: LayoutSearchService) {
         @RequestParam("types", required = true) types: List<TrackLayoutSearchedAssetType>,
         @RequestParam("includeDeleted", required = false) includeDeleted: Boolean = false,
     ): TrackLayoutSearchResult {
-        val layoutContext = LayoutContext.of(branch, publicationState)
-        return searchService.searchAssets(
-            layoutContext,
-            searchTerm,
-            limitPerResultType,
-            locationTrackSearchScope,
-            types,
-            includeDeleted,
-        )
+        val params =
+            AssetSearchParameters(
+                LayoutContext.of(branch, publicationState),
+                searchTerm,
+                limitPerResultType,
+                includeDeleted,
+            )
+
+        return searchService.searchAssets(locationTrackSearchScope, types, params)
     }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackController.kt
@@ -76,8 +76,9 @@ class LocationTrackController(
         @RequestParam("limit", required = true) limit: Int,
         @RequestParam("includeDeleted", required = false) includeDeleted: Boolean = false,
     ): List<LocationTrack> {
-        val context = LayoutContext.of(layoutBranch, publicationState)
-        return searchService.searchAllLocationTracks(context, searchTerm, limit, includeDeleted)
+        val params =
+            AssetSearchParameters(LayoutContext.of(layoutBranch, publicationState), searchTerm, limit, includeDeleted)
+        return searchService.searchAllLocationTracks(params)
     }
 
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -71,7 +71,10 @@ constructor(
         val trackNumbers = listOf(TrackNumber("track number 1"), TrackNumber("track number 11"))
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
-        assertEquals(0, searchService.searchAllTrackNumbers(searchParameters("tRaCk number", includeDeleted = false)).size)
+        assertEquals(
+            0,
+            searchService.searchAllTrackNumbers(searchParameters("tRaCk number", includeDeleted = false)).size,
+        )
     }
 
     @Test
@@ -82,16 +85,24 @@ constructor(
             val oid = Oid<LayoutTrackNumber>("1.2.3.4.5.6.$index")
             trackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, oid)
 
-            assertEquals(1, searchService.searchAllTrackNumbers(searchParameters(oid.toString(), includeDeleted = false)).size)
             assertEquals(
                 1,
-                searchService.searchAllTrackNumbers(searchParameters(trackNumberId.toString(), includeDeleted = false)).size,
+                searchService.searchAllTrackNumbers(searchParameters(oid.toString(), includeDeleted = false)).size,
+            )
+            assertEquals(
+                1,
+                searchService
+                    .searchAllTrackNumbers(searchParameters(trackNumberId.toString(), includeDeleted = false))
+                    .size,
             )
         }
 
         // LayoutState was set to DELETED, meaning that these track numbers should not be found by
         // free text.
-        assertEquals(0, searchService.searchAllTrackNumbers(searchParameters("tRaCk number", includeDeleted = false)).size)
+        assertEquals(
+            0,
+            searchService.searchAllTrackNumbers(searchParameters("tRaCk number", includeDeleted = false)).size,
+        )
     }
 
     @Test
@@ -286,25 +297,25 @@ constructor(
                 searchParameters("0001", includeDeleted = includeDeleted),
             )
 
-        val undeletedSearchResults = search(false)
-        val deletedSearchResults = search(true)
+        val searchResultsWithoutDeleted = search(false)
+        val searchResultsIncludingDeleted = search(true)
 
-        assertEquals(0, undeletedSearchResults.trackNumbers.size)
-        assertEquals(0, undeletedSearchResults.locationTracks.size)
-        assertEquals(0, undeletedSearchResults.switches.size)
-        assertEquals(0, undeletedSearchResults.kmPosts.size)
+        assertEquals(0, searchResultsWithoutDeleted.trackNumbers.size)
+        assertEquals(0, searchResultsWithoutDeleted.locationTracks.size)
+        assertEquals(0, searchResultsWithoutDeleted.switches.size)
+        assertEquals(0, searchResultsWithoutDeleted.kmPosts.size)
 
-        assertEquals(1, deletedSearchResults.locationTracks.size)
-        assertEquals(locationTrack.id, deletedSearchResults.locationTracks.first().id)
+        assertEquals(1, searchResultsIncludingDeleted.locationTracks.size)
+        assertEquals(locationTrack.id, searchResultsIncludingDeleted.locationTracks.first().id)
 
-        assertEquals(1, deletedSearchResults.trackNumbers.size)
-        assertEquals(trackNumber.id, deletedSearchResults.trackNumbers.first().id)
+        assertEquals(1, searchResultsIncludingDeleted.trackNumbers.size)
+        assertEquals(trackNumber.id, searchResultsIncludingDeleted.trackNumbers.first().id)
 
-        assertEquals(1, deletedSearchResults.switches.size)
-        assertEquals(sw.id, deletedSearchResults.switches.first().id)
+        assertEquals(1, searchResultsIncludingDeleted.switches.size)
+        assertEquals(sw.id, searchResultsIncludingDeleted.switches.first().id)
 
-        assertEquals(1, deletedSearchResults.kmPosts.size)
-        assertEquals(kmPost.id, deletedSearchResults.kmPosts.first().id)
+        assertEquals(1, searchResultsIncludingDeleted.kmPosts.size)
+        assertEquals(kmPost.id, searchResultsIncludingDeleted.kmPosts.first().id)
     }
 
     private fun saveTrackNumbersWithSaveRequests(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSearchServiceIT.kt
@@ -4,12 +4,12 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
-import fi.fta.geoviite.infra.geocoding.trackNumber
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory.EXISTING
 import fi.fta.geoviite.infra.util.FreeText
@@ -49,12 +49,9 @@ constructor(
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.IN_USE)
 
-        assertEquals(
-            2,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100, false).size,
-        )
-        assertEquals(3, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("11"), 100, false).size)
-        assertEquals(4, searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("1"), 100, false).size)
+        assertEquals(2, searchService.searchAllTrackNumbers(searchParameters("tRaCk number")).size)
+        assertEquals(3, searchService.searchAllTrackNumbers(searchParameters("11")).size)
+        assertEquals(4, searchService.searchAllTrackNumbers(searchParameters("1")).size)
     }
 
     @Test
@@ -62,19 +59,11 @@ constructor(
         val trackNumbers = (0..15).map { number -> TrackNumber("some track $number") }
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.IN_USE)
+        val params = searchParameters("some track")
 
-        assertEquals(
-            5,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 5, false).size,
-        )
-        assertEquals(
-            10,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 10, false).size,
-        )
-        assertEquals(
-            15,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("some track"), 15, false).size,
-        )
+        assertEquals(5, searchService.searchAllTrackNumbers(params.copy(limitPerResultType = 5)).size)
+        assertEquals(10, searchService.searchAllTrackNumbers(params.copy(limitPerResultType = 10)).size)
+        assertEquals(15, searchService.searchAllTrackNumbers(params.copy(limitPerResultType = 15)).size)
     }
 
     @Test
@@ -82,10 +71,7 @@ constructor(
         val trackNumbers = listOf(TrackNumber("track number 1"), TrackNumber("track number 11"))
 
         saveTrackNumbersWithSaveRequests(trackNumbers, LayoutState.DELETED)
-        assertEquals(
-            0,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100, false).size,
-        )
+        assertEquals(0, searchService.searchAllTrackNumbers(searchParameters("tRaCk number", includeDeleted = false)).size)
     }
 
     @Test
@@ -96,24 +82,16 @@ constructor(
             val oid = Oid<LayoutTrackNumber>("1.2.3.4.5.6.$index")
             trackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, oid)
 
+            assertEquals(1, searchService.searchAllTrackNumbers(searchParameters(oid.toString(), includeDeleted = false)).size)
             assertEquals(
                 1,
-                searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText(oid.toString()), 100, false).size,
-            )
-            assertEquals(
-                1,
-                searchService
-                    .searchAllTrackNumbers(MainLayoutContext.draft, FreeText(trackNumberId.toString()), 100, false)
-                    .size,
+                searchService.searchAllTrackNumbers(searchParameters(trackNumberId.toString(), includeDeleted = false)).size,
             )
         }
 
         // LayoutState was set to DELETED, meaning that these track numbers should not be found by
         // free text.
-        assertEquals(
-            0,
-            searchService.searchAllTrackNumbers(MainLayoutContext.draft, FreeText("tRaCk number"), 100, false).size,
-        )
+        assertEquals(0, searchService.searchAllTrackNumbers(searchParameters("tRaCk number", includeDeleted = false)).size)
     }
 
     @Test
@@ -126,8 +104,7 @@ constructor(
         val kp3 = mainDraftContext.save(kmPost(trackNumberId = trackNumber2.id, KmNumber(1234)))
         val kp4 = mainDraftContext.save(kmPost(trackNumberId = trackNumber1.id, KmNumber(4321)))
 
-        val result =
-            searchService.searchAllKmPosts(MainLayoutContext.draft, FreeText("1234"), 10, false).map { it.version }
+        val result = searchService.searchAllKmPosts(searchParameters("1234")).map { it.version }
         assertEquals(3, result.size)
         assertContains(result, kp1)
         assertContains(result, kp2)
@@ -139,8 +116,7 @@ constructor(
         val trackNumber1 = mainDraftContext.save(trackNumber(TrackNumber("001")))
         mainDraftContext.save(kmPost(trackNumberId = trackNumber1.id, KmNumber(1234)))
 
-        val result =
-            searchService.searchAllKmPosts(MainLayoutContext.draft, FreeText("123"), 10, false).map { it.version }
+        val result = searchService.searchAllKmPosts(searchParameters("123")).map { it.version }
         assertEquals(0, result.size)
     }
 
@@ -225,16 +201,13 @@ constructor(
 
         val searchResults =
             searchService.searchAssets(
-                MainLayoutContext.draft,
-                FreeText("bl"),
-                100,
                 lt1.id,
                 listOf(
                     TrackLayoutSearchedAssetType.LOCATION_TRACK,
                     TrackLayoutSearchedAssetType.SWITCH,
                     TrackLayoutSearchedAssetType.TRACK_NUMBER,
                 ),
-                false,
+                searchParameters("bl"),
             )
 
         assertEquals(3, searchResults.locationTracks.size)
@@ -259,17 +232,13 @@ constructor(
 
         fun search(term: String, branch: LayoutBranch) =
             searchService.searchAssets(
-                branch.draft,
-                FreeText(term),
-                100,
                 locationTrackSearchScope = null,
-                searchedAssetTypes =
-                    listOf(
-                        TrackLayoutSearchedAssetType.LOCATION_TRACK,
-                        TrackLayoutSearchedAssetType.SWITCH,
-                        TrackLayoutSearchedAssetType.TRACK_NUMBER,
-                    ),
-                false,
+                listOf(
+                    TrackLayoutSearchedAssetType.LOCATION_TRACK,
+                    TrackLayoutSearchedAssetType.SWITCH,
+                    TrackLayoutSearchedAssetType.TRACK_NUMBER,
+                ),
+                searchParameters(term, branch.draft),
             )
 
         val tn = testDBService.fetch(trackNumberVersion)
@@ -307,9 +276,6 @@ constructor(
 
         fun search(includeDeleted: Boolean) =
             searchService.searchAssets(
-                MainLayoutContext.official,
-                FreeText("0001"),
-                100,
                 locationTrackSearchScope = null,
                 listOf(
                     TrackLayoutSearchedAssetType.LOCATION_TRACK,
@@ -317,7 +283,7 @@ constructor(
                     TrackLayoutSearchedAssetType.TRACK_NUMBER,
                     TrackLayoutSearchedAssetType.KM_POST,
                 ),
-                includeDeleted,
+                searchParameters("0001", includeDeleted = includeDeleted),
             )
 
         val undeletedSearchResults = search(false)
@@ -356,4 +322,11 @@ constructor(
             }
             .map { saveRequest -> trackNumberService.insert(LayoutBranch.main, saveRequest).id }
     }
+
+    private fun searchParameters(
+        term: String,
+        layoutContext: LayoutContext = MainLayoutContext.draft,
+        limit: Int = 100,
+        includeDeleted: Boolean = false,
+    ) = AssetSearchParameters(layoutContext, FreeText(term), limit, includeDeleted)
 }


### PR DESCRIPTION
Käytännössä melko lailla tämän reviewkommentin mukaisesti: https://github.com/finnishtransportagency/geoviite/pull/1912#discussion_r2362305585

Ihan kaikkia parametreja en päätynyt tuonne uuteen data classiin tunkemaan. Syynä se, että nämä kaikki parametrit ovat sellaisia jotka voidaan välittää kivasti lähes kaikille, myös assettityyppikohtaisille hakufunktioille. Vaikka niiden logiikkaa ei sinällään haittaisi ottaa sisäänsä sijaintiraidehakuskooppia tai etsittyjä assettityyppejä, niin niiden toistaminen sellaisissa testeissä mitkä eivät niillä mitään tehneet, tuntui koodihaisulta -- varsinkin kun ka. data oikeasti oli testattavien funktioiden näkökannalta täysin turhaa.