### PR TITLE
General: Only validate first instance of a split switch structure alignment

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -426,6 +426,9 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
                         ),
                     )
                 }
-            SwitchConnectivity(alignments = linkableFullAlignments + linkableSplitAlignments, frontJoint = null)
+            SwitchConnectivity(
+                alignments = linkableFullAlignments + linkableSplitAlignments.distinctBy { it.joints },
+                frontJoint = null,
+            )
         }
     }


### PR DESCRIPTION
Varsin ad-hoc-fiksi siihen ongelmaan, että kun KRV-vaihteille on nyt lisätty viitospiste poikkeavien linjojen keskelle niin että on olemassa linjat 1-5-3 ja 4-5-2, vaihteiden topologiavalidointi näkee nyt paloitellut keskipisteeseen päättyvät linjat (eli 1-5, 4-5, 5-2 ja 5-3) kaikki kahtena, ja valittaa erikseen duplikaattilinkityksistä molemmille. Eli käytännössä ylimääräisestä koko vaihteen yli kulkevasta raiteesta tulee kaksi ylimääräistä duplikaattilinkitysvirhettä.

Tämä ei ole ihan sataprosenttinen ratkaisu, koska nythän vaihteen rakenteessa aiemmin määritellyt linjat tulevat hämmentävällä tavalla etuoikeutetuiksi; tämä vaan sattuu menemään oikein päin niin että olemassaolevat testit korjaantuu, koska muutetut linjat sattuvat olemaan vaihderakenteessa listan lopussa. Tiketöin erikseen ajattelun siitä, miten tämän saisi tehtyä aiheuttamatta tällaisia sudenkuoppia missä vaihderakenteen linjojen järjestys vaikuttaa validointiin näin.