### PR TITLE
GVT-3315 Fix partial duplicate edge merging in split

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -46,11 +46,9 @@ import fi.fta.geoviite.infra.tracklayout.TopologicalConnectivityType
 import fi.fta.geoviite.infra.tracklayout.topologicalConnectivityTypeOf
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.produceIf
+import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
-import kotlin.math.max
-import kotlin.math.min
 
 const val MAX_SPLIT_GEOM_ADJUSTMENT = 5.0
 
@@ -621,10 +619,12 @@ private fun connectPartialDuplicateEdges(
                 ?: failEdgeConnection(replacements.last(), e)
         }
     // The edges before and after the connecting ones are taken as-is
-    // Note: sublist in end-exclusive so hitting the min/max limits results in an empty list, as desired
-    val startEdges = geometry.edges.subList(0, max(0, replacementIndices.first - 2))
-    val endEdges = geometry.edges.subList(min(replacementIndices.last + 2, geometry.edges.size), geometry.edges.size)
-    return startEdges + listOfNotNull(startConnection) + replacements + listOfNotNull(endConnection) + endEdges
+    val startEdges =
+        if (replacementIndices.first <= 1) emptyList() else geometry.edges.subList(0, replacementIndices.first - 1)
+    val endEdges =
+        if (replacementIndices.last >= geometry.edges.lastIndex - 1) emptyList()
+        else geometry.edges.subList(replacementIndices.last + 2, geometry.edges.size)
+    return (startEdges + listOfNotNull(startConnection) + replacements + listOfNotNull(endConnection) + endEdges)
 }
 
 private fun failEdgeConnection(prev: LayoutEdge, next: LayoutEdge): Nothing =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -3,10 +3,16 @@ package fi.fta.geoviite.infra.tracklayout
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.linking.createGapIfNeeded
+import fi.fta.geoviite.infra.linking.slice
 import fi.fta.geoviite.infra.linking.splitSegments
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Range
+import fi.fta.geoviite.infra.math.angleDiffRads
 import fi.fta.geoviite.infra.math.boundingBoxCombining
+import fi.fta.geoviite.infra.math.directionBetweenPoints
+import fi.fta.geoviite.infra.math.isSame
+import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.LayoutNodeType.SWITCH
 import fi.fta.geoviite.infra.tracklayout.LayoutNodeType.TRACK_BOUNDARY
@@ -17,6 +23,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackBoundaryType.START
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType.INNER
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType.OUTER
 import java.util.*
+import kotlin.math.PI
 import kotlin.math.abs
 
 enum class TrackSwitchLinkType {
@@ -450,6 +457,48 @@ sealed class LayoutEdge : IAlignment<EdgeM> {
         val newEnd = endNode.takeIf { n -> n.type != TRACK_BOUNDARY } ?: endNode.withInnerBoundary(id, END)
         return if (newStart == startNode && newEnd == endNode) this else TmpLayoutEdge(newStart, newEnd, segments)
     }
+
+    private fun findStartConnectionM(preceding: LayoutEdge, seekDistance: Double, tolerance: Double): LineM<EdgeM>? {
+        if (firstSegmentStart.isSame(preceding.lastSegmentEnd, tolerance)) return LineM(0.0)
+        val prevEnd = preceding.lastSegmentEnd
+        val prevEndDirection = preceding.segments.last().endDirection
+        return allAlignmentPoints
+            .takeWhile { p -> lineLength(prevEnd, p) <= seekDistance }
+            .firstOrNull { p -> angleDiffRads(prevEndDirection, directionBetweenPoints(prevEnd, p)) < PI / 2 }
+            ?.m
+    }
+
+    private fun findEndConnectionM(following: LayoutEdge, seekDistance: Double, tolerance: Double): LineM<EdgeM>? {
+        if (lastSegmentEnd.isSame(following.firstSegmentStart, tolerance)) return length
+        val nextStart = following.firstSegmentStart
+        val nextStartDirection = following.segments.first().startDirection
+        return allAlignmentPointsDownward
+            .takeWhile { p -> lineLength(p, nextStart) <= seekDistance }
+            .firstOrNull { p -> angleDiffRads(nextStartDirection, directionBetweenPoints(p, nextStart)) < PI / 2 }
+            ?.m
+    }
+
+    fun connectStartFrom(
+        previousEdge: LayoutEdge,
+        maxAdjustDistance: Double,
+        tolerance: Double = LAYOUT_M_DELTA,
+    ): LayoutEdge? =
+        findStartConnectionM(previousEdge, maxAdjustDistance, tolerance)?.let { startConnectionM ->
+            val slicedSegments =
+                segments.takeIf { isSame(startConnectionM.distance, 0.0, tolerance) }
+                    ?: slice(segmentsWithM, Range(startConnectionM, length), tolerance)
+            val connectSegment = createGapIfNeeded(previousEdge.segments, slicedSegments)
+            withSegments(listOfNotNull(connectSegment) + slicedSegments)
+        }
+
+    fun connectEndTo(nextEdge: LayoutEdge, maxAdjustDistance: Double, tolerance: Double = LAYOUT_M_DELTA): LayoutEdge? =
+        findEndConnectionM(nextEdge, maxAdjustDistance, tolerance)?.let { endConnectionM ->
+            val slicedSegments =
+                segments.takeIf { isSame(endConnectionM.distance, length.distance, tolerance) }
+                    ?: slice(segmentsWithM, Range(LineM(0.0), endConnectionM), tolerance)
+            val connectSegment = createGapIfNeeded(slicedSegments, nextEdge.segments)
+            withSegments(slicedSegments + listOfNotNull(connectSegment))
+        }
 }
 
 data class TmpLayoutEdge(


### PR DESCRIPTION
Osittaisen duplikaatin splitissa tehdään nykyään geometrioiden yhdistelyä, siinä missä aiemmin logiikka oli ottaa splitissä aina koko raiteen geometria yhdestä paikasta. Koska geometriat tulee nyt eri paikoista (pätkä sourcelta, loput duplikaatilta) ne eivät välttämätt osu juuri täydellisesti kohdikain vaan pitää sovittaa yhteen.

Geometriaa joudutaan muokkaamaan kahdella tavalla:
- Jos geometriat kulkevat päällekäin yhdyskohdassa, täytyy suodattaa joitain pisteitä pois jotta vältetään sik-sak
- Jos geometriat eivät yllä aivan yhteen, täytyy väliin generoida pieni yhdyssegment liittämään ne
Molemmat voivat tapahtua myös yhtä aikaa (yhdyskohdassa raiteet kulkee rinnakain pätkän niin että niiden välissä on sivuttaissunnassa gap).

Pohdiskelun ja harhapolun jälkeen tämä on toteutettu niin että duplikaatin geometria sovitetaan lähderaiteelta tulevaan eikä päinvastoin, jolloin koko alkuperäisen lähderaiteen geometria pitäisi löytyä joltain splitin tulokselta muokkaamattomana (... paitsi vaihdelinkityksien takia).