### PR TITLE
GVT-3087 Add debug projection lines layer

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingController.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.util.toResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -38,6 +39,23 @@ class GeocodingController(
     ): ResponseEntity<TrackMeter> {
         val layoutContext = LayoutContext.of(branch, publicationState)
         return toResponse(geocodingService.getAddressIfWithin(layoutContext, trackNumberId, coordinate))
+    }
+
+    @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
+    @GetMapping("/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/projection-lines/{trackNumberId}")
+    fun getMeterProjectionLines(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
+        @PathVariable("trackNumberId") trackNumberId: IntId<LayoutTrackNumber>,
+    ): ResponseEntity<List<ProjectionLine<ReferenceLineM>>> {
+        val layoutContext = LayoutContext.of(branch, publicationState)
+        return toResponse(
+            geocodingService
+                .getGeocodingContext(layoutContext, trackNumberId)
+                ?.projectionLines
+                ?.getValue(Resolution.ONE_METER)
+                ?.value
+        )
     }
 
     @PreAuthorize(AUTH_VIEW_LAYOUT)

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1389,6 +1389,7 @@
         "geometry-km-post": "Suunnitelman tasakilometripisteet",
         "operating-points": "Liikennepaikat",
         "debug-1m": "Tasametripisteet",
+        "debug-projection-lines": "Geokoodauksen projektioviivat",
         "debug": "Debug",
         "debug-layout-graph": "Raidegraafi",
         "debug-layout-graph-nano": "Nano-tason graafi"

--- a/ui/src/common/geocoding-api.ts
+++ b/ui/src/common/geocoding-api.ts
@@ -3,11 +3,12 @@ import {
     LayoutTrackNumberId,
     LocationTrackId,
 } from 'track-layout/track-layout-model';
-import { Point } from 'model/geometry';
-import { LayoutContext, TrackMeter } from 'common/common-model';
+import { Line, Point } from 'model/geometry';
+import { LayoutContext, TimeStamp, TrackMeter } from 'common/common-model';
 import { API_URI, getNullable, queryParams } from 'api/api-fetch';
 import { pointString } from 'common/common-api';
 import { contextInUri } from 'track-layout/track-layout-api';
+import { asyncCache } from 'cache/cache';
 
 export const GEOCODING_URI = `${API_URI}/geocoding`;
 
@@ -27,6 +28,15 @@ export type AlignmentAddresses = {
     midPoints: AddressPoint[];
 };
 
+export type ProjectionLine = {
+    address: TrackMeter;
+    projection: Line;
+    referenceLineM: number;
+    referenceDirection: number;
+};
+
+const projectionLinesCache = asyncCache<LayoutTrackNumberId, ProjectionLine[] | undefined>();
+
 function geocodingUri(layoutContext: LayoutContext) {
     return `${GEOCODING_URI}/${contextInUri(layoutContext)}`;
 }
@@ -41,6 +51,18 @@ export async function getAddress(
     });
     return getNullable<TrackMeter>(
         `${geocodingUri(layoutContext)}/address/${trackNumberId}${params}`,
+    );
+}
+
+export async function getProjectionLines(
+    trackNumberId: LayoutTrackNumberId,
+    layoutContext: LayoutContext,
+    changeTime: TimeStamp,
+): Promise<ProjectionLine[] | undefined> {
+    return projectionLinesCache.get(changeTime, trackNumberId, () =>
+        getNullable(`${geocodingUri(layoutContext)}/projection-lines/${trackNumberId}`).then(
+            (data: ProjectionLine[] | undefined) => data,
+        ),
     );
 }
 

--- a/ui/src/map/layers/debug/debug-projection-lines-layer.ts
+++ b/ui/src/map/layers/debug/debug-projection-lines-layer.ts
@@ -1,0 +1,135 @@
+import Feature from 'ol/Feature';
+import OlView from 'ol/View';
+import { LineString } from 'ol/geom';
+import { Selection } from 'selection/selection-model';
+import { Stroke } from 'ol/style';
+import { LayoutContext } from 'common/common-model';
+import { getProjectionLines, ProjectionLine } from 'common/geocoding-api';
+import { DEBUG_PROJECTION_LINES } from '../utils/layer-visibility-limits';
+import { MapLayer } from 'map/layers/utils/layer-model';
+import {
+    createLayer,
+    GeoviiteMapLayer,
+    loadLayerData,
+    pointToCoords,
+} from 'map/layers/utils/layer-utils';
+import { first } from 'utils/array-utils';
+import { MapLayerName } from 'map/map-model';
+import { formatTrackMeter } from 'utils/geography-utils';
+import { ChangeTimes } from 'common/common-slice';
+import { getMaxTimestamp } from 'utils/date-utils';
+import { coordsToPoint, Line } from 'model/geometry';
+import { getLocationTrack } from 'track-layout/layout-location-track-api';
+import { expectDefined } from 'utils/type-utils';
+
+function extrapolateProjectionLine(line: Line, extrapolateToMeters: number): Line {
+    const dx = line.end.x - line.start.x;
+    const dy = line.end.y - line.start.y;
+    const length = Math.sqrt(dx * dx + dy * dy);
+    const ex = (dx / length) * extrapolateToMeters;
+    const ey = (dy / length) * extrapolateToMeters;
+
+    return {
+        start: { x: line.start.x - ex, y: line.start.y - ey },
+        end: { x: line.start.x + ex, y: line.start.y + ey },
+    };
+}
+
+const PROJECTION_LINE_EXTRAPOLATION_LENGTH = 1000;
+
+function createProjectionLineFeatures(
+    data: ProjectionLine[],
+    olView: OlView,
+): Feature<LineString>[] {
+    const style = {
+        stroke: new Stroke({
+            color: '#0000FF',
+            lineDash: [1, 20],
+            width: 5,
+        }),
+    };
+    // extremely ad-hoc optimization to make long reference lines destroy Firefox less completely: Avoid rendering
+    // distant projection lines
+    const viewCenter = olView.getCenter();
+    if (viewCenter === undefined) {
+        return [];
+    }
+    const centerPoint = coordsToPoint(viewCenter);
+    const dataToRender: ProjectionLine[] = [];
+    for (let i = 0; i < data.length; i += 1000) {
+        const point = expectDefined(data[i]).projection.start;
+        const dx = point.x - centerPoint.x,
+            dy = point.y - centerPoint.y;
+        if (
+            dx * dx + dy * dy <
+            PROJECTION_LINE_EXTRAPOLATION_LENGTH * PROJECTION_LINE_EXTRAPOLATION_LENGTH * 4
+        ) {
+            dataToRender.push(...data.slice(i, i + 1000));
+        }
+    }
+
+    return dataToRender.map((projectionLine) => {
+        const line = extrapolateProjectionLine(
+            projectionLine.projection,
+            PROJECTION_LINE_EXTRAPOLATION_LENGTH,
+        );
+        return new Feature({
+            geometry: new LineString([pointToCoords(line.start), pointToCoords(line.end)]),
+            text: formatTrackMeter(projectionLine.address),
+            style,
+        });
+    });
+}
+
+const layerName: MapLayerName = 'debug-projection-lines-layer';
+
+async function getDataPromise(
+    selection: Selection,
+    layoutContext: LayoutContext,
+    changeTimes: ChangeTimes,
+): Promise<ProjectionLine[] | undefined> {
+    const selectedLocationTrack = first(selection.selectedItems.locationTracks);
+
+    const trackNumberId =
+        first(selection.selectedItems.trackNumbers) ??
+        (
+            selectedLocationTrack &&
+            (await getLocationTrack(
+                selectedLocationTrack,
+                layoutContext,
+                changeTimes.layoutLocationTrack,
+            ))
+        )?.trackNumberId;
+
+    return (
+        trackNumberId &&
+        getProjectionLines(
+            trackNumberId,
+            layoutContext,
+            getMaxTimestamp(changeTimes.layoutReferenceLine, changeTimes.layoutKmPost),
+        )
+    );
+}
+
+export function createDebugProjectionLinesLayer(
+    existingOlLayer: GeoviiteMapLayer<LineString> | undefined,
+    selection: Selection,
+    layoutContext: LayoutContext,
+    resolution: number,
+    changeTimes: ChangeTimes,
+    olView: OlView,
+    onLoadingData: (loading: boolean) => void,
+): MapLayer {
+    const { layer, source, isLatest } = createLayer(layerName, existingOlLayer);
+
+    const dataPromise =
+        resolution > DEBUG_PROJECTION_LINES
+            ? Promise.resolve(undefined)
+            : getDataPromise(selection, layoutContext, changeTimes);
+
+    const createFeatures = (projectionLines: ProjectionLine[] | undefined) =>
+        projectionLines ? createProjectionLineFeatures(projectionLines, olView) : [];
+    loadLayerData(source, isLatest, onLoadingData, dataPromise, createFeatures);
+
+    return { name: layerName, layer: layer };
+}

--- a/ui/src/map/layers/utils/layer-visibility-limits.ts
+++ b/ui/src/map/layers/utils/layer-visibility-limits.ts
@@ -3,6 +3,7 @@ import { MapLayerName } from 'map/map-model';
 export const GEOMETRY_GRAPH = 50.0;
 export const LINKING_DOTS = 0.19;
 export const DEBUG_1M_POINTS = 0.06;
+export const DEBUG_PROJECTION_LINES = 1.0;
 
 export const HIGHLIGHTS_SHOW = 100.0;
 

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -46,6 +46,7 @@ export type MapLayerName =
     | 'plan-area-layer'
     | 'operating-points-layer'
     | 'debug-1m-points-layer'
+    | 'debug-projection-lines-layer'
     | 'debug-layer'
     | 'virtual-km-post-linking-layer'
     | 'virtual-hide-geometry-layer'
@@ -112,6 +113,7 @@ export type MapLayerMenuItemName =
     | 'geometry-km-post'
     | 'operating-points'
     | 'debug-1m'
+    | 'debug-projection-lines'
     | 'debug'
     | 'debug-layout-graph'
     | 'debug-layout-graph-nano';

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -109,6 +109,7 @@ const layerMenuItemMapLayers: Record<MapLayerMenuItemName, MapLayerName[]> = {
     'geometry-km-post': ['geometry-km-post-layer'],
     'operating-points': ['operating-points-layer'],
     'debug-1m': ['debug-1m-points-layer'],
+    'debug-projection-lines': ['debug-projection-lines-layer'],
     'debug': ['debug-layer'],
     'debug-layout-graph': ['debug-geometry-graph-layer'],
     'debug-layout-graph-nano': [], // This is technically a setting, not a map layer by itself.
@@ -188,6 +189,7 @@ export const initialMapState: Map = {
         ],
         debug: [
             { name: 'debug-1m', visible: false },
+            { name: 'debug-projection-lines', visible: false },
             { name: 'debug', visible: false },
             {
                 name: 'debug-layout-graph',

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -92,6 +92,7 @@ import { useResizeObserver } from 'utils/use-resize-observer';
 import { createDebugGeometryGraphLayer } from 'map/layers/debug/debug-geometry-graph-layer';
 import { PlanDownloadState } from 'map/plan-download/plan-download-store';
 import { PlanDownloadPopup } from 'map/plan-download/plan-download-popup';
+import { createDebugProjectionLinesLayer } from 'map/layers/debug/debug-projection-lines-layer';
 
 declare global {
     interface Window {
@@ -710,6 +711,16 @@ const MapView: React.FC<MapViewProps> = ({
                             selection,
                             layoutContext,
                             resolution,
+                            (loading) => onLayerLoading(layerName, loading),
+                        );
+                    case 'debug-projection-lines-layer':
+                        return createDebugProjectionLinesLayer(
+                            existingOlLayer as GeoviiteMapLayer<LineString>,
+                            selection,
+                            layoutContext,
+                            resolution,
+                            changeTimes,
+                            olView,
                             (loading) => onLayerLoading(layerName, loading),
                         );
                     case 'debug-layer':


### PR DESCRIPTION
Pelkkä debug-taso, eli tässä ei ole nyt erityisen tarkkaan pyritty minimoimaan ylimääräisen datan kuskausta (ratanumerolla 006 tulee parisataa megatavua projektioviivoja) taikka optimoimaan renderöimistä enemmän kuin juuri ja juuri sen verran ettei selaimet ihan kaadu. Mutta perustoimiva geokoodauksen havainnollistamiseen.