### PR TITLE
GVT-3584 Avoid linking plan layout geometries with jumpy segments

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryController.kt
@@ -18,6 +18,7 @@ import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geocoding.AlignmentStartAndEnd
 import fi.fta.geoviite.infra.geometry.GeometryPlanSortField.ID
 import fi.fta.geoviite.infra.geometry.GeometryPlanSortField.NAME
+import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.localization.LocalizationLanguage
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
@@ -360,4 +361,12 @@ constructor(private val geometryService: GeometryService, private val planLayout
             tickLength = tickLength,
         )
     }
+
+    @PreAuthorize(AUTH_VIEW_GEOMETRY)
+    @GetMapping("/plans/{planId}/alignments/{planAlignmentId}/elements-preventing-linking")
+    fun checkElementsPreventingLinking(
+        @PathVariable("planId") planId: IntId<GeometryPlan>,
+        @PathVariable("planAlignmentId") planAlignmentId: IntId<GeometryAlignment>,
+    ): ResponseEntity<List<PlanElementName>> =
+        toResponse(planLayoutService.checkElementsPreventingLinking(planId, planAlignmentId))
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/PlanLayoutService.kt
@@ -3,7 +3,9 @@ package fi.fta.geoviite.infra.geometry
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.tracklayout.GeometryPlanLayout
+import fi.fta.geoviite.infra.tracklayout.MAX_GAP_BETWEEN_SEGMENT_ENDS
 
 @GeoviiteService
 class PlanLayoutService(private val planLayoutCache: PlanLayoutCache, private val geometryDao: GeometryDao) {
@@ -24,6 +26,25 @@ class PlanLayoutService(private val planLayoutCache: PlanLayoutCache, private va
         pointListStepLength: Int = 1,
     ): Pair<GeometryPlanLayout?, TransformationError?> =
         getLayoutPlan(geometryDao.fetchPlanVersion(geometryPlanId), includeGeometryData, pointListStepLength)
+
+    fun checkElementsPreventingLinking(
+        planId: IntId<GeometryPlan>,
+        alignmentId: IntId<GeometryAlignment>,
+    ): List<PlanElementName>? {
+        val planVersion = geometryDao.fetchPlanVersion(planId)
+        val plan = geometryDao.fetchPlan(planVersion)
+        val planAlignment = plan.alignments.find { it.id == alignmentId } ?: return null
+        val planLayout = getLayoutPlan(planVersion).first ?: return null
+        val planLayoutAlignment = planLayout.alignments.find { it.id == alignmentId } ?: return null
+
+        return planLayoutAlignment.segments
+            .mapIndexed { index, segment -> segment to index }
+            .zipWithNext { (prev), (next, index) ->
+                index to prev.geometry.segmentEnd.isSame(next.geometry.segmentStart, MAX_GAP_BETWEEN_SEGMENT_ENDS)
+            }
+            .filter { (_, samePoint) -> !samePoint }
+            .mapNotNull { (index) -> planAlignment.elements[index].name }
+    }
 
     private fun handlePointListStepLength(
         layoutResult: Pair<GeometryPlanLayout?, TransformationError?>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -27,6 +27,8 @@ import java.util.*
 import kotlin.math.PI
 import kotlin.math.abs
 
+const val MAX_GAP_BETWEEN_SEGMENT_ENDS = 0.001
+
 enum class TrackSwitchLinkType {
     INNER,
     OUTER,
@@ -879,7 +881,7 @@ private fun verifyEdgeContent(edge: LayoutEdge) {
         }
     }
     edge.segments.zipWithNext().mapIndexed { i, (prev, next) ->
-        require(prev.segmentEnd.isSame(next.segmentStart, 0.001)) {
+        require(prev.segmentEnd.isSame(next.segmentStart, MAX_GAP_BETWEEN_SEGMENT_ENDS)) {
             "Edge segments should begin where the previous one ends: index=$i prev=${prev.segmentEnd} next=${next.segmentStart}"
         }
     }

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -783,6 +783,7 @@
                 "show-on-map": "Kohdista kartalla",
                 "no-linkable-location-tracks": "Sopivia sijaintiraiteita ei löytynyt linkitettäväksi.",
                 "no-linkable-reference-lines": "Sopivia pituusmittauslinjoja ei löytynyt linkitettäväksi.",
+                "elements-prevent-plan-linking": "Suunnitelmageometriassa on elementtejä, jotka eivät ala tarkasti siitä, mihin edellinen jäi: {{elementNames}}",
                 "part-of-unfinished-split": "Raiteen {{locationTrackName}} geometriaa ei voi muokata, ennen kuin jakamiseen liittyvä julkaisu on viety Ratkoon tai jaetun raiteen muokkaus on sallittu manuaalisesti."
             },
             "geometry-segment": {

--- a/ui/src/geometry/geometry-api.ts
+++ b/ui/src/geometry/geometry-api.ts
@@ -428,3 +428,17 @@ export async function getLocationTrackLinkingSummary(
             ),
     );
 }
+
+const elementsPreventingPlanAlignmentLinkingCache = asyncCache<string, string[] | undefined>();
+
+export async function checkElementsPreventingPlanAlignmentLinking(
+    planId: GeometryPlanId,
+    alignmentId: GeometryAlignmentId,
+): Promise<string[] | undefined> {
+    const key = `${planId}_${alignmentId}`;
+    return elementsPreventingPlanAlignmentLinkingCache.get(getChangeTimes().geometryPlan, key, () =>
+        getNullable(
+            `${GEOMETRY_URI}/plans/${planId}/alignments/${alignmentId}/elements-preventing-linking`,
+        ),
+    );
+}

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -64,6 +64,7 @@ import { EDIT_LAYOUT } from 'user/user-model';
 import { LinkingStatusLabel } from 'geoviite-design-lib/linking-status/linking-status-label';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import { LocalizationKey } from 'infra-model/infra-model-slice';
+import { checkElementsPreventingPlanAlignmentLinking } from 'geometry/geometry-api';
 
 function createLinkingGeometryWithAlignmentParameters(
     alignmentLinking: LinkingGeometryWithAlignment,
@@ -231,6 +232,11 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
         selectedLayoutLocationTrack?.id,
         layoutContext,
         changeTimes,
+    );
+
+    const elementsPreventingPlanAlignmentLinking = useLoader(
+        () => checkElementsPreventingPlanAlignmentLinking(planId, geometryAlignment.id),
+        [planId, geometryAlignment.id],
     );
 
     const canLink =
@@ -450,9 +456,28 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
 
                     {linkingState === undefined && (
                         <PrivilegeRequired privilege={EDIT_LAYOUT}>
+                            {layoutContext.publicationState === 'DRAFT' &&
+                                elementsPreventingPlanAlignmentLinking !== undefined &&
+                                elementsPreventingPlanAlignmentLinking.length > 0 && (
+                                    <MessageBox>
+                                        {t(
+                                            'tool-panel.alignment.geometry.elements-prevent-plan-linking',
+                                            {
+                                                elementNames:
+                                                    elementsPreventingPlanAlignmentLinking.join(
+                                                        ', ',
+                                                    ),
+                                            },
+                                        )}
+                                    </MessageBox>
+                                )}
                             <InfoboxButtons>
                                 <Button
-                                    disabled={layoutContext.publicationState !== 'DRAFT'}
+                                    disabled={
+                                        layoutContext.publicationState !== 'DRAFT' ||
+                                        elementsPreventingPlanAlignmentLinking === undefined ||
+                                        elementsPreventingPlanAlignmentLinking.length > 0
+                                    }
                                     title={
                                         layoutContext.publicationState === 'OFFICIAL'
                                             ? t(


### PR DESCRIPTION
Yksi ajatus heittona sen ongelman ratkaisuksi, että suunnitelman raidegeometriassa voi olla sellaista mätää, mikä aiheuttaa sisäisen virheen siinä vaiheessa, kun ollaan tekemässä linkitystä paikannuspohjaan; ja siitäpä oli hankala käyttäjän nähdä, mikä oli varsinainen ongelma.

Släkissä varsinainen keskustelu siitä, mikä voisi olla oikea ratkaisu. Mutta jos ei muuta, niin tämän kanssa pystyy ainakin vähän tunnustelemaan, missä kohti menee rikki asioita, jotka eivät ennen menneet rikki.