### PR TITLE
General: More reliable endM

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/TrackMeterHeights.kt
@@ -227,13 +227,12 @@ private fun <M : AlignmentM<M>, GM : GeocodingAlignmentM<GM>> getLastEndM(
     kms: List<GeocodingKm<GM>>,
     alignmentEnd: AddressPoint<M>,
     alignment: IAlignment<M>,
-): LineM<M> =
-    if (kms.last().kmNumber == alignmentEnd.address.kmNumber) alignmentEnd.point.m
-    else {
-        // null safety: Here we know we're on a track km before the alignment's end address,
-        // so the end address must be geocodable onto the alignment.
-        checkNotNull(geocodingContext.getTrackLocation(alignment, kms.last().endAddress)).point.m
-    }
+): LineM<M> {
+    val lastKmIndex = geocodingContext.kms.indexOfFirst { km -> km.kmNumber == kms.last().kmNumber }
+    return geocodingContext.kms.getOrNull(lastKmIndex + 1)?.let { nextKm ->
+        geocodingContext.getTrackLocation(alignment, nextKm.startAddress)?.point?.m
+    } ?: alignmentEnd.point.m
+}
 
 data class GeometryAlignmentBoundaryPoint<M : AlignmentM<M>>(val distanceOnAlignment: LineM<M>, val segmentIndex: Int)
 


### PR DESCRIPTION
km-heights-api.ts:getQueryableRange() ja sitä ympäröivä kakutus perustuu oletukseen, että ratakilometrien m-arvovälit kattavat koko alignmentin m-arvojen janan tasan. Mutta ratakilometrin endAddress perustuu endMeters-tietoon, jonka laskennassa on pyöristys, ja sen myötä on mahdollista, että yksi kilometri päättyy mikrometrin tai peri ennen seuraavan alkua, ja tästä sitten kaavio kyselee joka päivityksellä, mitä tässä välissä mahtaa olla. Sinällään siis miltei harmiton vaiva, mutta aiheuttaa ylimääräisiä hakuja, jotka vielä tekevät geokoodausta, eli hintaa niillä on.

Korjataan palaamalla tässä takaisin siihen malliin, että luotetaan ainoastaan kilometrien alkuosoitteisiin.