### PR TITLE
GVT-3557 & GVT-3558: Infoboksien nimeämisten yhtenäistäminen ja lukumäärien siirtäminen otsikoihin

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -613,7 +613,7 @@
             "cannot-shorten-deleted-track-number": "Poistettua ratanumeroa ei voi lyhentää",
             "no-geometry": "Ratanumerolla ei ole geometriaa",
             "cant-edit-while-linking": "Ratanumeron tietoja ei voi muokata linkitystilassa",
-            "location-tracks-title": "Sijaintiraiteet ({{count}})",
+            "location-tracks-title": "Ratanumeron sijaintiraiteet ({{count}})",
             "location-tracks-filter-by-area": "Vain kartalle osuvat raiteet",
             "no-location-tracks": "Ei sijaintiraiteita",
             "revert-dialog": {
@@ -628,7 +628,7 @@
         "km-post": {
             "layout": {
                 "show-on-map": "Kohdista kartalla",
-                "general-title": "Tasakmpisteen perustiedot",
+                "general-title": "Tasakilometripisteen perustiedot",
                 "km-post": "Tasakmpistetunnus",
                 "track-number": "Ratanumero",
                 "state": "Tila",
@@ -881,9 +881,9 @@
                 "diagram-visibility": "Kuvaaja"
             },
             "switch-links": {
-                "heading": "Raiteen vaihteet",
+                "heading": "Raiteen vaihteet ({{count}})",
                 "no-switches": "Raiteella ei ole vaihteita",
-                "show-more": "Näytä kaikki {{count}} kpl",
+                "show-more": "Näytä kaikki",
                 "no-location": "Ei sijaintia",
                 "not-existing": "Poistettu",
                 "detach": "Irrota"
@@ -895,9 +895,9 @@
                 "success-toast": "Vaihde {{switchName}} irrotettu raiteelta {{trackName}}"
             },
             "operational-point-links": {
-                "heading": "Raiteen toiminnalliset pisteet",
+                "heading": "Raiteen toiminnalliset pisteet ({{count}})",
                 "no-operational-points": "Raidetta ei ole linkitetty toiminnallisille pisteille",
-                "show-more": "Näytä kaikki {{count}} kpl",
+                "show-more": "Näytä kaikki",
                 "no-location": "Ei sijaintia",
                 "not-existing": "Poistettu",
                 "detach": "Irrota"
@@ -993,7 +993,7 @@
         },
         "operational-point": {
             "basic-info-heading": "Toiminnallisen pisteen perustiedot",
-            "location-heading": "Sijainti",
+            "location-heading": "Toiminnallisen pisteen sijainti",
             "log-heading": "Lokitiedot",
             "source": "Lähde",
             "identifier": "OID",
@@ -1006,9 +1006,9 @@
             "uic-code": "UIC-koodi",
             "location": "Sijainti",
             "address": "Rataosoite ({{trackNumber}})",
-            "address-unknown": "osoitetta ei voi laskea",
+            "address-unknown": "Osoitetta ei voi laskea",
             "no-linked-tracks-label": "Rataosoite",
-            "no-linked-tracks-text": "pisteeseen ei ole linkitetty raiteita",
+            "no-linked-tracks-text": "Pisteeseen ei ole linkitetty raiteita",
             "focus-on-map": "Kohdista kartalla",
             "set-location": "Aseta sijainti kartalla",
             "set-location-help": "Klikkaa toiminnallisen pisteen sijainti kartalle",
@@ -1027,7 +1027,7 @@
             "save-links": "Tallenna muutokset",
             "cancel-editing-links": "Peruuta",
             "switch-links": {
-                "infobox-header": "Vaihteet",
+                "infobox-header": "Toiminnallisen pisteen vaihteet ({{count}})",
                 "attached-header": "Toiminnalliseen pisteeseen linkitetyt vaihteet ({{count}} kpl)",
                 "detached-in-polygon-header": "Toiminnalliseen pisteeseen linkittämättömät, alueella sijaitsevat vaihteet ({{count}} kpl)",
                 "detach-all": "Irrota pisteeltä kaikki vaihteet ({{count}} kpl)",
@@ -1048,7 +1048,7 @@
                 "no-switches": "Ei vaihteita"
             },
             "track-links": {
-                "infobox-header": "Raiteet",
+                "infobox-header": "Toiminnallisen pisteen raiteet ({{count}})",
                 "attached-header": "Toiminnalliseen pisteeseen linkitetyt raiteet ({{count}} kpl)",
                 "detached-in-polygon-header": "Toiminnalliseen pisteeseen linkittämättömät, alueella sijaitsevat raiteet ({{count}} kpl)",
                 "detach-all": "Irrota pisteeltä kaikki raiteet ({{count}} kpl)",
@@ -1067,9 +1067,8 @@
                 "no-tracks": "Ei raiteita"
             },
             "station-links": {
-                "infobox-header": "Yhteydet muille liikennepaikoille",
-                "count": "{{count}} liikennepaikkaväliä",
-                "no-links": "Ei liikennepaikkavälejä"
+                "infobox-header": "Yhteydet muille toiminnallisille pisteille ({{count}})",
+                "no-links": "Ei yhteyksiä muille toiminnallisille pisteille"
             }
         },
         "disabled": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1048,9 +1048,9 @@
                 "no-switches": "Ei vaihteita"
             },
             "track-links": {
-                "infobox-header": "Toiminnallisen pisteen raiteet ({{count}})",
-                "attached-header": "Toiminnalliseen pisteeseen linkitetyt raiteet ({{count}} kpl)",
-                "detached-in-polygon-header": "Toiminnalliseen pisteeseen linkittämättömät, alueella sijaitsevat raiteet ({{count}} kpl)",
+                "infobox-header": "Toiminnallisen pisteen sijaintiraiteet ({{count}})",
+                "attached-header": "Toiminnalliseen pisteeseen linkitetyt sijaintiraiteet ({{count}} kpl)",
+                "detached-in-polygon-header": "Toiminnalliseen pisteeseen linkittämättömät, alueella sijaitsevat sijaintiraiteet ({{count}} kpl)",
                 "detach-all": "Irrota pisteeltä kaikki raiteet ({{count}} kpl)",
                 "attach-all": "Linkitä pisteeseen kaikki raiteet ({{count}} kpl)",
                 "show-all": "Näytä kaikki ({{count}} kpl)...",

--- a/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
@@ -67,7 +67,9 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
 
     return (
         <Infobox
-            title={t('tool-panel.location-track.operational-point-links.heading')}
+            title={t('tool-panel.location-track.operational-point-links.heading', {
+                count: operationalPoints?.length ?? 0,
+            })}
             qa-id={'location-track-operational-point-links-infobox'}
             contentVisible={contentVisible}
             onContentVisibilityChange={onContentVisibilityChange}>
@@ -107,9 +109,6 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
                                     onShowMore={() => setShowAll(!showAll)}
                                     showMoreText={t(
                                         'tool-panel.location-track.operational-point-links.show-more',
-                                        {
-                                            count: operationalPoints.length,
-                                        },
                                     )}
                                 />
                             )}
@@ -126,4 +125,3 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
         </Infobox>
     );
 };
-

--- a/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
@@ -100,7 +100,9 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
 
     return (
         <Infobox
-            title={t('tool-panel.location-track.switch-links.heading')}
+            title={t('tool-panel.location-track.switch-links.heading', {
+                count: switchesAll.length,
+            })}
             qa-id={'location-track-switch-links-infobox'}
             contentVisible={contentVisible}
             onContentVisibilityChange={onContentVisibilityChange}>
@@ -137,9 +139,6 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
                                     onShowMore={() => setShowAllSwitches(!showAllSwitches)}
                                     showMoreText={t(
                                         'tool-panel.location-track.switch-links.show-more',
-                                        {
-                                            count: switchesAll.length,
-                                        },
                                     )}
                                 />
                             )}

--- a/ui/src/tool-panel/operational-point/operational-point-station-links-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-station-links-infobox.tsx
@@ -49,7 +49,9 @@ export const OperationalPointStationLinksInfobox: React.FC<
 
     return (
         <Infobox
-            title={t('tool-panel.operational-point.station-links.infobox-header')}
+            title={t('tool-panel.operational-point.station-links.infobox-header', {
+                count: stationLinks?.length ?? 0,
+            })}
             contentVisible={contentVisible}
             onContentVisibilityChange={() => onVisibilityChange('stationLinks')}>
             {
@@ -62,30 +64,20 @@ export const OperationalPointStationLinksInfobox: React.FC<
                                 {t('tool-panel.operational-point.station-links.no-links')}
                             </p>
                         ) : (
-                            <>
-                                <p className="infobox__text">
-                                    {t('tool-panel.operational-point.station-links.count', {
-                                        count: stationLinks?.length ?? 0,
-                                    })}
-                                </p>
-                                <ul
-                                    className={
-                                        styles['operational-point-infobox__station-links-list']
-                                    }>
-                                    {(stationLinks ?? []).map((stationLink) => (
-                                        <li
-                                            key={`${stationLink.startOperationalPointId}-${stationLink.endOperationalPointId}-${stationLink.trackNumberId}`}>
-                                            <StationLinkView
-                                                stationLink={stationLink}
-                                                ownOperationalPointId={operationalPoint.id}
-                                                layoutContext={layoutContext}
-                                                changeTimes={changeTimes}
-                                                onSelectLocationTrack={onSelectLocationTrack}
-                                            />
-                                        </li>
-                                    ))}
-                                </ul>
-                            </>
+                            <ul className={styles['operational-point-infobox__station-links-list']}>
+                                {(stationLinks ?? []).map((stationLink) => (
+                                    <li
+                                        key={`${stationLink.startOperationalPointId}-${stationLink.endOperationalPointId}-${stationLink.trackNumberId}`}>
+                                        <StationLinkView
+                                            stationLink={stationLink}
+                                            ownOperationalPointId={operationalPoint.id}
+                                            layoutContext={layoutContext}
+                                            changeTimes={changeTimes}
+                                            onSelectLocationTrack={onSelectLocationTrack}
+                                        />
+                                    </li>
+                                ))}
+                            </ul>
                         )}
                     </InfoboxContent>
                 </ProgressIndicatorWrapper>

--- a/ui/src/tool-panel/operational-point/operational-point-switches-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-switches-infobox.tsx
@@ -218,7 +218,9 @@ export const OperationalPointSwitchesInfobox: React.FC<OperationalPointSwitchesI
 
     return (
         <Infobox
-            title={t('tool-panel.operational-point.switch-links.infobox-header')}
+            title={t('tool-panel.operational-point.switch-links.infobox-header', {
+                count: linkedItems.length,
+            })}
             contentVisible={contentVisible}
             onContentVisibilityChange={() => onVisibilityChange('switches')}>
             <InfoboxContent>

--- a/ui/src/tool-panel/operational-point/operational-point-tracks-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-tracks-infobox.tsx
@@ -186,7 +186,9 @@ export const OperationalPointTracksInfobox: React.FC<OperationalPointTracksInfob
 
     return (
         <Infobox
-            title={t('tool-panel.operational-point.track-links.infobox-header')}
+            title={t('tool-panel.operational-point.track-links.infobox-header', {
+                count: linkedTracks.length,
+            })}
             contentVisible={contentVisible}
             onContentVisibilityChange={() => onVisibilityChange('tracks')}>
             <InfoboxContent>


### PR DESCRIPTION
Meillä on ollut tähän mennessä hyvin sekalainen kavalkaadi nimeämiskäytäntöjä infoboksien otsikoissa, esim. ratanumerolla on ollut infoboksit nimeltä "Ratanumeron eheys" ja "Sijaintiraiteet". Nämä on nyt yhdistetty muotoon, jossa ensin kerrotaan assettityyppi ja sen jälkeen mikä infoboksi on kyseessä (esim. tuon edellämainitun esimerkin "Sijaintiraiteet" muuttui muotoon "Ratanumeron sijaintiraiteet")

Lisäksi sellaisten infoboksien, jotka listaavat muita kohteita (esim. tuo edellämainittu ratanumeron sijaintiraiteet), lukumäärätiedot on siirretty otsikoihin sulkujen sisään.