### PR TITLE
GVT-3548 Part 2: Sijaintiraiteen vaihdeinfoboksin ja toiminnalliset pisteet -infoboksin refaktorointi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -296,11 +296,18 @@ data class LocationTrackInfoboxExtras(
     val startSplitPoint: SplitPoint?,
     val endSplitPoint: SplitPoint?,
     val switches: List<LocationTrackInfoboxSwitch>,
+    val operationalPoints: List<LocationTrackInfoboxOperationalPoint>,
 )
 
 data class LocationTrackInfoboxSwitch(
     val switchId: IntId<LayoutSwitch>,
     val location: Point,
+    val displayAddress: TrackMeter?,
+)
+
+data class LocationTrackInfoboxOperationalPoint(
+    val operationalPointId: IntId<OperationalPoint>,
+    val location: Point?,
     val displayAddress: TrackMeter?,
 )
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -522,12 +522,10 @@ class LocationTrackService(
                                 operationalPointId = op.id as IntId,
                                 location = opLocation,
                                 displayAddress =
-                                    opLocation?.let { loc ->
-                                        geocodingContext
-                                            ?.getAddress(loc)
-                                            ?.takeIf { (_, intersectType) -> intersectType == IntersectType.WITHIN }
-                                            ?.first
-                                    },
+                                    opLocation
+                                        ?.let { loc -> geocodingContext?.getAddress(loc) }
+                                        ?.takeIf { (_, intersectType) -> intersectType == IntersectType.WITHIN }
+                                        ?.first,
                             )
                         }
                         .sortedBy { op -> op.displayAddress }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -511,6 +511,28 @@ class LocationTrackService(
                     .values
                     .sortedBy { it.displayAddress }
 
+            val operationalPoints =
+                track.operationalPointIds.let { opIds ->
+                    val versions = operationalPointDao.fetchVersions(layoutContext, true, opIds.toList())
+                    operationalPointDao
+                        .fetchMany(versions)
+                        .map { op ->
+                            val opLocation = op.location
+                            LocationTrackInfoboxOperationalPoint(
+                                operationalPointId = op.id as IntId,
+                                location = opLocation,
+                                displayAddress =
+                                    opLocation?.let { loc ->
+                                        geocodingContext
+                                            ?.getAddress(loc)
+                                            ?.takeIf { (_, intersectType) -> intersectType == IntersectType.WITHIN }
+                                            ?.first
+                                    },
+                            )
+                        }
+                        .sortedBy { op -> op.displayAddress }
+                }
+
             LocationTrackInfoboxExtras(
                 duplicateOf,
                 duplicates,
@@ -518,6 +540,7 @@ class LocationTrackService(
                 startSplitPoint,
                 endSplitPoint,
                 switches,
+                operationalPoints,
             )
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -1194,6 +1194,46 @@ constructor(
         assertTrue(oidMatchFunction(oidTerm.toString(), track2.track))
     }
 
+    @Test
+    fun `getInfoboxExtras includes operational point addresses`() {
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(
+                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
+                )
+                .id
+
+        val op1Id = mainOfficialContext.save(operationalPoint(name = "OP1", location = Point(50.0, 0.0), draft = false)).id
+        val op2Id =
+            mainOfficialContext.save(
+                operationalPoint(name = "OP2", draft = false).copy(location = null)
+            ).id
+
+        val (track, _) =
+            mainOfficialContext.save(
+                locationTrack(
+                    trackNumberId,
+                    draft = false,
+                    operationalPointIds = setOf(op1Id, op2Id),
+                ),
+                trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
+            )
+
+        val extras = locationTrackService.getInfoboxExtras(MainLayoutContext.official, track.id as IntId)
+        assertNotNull(extras)
+        assertEquals(2, extras!!.operationalPoints.size)
+
+        val op1Extra = extras.operationalPoints.find { it.operationalPointId == op1Id }
+        assertNotNull(op1Extra)
+        assertNotNull(op1Extra!!.location)
+        assertNotNull(op1Extra.displayAddress)
+
+        val op2Extra = extras.operationalPoints.find { it.operationalPointId == op2Id }
+        assertNotNull(op2Extra)
+        assertNull(op2Extra!!.location)
+        assertNull(op2Extra.displayAddress)
+    }
+
     private fun updateDraft(
         id: IntId<LocationTrack>,
         op: (LocationTrack, LocationTrackGeometry) -> Pair<LocationTrack, LocationTrackGeometry>,

--- a/ui/src/tool-panel/location-track/dialog/location-track-detach-operational-point-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-detach-operational-point-dialog.tsx
@@ -1,0 +1,100 @@
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { unlinkLocationTracksFromOperationalPoint } from 'track-layout/layout-location-track-api';
+import { updateAllChangeTimes } from 'common/change-time-api';
+import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
+import { LayoutContext } from 'common/common-model';
+import { LocationTrackId, OperationalPointId } from 'track-layout/track-layout-model';
+
+type LocationTrackDetachOperationalPointDialogProps = {
+    layoutContext: LayoutContext;
+    locationTrackId: LocationTrackId;
+    locationTrackName: string;
+    operationalPointId: OperationalPointId;
+    operationalPointName: string;
+    onClose: () => void;
+    onDetached: () => void;
+};
+
+export const LocationTrackDetachOperationalPointDialog: React.FC<
+    LocationTrackDetachOperationalPointDialogProps
+> = ({
+    layoutContext,
+    locationTrackId,
+    locationTrackName,
+    operationalPointId,
+    operationalPointName,
+    onClose,
+    onDetached,
+}) => {
+    const { t } = useTranslation();
+    const [isDetaching, setIsDetaching] = React.useState(false);
+
+    const detachOperationalPoint = () => {
+        setIsDetaching(true);
+        unlinkLocationTracksFromOperationalPoint(
+            layoutContext.branch,
+            [locationTrackId],
+            operationalPointId,
+        )
+            .then(async () => {
+                await updateAllChangeTimes();
+                Snackbar.success(
+                    t(
+                        'tool-panel.location-track.detach-operational-point-links-dialog.success-toast',
+                        {
+                            operationalPointName: operationalPointName,
+                            trackName: locationTrackName,
+                        },
+                    ),
+                );
+                onDetached();
+                onClose();
+            })
+            .finally(() => setIsDetaching(false));
+    };
+
+    return (
+        <Dialog
+            title={t(
+                'tool-panel.location-track.detach-operational-point-links-dialog.title',
+            )}
+            variant={DialogVariant.DARK}
+            allowClose={true}
+            onClose={onClose}
+            footerContent={
+                <>
+                    <Button
+                        onClick={onClose}
+                        variant={ButtonVariant.SECONDARY}
+                        disabled={isDetaching}>
+                        {t('button.cancel')}
+                    </Button>
+                    <div className={dialogStyles['dialog__footer-content--right-aligned']}>
+                        <Button
+                            disabled={isDetaching}
+                            isProcessing={isDetaching}
+                            variant={ButtonVariant.PRIMARY_WARNING}
+                            onClick={() => detachOperationalPoint()}>
+                            {t(
+                                'tool-panel.location-track.detach-operational-point-links-dialog.detach-button',
+                            )}
+                        </Button>
+                    </div>
+                </>
+            }>
+            <div className={'dialog__text'}>
+                {t(
+                    'tool-panel.location-track.detach-operational-point-links-dialog.message',
+                    {
+                        operationalPointName: operationalPointName,
+                        trackName: locationTrackName,
+                    },
+                )}
+            </div>
+        </Dialog>
+    );
+};

--- a/ui/src/tool-panel/location-track/dialog/location-track-detach-switch-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-detach-switch-dialog.tsx
@@ -1,0 +1,85 @@
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { detachSwitchFromLocationTrack } from 'track-layout/layout-location-track-api';
+import { updateLocationTrackChangeTime } from 'common/change-time-api';
+import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
+import { LayoutContext } from 'common/common-model';
+import { LayoutSwitchId, LocationTrackId } from 'track-layout/track-layout-model';
+
+type LocationTrackDetachSwitchDialogProps = {
+    layoutContext: LayoutContext;
+    locationTrackId: LocationTrackId;
+    locationTrackName: string;
+    switchId: LayoutSwitchId;
+    switchName: string;
+    onClose: () => void;
+    onDetached: () => void;
+};
+
+export const LocationTrackDetachSwitchDialog: React.FC<
+    LocationTrackDetachSwitchDialogProps
+> = ({
+    layoutContext,
+    locationTrackId,
+    locationTrackName,
+    switchId,
+    switchName,
+    onClose,
+    onDetached,
+}) => {
+    const { t } = useTranslation();
+    const [isDetaching, setIsDetaching] = React.useState(false);
+
+    const detachSwitch = () => {
+        setIsDetaching(true);
+        detachSwitchFromLocationTrack(layoutContext.branch, locationTrackId, switchId)
+            .then(() => updateLocationTrackChangeTime())
+            .then(() => {
+                Snackbar.success(
+                    'tool-panel.location-track.detach-switch-links-dialog.success-toast',
+                );
+                onDetached();
+                onClose();
+            })
+            .finally(() => setIsDetaching(false));
+    };
+
+    return (
+        <Dialog
+            title={t('tool-panel.location-track.detach-switch-links-dialog.title')}
+            variant={DialogVariant.DARK}
+            allowClose={true}
+            onClose={onClose}
+            footerContent={
+                <>
+                    <Button
+                        onClick={onClose}
+                        variant={ButtonVariant.SECONDARY}
+                        disabled={isDetaching}>
+                        {t('button.cancel')}
+                    </Button>
+                    <div className={dialogStyles['dialog__footer-content--right-aligned']}>
+                        <Button
+                            disabled={isDetaching}
+                            isProcessing={isDetaching}
+                            variant={ButtonVariant.PRIMARY_WARNING}
+                            onClick={() => detachSwitch()}>
+                            {t(
+                                'tool-panel.location-track.detach-switch-links-dialog.detach-button',
+                            )}
+                        </Button>
+                    </div>
+                </>
+            }>
+            <div className={'dialog__text'}>
+                {t('tool-panel.location-track.detach-switch-links-dialog.message', {
+                    switchName: switchName,
+                    trackName: locationTrackName,
+                })}
+            </div>
+        </Dialog>
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.scss
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.scss
@@ -2,7 +2,7 @@
     display: grid;
     margin-bottom: 12px;
     row-gap: 4px;
-    grid-template-columns: max-content 100px auto 70px;
+    grid-template-columns: max-content max-content auto 70px;
     grid-column-gap: 4px;
 
     &__remark {

--- a/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
@@ -7,11 +7,12 @@ import {
     OperationalPoint,
     OperationalPointId,
 } from 'track-layout/track-layout-model';
+import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-utils';
 import { LayoutContext, TrackMeter } from 'common/common-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
 import { unlinkLocationTracksFromOperationalPoint } from 'track-layout/layout-location-track-api';
-import { geocodingChangeTime, updateAllChangeTimes } from 'common/change-time-api';
+import { updateAllChangeTimes } from 'common/change-time-api';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import styles from './location-track-operational-point-links-infobox.scss';
 import { ChangeTimes } from 'common/common-slice';
@@ -25,7 +26,6 @@ import {
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getManyOperationalPoints } from 'track-layout/layout-operational-point-api';
-import { getAddress } from 'common/geocoding-api';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
 import { createClassName } from 'vayla-design-lib/utils';
@@ -39,11 +39,6 @@ type LocationTrackOperationalPointLinksInfoboxProps = {
     layoutContext: LayoutContext;
     changeTimes: ChangeTimes;
     onSelect: (items: OnSelectOptions) => void;
-};
-
-type OperationalPointAddress = {
-    operationalPointId: OperationalPointId;
-    address: TrackMeter | undefined;
 };
 
 export const LocationTrackOperationalPointLinksInfobox: React.FC<
@@ -86,53 +81,24 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
             .finally(() => setIsDetaching(false));
     };
 
-    const [operationalPoints, opLoadStatus] = useLoaderWithStatus(
-        () =>
-            getManyOperationalPoints(
-                locationTrack.operationalPointIds,
-                layoutContext,
-                changeTimes.operationalPoints,
-            ),
+    const [infoboxExtras, infoboxExtrasLoadStatus] = useLocationTrackInfoboxExtras(
+        locationTrack.id,
+        layoutContext,
+        changeTimes,
+    );
+    const operationalPointExtras = infoboxExtras?.operationalPoints ?? [];
+    const opIds = operationalPointExtras.map((op) => op.operationalPointId);
+
+    const [operationalPoints, linkedPointFetchStatus] = useLoaderWithStatus(
+        () => getManyOperationalPoints(opIds, layoutContext, changeTimes.operationalPoints),
         [
-            JSON.stringify(locationTrack.operationalPointIds),
             locationTrack.id,
+            JSON.stringify(opIds),
             layoutContext.branch,
             layoutContext.publicationState,
             changeTimes.operationalPoints,
         ],
     );
-
-    const [addresses, addressLoadStatus] = useLoaderWithStatus(async () => {
-        if (!operationalPoints) return [];
-        const results: OperationalPointAddress[] = await Promise.all(
-            operationalPoints.map(async (op) => ({
-                operationalPointId: op.id,
-                address: op.location
-                    ? await getAddress(locationTrack.trackNumberId, op.location, layoutContext)
-                    : undefined,
-            })),
-        );
-        return results;
-    }, [
-        operationalPoints,
-        locationTrack.trackNumberId,
-        layoutContext.branch,
-        layoutContext.publicationState,
-        geocodingChangeTime(changeTimes),
-    ]);
-
-    const addressMap = React.useMemo(() => {
-        const map: Record<string, TrackMeter | undefined> = {};
-        (addresses ?? []).forEach((a) => {
-            map[a.operationalPointId] = a.address;
-        });
-        return map;
-    }, [addresses]);
-
-    const operationalPointsAll = (operationalPoints ?? []).map((op) => ({
-        operationalPoint: op,
-        address: addressMap[op.id],
-    }));
 
     const [showAll, setShowAll] = React.useState(false);
 
@@ -146,12 +112,12 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
                 <ProgressIndicatorWrapper
                     indicator={ProgressIndicatorType.Area}
                     inProgress={
-                        opLoadStatus !== LoaderStatus.Ready ||
-                        addressLoadStatus !== LoaderStatus.Ready
+                        infoboxExtrasLoadStatus !== LoaderStatus.Ready ||
+                        linkedPointFetchStatus !== LoaderStatus.Ready
                     }
                     inline={true}>
                     <InfoboxContent>
-                        {operationalPointsAll.length > 0 ? (
+                        {!!operationalPoints && operationalPoints.length > 0 ? (
                             <React.Fragment>
                                 <div
                                     className={
@@ -160,30 +126,33 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
                                         ]
                                     }>
                                     {(showAll
-                                        ? operationalPointsAll
-                                        : operationalPointsAll.slice(
-                                              0,
-                                              maxOperationalPointsToDisplay,
-                                          )
-                                    ).map(({ operationalPoint, address }) => (
+                                        ? operationalPoints
+                                        : operationalPoints.slice(0, maxOperationalPointsToDisplay)
+                                    ).map((operationalPoint) => (
                                         <LocationTrackOperationalPointLink
                                             key={operationalPoint.id}
                                             operationalPoint={operationalPoint}
-                                            address={address}
+                                            address={
+                                                operationalPointExtras?.find(
+                                                    (op) =>
+                                                        op.operationalPointId ===
+                                                        operationalPoint.id,
+                                                )?.displayAddress
+                                            }
                                             layoutContext={layoutContext}
                                             setShowingDialogToDetachOp={setShowingDialogToDetachOp}
                                             onSelect={onSelect}
                                         />
                                     ))}
                                 </div>
-                                {operationalPointsAll.length > maxOperationalPointsToDisplay && (
+                                {operationalPoints.length > maxOperationalPointsToDisplay && (
                                     <ShowMoreButton
                                         expanded={showAll}
                                         onShowMore={() => setShowAll(!showAll)}
                                         showMoreText={t(
                                             'tool-panel.location-track.operational-point-links.show-more',
                                             {
-                                                count: operationalPointsAll.length,
+                                                count: operationalPoints.length,
                                             },
                                         )}
                                     />

--- a/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
@@ -1,19 +1,10 @@
-import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Infobox from 'tool-panel/infobox/infobox';
-import {
-    LayoutLocationTrack,
-    OperationalPoint,
-    OperationalPointId,
-} from 'track-layout/track-layout-model';
+import { LayoutLocationTrack, OperationalPoint } from 'track-layout/track-layout-model';
 import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-utils';
 import { LayoutContext, TrackMeter } from 'common/common-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
-import { unlinkLocationTracksFromOperationalPoint } from 'track-layout/layout-location-track-api';
-import { updateAllChangeTimes } from 'common/change-time-api';
-import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import styles from './location-track-operational-point-links-infobox.scss';
 import { ChangeTimes } from 'common/common-slice';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
@@ -29,6 +20,7 @@ import { getManyOperationalPoints } from 'track-layout/layout-operational-point-
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
 import { createClassName } from 'vayla-design-lib/utils';
+import { LocationTrackDetachOperationalPointDialog } from './dialog/location-track-detach-operational-point-dialog';
 
 const maxOperationalPointsToDisplay = 10;
 
@@ -52,34 +44,6 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
     onSelect,
 }) => {
     const { t } = useTranslation();
-    const [showingDialogToDetachOp, setShowingDialogToDetachOp] = React.useState<
-        { id: OperationalPointId; name: string } | undefined
-    >(undefined);
-    const [isDetaching, setIsDetaching] = React.useState(false);
-
-    const detachOperationalPoint = () => {
-        if (showingDialogToDetachOp === undefined) return;
-        setIsDetaching(true);
-        unlinkLocationTracksFromOperationalPoint(
-            layoutContext.branch,
-            [locationTrack.id],
-            showingDialogToDetachOp.id,
-        )
-            .then(async () => {
-                await updateAllChangeTimes();
-                setShowingDialogToDetachOp(undefined);
-                Snackbar.success(
-                    t(
-                        'tool-panel.location-track.detach-operational-point-links-dialog.success-toast',
-                        {
-                            operationalPointName: showingDialogToDetachOp.name,
-                            trackName: locationTrack.name,
-                        },
-                    ),
-                );
-            })
-            .finally(() => setIsDetaching(false));
-    };
 
     const [infoboxExtras, infoboxExtrasLoadStatus] = useLocationTrackInfoboxExtras(
         locationTrack.id,
@@ -101,133 +65,90 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
     );
 
     const [showAll, setShowAll] = React.useState(false);
+    const operationalPointsToShow =
+        (showAll
+            ? operationalPoints
+            : operationalPoints?.slice(0, maxOperationalPointsToDisplay)) ?? [];
 
     return (
-        <>
-            <Infobox
-                title={t('tool-panel.location-track.operational-point-links.heading')}
-                qa-id={'location-track-operational-point-links-infobox'}
-                contentVisible={contentVisible}
-                onContentVisibilityChange={onContentVisibilityChange}>
-                <ProgressIndicatorWrapper
-                    indicator={ProgressIndicatorType.Area}
-                    inProgress={
-                        infoboxExtrasLoadStatus !== LoaderStatus.Ready ||
-                        linkedPointFetchStatus !== LoaderStatus.Ready
-                    }
-                    inline={true}>
-                    <InfoboxContent>
-                        {!!operationalPoints && operationalPoints.length > 0 ? (
-                            <React.Fragment>
-                                <div
-                                    className={
-                                        styles[
-                                            'location-track-operational-point-links-infobox-list'
-                                        ]
-                                    }>
-                                    {(showAll
-                                        ? operationalPoints
-                                        : operationalPoints.slice(0, maxOperationalPointsToDisplay)
-                                    ).map((operationalPoint) => (
-                                        <LocationTrackOperationalPointLink
-                                            key={operationalPoint.id}
-                                            operationalPoint={operationalPoint}
-                                            address={
-                                                operationalPointExtras?.find(
-                                                    (op) =>
-                                                        op.operationalPointId ===
-                                                        operationalPoint.id,
-                                                )?.displayAddress
-                                            }
-                                            layoutContext={layoutContext}
-                                            setShowingDialogToDetachOp={setShowingDialogToDetachOp}
-                                            onSelect={onSelect}
-                                        />
-                                    ))}
-                                </div>
-                                {operationalPoints.length > maxOperationalPointsToDisplay && (
-                                    <ShowMoreButton
-                                        expanded={showAll}
-                                        onShowMore={() => setShowAll(!showAll)}
-                                        showMoreText={t(
-                                            'tool-panel.location-track.operational-point-links.show-more',
-                                            {
-                                                count: operationalPoints.length,
-                                            },
-                                        )}
+        <Infobox
+            title={t('tool-panel.location-track.operational-point-links.heading')}
+            qa-id={'location-track-operational-point-links-infobox'}
+            contentVisible={contentVisible}
+            onContentVisibilityChange={onContentVisibilityChange}>
+            <ProgressIndicatorWrapper
+                indicator={ProgressIndicatorType.Area}
+                inProgress={
+                    infoboxExtrasLoadStatus !== LoaderStatus.Ready ||
+                    linkedPointFetchStatus !== LoaderStatus.Ready
+                }
+                inline={true}>
+                <InfoboxContent>
+                    {!!operationalPoints && operationalPoints.length > 0 ? (
+                        <React.Fragment>
+                            <div
+                                className={
+                                    styles['location-track-operational-point-links-infobox-list']
+                                }>
+                                {operationalPointsToShow.map((operationalPoint) => (
+                                    <LocationTrackOperationalPointRow
+                                        key={operationalPoint.id}
+                                        operationalPoint={operationalPoint}
+                                        address={
+                                            operationalPointExtras?.find(
+                                                (op) =>
+                                                    op.operationalPointId === operationalPoint.id,
+                                            )?.displayAddress
+                                        }
+                                        layoutContext={layoutContext}
+                                        locationTrack={locationTrack}
+                                        onSelect={onSelect}
                                     />
-                                )}
-                            </React.Fragment>
-                        ) : (
-                            <p className={'infobox__text'}>
-                                {t(
-                                    'tool-panel.location-track.operational-point-links.no-operational-points',
-                                )}
-                            </p>
-                        )}
-                    </InfoboxContent>
-                </ProgressIndicatorWrapper>
-            </Infobox>
-            {showingDialogToDetachOp && (
-                <Dialog
-                    title={t(
-                        'tool-panel.location-track.detach-operational-point-links-dialog.title',
-                    )}
-                    variant={DialogVariant.DARK}
-                    allowClose={true}
-                    onClose={() => setShowingDialogToDetachOp(undefined)}
-                    footerContent={
-                        <>
-                            <Button
-                                onClick={() => setShowingDialogToDetachOp(undefined)}
-                                variant={ButtonVariant.SECONDARY}
-                                disabled={isDetaching}>
-                                {t('button.cancel')}
-                            </Button>
-                            <div className={dialogStyles['dialog__footer-content--right-aligned']}>
-                                <Button
-                                    disabled={isDetaching}
-                                    isProcessing={isDetaching}
-                                    variant={ButtonVariant.PRIMARY_WARNING}
-                                    onClick={() => detachOperationalPoint()}>
-                                    {t(
-                                        'tool-panel.location-track.detach-operational-point-links-dialog.detach-button',
-                                    )}
-                                </Button>
+                                ))}
                             </div>
-                        </>
-                    }>
-                    <div className={'dialog__text'}>
-                        {t(
-                            'tool-panel.location-track.detach-operational-point-links-dialog.message',
-                            {
-                                operationalPointName: showingDialogToDetachOp.name,
-                                trackName: locationTrack.name,
-                            },
-                        )}
-                    </div>
-                </Dialog>
-            )}
-        </>
+                            {operationalPoints.length > maxOperationalPointsToDisplay && (
+                                <ShowMoreButton
+                                    expanded={showAll}
+                                    onShowMore={() => setShowAll(!showAll)}
+                                    showMoreText={t(
+                                        'tool-panel.location-track.operational-point-links.show-more',
+                                        {
+                                            count: operationalPoints.length,
+                                        },
+                                    )}
+                                />
+                            )}
+                        </React.Fragment>
+                    ) : (
+                        <p className={'infobox__text'}>
+                            {t(
+                                'tool-panel.location-track.operational-point-links.no-operational-points',
+                            )}
+                        </p>
+                    )}
+                </InfoboxContent>
+            </ProgressIndicatorWrapper>
+        </Infobox>
     );
 };
 
-type LocationTrackOperationalPointLinkProps = {
+type LocationTrackOperationalPointRowProps = {
     operationalPoint: OperationalPoint;
     address: TrackMeter | undefined;
     layoutContext: LayoutContext;
-    setShowingDialogToDetachOp: (detach: { id: OperationalPointId; name: string }) => void;
+    locationTrack: LayoutLocationTrack;
     onSelect: (items: OnSelectOptions) => void;
 };
 
-const LocationTrackOperationalPointLink: React.FC<LocationTrackOperationalPointLinkProps> = ({
+const LocationTrackOperationalPointRow: React.FC<LocationTrackOperationalPointRowProps> = ({
     operationalPoint,
     address,
     layoutContext,
-    setShowingDialogToDetachOp,
+    locationTrack,
     onSelect,
 }) => {
     const { t } = useTranslation();
+    const [showDetachDialog, setShowDetachDialog] = React.useState(false);
     const remarkClassNames = createClassName(
         styles['location-track-operational-point-links-infobox-list__remark'],
         infoboxStyles['infobox__list-cell--strong'],
@@ -247,7 +168,7 @@ const LocationTrackOperationalPointLink: React.FC<LocationTrackOperationalPointL
                 />
             </div>
             <div className={infoboxStyles['infobox__list-cell--strong']}>
-                {address === undefined ? (
+                {!address ? (
                     t('tool-panel.location-track.operational-point-links.no-location')
                 ) : (
                     <NavigableTrackMeter
@@ -266,11 +187,22 @@ const LocationTrackOperationalPointLink: React.FC<LocationTrackOperationalPointL
                     <Button
                         size={ButtonSize.SMALL}
                         variant={ButtonVariant.GHOST}
-                        onClick={() => setShowingDialogToDetachOp(operationalPoint)}>
+                        onClick={() => setShowDetachDialog(true)}>
                         {t('tool-panel.location-track.operational-point-links.detach')}
                     </Button>
                 )}
             </div>
+            {showDetachDialog && (
+                <LocationTrackDetachOperationalPointDialog
+                    layoutContext={layoutContext}
+                    locationTrackId={locationTrack.id}
+                    locationTrackName={locationTrack.name}
+                    operationalPointId={operationalPoint.id}
+                    operationalPointName={operationalPoint.name}
+                    onClose={() => setShowDetachDialog(false)}
+                    onDetached={() => setShowDetachDialog(false)}
+                />
+            )}
         </>
     );
 };

--- a/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Infobox from 'tool-panel/infobox/infobox';
-import { LayoutLocationTrack, OperationalPoint } from 'track-layout/track-layout-model';
+import { LayoutLocationTrack } from 'track-layout/track-layout-model';
 import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-utils';
-import { LayoutContext, TrackMeter } from 'common/common-model';
-import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import { LayoutContext } from 'common/common-model';
 import styles from './location-track-operational-point-links-infobox.scss';
 import { ChangeTimes } from 'common/common-slice';
-import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
-import { OperationalPointBadge } from 'geoviite-design-lib/operational-point/operational-point-badge';
 import { OnSelectOptions } from 'selection/selection-model';
 import { ShowMoreButton } from 'show-more-button/show-more-button';
 import {
@@ -18,9 +15,7 @@ import {
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getManyOperationalPoints } from 'track-layout/layout-operational-point-api';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
-import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
-import { createClassName } from 'vayla-design-lib/utils';
-import { LocationTrackDetachOperationalPointDialog } from './dialog/location-track-detach-operational-point-dialog';
+import { LocationTrackOperationalPointRow } from './location-track-operational-point-row';
 
 const maxOperationalPointsToDisplay = 10;
 
@@ -132,77 +127,3 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
     );
 };
 
-type LocationTrackOperationalPointRowProps = {
-    operationalPoint: OperationalPoint;
-    address: TrackMeter | undefined;
-    layoutContext: LayoutContext;
-    locationTrack: LayoutLocationTrack;
-    onSelect: (items: OnSelectOptions) => void;
-};
-
-const LocationTrackOperationalPointRow: React.FC<LocationTrackOperationalPointRowProps> = ({
-    operationalPoint,
-    address,
-    layoutContext,
-    locationTrack,
-    onSelect,
-}) => {
-    const { t } = useTranslation();
-    const [showDetachDialog, setShowDetachDialog] = React.useState(false);
-    const remarkClassNames = createClassName(
-        styles['location-track-operational-point-links-infobox-list__remark'],
-        infoboxStyles['infobox__list-cell--strong'],
-    );
-
-    return (
-        <>
-            <div>
-                <OperationalPointBadge
-                    operationalPoint={operationalPoint}
-                    onClick={() =>
-                        onSelect({
-                            operationalPoints: [operationalPoint.id],
-                            selectedTab: { id: operationalPoint.id, type: 'OPERATIONAL_POINT' },
-                        })
-                    }
-                />
-            </div>
-            <div className={infoboxStyles['infobox__list-cell--strong']}>
-                {!address ? (
-                    t('tool-panel.location-track.operational-point-links.no-location')
-                ) : (
-                    <NavigableTrackMeter
-                        trackMeter={address}
-                        displayDecimals={false}
-                        location={operationalPoint.location}
-                    />
-                )}
-            </div>
-            <div className={remarkClassNames}>
-                {operationalPoint.state === 'DELETED' &&
-                    t('tool-panel.location-track.operational-point-links.not-existing')}
-            </div>
-            <div>
-                {layoutContext.publicationState === 'DRAFT' && (
-                    <Button
-                        size={ButtonSize.SMALL}
-                        variant={ButtonVariant.GHOST}
-                        onClick={() => setShowDetachDialog(true)}>
-                        {t('tool-panel.location-track.operational-point-links.detach')}
-                    </Button>
-                )}
-            </div>
-            {showDetachDialog && (
-                <LocationTrackDetachOperationalPointDialog
-                    layoutContext={layoutContext}
-                    locationTrackId={locationTrack.id}
-                    locationTrackName={locationTrack.name}
-                    operationalPointId={operationalPoint.id}
-                    operationalPointName={operationalPoint.name}
-                    onClose={() => setShowDetachDialog(false)}
-                    onDetached={() => setShowDetachDialog(false)}
-                />
-            )}
-        </>
-    );
-};

--- a/ui/src/tool-panel/location-track/location-track-operational-point-row.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-row.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LayoutLocationTrack, OperationalPoint } from 'track-layout/track-layout-model';
+import { LayoutContext, TrackMeter } from 'common/common-model';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import styles from './location-track-operational-point-links-infobox.scss';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
+import { OperationalPointBadge } from 'geoviite-design-lib/operational-point/operational-point-badge';
+import { OnSelectOptions } from 'selection/selection-model';
+import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
+import { createClassName } from 'vayla-design-lib/utils';
+import { LocationTrackDetachOperationalPointDialog } from './dialog/location-track-detach-operational-point-dialog';
+
+type LocationTrackOperationalPointRowProps = {
+    operationalPoint: OperationalPoint;
+    address: TrackMeter | undefined;
+    layoutContext: LayoutContext;
+    locationTrack: LayoutLocationTrack;
+    onSelect: (items: OnSelectOptions) => void;
+};
+
+export const LocationTrackOperationalPointRow: React.FC<
+    LocationTrackOperationalPointRowProps
+> = ({ operationalPoint, address, layoutContext, locationTrack, onSelect }) => {
+    const { t } = useTranslation();
+    const [showDetachDialog, setShowDetachDialog] = React.useState(false);
+    const remarkClassNames = createClassName(
+        styles['location-track-operational-point-links-infobox-list__remark'],
+        infoboxStyles['infobox__list-cell--strong'],
+    );
+
+    return (
+        <>
+            <div>
+                <OperationalPointBadge
+                    operationalPoint={operationalPoint}
+                    onClick={() =>
+                        onSelect({
+                            operationalPoints: [operationalPoint.id],
+                            selectedTab: { id: operationalPoint.id, type: 'OPERATIONAL_POINT' },
+                        })
+                    }
+                />
+            </div>
+            <div className={infoboxStyles['infobox__list-cell--strong']}>
+                {!address ? (
+                    t('tool-panel.location-track.operational-point-links.no-location')
+                ) : (
+                    <NavigableTrackMeter
+                        trackMeter={address}
+                        displayDecimals={false}
+                        location={operationalPoint.location}
+                    />
+                )}
+            </div>
+            <div className={remarkClassNames}>
+                {operationalPoint.state === 'DELETED' &&
+                    t('tool-panel.location-track.operational-point-links.not-existing')}
+            </div>
+            <div>
+                {layoutContext.publicationState === 'DRAFT' && (
+                    <Button
+                        size={ButtonSize.SMALL}
+                        variant={ButtonVariant.GHOST}
+                        onClick={() => setShowDetachDialog(true)}>
+                        {t('tool-panel.location-track.operational-point-links.detach')}
+                    </Button>
+                )}
+            </div>
+            {showDetachDialog && (
+                <LocationTrackDetachOperationalPointDialog
+                    layoutContext={layoutContext}
+                    locationTrackId={locationTrack.id}
+                    locationTrackName={locationTrack.name}
+                    operationalPointId={operationalPoint.id}
+                    operationalPointName={operationalPoint.name}
+                    onClose={() => setShowDetachDialog(false)}
+                    onDetached={() => setShowDetachDialog(false)}
+                />
+            )}
+        </>
+    );
+};

--- a/ui/src/tool-panel/location-track/location-track-switch-links-infobox.scss
+++ b/ui/src/tool-panel/location-track/location-track-switch-links-infobox.scss
@@ -5,7 +5,7 @@
     display: grid;
     margin-bottom: 12px;
     row-gap: 4px;
-    grid-template-columns: max-content 100px auto 70px;
+    grid-template-columns: max-content max-content auto 70px;
     grid-column-gap: 4px;
 
     &__caption {

--- a/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
@@ -1,20 +1,11 @@
-import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Infobox from 'tool-panel/infobox/infobox';
-import { LayoutLocationTrack, LayoutSwitch, LayoutSwitchId } from 'track-layout/track-layout-model';
+import { LayoutLocationTrack, LayoutSwitchId } from 'track-layout/track-layout-model';
 import { useLocationTrackInfoboxExtras } from 'track-layout/track-layout-react-utils';
-import { LayoutContext, TrackMeter } from 'common/common-model';
-import { Point } from 'model/geometry';
-import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
-import { detachSwitchFromLocationTrack } from 'track-layout/layout-location-track-api';
-import { updateLocationTrackChangeTime } from 'common/change-time-api';
-import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
+import { LayoutContext } from 'common/common-model';
 import styles from './location-track-switch-links-infobox.scss';
 import { ChangeTimes } from 'common/common-slice';
-import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
-import { SwitchBadge } from 'geoviite-design-lib/switch/switch-badge';
 import { OnSelectOptions } from 'selection/selection-model';
 import { ShowMoreButton } from 'show-more-button/show-more-button';
 import { LayoutValidationIssue, ValidatedLocationTrack } from 'publication/publication-model';
@@ -25,8 +16,7 @@ import {
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getSwitches } from 'track-layout/layout-switch-api';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
-import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
-import { createClassName } from 'vayla-design-lib/utils';
+import { LocationTrackSwitchRow } from './location-track-switch-row';
 
 const maxSwitchesToDisplay = 10;
 
@@ -73,28 +63,6 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
     const switches =
         useLocationTrackInfoboxExtras(locationTrack.id, layoutContext, changeTimes)[0]?.switches ??
         [];
-    const [showingDialogToDetachSwitch, setShowingDialogToDetachSwitch] = React.useState<
-        { id: LayoutSwitchId; name: string } | undefined
-    >(undefined);
-    const [isDetachingSwitch, setIsDetachingSwitch] = React.useState(false);
-
-    const detachSwitch = () => {
-        if (showingDialogToDetachSwitch === undefined) return;
-        setIsDetachingSwitch(true);
-        detachSwitchFromLocationTrack(
-            layoutContext.branch,
-            locationTrack.id,
-            showingDialogToDetachSwitch.id,
-        )
-            .then(() => updateLocationTrackChangeTime())
-            .then(() => {
-                setIsDetachingSwitch(false);
-                setShowingDialogToDetachSwitch(undefined);
-                Snackbar.success(
-                    'tool-panel.location-track.detach-switch-links-dialog.success-toast',
-                );
-            });
-    };
     const switchIds = switches.map((s) => s.switchId);
 
     const [switchItems, switchItemLoadStatus] = useLoaderWithStatus(
@@ -131,169 +99,58 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
     const [showAllSwitches, setShowAllSwitches] = React.useState(false);
 
     return (
-        <>
-            <Infobox
-                title={t('tool-panel.location-track.switch-links.heading')}
-                qa-id={'location-track-switch-links-infobox'}
-                contentVisible={contentVisible}
-                onContentVisibilityChange={onContentVisibilityChange}>
-                <ProgressIndicatorWrapper
-                    indicator={ProgressIndicatorType.Area}
-                    inProgress={
-                        switchItemLoadStatus !== LoaderStatus.Ready ||
-                        validationLoaderStatus !== LoaderStatus.Ready
-                    }
-                    inline={true}>
-                    <InfoboxContent>
-                        {switchesAll.length > 0 ? (
-                            <React.Fragment>
-                                <div className={styles['location-track-switch-links-infobox-list']}>
-                                    {(showAllSwitches
-                                        ? switchesAll
-                                        : switchesAll.slice(0, maxSwitchesToDisplay)
-                                    ).map(({ switchItem, location, address, validationIssues }) => (
-                                        <LocationTrackSwitchLink
-                                            key={switchItem.id}
-                                            layoutContext={layoutContext}
-                                            switchItem={switchItem}
-                                            location={location}
-                                            displayAddress={address}
-                                            validationIssues={validationIssues}
-                                            setShowingDialogToDetachSwitch={
-                                                setShowingDialogToDetachSwitch
-                                            }
-                                            onSelect={onSelect}
-                                        />
-                                    ))}
-                                </div>
-                                {switches.length > maxSwitchesToDisplay && (
-                                    <ShowMoreButton
-                                        expanded={showAllSwitches}
-                                        onShowMore={() => setShowAllSwitches(!showAllSwitches)}
-                                        showMoreText={t(
-                                            'tool-panel.location-track.switch-links.show-more',
-                                            {
-                                                count: switchesAll.length,
-                                            },
-                                        )}
+        <Infobox
+            title={t('tool-panel.location-track.switch-links.heading')}
+            qa-id={'location-track-switch-links-infobox'}
+            contentVisible={contentVisible}
+            onContentVisibilityChange={onContentVisibilityChange}>
+            <ProgressIndicatorWrapper
+                indicator={ProgressIndicatorType.Area}
+                inProgress={
+                    switchItemLoadStatus !== LoaderStatus.Ready ||
+                    validationLoaderStatus !== LoaderStatus.Ready
+                }
+                inline={true}>
+                <InfoboxContent>
+                    {switchesAll.length > 0 ? (
+                        <React.Fragment>
+                            <div className={styles['location-track-switch-links-infobox-list']}>
+                                {(showAllSwitches
+                                    ? switchesAll
+                                    : switchesAll.slice(0, maxSwitchesToDisplay)
+                                ).map(({ switchItem, location, address, validationIssues }) => (
+                                    <LocationTrackSwitchRow
+                                        key={switchItem.id}
+                                        layoutContext={layoutContext}
+                                        switchItem={switchItem}
+                                        location={location}
+                                        displayAddress={address}
+                                        validationIssues={validationIssues}
+                                        locationTrack={locationTrack}
+                                        onSelect={onSelect}
                                     />
-                                )}
-                            </React.Fragment>
-                        ) : (
-                            <p className={'infobox__text'}>
-                                {t('tool-panel.location-track.switch-links.no-switches')}
-                            </p>
-                        )}
-                    </InfoboxContent>
-                </ProgressIndicatorWrapper>
-            </Infobox>
-            {showingDialogToDetachSwitch && (
-                <Dialog
-                    title={t('tool-panel.location-track.detach-switch-links-dialog.title')}
-                    variant={DialogVariant.DARK}
-                    allowClose={true}
-                    onClose={() => setShowingDialogToDetachSwitch(undefined)}
-                    footerContent={
-                        <>
-                            <Button
-                                onClick={() => setShowingDialogToDetachSwitch(undefined)}
-                                variant={ButtonVariant.SECONDARY}
-                                disabled={isDetachingSwitch}>
-                                {t('button.cancel')}
-                            </Button>
-                            <div className={dialogStyles['dialog__footer-content--right-aligned']}>
-                                <Button
-                                    disabled={isDetachingSwitch}
-                                    isProcessing={isDetachingSwitch}
-                                    variant={ButtonVariant.PRIMARY_WARNING}
-                                    onClick={() => detachSwitch()}>
-                                    {t(
-                                        'tool-panel.location-track.detach-switch-links-dialog.detach-button',
-                                    )}
-                                </Button>
+                                ))}
                             </div>
-                        </>
-                    }>
-                    <div className={'dialog__text'}>
-                        {t('tool-panel.location-track.detach-switch-links-dialog.message', {
-                            switchName: showingDialogToDetachSwitch.name,
-                            trackName: locationTrack.name,
-                        })}
-                    </div>
-                </Dialog>
-            )}
-        </>
-    );
-};
-
-type ShowingDialogToDetachSwitch = { id: LayoutSwitchId; name: string };
-
-type LocationTrackSwitchLinkProps = {
-    layoutContext: LayoutContext;
-    switchItem: LayoutSwitch;
-    validationIssues: LayoutValidationIssue[];
-    location?: Point;
-    displayAddress?: TrackMeter;
-    setShowingDialogToDetachSwitch: (detach: ShowingDialogToDetachSwitch) => void;
-    onSelect: (items: OnSelectOptions) => void;
-};
-const LocationTrackSwitchLink: React.FC<LocationTrackSwitchLinkProps> = ({
-    layoutContext,
-    switchItem,
-    validationIssues,
-    location,
-    displayAddress,
-    setShowingDialogToDetachSwitch,
-    onSelect,
-}) => {
-    const { t } = useTranslation();
-    const remarkClassNames = createClassName(
-        styles['location-track-switch-links-infobox-list__remark'],
-        infoboxStyles['infobox__list-cell--strong'],
-    );
-
-    return (
-        <>
-            <div
-                title={validationIssues
-                    .map((issue) => t(issue.localizationKey, issue.params))
-                    .join('\n')}>
-                <SwitchBadge
-                    switchItem={switchItem}
-                    switchIsValid={validationIssues.length === 0}
-                    onClick={() =>
-                        onSelect({
-                            switches: [switchItem.id],
-                            selectedTab: { id: switchItem.id, type: 'SWITCH' },
-                        })
-                    }
-                />
-            </div>
-            <div className={infoboxStyles['infobox__list-cell--strong']}>
-                {displayAddress === undefined ? (
-                    t('tool-panel.location-track.switch-links.no-location')
-                ) : (
-                    <NavigableTrackMeter
-                        trackMeter={displayAddress}
-                        displayDecimals={false}
-                        location={location}
-                    />
-                )}
-            </div>
-            <div className={remarkClassNames}>
-                {switchItem.stateCategory === 'NOT_EXISTING' &&
-                    t('tool-panel.location-track.switch-links.not-existing')}
-            </div>
-            <div>
-                {layoutContext.publicationState === 'DRAFT' && (
-                    <Button
-                        size={ButtonSize.SMALL}
-                        variant={ButtonVariant.GHOST}
-                        onClick={() => setShowingDialogToDetachSwitch(switchItem)}>
-                        {t('tool-panel.location-track.switch-links.detach')}
-                    </Button>
-                )}
-            </div>
-        </>
+                            {switches.length > maxSwitchesToDisplay && (
+                                <ShowMoreButton
+                                    expanded={showAllSwitches}
+                                    onShowMore={() => setShowAllSwitches(!showAllSwitches)}
+                                    showMoreText={t(
+                                        'tool-panel.location-track.switch-links.show-more',
+                                        {
+                                            count: switchesAll.length,
+                                        },
+                                    )}
+                                />
+                            )}
+                        </React.Fragment>
+                    ) : (
+                        <p className={'infobox__text'}>
+                            {t('tool-panel.location-track.switch-links.no-switches')}
+                        </p>
+                    )}
+                </InfoboxContent>
+            </ProgressIndicatorWrapper>
+        </Infobox>
     );
 };

--- a/ui/src/tool-panel/location-track/location-track-switch-row.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-row.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LayoutLocationTrack, LayoutSwitch } from 'track-layout/track-layout-model';
+import { LayoutContext, TrackMeter } from 'common/common-model';
+import { Point } from 'model/geometry';
+import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
+import styles from './location-track-switch-links-infobox.scss';
+import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
+import { SwitchBadge } from 'geoviite-design-lib/switch/switch-badge';
+import { OnSelectOptions } from 'selection/selection-model';
+import { LayoutValidationIssue } from 'publication/publication-model';
+import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
+import { createClassName } from 'vayla-design-lib/utils';
+import { LocationTrackDetachSwitchDialog } from './dialog/location-track-detach-switch-dialog';
+
+type LocationTrackSwitchRowProps = {
+    layoutContext: LayoutContext;
+    switchItem: LayoutSwitch;
+    validationIssues: LayoutValidationIssue[];
+    location?: Point;
+    displayAddress?: TrackMeter;
+    locationTrack: LayoutLocationTrack;
+    onSelect: (items: OnSelectOptions) => void;
+};
+
+export const LocationTrackSwitchRow: React.FC<LocationTrackSwitchRowProps> = ({
+    layoutContext,
+    switchItem,
+    validationIssues,
+    location,
+    displayAddress,
+    locationTrack,
+    onSelect,
+}) => {
+    const { t } = useTranslation();
+    const [showDetachDialog, setShowDetachDialog] = React.useState(false);
+    const remarkClassNames = createClassName(
+        styles['location-track-switch-links-infobox-list__remark'],
+        infoboxStyles['infobox__list-cell--strong'],
+    );
+
+    return (
+        <>
+            <div
+                title={validationIssues
+                    .map((issue) => t(issue.localizationKey, issue.params))
+                    .join('\n')}>
+                <SwitchBadge
+                    switchItem={switchItem}
+                    switchIsValid={validationIssues.length === 0}
+                    onClick={() =>
+                        onSelect({
+                            switches: [switchItem.id],
+                            selectedTab: { id: switchItem.id, type: 'SWITCH' },
+                        })
+                    }
+                />
+            </div>
+            <div className={infoboxStyles['infobox__list-cell--strong']}>
+                {displayAddress === undefined ? (
+                    t('tool-panel.location-track.switch-links.no-location')
+                ) : (
+                    <NavigableTrackMeter
+                        trackMeter={displayAddress}
+                        displayDecimals={false}
+                        location={location}
+                    />
+                )}
+            </div>
+            <div className={remarkClassNames}>
+                {switchItem.stateCategory === 'NOT_EXISTING' &&
+                    t('tool-panel.location-track.switch-links.not-existing')}
+            </div>
+            <div>
+                {layoutContext.publicationState === 'DRAFT' && (
+                    <Button
+                        size={ButtonSize.SMALL}
+                        variant={ButtonVariant.GHOST}
+                        onClick={() => setShowDetachDialog(true)}>
+                        {t('tool-panel.location-track.switch-links.detach')}
+                    </Button>
+                )}
+            </div>
+            {showDetachDialog && (
+                <LocationTrackDetachSwitchDialog
+                    layoutContext={layoutContext}
+                    locationTrackId={locationTrack.id}
+                    locationTrackName={locationTrack.name}
+                    switchId={switchItem.id}
+                    switchName={switchItem.name}
+                    onClose={() => setShowDetachDialog(false)}
+                    onDetached={() => setShowDetachDialog(false)}
+                />
+            )}
+        </>
+    );
+};

--- a/ui/src/track-layout/layout-location-track-api.ts
+++ b/ui/src/track-layout/layout-location-track-api.ts
@@ -119,6 +119,7 @@ export function locationTrackInfoboxExtrasChangeTime(changeTimes: ChangeTimes): 
         changeTimes.layoutReferenceLine,
         changeTimes.layoutKmPost,
         changeTimes.split,
+        changeTimes.operationalPoints,
     );
 }
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -349,11 +349,18 @@ export type LocationTrackInfoboxExtras = {
     endSplitPoint?: SplitPoint;
     partOfUnfinishedSplit?: boolean;
     switches: LocationTrackInfoboxSwitch[];
+    operationalPoints: LocationTrackInfoboxOperationalPoint[];
 };
 
 export type LocationTrackInfoboxSwitch = {
     switchId: LayoutSwitchId;
     location: Point;
+    displayAddress?: TrackMeter;
+};
+
+export type LocationTrackInfoboxOperationalPoint = {
+    operationalPointId: OperationalPointId;
+    location?: Point;
     displayAddress?: TrackMeter;
 };
 


### PR DESCRIPTION
Täällä siis käytännössä tehty pullarin https://github.com/finnishtransportagency/geoviite/pull/2241 huomioiden perusteella refaktorointia ja osiin hajottamista sijaintiraiteen toiminnallisten pisteiden listauksen ja vaihdelistauksen infobokseille. Käytännössä tehty seuraavaa:

* Jaettu kummatkin infoboksit paremmin komponentteihin ja mietitty komponenttien vastuualueita hitusen uudelleen. 
  1. Rivikomponentti (joka oli jo aiemminkin oma komponenttinsa) siirretty omaan tiedostoonsa
  2. Confirm-dialogi irrotettu omaan komponenttiinsa infoboksista ja siirretty rivin lapseksi. Dialogithan portaloidaan aina bodyyn, joten käytännön vaikutusta DOM:iin tällä ei ole. Dialogin tilanhallinta sen sijaan muuttuu merkittävästi simppelimmäksi, kun dialogiin liittyvät jutut voi säilöä rivin sisäisenä tilana
* Lisätty sijaintiraiteeseen linkitetyt toiminnalliset pisteet osoitteineen `LocationTrackInfoboxExtras`:iin. Tällöin kunkin toiminnallisen pisteen osoitetta ei tarvitse kysellä erikseen bäkkäriltä, eikä niitä varten tarvitse toteuttaa mitään erillistä geokoodauksen massahakua