### PR TITLE
General: Clean up todo from new switch linking. This is handled in to pology linking.

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTest.kt
@@ -319,15 +319,6 @@ class SwitchFittingTest {
         assertJoint(fitted, 2, trackA.locationTrack, expectedM = LineM(distance1to2))
         assertJoint(fitted, 1, trackC.locationTrack, expectedM = LineM(0.0))
         assertJoint(fitted, 3, trackC.locationTrack, expectedM = LineM(distance1to3.distance))
-
-        // TODO: Selvitettävä vielä, vaikka todennäköisesti tällä ei ole juuri merkitystä.
-        /*
-        Eli track B:n osalta snäppäystä ei tällä hetkellä tapahdu, vaan getBestMatchesForJoint-funktio
-        suodattaa pois snpäpätyn matchin, jolloin jää jäljelle snäppäämätön match. Näin tapahtuu, koska tällä
-        raiteella on match vain yhteen jointtiin (numero 1), jolloin joint 1 on sekä start että end joint,
-        jolloin end tyyppinen match suodattuu pois.
-        */
-        // assertJoint(fitted, 1, trackB.locationTrack, expectedM = trackBLength)
     }
 
     @Test


### PR DESCRIPTION
Pelkkä kommentoidun jutun siivous, mutta pistän 1.19 kautta koska alkuperäinen TODO liittyy 1.19 muutoksien loppuselvityksiin (ja koska 1.19 on muutenkin julkaisu vielä tulossa).