### PR TITLE
GVT-3441 Use dependabot for dep alerts and updates + use hash-pinned non-native github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "org.seleniumhq*"
     groups:
       spring-boot:
         patterns:
@@ -17,13 +19,29 @@ updates:
       jackson:
         patterns:
           - "com.fasterxml.jackson*"
+      flyway:
+        patterns:
+          - "org.flywaydb*"
+      geotools:
+        patterns:
+          - "org.geotools*"
+      auth0:
+        patterns:
+          - "com.auth0*"
+      jakarta-xml:
+        patterns:
+          - "jakarta.activation*"
+          - "jakarta.xml.bind*"
+          - "org.glassfish.jaxb*"
       test-dependencies:
         dependency-type: "development"
         patterns:
-          - "org.seleniumhq*"
           - "org.mock-server*"
           - "org.apache.httpcomponents*"
           - "io.projectreactor:reactor-test"
+      other:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/ui"
@@ -37,6 +55,11 @@ updates:
           - "react"
           - "react-*"
           - "@types/react*"
+          - "@reduxjs/*"
+          - "redux"
+          - "redux-*"
+          - "i18next"
+          - "i18next-*"
       eslint:
         patterns:
           - "eslint*"
@@ -55,6 +78,9 @@ updates:
           - "webpack-*"
           - "*-webpack-plugin"
           - "*-loader"
+      other:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,66 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/infra"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      spring-boot:
+        patterns:
+          - "org.springframework*"
+          - "io.spring*"
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*"
+      test-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "org.seleniumhq*"
+          - "org.mock-server*"
+          - "org.apache.httpcomponents*"
+          - "io.projectreactor:reactor-test"
 
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-*"
+          - "@types/react*"
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "*eslint*"
+          - "typescript-eslint"
+      jest:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "@jest/*"
+          - "ts-jest"
+      webpack:
+        patterns:
+          - "webpack"
+          - "webpack-*"
+          - "*-webpack-plugin"
+          - "*-loader"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
 
       - name: Create cache key for Postgres Docker image
         id: hash-postgres-dockerfile
@@ -82,7 +82,7 @@ jobs:
           ./run_it_tests_without_cache.sh
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6.3.1
+        uses: mikepenz/action-junit-report@49b2ca06f62aa7ef83ae6769a2179271e160d8e4 # v6.3.1
         if: success() || failure()
         with:
           report_paths: '**/build/test-results/*test*/TEST*.xml'


### PR DESCRIPTION
Tässä pullari muutoksista. Näihin tulee luultavasti vielä säätöä mutta näen vaikutukset vasta mainissa (ja siksi mergeän ne samantien, mutta kommentoikaa silti)