### PR TITLE
GVT-3546: Raide- ja vaihdelinkkien hanskaus toiminnallisen pisteen poistossa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPoint.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPoint.kt
@@ -170,6 +170,16 @@ data class InternalOperationalPointSaveRequest(
     val rinfIdOverride: RinfId?,
 )
 
+data class InternalOperationalPointUpdateRequest(
+    val name: OperationalPointInputName,
+    val abbreviation: OperationalPointInputAbbreviation?,
+    val rinfType: OperationalPointRinfType,
+    val state: OperationalPointState,
+    val uicCode: UicCode,
+    val rinfIdOverride: RinfId?,
+    val severLinks: Boolean,
+)
+
 data class ExternalOperationalPointSaveRequest(val rinfType: OperationalPointRinfType?, val rinfIdOverride: RinfId?)
 
 enum class OperationalPointRinfType {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
@@ -83,7 +83,7 @@ class OperationalPointController(
     fun updateInternalOperationalPoint(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
         @PathVariable("id") id: IntId<OperationalPoint>,
-        @RequestBody request: InternalOperationalPointSaveRequest,
+        @RequestBody request: InternalOperationalPointUpdateRequest,
     ): IntId<OperationalPoint> {
         return operationalPointService.update(layoutBranch, id, request).id
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
@@ -66,9 +66,9 @@ class OperationalPointService(
     fun update(
         branch: LayoutBranch,
         id: IntId<OperationalPoint>,
-        request: InternalOperationalPointSaveRequest,
-    ): LayoutRowVersion<OperationalPoint> =
-        saveDraft(
+        request: InternalOperationalPointUpdateRequest,
+    ): LayoutRowVersion<OperationalPoint> {
+        val version = saveDraft(
             branch,
             dao.getOrThrow(branch.draft, id)
                 .also {
@@ -86,6 +86,11 @@ class OperationalPointService(
                     rinfIdOverride = request.rinfIdOverride,
                 ),
         )
+        if (request.severLinks) {
+            clearOperationalPointReferences(branch, version.id)
+        }
+        return version
+    }
 
     @Transactional
     fun update(

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -2404,7 +2404,12 @@
         "delete-confirm-dialog": {
             "title": "Toiminnallisen pisteen poistaminen paikannuspohjasta",
             "deleted-op-not-allowed": "Poistettu-tilainen toiminnallinen piste ei voi olla osa paikannuspohjaa.",
-            "confirm": "Haluatko poistaa toiminnallisen pisteen paikannuspohjasta?"
+            "confirm": "Haluatko poistaa toiminnallisen pisteen paikannuspohjasta?",
+            "linked-assets-warning": "Toiminnalliseen pisteeseen on linkitetty seuraavia kohteita:",
+            "linked-switches-heading": "Vaihteet:",
+            "linked-location-tracks-heading": "Raiteet:",
+            "sever-links-explanation": "Linkitykset on purettava tai kohteet on poistettava, jotta toiminnallisen pisteen poisto voidaan julkaista.",
+            "sever-links-checkbox": "Pura linkitykset toiminnalliseen pisteeseen"
         },
         "validation": {
             "invalid-name": "Virheellinen nimi",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -99,7 +99,7 @@ constructor(
                 .update(
                     LayoutBranch.main,
                     original.id,
-                    internalPointSaveRequest(
+                    internalPointUpdateRequest(
                         name = "updated",
                         abbreviation = "upd",
                         rinfType = OperationalPointRinfType.PASSENGER_TERMINAL,
@@ -132,7 +132,7 @@ constructor(
                 .id
 
         assertThrows<SavingFailureException> {
-            operationalPointService.update(LayoutBranch.main, external, internalPointSaveRequest("updated"))
+            operationalPointService.update(LayoutBranch.main, external, internalPointUpdateRequest("updated"))
         }
     }
 
@@ -199,7 +199,7 @@ constructor(
         operationalPointService.publish(LayoutBranch.main, firstDraft)
         val assignedOid = operationalPointDao.fetchExternalId(LayoutBranch.main, firstDraft.id)
         assertNotNull(assignedOid)
-        operationalPointService.update(LayoutBranch.main, firstDraft.id, internalPointSaveRequest("b"))
+        operationalPointService.update(LayoutBranch.main, firstDraft.id, internalPointUpdateRequest("b"))
         operationalPointService.publish(LayoutBranch.main, firstDraft)
         val oidAfterSecondPublication = operationalPointDao.fetchExternalId(LayoutBranch.main, firstDraft.id)
         assertEquals(assignedOid.oid, oidAfterSecondPublication?.oid)
@@ -408,10 +408,69 @@ constructor(
             rinfIdOverride,
         )
 
+    private fun internalPointUpdateRequest(
+        name: String = "name",
+        abbreviation: String = name,
+        rinfType: OperationalPointRinfType = OperationalPointRinfType.SMALL_STATION,
+        state: OperationalPointState = OperationalPointState.IN_USE,
+        uicCode: String = "10101",
+        rinfIdOverride: RinfId? = null,
+        severLinks: Boolean = false,
+    ) =
+        InternalOperationalPointUpdateRequest(
+            OperationalPointInputName(name),
+            OperationalPointInputAbbreviation(abbreviation),
+            rinfType,
+            state,
+            UicCode(uicCode),
+            rinfIdOverride,
+            severLinks,
+        )
+
     private fun externalPointSaveRequest(
         rinfType: OperationalPointRinfType = OperationalPointRinfType.SMALL_STATION,
         rinfIdOverride: RinfId? = null,
     ) = ExternalOperationalPointSaveRequest(rinfType, rinfIdOverride)
+
+    @Test
+    fun `update with severLinks = true clears references from location tracks and switches`() {
+        val opId = operationalPointService.insert(LayoutBranch.main, internalPointSaveRequest("op")).id
+        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+
+        val locationTrack = mainDraftContext.save(locationTrack(trackNumberId, operationalPointIds = setOf(opId))).id
+        val switch = mainDraftContext.save(switch(operationalPointId = opId)).id
+
+        operationalPointService.update(
+            LayoutBranch.main,
+            opId,
+            internalPointUpdateRequest(name = "op", state = OperationalPointState.DELETED, severLinks = true),
+        )
+
+        val trackAfter = locationTrackService.getOrThrow(mainDraftContext.context, locationTrack)
+        assertEquals(emptySet<Nothing>(), trackAfter.operationalPointIds)
+        val switchAfter = switchService.getOrThrow(mainDraftContext.context, switch)
+        assertNull(switchAfter.operationalPointId)
+    }
+
+    @Test
+    fun `update with severLinks = false preserves references on location tracks and switches`() {
+        val opId = operationalPointService.insert(LayoutBranch.main, internalPointSaveRequest("op")).id
+        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+
+        val locationTrack = mainDraftContext.save(locationTrack(trackNumberId, operationalPointIds = setOf(opId))).id
+        val switch = mainDraftContext.save(switch(operationalPointId = opId)).id
+
+        operationalPointService.update(
+            LayoutBranch.main,
+            opId,
+            internalPointUpdateRequest(name = "op", state = OperationalPointState.DELETED, severLinks = false),
+        )
+
+        val trackAfter = locationTrackService.getOrThrow(mainDraftContext.context, locationTrack)
+        assertEquals(setOf(opId), trackAfter.operationalPointIds)
+        val switchAfter = switchService.getOrThrow(mainDraftContext.context, switch)
+        assertEquals(opId, switchAfter.operationalPointId)
+    }
 
     @Test
     fun `should reject setting rinf_id_generated once set`() {

--- a/ui/src/tool-panel/operational-point/dialog/internal-operational-point-edit-dialog.tsx
+++ b/ui/src/tool-panel/operational-point/dialog/internal-operational-point-edit-dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Dialog } from 'geoviite-design-lib/dialog/dialog';
 import { FormLayout, FormLayoutColumn } from 'geoviite-design-lib/form-layout/form-layout';
 import { Heading, HeadingSize } from 'vayla-design-lib/heading/heading';
 import { FieldLayout } from 'vayla-design-lib/field-layout/field-layout';
@@ -21,6 +21,7 @@ import {
     initialInternalOperationalPointEditState,
     InternalOperationalPointEditState,
     InternalOperationalPointSaveRequest,
+    InternalOperationalPointUpdateRequest,
     reducer,
 } from 'tool-panel/operational-point/dialog/internal-operational-point-edit-store';
 import { createDelegatesWithDispatcher } from 'store/store-utils';
@@ -45,6 +46,16 @@ import {
     hasSameRinfId,
     withConditionalRinfIdOverride,
 } from 'tool-panel/operational-point/operational-point-utils';
+import { useLoaderWithStatus } from 'utils/react-utils';
+import {
+    findOperationalPointLocationTracks,
+    getLocationTracks,
+} from 'track-layout/layout-location-track-api';
+import {
+    findOperationalPointSwitches,
+    getSwitches,
+} from 'track-layout/layout-switch-api';
+import { OperationalPointDeleteConfirmationDialog } from 'tool-panel/operational-point/dialog/operational-point-delete-confirmation-dialog';
 
 type InternalOperationalPointEditDialogProps = {
     operationalPoint: OperationalPoint | undefined;
@@ -89,6 +100,27 @@ export const InternalOperationalPointEditDialog: React.FC<
     const [deleteOperationalPointConfirmDialogOpen, setDeleteOperationalPointConfirmDialogOpen] =
         React.useState(false);
     const [isSaving, setIsSaving] = React.useState(false);
+
+    const [linkedAssets, linkedAssetsLoaderStatus] = useLoaderWithStatus(async () => {
+        if (!operationalPoint) return { tracks: [], switches: [] };
+        const [tracks, switches] = await Promise.all([
+            findOperationalPointLocationTracks(layoutContext, operationalPoint.id).then(
+                (result) =>
+                    result ? getLocationTracks(result.assigned, layoutContext) : [],
+            ),
+            findOperationalPointSwitches(layoutContext, operationalPoint.id).then(
+                (swOps) => {
+                    const linkedIds = swOps
+                        .filter((s) => s.isLinked)
+                        .map((s) => s.switchId);
+                    return linkedIds.length > 0
+                        ? getSwitches(linkedIds, layoutContext)
+                        : [];
+                },
+            ),
+        ]);
+        return { tracks, switches };
+    }, [layoutContext.branch, layoutContext.publicationState, operationalPoint?.id]);
 
     const stateOptions = operationalPointStates.map((s) =>
         s.value !== 'DELETED' || !isDraftOnly ? s : { ...s, disabled: true },
@@ -180,13 +212,18 @@ export const InternalOperationalPointEditDialog: React.FC<
         id: OperationalPointId,
         updatedOperationalPoint: InternalOperationalPointSaveRequest,
         allowRinfIdOverride: boolean,
+        severLinks: boolean,
     ) {
         setIsSaving(true);
         const saveRequest = withConditionalRinfIdOverride(
             updatedOperationalPoint,
             allowRinfIdOverride,
         );
-        updateInternalOperationalPoint(id, saveRequest, layoutContext)
+        const updateRequest: InternalOperationalPointUpdateRequest = {
+            ...saveRequest,
+            severLinks,
+        };
+        updateInternalOperationalPoint(id, updateRequest, layoutContext)
             .then(
                 () => {
                     onSave(id);
@@ -205,6 +242,7 @@ export const InternalOperationalPointEditDialog: React.FC<
                   operationalPoint.id,
                   state.operationalPoint,
                   state.editingRinfId,
+                  false,
               );
 
     const saveOrConfirm = () =>
@@ -212,8 +250,15 @@ export const InternalOperationalPointEditDialog: React.FC<
             ? setDeleteOperationalPointConfirmDialogOpen(true)
             : save();
 
-    const deleteOperationalPoint = () => {
-        save();
+    const deleteOperationalPoint = (severLinks: boolean) => {
+        if (operationalPoint) {
+            saveUpdatedOperationalPoint(
+                operationalPoint.id,
+                state.operationalPoint,
+                state.editingRinfId,
+                severLinks,
+            );
+        }
         setDeleteOperationalPointConfirmDialogOpen(false);
     };
 
@@ -392,32 +437,14 @@ export const InternalOperationalPointEditDialog: React.FC<
                 />
             )}
             {deleteOperationalPointConfirmDialogOpen && (
-                <Dialog
-                    title={t('operational-point-dialog.delete-confirm-dialog.title')}
+                <OperationalPointDeleteConfirmationDialog
+                    linkedLocationTracks={linkedAssets?.tracks ?? []}
+                    linkedSwitches={linkedAssets?.switches ?? []}
+                    linkedAssetsLoaderStatus={linkedAssetsLoaderStatus}
+                    onConfirm={(severLinks) => deleteOperationalPoint(severLinks)}
                     onClose={() => setDeleteOperationalPointConfirmDialogOpen(false)}
-                    variant={DialogVariant.DARK}
-                    allowClose={false}
-                    footerContent={
-                        <div className={dialogStyles['dialog__footer-content--centered']}>
-                            <Button
-                                variant={ButtonVariant.SECONDARY}
-                                onClick={() => setDeleteOperationalPointConfirmDialogOpen(false)}>
-                                {t('button.cancel')}
-                            </Button>
-                            <Button
-                                variant={ButtonVariant.PRIMARY_WARNING}
-                                onClick={deleteOperationalPoint}>
-                                {t('button.delete')}
-                            </Button>
-                        </div>
-                    }>
-                    <div className={dialogStyles['dialog__text']}>
-                        {t('operational-point-dialog.delete-confirm-dialog.deleted-op-not-allowed')}
-                    </div>
-                    <div className={dialogStyles['dialog__text']}>
-                        {t('operational-point-dialog.delete-confirm-dialog.confirm')}
-                    </div>
-                </Dialog>
+                    isSaving={isSaving}
+                />
             )}
         </React.Fragment>
     );

--- a/ui/src/tool-panel/operational-point/dialog/internal-operational-point-edit-store.ts
+++ b/ui/src/tool-panel/operational-point/dialog/internal-operational-point-edit-store.ts
@@ -33,6 +33,10 @@ export type InternalOperationalPointSaveRequest = OperationalPointSaveRequestBas
     uicCode: UICCode;
 };
 
+export type InternalOperationalPointUpdateRequest = InternalOperationalPointSaveRequest & {
+    severLinks: boolean;
+};
+
 function validateInternalOperationalPoint(
     saveRequest: InternalOperationalPointSaveRequest,
     editingRinfId: boolean,

--- a/ui/src/tool-panel/operational-point/dialog/operational-point-delete-confirmation-dialog.scss
+++ b/ui/src/tool-panel/operational-point/dialog/operational-point-delete-confirmation-dialog.scss
@@ -1,0 +1,4 @@
+.op-delete-confirmation-dialog__linked-assets-list {
+    max-height: 200px;
+    overflow-y: auto;
+}

--- a/ui/src/tool-panel/operational-point/dialog/operational-point-delete-confirmation-dialog.tsx
+++ b/ui/src/tool-panel/operational-point/dialog/operational-point-delete-confirmation-dialog.tsx
@@ -1,0 +1,145 @@
+import { Dialog, DialogVariant } from 'geoviite-design-lib/dialog/dialog';
+import { Button, ButtonVariant } from 'vayla-design-lib/button/button';
+import { Checkbox } from 'vayla-design-lib/checkbox/checkbox';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import dialogStyles from 'geoviite-design-lib/dialog/dialog.scss';
+import styles from './operational-point-delete-confirmation-dialog.scss';
+import { LoaderStatus } from 'utils/react-utils';
+import { Spinner } from 'vayla-design-lib/spinner/spinner';
+import { LayoutLocationTrack, LayoutSwitch } from 'track-layout/track-layout-model';
+
+type LinkedAssetsContentProps = {
+    linkedLocationTracks: LayoutLocationTrack[];
+    linkedSwitches: LayoutSwitch[];
+    severLinks: boolean;
+    onSeverLinksChange: (severLinks: boolean) => void;
+};
+
+const LinkedAssetsContent: React.FC<LinkedAssetsContentProps> = ({
+    linkedLocationTracks,
+    linkedSwitches,
+    severLinks,
+    onSeverLinksChange,
+}) => {
+    const { t } = useTranslation();
+
+    return (
+        <React.Fragment>
+            <p>{t('operational-point-dialog.delete-confirm-dialog.deleted-op-not-allowed')}</p>
+            <div className={'dialog__text'}>
+                <p>{t('operational-point-dialog.delete-confirm-dialog.linked-assets-warning')}</p>
+                <div className={styles['op-delete-confirmation-dialog__linked-assets-list']}>
+                    {linkedSwitches.length > 0 && (
+                        <React.Fragment>
+                            <strong>
+                                {t(
+                                    'operational-point-dialog.delete-confirm-dialog.linked-switches-heading',
+                                )}
+                            </strong>
+                            <ul>
+                                {linkedSwitches.map((sw) => (
+                                    <li key={sw.id}>{sw.name}</li>
+                                ))}
+                            </ul>
+                        </React.Fragment>
+                    )}
+                    {linkedLocationTracks.length > 0 && (
+                        <React.Fragment>
+                            <strong>
+                                {t(
+                                    'operational-point-dialog.delete-confirm-dialog.linked-location-tracks-heading',
+                                )}
+                            </strong>
+                            <ul>
+                                {linkedLocationTracks.map((lt) => (
+                                    <li key={lt.id}>{lt.name}</li>
+                                ))}
+                            </ul>
+                        </React.Fragment>
+                    )}
+                </div>
+                <p>{t('operational-point-dialog.delete-confirm-dialog.sever-links-explanation')}</p>
+            </div>
+            <Checkbox checked={severLinks} onChange={(e) => onSeverLinksChange(e.target.checked)}>
+                {t('operational-point-dialog.delete-confirm-dialog.sever-links-checkbox')}
+            </Checkbox>
+        </React.Fragment>
+    );
+};
+
+const NoLinkedAssetsContent: React.FC = () => {
+    const { t } = useTranslation();
+
+    return (
+        <div>
+            <p>{t('operational-point-dialog.delete-confirm-dialog.deleted-op-not-allowed')}</p>
+            <div className={'dialog__text'}>
+                {t('operational-point-dialog.delete-confirm-dialog.confirm')}
+            </div>
+        </div>
+    );
+};
+
+type OperationalPointDeleteConfirmationDialogProps = {
+    linkedLocationTracks: LayoutLocationTrack[];
+    linkedSwitches: LayoutSwitch[];
+    linkedAssetsLoaderStatus: LoaderStatus;
+    onConfirm: (severLinks: boolean) => void;
+    onClose: () => void;
+    isSaving: boolean;
+};
+
+export const OperationalPointDeleteConfirmationDialog: React.FC<
+    OperationalPointDeleteConfirmationDialogProps
+> = ({
+    linkedLocationTracks,
+    linkedSwitches,
+    linkedAssetsLoaderStatus,
+    onConfirm,
+    onClose,
+    isSaving,
+}) => {
+    const { t } = useTranslation();
+
+    const [severLinks, setSeverLinks] = React.useState(true);
+
+    const linkedAssetsLoaded = linkedAssetsLoaderStatus === LoaderStatus.Ready;
+    const hasLinkedAssets = linkedLocationTracks.length > 0 || linkedSwitches.length > 0;
+
+    return (
+        <Dialog
+            title={t('operational-point-dialog.delete-confirm-dialog.title')}
+            variant={DialogVariant.DARK}
+            allowClose={false}
+            footerContent={
+                <div className={dialogStyles['dialog__footer-content--centered']}>
+                    <Button onClick={onClose} variant={ButtonVariant.SECONDARY} disabled={isSaving}>
+                        {t('button.cancel')}
+                    </Button>
+                    <Button
+                        disabled={isSaving || !linkedAssetsLoaded}
+                        isProcessing={isSaving}
+                        variant={ButtonVariant.PRIMARY_WARNING}
+                        onClick={() => onConfirm(severLinks)}>
+                        {t('button.delete')}
+                    </Button>
+                </div>
+            }>
+            {linkedAssetsLoaded ? (
+                hasLinkedAssets ? (
+                    <LinkedAssetsContent
+                        linkedLocationTracks={linkedLocationTracks}
+                        linkedSwitches={linkedSwitches}
+                        severLinks={severLinks}
+                        onSeverLinksChange={setSeverLinks}
+                    />
+                ) : (
+                    <NoLinkedAssetsContent />
+                )
+            ) : (
+                <Spinner />
+            )}
+        </Dialog>
+    );
+};

--- a/ui/src/track-layout/layout-operational-point-api.ts
+++ b/ui/src/track-layout/layout-operational-point-api.ts
@@ -21,7 +21,7 @@ import {
     TRACK_LAYOUT_URI,
 } from 'track-layout/track-layout-api';
 import { getChangeTimes, updateOperationalPointsChangeTime } from 'common/change-time-api';
-import { InternalOperationalPointSaveRequest } from 'tool-panel/operational-point/dialog/internal-operational-point-edit-store';
+import { InternalOperationalPointSaveRequest, InternalOperationalPointUpdateRequest } from 'tool-panel/operational-point/dialog/internal-operational-point-edit-store';
 import { ExternalOperationalPointSaveRequest } from 'tool-panel/operational-point/dialog/external-operational-point-edit-store';
 import { Point, Polygon } from 'model/geometry';
 import { ValidatedOperationalPoint } from 'publication/publication-model';
@@ -30,6 +30,7 @@ import { getMaxTimestamp } from 'utils/date-utils';
 type OriginInUri = 'internal' | 'external';
 type OperationalPointSaveRequest =
     | InternalOperationalPointSaveRequest
+    | InternalOperationalPointUpdateRequest
     | ExternalOperationalPointSaveRequest;
 
 const allOperationalPointsCache = asyncCache<string, OperationalPoint[]>();
@@ -129,7 +130,7 @@ async function updateOperationalPoint(
 
 export const updateInternalOperationalPoint = (
     id: OperationalPointId,
-    updatedOperationalPoint: InternalOperationalPointSaveRequest,
+    updatedOperationalPoint: InternalOperationalPointUpdateRequest,
     layoutContext: LayoutContext,
 ): Promise<OperationalPointId> =>
     updateOperationalPoint(id, 'internal', updatedOperationalPoint, layoutContext);


### PR DESCRIPTION
Vaihde- ja raidelinkeille tulee tehdä jotain toiminnallisen pisteen poistossa, muuten julkaisuvalidointi huutaa eikä poistoa pysty julkaisemaan. Täten täällä toteutettu hyvin samantyyppinen mekanismi kuin vaihteenkin raidelinkkeihin vaihteen poistossa:

* Poiston varmistusdialogissa listataan kaikki raiteet ja vaihteet jotka ovat kiinni ka. toiminnallisessa pisteessä.
  * Jos toiminnallisessa pisteessä on kiinni raiteita ja/tai vaihteita, näytetään varmistusdialogissa listaus niistä sekä checkbox, jolla voidaan kontrolloida sitä poistetaanko linkit vai ei (defaulttina päällä)
  * Jos toiminnallisessa pisteessä ei ole kiinni mitään, näytetään aiemman mukainen checkboxiton dialogi
* Tieto linkkien poistotarpeesta välitetään bäkkärille tallennuspyyntötietorakenteessa
  * Tätä varten samoin kuin vaihteenkin kanssa, sisäisen toiminnallisen pisteen `SaveRequest` on nyt eriytetty käyttötilannekohtaisesti `UpdateRequest`:iin (jota käytetään kun muokataan jo valmiiksi kannassa olevaa toiminnallista pistettä) ja `SaveRequest`:iin (jota käytetään kun halutaan luoda kokonaan uusi toiminnallinen piste)