### PR TITLE
GVT-3149 Add OID generation facilities

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/GeoviiteOidDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/GeoviiteOidDao.kt
@@ -1,0 +1,26 @@
+package fi.fta.geoviite.infra.common
+
+import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.getOid
+import fi.fta.geoviite.infra.util.queryOne
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+
+enum class OidType {}
+
+enum class OidSequenceState {
+    ACTIVE,
+    DEPRECATED,
+}
+
+@Component
+class GeoviiteOidDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+    fun <T> reserveOid(type: OidType) {
+        val sql =
+            """
+                select common.generate_oid(:type) as oid
+            """
+                .trimIndent()
+        return jdbcTemplate.queryOne(sql, mapOf("type" to type.name)) { rs, _ -> rs.getOid<T>("oid") }
+    }
+}

--- a/infra/src/main/resources/db/migration/prod/V129__add_oid_generation.sql
+++ b/infra/src/main/resources/db/migration/prod/V129__add_oid_generation.sql
@@ -1,0 +1,58 @@
+create table common.oid_spaces
+(
+  name      text not null primary key,
+  oid_space text not null,
+  constraint oid_spaces_oid_space_uk unique (oid_space)
+);
+
+insert into common.oid_spaces
+  values
+    ('Geoviite', '1.2.246.578.13');
+
+
+create table common.oid_types
+(
+  type_name text not null primary key
+);
+
+create type common.oid_sequence_state as enum (
+  'ACTIVE',
+  'DEPRECATED'
+  );
+
+create table common.oid_sequences
+(
+  group_number integer                   not null,
+  number       integer                   not null,
+  service_oid  text                      not null,
+  type         text                      not null references common.oid_types (type_name),
+  state        common.oid_sequence_state not null,
+  oid          text                      not null generated always as (service_oid || '.' || group_number || '.' || number) stored,
+  seq_name     text                      not null generated always as ('oid_' || service_oid || '.' || group_number || '.' || number || '_seq') stored,
+  primary key (group_number, number),
+  constraint oid_sequences_service_oid_fk foreign key (service_oid) references common.oid_spaces (oid_space),
+  constraint oid_sequences_type_uk unique (type)
+);
+
+create function insert_oid_sequence() returns trigger as
+$$
+begin
+  execute format('create sequence if not exists common.%I', new.seq_name);
+  return new;
+end;
+$$
+  language plpgsql;
+
+create trigger insert_oid_sequence_trigger
+  after insert
+  on common.oid_sequences
+  for each row
+execute function insert_oid_sequence();
+
+create function common.generate_oid(type_in text) returns text as
+$$
+select service_oid || '.' || group_number || '.' || number || '.' || nextval(format('common.%I', seq_name))
+  from common.oid_sequences
+  where type = type_in
+$$
+  language sql;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/GeoviiteOidDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/GeoviiteOidDaoIT.kt
@@ -1,0 +1,58 @@
+package fi.fta.geoviite.infra.common
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
+import fi.fta.geoviite.infra.util.getOid
+import fi.fta.geoviite.infra.util.queryOne
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class GeoviiteOidDaoIT @Autowired constructor(val geoviiteOidDao: GeoviiteOidDao) : DBTestBase() {
+
+    @Test
+    fun `create a new oid sequence and generate oids from it`() {
+        transactionalForcingRollback {
+            jdbc.execute("""insert into common.oid_types values('abc')""") { it.execute() }
+            jdbc.execute(
+                """
+                    insert into common.oid_sequences(type, service_oid, group_number, number, state)
+                    values ('abc', '1.2.246.578.13', 123, 456, 'ACTIVE')
+                """
+                    .trimIndent()
+            ) {
+                it.execute()
+            }
+            val a =
+                jdbc.queryOne("select common.generate_oid(:type) as oid", mapOf("type" to "abc")) { rs, _ ->
+                    rs.getOid<LayoutKmPost>("oid")
+                }
+            val b =
+                jdbc.queryOne("select common.generate_oid(:type) as oid", mapOf("type" to "abc")) { rs, _ ->
+                    rs.getOid<LayoutKmPost>("oid")
+                }
+            val c =
+                jdbc.queryOne("select common.generate_oid(:type) as oid", mapOf("type" to "abc")) { rs, _ ->
+                    rs.getOid<LayoutKmPost>("oid")
+                }
+            assertEquals("1.2.246.578.13.123.456.1", a.toString())
+            assertEquals("1.2.246.578.13.123.456.2", b.toString())
+            assertEquals("1.2.246.578.13.123.456.3", c.toString())
+        }
+    }
+
+    private fun transactionalForcingRollback(callback: () -> Unit) {
+        try {
+            transactional {
+                callback()
+                throw ForceRollback()
+            }
+        } catch (_: ForceRollback) {}
+    }
+}
+
+private class ForceRollback : RuntimeException()


### PR DESCRIPTION
Tiketissä oli speksattu parikin asiaa vähän kyseenalaisesti, joten esitänpä pullarin muodossa, mitkä on sellaisia että pitää ihan selvästi tehdä eri tavalla, ja mitkä sellaisia että öö mitenkähän tämä olisi järkevintä tehdä.

Nyt:

- oid_types on taulu, ei tyyppi. Postgressin enumit on muutenkin aika ärsyttäviä käyttää yhtikäs laisinkaan dynaamiselle tiedolle. Tässä tapauksessa siitä piti tehdä taulu, jotta pystyy kirjoittamaan yhtäkään testinkään näköistä asiaa tälle koodille, koska postgressissä arvojen lisääminen enumiin ei ole transaktion sisällä tuettu operaatio (ts. uutta arvoa voi käyttää vasta kun se on kommitoitu), ja arvojen poistuminen enumista ei onnistu lainkaan
- oid-sekvenssien nimissä on mukana koko prefiksi, ja siinähän on oid-rakenteen pisteet mukana siis. Siispä niihin ei pysty viittaamaan käyttämättä heittomerkkejä tai format('%I'):tä
- generate_oid ei etsi sekvenssejä muuten kuin pelkän tyypin perusteella, eli periaatteessa koko oid_sequences-taulu on aika ylimääräistä asiaa. Mutta kyyyllä sen olemassaolo kai jonkin verran elämää selkeyttää, ja tulevaisuudessa jos vaikka päätetäänkin että nyt aloitetaan uusi km-tolppien sekvenssi tästä uudesta kohti, voidaan vaikka laajentaa generate_oid-funktiota hakemaan tyyppikohtaisesti uusin sekvenssi tjsp..