### PR TITLE
GVT-3434: Estetään pilkotun raiteen palauttaminen käyttöön

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -655,7 +655,7 @@ constructor(
 
             val finishedSplitSourceIssues =
                 if (track.exists && validationContext.isLocationTrackSourceOfAnyFinishedSplit(id)) {
-                    listOf(validationError("$VALIDATION_SPLIT.finished-source-not-deleted"))
+                    listOf(validationError("$VALIDATION_SPLIT.source-not-deleted"))
                 } else emptyList()
 
             (switchTrackIssues +

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
 import fi.fta.geoviite.infra.split.SplitLayoutValidationIssues
 import fi.fta.geoviite.infra.split.SplitService
+import fi.fta.geoviite.infra.split.VALIDATION_SPLIT
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
@@ -652,12 +653,18 @@ constructor(
                     validationContext.target.validationTargetType,
                 )
 
+            val finishedSplitSourceIssues =
+                if (track.exists && validationContext.isLocationTrackSourceOfAnyFinishedSplit(id)) {
+                    listOf(validationError("$VALIDATION_SPLIT.finished-source-not-deleted"))
+                } else emptyList()
+
             (switchTrackIssues +
                 duplicateIssues +
                 alignmentIssues +
                 geocodingIssues +
                 switchNameIssues +
                 nameDuplicationIssues +
+                finishedSplitSourceIssues +
                 trackNetworkTopologyIssues +
                 incomingReferenceIssues +
                 outgoingReferenceIssues +

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -295,6 +295,9 @@ class ValidationContext(
     fun getUnfinishedSplits(): List<Split> =
         allUnfinishedSplits.filter { split -> split.publicationId != null || publicationSet.containsSplit(split.id) }
 
+    fun isLocationTrackSourceOfAnyFinishedSplit(id: IntId<LocationTrack>): Boolean =
+        splitService.isLocationTrackSourceOfAnyFinishedSplit(target.candidateBranch, id)
+
     fun getGeocodingContext(trackNumberId: IntId<LayoutTrackNumber>) =
         getGeocodingContextCacheKey(trackNumberId)?.let { key -> geocodingService.getGeocodingContext(key) }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -361,7 +361,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             .also { _ -> logger.daoAccess(AccessType.FETCH, Split::class, "publicationIds" to publicationIds) }
     }
 
-    fun isLocationTracksPartOfAnyUnfinishedSplit(
+    fun getUnfinishedSplitsContainingLocationTracks(
         branch: LayoutBranch,
         locationTrackIds: Collection<IntId<LocationTrack>>,
     ) = fetchUnfinishedSplits(branch).filter { split -> locationTrackIds.any { lt -> split.containsLocationTrack(lt) } }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -22,10 +22,10 @@ import fi.fta.geoviite.infra.util.getOne
 import fi.fta.geoviite.infra.util.getOptional
 import fi.fta.geoviite.infra.util.getRowVersion
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
 
 private fun toSplit(rs: ResultSet, targetLocationTracks: List<SplitTarget>) =
     Split(
@@ -361,8 +361,30 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             .also { _ -> logger.daoAccess(AccessType.FETCH, Split::class, "publicationIds" to publicationIds) }
     }
 
-    fun locationTracksPartOfAnyUnfinishedSplit(
+    fun isLocationTracksPartOfAnyUnfinishedSplit(
         branch: LayoutBranch,
         locationTrackIds: Collection<IntId<LocationTrack>>,
     ) = fetchUnfinishedSplits(branch).filter { split -> locationTrackIds.any { lt -> split.containsLocationTrack(lt) } }
+
+    fun isLocationTrackSourceOfAnyFinishedSplit(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>): Boolean {
+        val sql =
+            """
+            select exists(
+                select 1
+                from publication.split
+                    inner join layout.location_track_version ltv
+                        on split.source_location_track_id = ltv.id
+                         and split.layout_context_id = ltv.layout_context_id
+                         and split.source_location_track_version = ltv.version
+                where split.bulk_transfer_state = 'DONE'
+                  and (ltv.design_id is null or ltv.design_id = :design_id)
+                  and split.source_location_track_id = :location_track_id
+            ) as result
+            """
+                .trimIndent()
+
+        val params = mapOf("design_id" to branch.designId?.intValue, "location_track_id" to locationTrackId.intValue)
+
+        return jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getBoolean("result") } ?: false
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -366,7 +366,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
         locationTrackIds: Collection<IntId<LocationTrack>>,
     ) = fetchUnfinishedSplits(branch).filter { split -> locationTrackIds.any { lt -> split.containsLocationTrack(lt) } }
 
-    fun isLocationTrackSourceOfAnyFinishedSplit(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>): Boolean {
+    fun isSplitSource(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>): Boolean {
         val sql =
             """
             select exists(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -107,10 +107,8 @@ class SplitService(
             }
         }
 
-    fun isLocationTrackSourceOfAnyFinishedSplit(
-        branch: LayoutBranch,
-        locationTrackId: IntId<LocationTrack>,
-    ): Boolean = splitDao.isLocationTrackSourceOfAnyFinishedSplit(branch, locationTrackId)
+    fun isLocationTrackSourceOfAnyFinishedSplit(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>): Boolean =
+        splitDao.isSplitSource(branch, locationTrackId)
 
     fun fetchPublicationVersions(
         branch: LayoutBranch,
@@ -195,10 +193,9 @@ class SplitService(
             candidates.locationTracks
                 .associate { version ->
                     val ltSplitIssues = validateSplitForLocationTrack(version.id, context)
-                    val contentIssues =
-                        splitIssues.mapNotNull { (split, error) ->
-                            if (split.containsLocationTrack(version.id)) error else null
-                        }
+                    val contentIssues = splitIssues.mapNotNull { (split, error) ->
+                        if (split.containsLocationTrack(version.id)) error else null
+                    }
                     version.id to ltSplitIssues + contentIssues
                 }
                 .filterValues { it.isNotEmpty() }
@@ -277,11 +274,9 @@ class SplitService(
         splits: List<Pair<Split, LocationTrack>>,
         track: LocationTrack,
     ): List<LayoutValidationIssue> {
-        val splitSourceLocationTrackErrors =
-            splits.flatMap { (split, _) ->
-                if (split.sourceLocationTrackId == trackId) validateSplitSourceLocationTrack(track, split)
-                else emptyList()
-            }
+        val splitSourceLocationTrackErrors = splits.flatMap { (split, _) ->
+            if (split.sourceLocationTrackId == trackId) validateSplitSourceLocationTrack(track, split) else emptyList()
+        }
 
         val statusErrors = splits.mapNotNull { (split, sourceTrack) -> validateSplitStatus(track, sourceTrack, split) }
 
@@ -294,12 +289,9 @@ class SplitService(
         // - Changes to the geocoding context are blocked for any tracks associated with a split
         val draftSplits = splits.filter { (split, _) -> split.publicationId == null }
 
-        val trackNumberMismatchErrors =
-            draftSplits.mapNotNull { (split, sourceTrack) ->
-                produceIf(split.containsTargetTrack(trackId)) {
-                    validateTargetTrackNumberIsUnchanged(sourceTrack, track)
-                }
-            }
+        val trackNumberMismatchErrors = draftSplits.mapNotNull { (split, sourceTrack) ->
+            produceIf(split.containsTargetTrack(trackId)) { validateTargetTrackNumberIsUnchanged(sourceTrack, track) }
+        }
 
         // Geometry error checking is skipped if the track numbers are different between any source
         // & target tracks,
@@ -326,27 +318,24 @@ class SplitService(
         // addresspoints in
         // the validation context (that is: draft target geometry is a subset of draft source
         // geometry)
-        val targetGeometryErrors =
-            splits.mapNotNull { (split, sourceTrack) ->
-                split.getTargetLocationTrack(trackId)?.let { target ->
-                    val (sourceAddresses, targetAddresses) =
-                        getTargetValidationAddressPoints(sourceTrack, target, context)
-                    validateTargetGeometry(target.operation, targetAddresses, sourceAddresses)
-                }
+        val targetGeometryErrors = splits.mapNotNull { (split, sourceTrack) ->
+            split.getTargetLocationTrack(trackId)?.let { target ->
+                val (sourceAddresses, targetAddresses) = getTargetValidationAddressPoints(sourceTrack, target, context)
+                validateTargetGeometry(target.operation, targetAddresses, sourceAddresses)
             }
+        }
 
         // Source address validation ensures that the in-validationcontext source addresspoints are
         // unchanged from the
         // official ones (that is: draft source geometry == official source geometry)
-        val sourceGeometryErrors =
-            splits.mapNotNull { (_, sourceTrack) ->
-                produceIf(trackId == sourceTrack.id) {
-                    val draftAddresses = context.getAddressPoints(sourceTrack)?.addresses
-                    val officialAddresses =
-                        geocodingService.getAddressPoints(context.target.baseContext, trackId)?.addresses
-                    validateSourceGeometry(draftAddresses, officialAddresses)
-                }
+        val sourceGeometryErrors = splits.mapNotNull { (_, sourceTrack) ->
+            produceIf(trackId == sourceTrack.id) {
+                val draftAddresses = context.getAddressPoints(sourceTrack)?.addresses
+                val officialAddresses =
+                    geocodingService.getAddressPoints(context.target.baseContext, trackId)?.addresses
+                validateSourceGeometry(draftAddresses, officialAddresses)
             }
+        }
 
         return targetGeometryErrors + sourceGeometryErrors
     }
@@ -364,31 +353,27 @@ class SplitService(
                 val end = geocodingContext.toAddressPoint(sourceEndPoint)?.first
                 if (start != null && end != null) start to end else null
             }
-        val sourceAddresses: List<AddressPoint<LocationTrackM>>? =
-            sourceAddressPointRange?.let { (start, end) ->
-                context
-                    .getAddressPoints(sourceTrack)
-                    ?.addresses
-                    ?.midPoints
-                    ?.filter { p -> p.address > start.address && p.address < end.address }
-                    ?.let { midPoints ->
-                        listOfNotNull(start.withIntegerPrecision()) +
-                            midPoints +
-                            listOfNotNull(end.withIntegerPrecision())
-                    }
-            }
+        val sourceAddresses: List<AddressPoint<LocationTrackM>>? = sourceAddressPointRange?.let { (start, end) ->
+            context
+                .getAddressPoints(sourceTrack)
+                ?.addresses
+                ?.midPoints
+                ?.filter { p -> p.address > start.address && p.address < end.address }
+                ?.let { midPoints ->
+                    listOfNotNull(start.withIntegerPrecision()) + midPoints + listOfNotNull(end.withIntegerPrecision())
+                }
+        }
 
-        val targetAddresses =
-            sourceAddressPointRange?.let { (sourceStart, sourceEnd) ->
-                val addressRange = sourceStart.address..sourceEnd.address
-                context.getAddressPoints(target.locationTrackId)?.addresses?.integerPrecisionPoints?.let { points ->
-                    if (target.operation == SplitTargetOperation.TRANSFER) {
-                        points.filter { p -> p.address in addressRange }
-                    } else {
-                        points
-                    }
+        val targetAddresses = sourceAddressPointRange?.let { (sourceStart, sourceEnd) ->
+            val addressRange = sourceStart.address..sourceEnd.address
+            context.getAddressPoints(target.locationTrackId)?.addresses?.integerPrecisionPoints?.let { points ->
+                if (target.operation == SplitTargetOperation.TRANSFER) {
+                    points.filter { p -> p.address in addressRange }
+                } else {
+                    points
                 }
             }
+        }
 
         return sourceAddresses to targetAddresses
     }
@@ -461,12 +446,11 @@ class SplitService(
                 targets = collectSplitTargetParams(branch, request.targetTracks, suggestions),
             )
 
-        val savedSplitTargetLocationTracks =
-            targetResults.map { result ->
-                val response = locationTrackService.saveDraft(branch, result.locationTrack, result.geometry)
-                val (resultTrack, resultGeometry) = locationTrackService.getWithGeometry(response)
-                result.copy(locationTrack = resultTrack, geometry = resultGeometry)
-            }
+        val savedSplitTargetLocationTracks = targetResults.map { result ->
+            val response = locationTrackService.saveDraft(branch, result.locationTrack, result.geometry)
+            val (resultTrack, resultGeometry) = locationTrackService.getWithGeometry(response)
+            result.copy(locationTrack = resultTrack, geometry = resultGeometry)
+        }
 
         geocodingService.getGeocodingContext(branch.draft, sourceTrack.trackNumberId)?.let { geocodingContext ->
             updateUnusedDuplicateReferencesToSplitTargetTracks(
@@ -586,18 +570,17 @@ fun findPartialDuplicateCuttingPoint(
             },
             { "Failed to find a shared split point from split source and target tracks" },
         )
-    val splitPointByRequestedSwitch =
-        requestedSwitch?.let {
-            val (switchId, jointNumber) = requestedSwitch
-            requireNotNull(
-                targetSplitPoints.find { targetSplitPoint ->
-                    targetSplitPoint is SwitchSplitPoint &&
-                        targetSplitPoint.switchId == switchId &&
-                        targetSplitPoint.jointNumber == jointNumber
-                },
-                { "Failed to find a switch split point by requested switch" },
-            )
-        }
+    val splitPointByRequestedSwitch = requestedSwitch?.let {
+        val (switchId, jointNumber) = requestedSwitch
+        requireNotNull(
+            targetSplitPoints.find { targetSplitPoint ->
+                targetSplitPoint is SwitchSplitPoint &&
+                    targetSplitPoint.switchId == switchId &&
+                    targetSplitPoint.jointNumber == jointNumber
+            },
+            { "Failed to find a switch split point by requested switch" },
+        )
+    }
     return splitPointByRequestedSwitch ?: lastSharedSplitPoint
 }
 
@@ -880,17 +863,16 @@ private fun cutEdges(geometry: LocationTrackGeometry, indices: ClosedRange<Int>)
 
 private fun verifySwitchSuggestions(
     suggestions: List<Pair<IntId<LayoutSwitch>, SuggestedSwitch?>>
-): List<Pair<IntId<LayoutSwitch>, SuggestedSwitch>> =
-    suggestions.map { (id, suggestion) ->
-        if (suggestion == null) {
-            throw SplitFailureException(
-                message = "Switch re-linking failed to produce a suggestion: switch=$id",
-                localizedMessageKey = "switch-linking-failed",
-            )
-        } else {
-            id to suggestion
-        }
+): List<Pair<IntId<LayoutSwitch>, SuggestedSwitch>> = suggestions.map { (id, suggestion) ->
+    if (suggestion == null) {
+        throw SplitFailureException(
+            message = "Switch re-linking failed to produce a suggestion: switch=$id",
+            localizedMessageKey = "switch-linking-failed",
+        )
+    } else {
+        id to suggestion
     }
+}
 
 private data class GeocodedLocationTrack(
     val track: LocationTrack,
@@ -912,11 +894,13 @@ private fun findNewLocationTracksForUnusedDuplicates(
     unusedDuplicates: List<Pair<LocationTrack, LocationTrackGeometry>>,
     splitTargetLocationTracks: List<SplitTargetResult>,
 ): List<Pair<LocationTrack, LocationTrackGeometry>> {
-    val geocodedUnusedDuplicates =
-        unusedDuplicates.mapNotNull { (track, geometry) -> getGeocoded(geocodingContext, track, geometry) }
+    val geocodedUnusedDuplicates = unusedDuplicates.mapNotNull { (track, geometry) ->
+        getGeocoded(geocodingContext, track, geometry)
+    }
 
-    val geocodedSplitTargets =
-        splitTargetLocationTracks.mapNotNull { (track, geometry) -> getGeocoded(geocodingContext, track, geometry) }
+    val geocodedSplitTargets = splitTargetLocationTracks.mapNotNull { (track, geometry) ->
+        getGeocoded(geocodingContext, track, geometry)
+    }
 
     return geocodedUnusedDuplicates.map { duplicate ->
         geocodedSplitTargets

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -107,6 +107,11 @@ class SplitService(
             }
         }
 
+    fun isLocationTrackSourceOfAnyFinishedSplit(
+        branch: LayoutBranch,
+        locationTrackId: IntId<LocationTrack>,
+    ): Boolean = splitDao.isLocationTrackSourceOfAnyFinishedSplit(branch, locationTrackId)
+
     fun fetchPublicationVersions(
         branch: LayoutBranch,
         locationTracks: List<IntId<LocationTrack>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -53,20 +53,19 @@ internal fun validateSplitContent(
             emptyList()
         }
 
-    val contentErrors =
-        publicationSplits.flatMap { split ->
-            val containsSource = trackVersions.any { it.id == split.sourceLocationTrackId }
-            val containsTargets =
-                split.targetLocationTracks.all { tlt -> trackVersions.any { it.id == tlt.locationTrackId } }
-            val containsSwitches = split.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
-            listOfNotNull(
-                    validate(containsSource && containsTargets, ERROR) {
-                        "$VALIDATION_SPLIT.split-missing-location-tracks"
-                    },
-                    validate(containsSwitches, ERROR) { "$VALIDATION_SPLIT.split-missing-switches" },
-                )
-                .map { e -> split to e }
-        }
+    val contentErrors = publicationSplits.flatMap { split ->
+        val containsSource = trackVersions.any { it.id == split.sourceLocationTrackId }
+        val containsTargets =
+            split.targetLocationTracks.all { tlt -> trackVersions.any { it.id == tlt.locationTrackId } }
+        val containsSwitches = split.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
+        listOfNotNull(
+                validate(containsSource && containsTargets, ERROR) {
+                    "$VALIDATION_SPLIT.split-missing-location-tracks"
+                },
+                validate(containsSwitches, ERROR) { "$VALIDATION_SPLIT.split-missing-switches" },
+            )
+            .map { e -> split to e }
+    }
 
     return listOf(multipleSplitsStagedErrors, contentErrors).flatten()
 }
@@ -122,9 +121,7 @@ internal fun validateSplitStatus(
 
 internal fun validateSplitSourceLocationTrack(locationTrack: LocationTrack, split: Split): List<LayoutValidationIssue> =
     listOfNotNull(
-        produceIf(locationTrack.exists) {
-            validationError("$VALIDATION_SPLIT.source-not-deleted", "sourceName" to locationTrack.name)
-        },
+        produceIf(locationTrack.exists) { validationError("$VALIDATION_SPLIT.source-not-deleted") },
         produceIf(locationTrack.version != split.sourceLocationTrackVersion) {
             validationError("$VALIDATION_SPLIT.source-edited-after-split", "sourceName" to locationTrack.name)
         },

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -291,7 +291,8 @@ data class LocationTrack(
 
 enum class PartOfSplit {
     FINISHED_SOURCE_TRACK,
-    UNFINISHED,
+    UNFINISHED_SOURCE_TRACK,
+    UNFINISHED_TARGET_TRACK,
     NONE,
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -289,10 +289,16 @@ data class LocationTrack(
         copy(contextData = contextData)
 }
 
+enum class PartOfSplit {
+    FINISHED_SOURCE_TRACK,
+    UNFINISHED,
+    NONE,
+}
+
 data class LocationTrackInfoboxExtras(
     val duplicateOf: LocationTrackDuplicate?,
     val duplicates: List<LocationTrackDuplicate>,
-    val partOfUnfinishedSplit: Boolean?,
+    val partOfSplit: PartOfSplit,
     val startSplitPoint: SplitPoint?,
     val endSplitPoint: SplitPoint?,
     val switches: List<LocationTrackInfoboxSwitch>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -491,8 +491,14 @@ class LocationTrackService(
             val startSplitPoint = createSplitPoint(start, startSwitchLink?.id, START, geocodingContext)
             val endSplitPoint = createSplitPoint(end, endSwitchLink?.id, END, geocodingContext)
 
-            val partOfUnfinishedSplit =
-                splitDao.locationTracksPartOfAnyUnfinishedSplit(layoutContext.branch, listOf(id)).isNotEmpty()
+            val partOfSplit =
+                when {
+                    splitDao.isLocationTracksPartOfAnyUnfinishedSplit(layoutContext.branch, listOf(id)).isNotEmpty() ->
+                        PartOfSplit.UNFINISHED
+                    splitDao.isLocationTrackSourceOfAnyFinishedSplit(layoutContext.branch, id) ->
+                        PartOfSplit.FINISHED_SOURCE_TRACK
+                    else -> PartOfSplit.NONE
+                }
 
             val switches =
                 geometry.trackSwitchLinks
@@ -534,7 +540,7 @@ class LocationTrackService(
             LocationTrackInfoboxExtras(
                 duplicateOf,
                 duplicates,
-                partOfUnfinishedSplit,
+                partOfSplit,
                 startSplitPoint,
                 endSplitPoint,
                 switches,
@@ -618,46 +624,42 @@ class LocationTrackService(
         layoutContext: LayoutContext,
         requests: List<TopologyRecalculationRequest>,
     ): List<List<Pair<LocationTrack, LocationTrackGeometry>>> {
-        val changedTracksByRequestIx =
-            requests.map { request ->
-                request.changedTracks.map { (track, geometry) ->
-                    val trackId =
-                        requireNotNull(track.id as? IntId) { "A track must have a stored ID for node combining." }
-                    track to geometry.withLocationTrackId(trackId)
-                }
+        val changedTracksByRequestIx = requests.map { request ->
+            request.changedTracks.map { (track, geometry) ->
+                val trackId = requireNotNull(track.id as? IntId) { "A track must have a stored ID for node combining." }
+                track to geometry.withLocationTrackId(trackId)
             }
+        }
 
         val dbNodeConnectionsByTargetIxByRequestIx =
             processFlattened(requests.map { it.jointLocations }) { target ->
                 alignmentDao.getNodeConnectionsNearPoints(layoutContext, target, TOPOLOGY_CALC_DISTANCE)
             }
 
-        val nearbyConnections =
-            requests.mapIndexed { index, request ->
-                val changedTracks = request.changedTracks
-                val changedTrackIds = changedTracks.mapNotNull { (t, _) -> t.id as? IntId }.toSet()
+        val nearbyConnections = requests.mapIndexed { index, request ->
+            val changedTracks = request.changedTracks
+            val changedTrackIds = changedTracks.mapNotNull { (t, _) -> t.id as? IntId }.toSet()
 
-                val dbConnectionsByTargetIx =
-                    dbNodeConnectionsByTargetIxByRequestIx[index].map { targetConnections ->
-                        targetConnections
-                            .mapNotNull { c -> c.filterOut(changedTrackIds) }
-                            .map { c -> NodeReplacementTarget(c.node, c.trackVersions.map(::getWithGeometry)) }
-                    }
-
-                val changedTrackConnectionsByTargetIx =
-                    request.jointLocations.map { target ->
-                        changedTracks.flatMap { (track, geometry) ->
-                            geometry.nodesWithLocation
-                                .filter { (_, location) -> target.isWithinDistance(location, TOPOLOGY_CALC_DISTANCE) }
-                                .map { (node, _) -> NodeReplacementTarget(node, track, geometry) }
-                        }
-                    }
-
-                dbConnectionsByTargetIx.zip(changedTrackConnectionsByTargetIx) { dbConnections, changedTrackConnections
-                    ->
-                    mergeNodeConnections(dbConnections + changedTrackConnections)
+            val dbConnectionsByTargetIx =
+                dbNodeConnectionsByTargetIxByRequestIx[index].map { targetConnections ->
+                    targetConnections
+                        .mapNotNull { c -> c.filterOut(changedTrackIds) }
+                        .map { c -> NodeReplacementTarget(c.node, c.trackVersions.map(::getWithGeometry)) }
                 }
+
+            val changedTrackConnectionsByTargetIx =
+                request.jointLocations.map { target ->
+                    changedTracks.flatMap { (track, geometry) ->
+                        geometry.nodesWithLocation
+                            .filter { (_, location) -> target.isWithinDistance(location, TOPOLOGY_CALC_DISTANCE) }
+                            .map { (node, _) -> NodeReplacementTarget(node, track, geometry) }
+                    }
+                }
+
+            dbConnectionsByTargetIx.zip(changedTrackConnectionsByTargetIx) { dbConnections, changedTrackConnections ->
+                mergeNodeConnections(dbConnections + changedTrackConnections)
             }
+        }
 
         return requests.mapIndexed { index, request ->
             recalculateTopology(nearbyConnections[index], changedTracksByRequestIx[index])
@@ -670,11 +672,10 @@ class LocationTrackService(
         changedTracksTmp: List<Pair<LocationTrack, LocationTrackGeometry>>,
         locations: List<MultiPoint>,
     ): List<Pair<LocationTrack, LocationTrackGeometry>> {
-        val changedTracks =
-            changedTracksTmp.map { (track, geometry) ->
-                val trackId = requireNotNull(track.id as? IntId) { "A track must have a stored ID for node combining." }
-                track to geometry.withLocationTrackId(trackId)
-            }
+        val changedTracks = changedTracksTmp.map { (track, geometry) ->
+            val trackId = requireNotNull(track.id as? IntId) { "A track must have a stored ID for node combining." }
+            track to geometry.withLocationTrackId(trackId)
+        }
         val request = TopologyRecalculationRequest(changedTracks, locations)
         return recalculateTopologies(layoutContext, listOf(request)).first()
     }
@@ -818,32 +819,30 @@ class LocationTrackService(
         branch: LayoutBranch,
         ids: List<IntId<LocationTrack>>,
         operationalPointId: IntId<OperationalPoint>,
-    ): List<IntId<LocationTrack>> =
-        ids.map { id ->
-            val (draft, geometry) = getWithGeometryOrThrow(branch.draft, id)
-            saveDraft(
-                    branch,
-                    draft.copy(operationalPointIds = draft.operationalPointIds.plus(operationalPointId)),
-                    geometry,
-                )
-                .id
-        }
+    ): List<IntId<LocationTrack>> = ids.map { id ->
+        val (draft, geometry) = getWithGeometryOrThrow(branch.draft, id)
+        saveDraft(
+                branch,
+                draft.copy(operationalPointIds = draft.operationalPointIds.plus(operationalPointId)),
+                geometry,
+            )
+            .id
+    }
 
     @Transactional
     fun unlinkFromOperationalPoint(
         branch: LayoutBranch,
         ids: List<IntId<LocationTrack>>,
         operationalPointId: IntId<OperationalPoint>,
-    ): List<IntId<LocationTrack>> =
-        ids.map { id ->
-            val (draft, geometry) = getWithGeometryOrThrow(branch.draft, id)
-            saveDraft(
-                    branch,
-                    draft.copy(operationalPointIds = draft.operationalPointIds.minus(operationalPointId)),
-                    geometry,
-                )
-                .id
-        }
+    ): List<IntId<LocationTrack>> = ids.map { id ->
+        val (draft, geometry) = getWithGeometryOrThrow(branch.draft, id)
+        saveDraft(
+                branch,
+                draft.copy(operationalPointIds = draft.operationalPointIds.minus(operationalPointId)),
+                geometry,
+            )
+            .id
+    }
 
     @Transactional
     fun detachSwitch(
@@ -911,11 +910,10 @@ private fun recalculateTopology(
     nearbyConnections: List<List<NodeReplacementTarget>>,
     changedTracksTmp: List<Pair<LocationTrack, LocationTrackGeometry>>,
 ): List<Pair<LocationTrack, LocationTrackGeometry>> {
-    val changedTracks =
-        changedTracksTmp.map { (track, geometry) ->
-            val trackId = requireNotNull(track.id as? IntId) { "A track must have a stored ID for node combining." }
-            track to geometry.withLocationTrackId(trackId)
-        }
+    val changedTracks = changedTracksTmp.map { (track, geometry) ->
+        val trackId = requireNotNull(track.id as? IntId) { "A track must have a stored ID for node combining." }
+        track to geometry.withLocationTrackId(trackId)
+    }
     val combinations =
         nearbyConnections.map { connections -> resolveNodeCombinations(connections) }.let(::mergeNodeCombinations)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -491,10 +491,17 @@ class LocationTrackService(
             val startSplitPoint = createSplitPoint(start, startSwitchLink?.id, START, geocodingContext)
             val endSplitPoint = createSplitPoint(end, endSwitchLink?.id, END, geocodingContext)
 
+            val unfinishedSplits =
+                splitDao.isLocationTracksPartOfAnyUnfinishedSplit(layoutContext.branch, listOf(id))
+
             val partOfSplit =
                 when {
-                    splitDao.isLocationTracksPartOfAnyUnfinishedSplit(layoutContext.branch, listOf(id)).isNotEmpty() ->
-                        PartOfSplit.UNFINISHED
+                    unfinishedSplits.isNotEmpty() ->
+                        if (unfinishedSplits.any { it.sourceLocationTrackId == id }) {
+                            PartOfSplit.UNFINISHED_SOURCE_TRACK
+                        } else {
+                            PartOfSplit.UNFINISHED_TARGET_TRACK
+                        }
                     splitDao.isLocationTrackSourceOfAnyFinishedSplit(layoutContext.branch, id) ->
                         PartOfSplit.FINISHED_SOURCE_TRACK
                     else -> PartOfSplit.NONE

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -492,18 +492,13 @@ class LocationTrackService(
             val endSplitPoint = createSplitPoint(end, endSwitchLink?.id, END, geocodingContext)
 
             val unfinishedSplits =
-                splitDao.isLocationTracksPartOfAnyUnfinishedSplit(layoutContext.branch, listOf(id))
+                splitDao.getUnfinishedSplitsContainingLocationTracks(layoutContext.branch, listOf(id))
 
             val partOfSplit =
                 when {
-                    unfinishedSplits.isNotEmpty() ->
-                        if (unfinishedSplits.any { it.sourceLocationTrackId == id }) {
-                            PartOfSplit.UNFINISHED_SOURCE_TRACK
-                        } else {
-                            PartOfSplit.UNFINISHED_TARGET_TRACK
-                        }
-                    splitDao.isLocationTrackSourceOfAnyFinishedSplit(layoutContext.branch, id) ->
-                        PartOfSplit.FINISHED_SOURCE_TRACK
+                    unfinishedSplits.any { it.sourceLocationTrackId == id } -> PartOfSplit.UNFINISHED_SOURCE_TRACK
+                    unfinishedSplits.isNotEmpty() -> PartOfSplit.UNFINISHED_TARGET_TRACK
+                    splitDao.isSplitSource(layoutContext.branch, id) -> PartOfSplit.FINISHED_SOURCE_TRACK
                     else -> PartOfSplit.NONE
                 }
 

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -513,6 +513,7 @@
         "full-name": "Valmis tunnus",
         "track-number": "Ratanumero",
         "state": "Tila",
+        "state-disabled-by-split": "Raiteen tilaa ei voi muokata koska raide on jaettu",
         "track-type": "Raidetyyppi",
         "owner": "Omistaja",
         "track-metadata": "Raiteen metatiedot",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1927,6 +1927,7 @@
                 "km-post-too-far-from-reference-line": "Ratanumeron {{trackNumber}} tasakilometripiste {{kmNumber}} sijaitsee liian kaukana pituusmittauslinjalta"
             },
             "split": {
+                "finished-source-not-deleted": "Raide on jaettu, mutta se ei ole Poistettu-tilassa",
                 "source-not-deleted": "Jaettava raide {{sourceName}} ei ole Poistettu-tilassa",
                 "source-edited-after-split": "Jaettavaa raidetta {{sourceName}} on muokattu vaikka jako on vielä kesken",
                 "source-and-target-track-numbers-are-different": "Jakamisessa syntynyt raide {{targetName}} on eri ratanumerolla on kuin alkuperäinen jaettu raide {{sourceName}}",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1927,8 +1927,7 @@
                 "km-post-too-far-from-reference-line": "Ratanumeron {{trackNumber}} tasakilometripiste {{kmNumber}} sijaitsee liian kaukana pituusmittauslinjalta"
             },
             "split": {
-                "finished-source-not-deleted": "Raide on jaettu, mutta se ei ole Poistettu-tilassa",
-                "source-not-deleted": "Jaettava raide {{sourceName}} ei ole Poistettu-tilassa",
+                "source-not-deleted": "Raide on jaettu, mutta se ei ole Poistettu-tilassa",
                 "source-edited-after-split": "Jaettavaa raidetta {{sourceName}} on muokattu vaikka jako on vielä kesken",
                 "source-and-target-track-numbers-are-different": "Jakamisessa syntynyt raide {{targetName}} on eri ratanumerolla on kuin alkuperäinen jaettu raide {{sourceName}}",
                 "duplicate-on-different-track-number": "Duplikaattiraide {{duplicateTrack}} on eri ratanumerolla kuin jaettava raide",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -1287,32 +1287,44 @@ constructor(
             LayoutValidationIssue(
                 LayoutValidationIssueType.ERROR,
                 LocalizationKey.of("validation.layout.split.source-not-deleted"),
-                localizationParams("sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack).name),
+                localizationParams(),
             ),
         )
     }
 
     @Test
-    fun `split source location track validation should fail if source of a finished split isn't deleted`() {
+    fun `split source location track validation should fail if source of a published split isn't deleted`() {
         val splitSetup = publicationTestSupportService.simpleSplitSetup()
 
         val splitId = publicationTestSupportService.saveSplit(splitSetup.sourceTrack, splitSetup.targetParams)
-        splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
+        publish(publicationService, locationTracks = splitSetup.trackIds)
+        val locationTrack = locationTrackDao.getOrThrow(MainLayoutContext.official, splitSetup.sourceTrack.id)
+        locationTrackService
+            .saveDraft(
+                LayoutBranch.main,
+                locationTrack.copy(state = LocationTrackState.IN_USE),
+                alignmentDao.fetch(locationTrack.version!!),
+            )
+            .let(locationTrackDao::fetch)
 
-        val sourceTrack = locationTrackDao.fetch(splitSetup.sourceTrack)
-        locationTrackService.saveDraft(
-            LayoutBranch.main,
-            sourceTrack.copy(state = LocationTrackState.IN_USE),
-            alignmentDao.fetch(splitSetup.sourceTrack),
-        )
-
-        val errors = validateLocationTracks(splitSetup.sourceTrack.id)
+        val errorsBeforeBulkTransfer = validateLocationTracks(splitSetup.sourceTrack.id)
         assertContains(
-            errors,
+            errorsBeforeBulkTransfer,
             LayoutValidationIssue(
                 LayoutValidationIssueType.ERROR,
-                LocalizationKey.of("validation.layout.split.finished-source-not-deleted"),
-                localizationParams("sourceName" to sourceTrack.name),
+                LocalizationKey.of("validation.layout.split.source-not-deleted"),
+                localizationParams(),
+            ),
+        )
+        splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
+
+        val errorAfterBulkTransfer = validateLocationTracks(splitSetup.sourceTrack.id)
+        assertContains(
+            errorAfterBulkTransfer,
+            LayoutValidationIssue(
+                LayoutValidationIssueType.ERROR,
+                LocalizationKey.of("validation.layout.split.source-not-deleted"),
+                localizationParams(),
             ),
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -425,8 +425,9 @@ constructor(
             "validation.layout.location-track.reference-from-location-track-duplicate-of.not-published",
         )
 
-    private fun containsError(errors: List<LayoutValidationIssue>, key: String) =
-        errors.any { e -> e.localizationKey.toString() == key }
+    private fun containsError(errors: List<LayoutValidationIssue>, key: String) = errors.any { e ->
+        e.localizationKey.toString() == key
+    }
 
     private fun validateLocationTrack(
         toValidate: IntId<LocationTrack>,
@@ -832,8 +833,9 @@ constructor(
         index: Int,
     ) {
         val allKeys = expected.map { it.localizationKey.toString() } + actual.map { it.localizationKey.toString() }
-        val commonPrefix =
-            allKeys.reduce { acc, next -> acc.take(acc.zip(next) { a, b -> a == b }.takeWhile { it }.count()) }
+        val commonPrefix = allKeys.reduce { acc, next ->
+            acc.take(acc.zip(next) { a, b -> a == b }.takeWhile { it }.count())
+        }
 
         fun cleanupKey(key: LocalizationKey) = key.toString().let { k -> if (commonPrefix.length > 3) "...$k" else k }
 
@@ -1286,6 +1288,31 @@ constructor(
                 LayoutValidationIssueType.ERROR,
                 LocalizationKey.of("validation.layout.split.source-not-deleted"),
                 localizationParams("sourceName" to locationTrackDao.fetch(splitSetup.sourceTrack).name),
+            ),
+        )
+    }
+
+    @Test
+    fun `split source location track validation should fail if source of a finished split isn't deleted`() {
+        val splitSetup = publicationTestSupportService.simpleSplitSetup()
+
+        val splitId = publicationTestSupportService.saveSplit(splitSetup.sourceTrack, splitSetup.targetParams)
+        splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
+
+        val sourceTrack = locationTrackDao.fetch(splitSetup.sourceTrack)
+        locationTrackService.saveDraft(
+            LayoutBranch.main,
+            sourceTrack.copy(state = LocationTrackState.IN_USE),
+            alignmentDao.fetch(splitSetup.sourceTrack),
+        )
+
+        val errors = validateLocationTracks(splitSetup.sourceTrack.id)
+        assertContains(
+            errors,
+            LayoutValidationIssue(
+                LayoutValidationIssueType.ERROR,
+                LocalizationKey.of("validation.layout.split.finished-source-not-deleted"),
+                localizationParams("sourceName" to sourceTrack.name),
             ),
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -12,10 +12,10 @@ import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
@@ -136,7 +136,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
     }
 
     @Test
-    fun `isLocationTrackSourceOfAnyFinishedSplit returns true for source track and false for target tracks of finished splits`() {
+    fun `isSplitSource returns true for source track and false for target tracks of finished splits`() {
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val geometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
 
@@ -152,14 +152,14 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 updatedDuplicates = emptyList(),
             )
 
-        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, sourceTrack.id))
-        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, targetTrack.id))
+        assertFalse(splitDao.isSplitSource(LayoutBranch.main, sourceTrack.id))
+        assertFalse(splitDao.isSplitSource(LayoutBranch.main, targetTrack.id))
 
         splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
 
-        assertTrue(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, sourceTrack.id))
-        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, targetTrack.id))
-        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, unrelatedTrack.id))
+        assertTrue(splitDao.isSplitSource(LayoutBranch.main, sourceTrack.id))
+        assertFalse(splitDao.isSplitSource(LayoutBranch.main, targetTrack.id))
+        assertFalse(splitDao.isSplitSource(LayoutBranch.main, unrelatedTrack.id))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
@@ -132,6 +133,33 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
 
         assertTrue { splits.any { s -> s.id == pendingSplitId } }
         assertTrue { splits.none { s -> s.id == doneSplit } }
+    }
+
+    @Test
+    fun `isLocationTrackSourceOfAnyFinishedSplit returns true for source track and false for target tracks of finished splits`() {
+        val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
+        val geometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
+
+        val sourceTrack = mainOfficialContext.save(locationTrack(trackNumberId), geometry)
+        val targetTrack = mainDraftContext.save(locationTrack(trackNumberId), geometry)
+        val unrelatedTrack = mainOfficialContext.save(locationTrack(trackNumberId), geometry)
+
+        val splitId =
+            splitDao.saveSplit(
+                sourceTrack,
+                listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
+                listOf(mainOfficialContext.createSwitch().id),
+                updatedDuplicates = emptyList(),
+            )
+
+        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, sourceTrack.id))
+        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, targetTrack.id))
+
+        splitDao.updateSplit(splitId, bulkTransferState = BulkTransferState.DONE)
+
+        assertTrue(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, sourceTrack.id))
+        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, targetTrack.id))
+        assertFalse(splitDao.isLocationTrackSourceOfAnyFinishedSplit(LayoutBranch.main, unrelatedTrack.id))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -20,9 +20,11 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.MultiPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
+import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -35,7 +37,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -51,7 +52,7 @@ constructor(
     private val splitService: SplitService,
     private val splitTestDataService: SplitTestDataService,
     private val layoutTrackNumberService: LayoutTrackNumberService,
-    private val splitDao: fi.fta.geoviite.infra.split.SplitDao,
+    private val splitDao: SplitDao,
 ) : DBTestBase() {
     @BeforeEach
     fun setup() {
@@ -1204,19 +1205,13 @@ constructor(
                 )
                 .id
 
-        val op1Id = mainOfficialContext.save(operationalPoint(name = "OP1", location = Point(50.0, 0.0), draft = false)).id
-        val op2Id =
-            mainOfficialContext.save(
-                operationalPoint(name = "OP2", draft = false).copy(location = null)
-            ).id
+        val op1Id =
+            mainOfficialContext.save(operationalPoint(name = "OP1", location = Point(50.0, 0.0), draft = false)).id
+        val op2Id = mainOfficialContext.save(operationalPoint(name = "OP2", draft = false).copy(location = null)).id
 
         val (track, _) =
             mainOfficialContext.save(
-                locationTrack(
-                    trackNumberId,
-                    draft = false,
-                    operationalPointIds = setOf(op1Id, op2Id),
-                ),
+                locationTrack(trackNumberId, draft = false, operationalPointIds = setOf(op1Id, op2Id)),
                 trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
             )
 
@@ -1248,18 +1243,22 @@ constructor(
             assertEquals(PartOfSplit.NONE, extrasBeforeSplit!!.partOfSplit)
         }
 
-        val splitId = splitDao.saveSplit(
-            sourceTrack,
-            listOf(
-                fi.fta.geoviite.infra.split.SplitTarget(
-                    targetTrack.id, 0..0, fi.fta.geoviite.infra.split.SplitTargetOperation.CREATE,
+        val splitId =
+            splitDao.saveSplit(
+                sourceTrack,
+                listOf(
+                    fi.fta.geoviite.infra.split.SplitTarget(
+                        targetTrack.id,
+                        0..0,
+                        fi.fta.geoviite.infra.split.SplitTargetOperation.CREATE,
+                    )
                 ),
-            ),
-            listOf(mainOfficialContext.createSwitch().id),
-            updatedDuplicates = emptyList(),
-        )
+                listOf(mainOfficialContext.createSwitch().id),
+                updatedDuplicates = emptyList(),
+            )
 
-        locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id).also { extrasSourceUnfinished ->
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id).also { extrasSourceUnfinished
+            ->
             assertNotNull(extrasSourceUnfinished)
             assertEquals(PartOfSplit.UNFINISHED_SOURCE_TRACK, extrasSourceUnfinished!!.partOfSplit)
         }
@@ -1402,15 +1401,10 @@ constructor(
         }
 }
 
-fun assertContains(polygon: Polygon, vararg points: Point) =
-    points.forEach { p ->
-        assertTrue(contains(polygon, p, LAYOUT_SRID), "Expected polygon to overlap location: point=$p polygon=$polygon")
-    }
+fun assertContains(polygon: Polygon, vararg points: Point) = points.forEach { p ->
+    assertTrue(contains(polygon, p, LAYOUT_SRID), "Expected polygon to overlap location: point=$p polygon=$polygon")
+}
 
-fun assertDoesntContain(polygon: Polygon, vararg points: Point) =
-    points.forEach { p ->
-        assertFalse(
-            contains(polygon, p, LAYOUT_SRID),
-            "Expected polygon to overlap location: point=$p polygon=$polygon",
-        )
-    }
+fun assertDoesntContain(polygon: Polygon, vararg points: Point) = points.forEach { p ->
+    assertFalse(contains(polygon, p, LAYOUT_SRID), "Expected polygon to overlap location: point=$p polygon=$polygon")
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -51,6 +51,7 @@ constructor(
     private val splitService: SplitService,
     private val splitTestDataService: SplitTestDataService,
     private val layoutTrackNumberService: LayoutTrackNumberService,
+    private val splitDao: fi.fta.geoviite.infra.split.SplitDao,
 ) : DBTestBase() {
     @BeforeEach
     fun setup() {
@@ -1232,6 +1233,40 @@ constructor(
         assertNotNull(op2Extra)
         assertNull(op2Extra!!.location)
         assertNull(op2Extra.displayAddress)
+    }
+
+    @Test
+    fun `getInfoboxExtras returns correct partOfSplit value`() {
+        val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
+        val geometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
+
+        val sourceTrack = mainOfficialContext.save(locationTrack(trackNumberId), geometry)
+        val targetTrack = mainDraftContext.save(locationTrack(trackNumberId), geometry)
+
+        val extrasBeforeSplit = locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id)
+        assertNotNull(extrasBeforeSplit)
+        assertEquals(PartOfSplit.NONE, extrasBeforeSplit!!.partOfSplit)
+
+        val splitId = splitDao.saveSplit(
+            sourceTrack,
+            listOf(
+                fi.fta.geoviite.infra.split.SplitTarget(
+                    targetTrack.id, 0..0, fi.fta.geoviite.infra.split.SplitTargetOperation.CREATE,
+                ),
+            ),
+            listOf(mainOfficialContext.createSwitch().id),
+            updatedDuplicates = emptyList(),
+        )
+
+        val extrasUnfinished = locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id)
+        assertNotNull(extrasUnfinished)
+        assertEquals(PartOfSplit.UNFINISHED, extrasUnfinished!!.partOfSplit)
+
+        splitDao.updateSplit(splitId, bulkTransferState = fi.fta.geoviite.infra.split.BulkTransferState.DONE)
+
+        val extrasFinished = locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id)
+        assertNotNull(extrasFinished)
+        assertEquals(PartOfSplit.FINISHED_SOURCE_TRACK, extrasFinished!!.partOfSplit)
     }
 
     private fun updateDraft(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -1243,9 +1243,10 @@ constructor(
         val sourceTrack = mainOfficialContext.save(locationTrack(trackNumberId), geometry)
         val targetTrack = mainDraftContext.save(locationTrack(trackNumberId), geometry)
 
-        val extrasBeforeSplit = locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id)
-        assertNotNull(extrasBeforeSplit)
-        assertEquals(PartOfSplit.NONE, extrasBeforeSplit!!.partOfSplit)
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id).also { extrasBeforeSplit ->
+            assertNotNull(extrasBeforeSplit)
+            assertEquals(PartOfSplit.NONE, extrasBeforeSplit!!.partOfSplit)
+        }
 
         val splitId = splitDao.saveSplit(
             sourceTrack,
@@ -1258,15 +1259,27 @@ constructor(
             updatedDuplicates = emptyList(),
         )
 
-        val extrasUnfinished = locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id)
-        assertNotNull(extrasUnfinished)
-        assertEquals(PartOfSplit.UNFINISHED, extrasUnfinished!!.partOfSplit)
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id).also { extrasSourceUnfinished ->
+            assertNotNull(extrasSourceUnfinished)
+            assertEquals(PartOfSplit.UNFINISHED_SOURCE_TRACK, extrasSourceUnfinished!!.partOfSplit)
+        }
+
+        locationTrackService.getInfoboxExtras(MainLayoutContext.draft, targetTrack.id).also { extrasTargetUnfinished ->
+            assertNotNull(extrasTargetUnfinished)
+            assertEquals(PartOfSplit.UNFINISHED_TARGET_TRACK, extrasTargetUnfinished!!.partOfSplit)
+        }
 
         splitDao.updateSplit(splitId, bulkTransferState = fi.fta.geoviite.infra.split.BulkTransferState.DONE)
 
-        val extrasFinished = locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id)
-        assertNotNull(extrasFinished)
-        assertEquals(PartOfSplit.FINISHED_SOURCE_TRACK, extrasFinished!!.partOfSplit)
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id).also { extrasSourceFinished ->
+            assertNotNull(extrasSourceFinished)
+            assertEquals(PartOfSplit.FINISHED_SOURCE_TRACK, extrasSourceFinished!!.partOfSplit)
+        }
+
+        locationTrackService.getInfoboxExtras(MainLayoutContext.draft, targetTrack.id).also { extrasTargetFinished ->
+            assertNotNull(extrasTargetFinished)
+            assertEquals(PartOfSplit.NONE, extrasTargetFinished!!.partOfSplit)
+        }
     }
 
     private fun updateDraft(

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -236,13 +236,13 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     const canLink =
         !linkingCallInProgress &&
         linkingState?.state === 'allSet' &&
-        !selectedLocationTrackInfoboxExtras?.partOfUnfinishedSplit;
+        selectedLocationTrackInfoboxExtras?.partOfSplit !== 'UNFINISHED';
 
     const canLockAlignment =
         (linkingAlignmentType === 'REFERENCE_LINE' && selectedLayoutReferenceLine) ||
         (linkingAlignmentType === 'LOCATION_TRACK' &&
             selectedLayoutLocationTrack &&
-            !selectedLocationTrackInfoboxExtras?.partOfUnfinishedSplit);
+            selectedLocationTrackInfoboxExtras?.partOfSplit !== 'UNFINISHED');
 
     const [linkedAlignmentIds, linkedAlignmentIdsStatus] = useLoaderWithStatus(
         () => getLinkedAlignmentIdsInPlan(planId, layoutContext),
@@ -420,7 +420,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                         setShowAddLocationTrackDialog(true)
                                     }
                                     selectedPartOfUnfinishedSplit={
-                                        selectedLocationTrackInfoboxExtras?.partOfUnfinishedSplit ||
+                                        selectedLocationTrackInfoboxExtras?.partOfSplit === 'UNFINISHED' ||
                                         false
                                     }
                                 />

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-linking-infobox.tsx
@@ -5,6 +5,7 @@ import InfoboxField from 'tool-panel/infobox/infobox-field';
 import styles from './geometry-alignment-infobox.scss';
 import InfoboxContent, { InfoboxContentSpread } from 'tool-panel/infobox/infobox-content';
 import {
+    isPartOfUnfinishedSplit,
     LayoutLocationTrack,
     LayoutReferenceLine,
     LocationTrackId,
@@ -236,13 +237,13 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
     const canLink =
         !linkingCallInProgress &&
         linkingState?.state === 'allSet' &&
-        selectedLocationTrackInfoboxExtras?.partOfSplit !== 'UNFINISHED';
+        !isPartOfUnfinishedSplit(selectedLocationTrackInfoboxExtras?.partOfSplit);
 
     const canLockAlignment =
         (linkingAlignmentType === 'REFERENCE_LINE' && selectedLayoutReferenceLine) ||
         (linkingAlignmentType === 'LOCATION_TRACK' &&
             selectedLayoutLocationTrack &&
-            selectedLocationTrackInfoboxExtras?.partOfSplit !== 'UNFINISHED');
+            !isPartOfUnfinishedSplit(selectedLocationTrackInfoboxExtras?.partOfSplit));
 
     const [linkedAlignmentIds, linkedAlignmentIdsStatus] = useLoaderWithStatus(
         () => getLinkedAlignmentIdsInPlan(planId, layoutContext),
@@ -420,8 +421,7 @@ const GeometryAlignmentLinkingInfobox: React.FC<GeometryAlignmentLinkingInfoboxP
                                         setShowAddLocationTrackDialog(true)
                                     }
                                     selectedPartOfUnfinishedSplit={
-                                        selectedLocationTrackInfoboxExtras?.partOfSplit === 'UNFINISHED' ||
-                                        false
+                                        isPartOfUnfinishedSplit(selectedLocationTrackInfoboxExtras?.partOfSplit)
                                     }
                                 />
                             )}

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -163,6 +163,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     const stateOptions = locationTrackStates
         .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));
+    const finishedSplitStateOptions = locationTrackStates
+        .map((s) => (s.value === 'DELETED' ? s : { ...s, disabled: true }))
+        .map((ls) => ({ ...ls, qaId: ls.value }));
 
     const typeOptions = locationTrackTypes.map((ls) => ({ ...ls, qaId: ls.value }));
     const topologicalConnectivityOptions = topologicalConnectivityTypes.map((tc) => ({
@@ -277,7 +280,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     const saveOrConfirm = () => {
         if (
             state.locationTrack?.state === 'DELETED' &&
-            state.existingLocationTrack?.state !== 'DELETED'
+            state.existingLocationTrack?.state !== 'DELETED' &&
+            extraInfo?.partOfSplit !== 'FINISHED_SOURCE_TRACK'
         ) {
             setNonDraftDeleteConfirmationVisible(true);
         } else {
@@ -462,13 +466,19 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                 <Dropdown
                                     qaId="location-track-state"
                                     value={state.locationTrack?.state}
-                                    options={stateOptions}
+                                    options={
+                                        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK'
+                                            ? finishedSplitStateOptions
+                                            : stateOptions
+                                    }
                                     onChange={(value) => value && updateProp('state', value)}
                                     onBlur={() => stateActions.onCommitField('state')}
                                     hasError={hasErrors('state')}
-                                    disabled={isPartOfSplit}
+                                    disabled={
+                                        isPartOfSplit && props.locationTrack?.state === 'DELETED'
+                                    }
                                     title={
-                                        isPartOfSplit
+                                        isPartOfSplit && props.locationTrack?.state === 'DELETED'
                                             ? t('location-track-dialog.state-disabled-by-split')
                                             : undefined
                                     }

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -374,7 +374,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         ) || [];
 
     const isPartOfSplit =
-        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK' || extraInfo?.partOfSplit === 'UNFINISHED';
+        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK' ||
+        extraInfo?.partOfSplit === 'UNFINISHED';
     return (
         <React.Fragment>
             <Dialog

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -377,9 +377,11 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                 d.duplicateStatus.duplicateOfId === state.existingLocationTrack?.id,
         ) || [];
 
-    const isPartOfSplit =
+    const isSplitSourceTrack =
         extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK' ||
-        extraInfo?.partOfSplit === 'UNFINISHED';
+        extraInfo?.partOfSplit === 'UNFINISHED_SOURCE_TRACK';
+    const stateEditingDisabled = isSplitSourceTrack && props.locationTrack?.state === 'DELETED';
+
     return (
         <React.Fragment>
             <Dialog
@@ -467,18 +469,16 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                     qaId="location-track-state"
                                     value={state.locationTrack?.state}
                                     options={
-                                        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK'
+                                        isSplitSourceTrack
                                             ? finishedSplitStateOptions
                                             : stateOptions
                                     }
                                     onChange={(value) => value && updateProp('state', value)}
                                     onBlur={() => stateActions.onCommitField('state')}
                                     hasError={hasErrors('state')}
-                                    disabled={
-                                        isPartOfSplit && props.locationTrack?.state === 'DELETED'
-                                    }
+                                    disabled={stateEditingDisabled}
                                     title={
-                                        isPartOfSplit && props.locationTrack?.state === 'DELETED'
+                                        stateEditingDisabled
                                             ? t('location-track-dialog.state-disabled-by-split')
                                             : undefined
                                     }

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -373,6 +373,8 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                 d.duplicateStatus.duplicateOfId === state.existingLocationTrack?.id,
         ) || [];
 
+    const isPartOfSplit =
+        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK' || extraInfo?.partOfSplit === 'UNFINISHED';
     return (
         <React.Fragment>
             <Dialog
@@ -463,6 +465,12 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                     onChange={(value) => value && updateProp('state', value)}
                                     onBlur={() => stateActions.onCommitField('state')}
                                     hasError={hasErrors('state')}
+                                    disabled={isPartOfSplit}
+                                    title={
+                                        isPartOfSplit
+                                            ? t('location-track-dialog.state-disabled-by-split')
+                                            : undefined
+                                    }
                                     wide
                                     searchable
                                 />

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -166,7 +166,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
     const stateOptions = locationTrackStates
         .map((s) => (s.value !== 'DELETED' || canSetDeleted ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));
-    const finishedSplitStateOptions = locationTrackStates
+    const splitSourceTrackStateOptions = locationTrackStates
         .map((s) => (s.value === 'DELETED' ? s : { ...s, disabled: true }))
         .map((ls) => ({ ...ls, qaId: ls.value }));
 
@@ -470,7 +470,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                                     value={state.locationTrack?.state}
                                     options={
                                         isSplitSourceTrack
-                                            ? finishedSplitStateOptions
+                                            ? splitSourceTrackStateOptions
                                             : stateOptions
                                     }
                                     onChange={(value) => value && updateProp('state', value)}

--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -151,6 +151,9 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         layoutContextDraft,
         props.changeTimes,
     );
+    const isSplitSourceTrack =
+        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK' ||
+        extraInfo?.partOfSplit === 'UNFINISHED_SOURCE_TRACK';
 
     const hasOfficialLocationTrack =
         useLocationTrack(
@@ -281,7 +284,7 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         if (
             state.locationTrack?.state === 'DELETED' &&
             state.existingLocationTrack?.state !== 'DELETED' &&
-            extraInfo?.partOfSplit !== 'FINISHED_SOURCE_TRACK'
+            !isSplitSourceTrack
         ) {
             setNonDraftDeleteConfirmationVisible(true);
         } else {
@@ -377,9 +380,6 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
                 d.duplicateStatus.duplicateOfId === state.existingLocationTrack?.id,
         ) || [];
 
-    const isSplitSourceTrack =
-        extraInfo?.partOfSplit === 'FINISHED_SOURCE_TRACK' ||
-        extraInfo?.partOfSplit === 'UNFINISHED_SOURCE_TRACK';
     const stateEditingDisabled = isSplitSourceTrack && props.locationTrack?.state === 'DELETED';
 
     return (

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -183,7 +183,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
             return t('tool-panel.location-track.splitting.validation.branch-not-main');
         }
 
-        if (extraInfo?.partOfUnfinishedSplit) {
+        if (extraInfo?.partOfSplit === 'UNFINISHED') {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
         }
 
@@ -220,7 +220,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     const getModifyStartOrEndDisabledReasonTranslated = () => {
         if (!isDraft) {
             return t('tool-panel.disabled.activity-disabled-in-official-mode');
-        } else if (splittingState || extraInfo?.partOfUnfinishedSplit) {
+        } else if (splittingState || extraInfo?.partOfSplit === 'UNFINISHED') {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
         } else if (locationTrack.state === 'DELETED') {
             return t('tool-panel.location-track.cannot-shorten-deleted-track');
@@ -369,7 +369,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         locationTrack.state === 'DELETED' ||
         !isDraft ||
         !!splittingState ||
-        extraInfo?.partOfUnfinishedSplit ||
+        extraInfo?.partOfSplit === 'UNFINISHED' ||
         !startAndEndPoints?.start?.point ||
         !startAndEndPoints?.end?.point ||
         startingSplitting;
@@ -380,7 +380,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         locationTrack.isDraft ||
         duplicatesOnOtherTrackNumbers ||
         duplicatesOnOtherLocationTracks ||
-        extraInfo?.partOfUnfinishedSplit ||
+        extraInfo?.partOfSplit === 'UNFINISHED' ||
         startingSplitting ||
         !startAndEndAddressDefined ||
         layoutContext.branch !== 'MAIN';
@@ -417,7 +417,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
 
                             {linkingState === undefined && (
                                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                    {isDraft && extraInfo?.partOfUnfinishedSplit && (
+                                    {isDraft && extraInfo?.partOfSplit === 'UNFINISHED' && (
                                         <InfoboxContentSpread>
                                             <MessageBox>
                                                 {t(
@@ -479,7 +479,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                 {isMainDraft && !linkingState && (
                                     <React.Fragment>
                                         {locationTrack.isDraft &&
-                                            !extraInfo?.partOfUnfinishedSplit && (
+                                            extraInfo?.partOfSplit !== 'UNFINISHED' && (
                                                 <InfoboxContentSpread>
                                                     <MessageBox>
                                                         {t(
@@ -489,7 +489,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 </InfoboxContentSpread>
                                             )}
                                         {duplicatesOnOtherTrackNumbers &&
-                                            !extraInfo?.partOfUnfinishedSplit && (
+                                            extraInfo?.partOfSplit !== 'UNFINISHED' && (
                                                 <InfoboxContentSpread>
                                                     <MessageBox>
                                                         {t(
@@ -499,7 +499,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 </InfoboxContentSpread>
                                             )}
                                         {duplicatesOnOtherLocationTracks &&
-                                            !extraInfo?.partOfUnfinishedSplit && (
+                                            extraInfo?.partOfSplit !== 'UNFINISHED' && (
                                                 <InfoboxContentSpread>
                                                     <MessageBox>
                                                         {t(

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -19,6 +19,7 @@ import { formatToTM35FINString } from 'utils/geography-utils';
 import Infobox from 'tool-panel/infobox/infobox';
 import {
     AlignmentEndPoint,
+    isPartOfUnfinishedSplit,
     LAYOUT_SRID,
     LayoutLocationTrack,
     LayoutSwitchId,
@@ -183,7 +184,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
             return t('tool-panel.location-track.splitting.validation.branch-not-main');
         }
 
-        if (extraInfo?.partOfSplit === 'UNFINISHED') {
+        if (isPartOfUnfinishedSplit(extraInfo?.partOfSplit)) {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
         }
 
@@ -220,7 +221,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     const getModifyStartOrEndDisabledReasonTranslated = () => {
         if (!isDraft) {
             return t('tool-panel.disabled.activity-disabled-in-official-mode');
-        } else if (splittingState || extraInfo?.partOfSplit === 'UNFINISHED') {
+        } else if (splittingState || isPartOfUnfinishedSplit(extraInfo?.partOfSplit)) {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
         } else if (locationTrack.state === 'DELETED') {
             return t('tool-panel.location-track.cannot-shorten-deleted-track');
@@ -369,7 +370,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         locationTrack.state === 'DELETED' ||
         !isDraft ||
         !!splittingState ||
-        extraInfo?.partOfSplit === 'UNFINISHED' ||
+        isPartOfUnfinishedSplit(extraInfo?.partOfSplit) ||
         !startAndEndPoints?.start?.point ||
         !startAndEndPoints?.end?.point ||
         startingSplitting;
@@ -380,7 +381,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         locationTrack.isDraft ||
         duplicatesOnOtherTrackNumbers ||
         duplicatesOnOtherLocationTracks ||
-        extraInfo?.partOfSplit === 'UNFINISHED' ||
+        isPartOfUnfinishedSplit(extraInfo?.partOfSplit) ||
         startingSplitting ||
         !startAndEndAddressDefined ||
         layoutContext.branch !== 'MAIN';
@@ -417,7 +418,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
 
                             {linkingState === undefined && (
                                 <PrivilegeRequired privilege={EDIT_LAYOUT}>
-                                    {isDraft && extraInfo?.partOfSplit === 'UNFINISHED' && (
+                                    {isDraft && isPartOfUnfinishedSplit(extraInfo?.partOfSplit) && (
                                         <InfoboxContentSpread>
                                             <MessageBox>
                                                 {t(
@@ -479,7 +480,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                 {isMainDraft && !linkingState && (
                                     <React.Fragment>
                                         {locationTrack.isDraft &&
-                                            extraInfo?.partOfSplit !== 'UNFINISHED' && (
+                                            !isPartOfUnfinishedSplit(extraInfo?.partOfSplit) && (
                                                 <InfoboxContentSpread>
                                                     <MessageBox>
                                                         {t(
@@ -489,7 +490,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 </InfoboxContentSpread>
                                             )}
                                         {duplicatesOnOtherTrackNumbers &&
-                                            extraInfo?.partOfSplit !== 'UNFINISHED' && (
+                                            !isPartOfUnfinishedSplit(extraInfo?.partOfSplit) && (
                                                 <InfoboxContentSpread>
                                                     <MessageBox>
                                                         {t(
@@ -499,7 +500,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                                 </InfoboxContentSpread>
                                             )}
                                         {duplicatesOnOtherLocationTracks &&
-                                            extraInfo?.partOfSplit !== 'UNFINISHED' && (
+                                            !isPartOfUnfinishedSplit(extraInfo?.partOfSplit) && (
                                                 <InfoboxContentSpread>
                                                     <MessageBox>
                                                         {t(

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -342,12 +342,14 @@ export type LocationTrackDuplicate = {
     length: number;
 };
 
+export type PartOfSplit = 'FINISHED_SOURCE_TRACK' | 'UNFINISHED' | 'NONE';
+
 export type LocationTrackInfoboxExtras = {
     duplicateOf?: LocationTrackDuplicate;
     duplicates: LocationTrackDuplicate[];
     startSplitPoint?: SplitPoint;
     endSplitPoint?: SplitPoint;
-    partOfUnfinishedSplit?: boolean;
+    partOfSplit: PartOfSplit;
     switches: LocationTrackInfoboxSwitch[];
     operationalPoints: LocationTrackInfoboxOperationalPoint[];
 };

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -342,7 +342,15 @@ export type LocationTrackDuplicate = {
     length: number;
 };
 
-export type PartOfSplit = 'FINISHED_SOURCE_TRACK' | 'UNFINISHED' | 'NONE';
+export type PartOfSplit =
+    | 'FINISHED_SOURCE_TRACK'
+    | 'UNFINISHED_SOURCE_TRACK'
+    | 'UNFINISHED_TARGET_TRACK'
+    | 'NONE';
+
+export function isPartOfUnfinishedSplit(partOfSplit: PartOfSplit | undefined): boolean {
+    return partOfSplit === 'UNFINISHED_SOURCE_TRACK' || partOfSplit === 'UNFINISHED_TARGET_TRACK';
+}
 
 export type LocationTrackInfoboxExtras = {
     duplicateOf?: LocationTrackDuplicate;


### PR DESCRIPTION
Täällä siis käytännössä tehty seuraavaa:

- Lisätty bäkkärille julkaisuvalidaatioon virhe siitä, jos jonkin splittauksen lähderaidetta koitetaan käydä palauttamassa
  - Jo julkaistun splitin lähderaiteen sai siis aiemmin käydä palauttamassa, sillä lähderaiteen tilaa tutkinutta aiempaa julkaisuvalidaatiota kiinnosti vain oliko splittaus vielä julkaisematta
  - Jumpattu edellämainitun validaation sanamuotoja kattamaan paremmin molemmat tilanteet
- Lisätty sijaintiraiteen muokkausdialogiin disablointi tiladropdownille tilanteisiin, joissa käsillä on splittauksen lähderaide
  - Jos lähderaiteen tila on Poistettu, koko kenttä on disabloitu
  - Jos lähderaiteen tila on _jotain muuta kuin_ Poistettu, dropdownin saa auki. Tällöin kaikki muut vaihtoehdot kuin Poistettu on disabloitu. 
    - Tässä taustalla on ajatuksena, että tällä tavalla tilaltaan jonkinlaiseen jojoon mennyt lähderaide saataisiin korjattua poistetuksi
    - Tässä tilanteessa ei myöskään näytetä poiston varmistusdialogia
  - Tätä varten extendattu sijaintiraiteen infobox-extrojen boolean-tieto siitä, onko raide osa ei-valmista splittiä enumiksi joka kertoo onko kyseessä ei-splitattu raide, ei-valmiin splitin lähde tai kohderaide vai valmiin splitin lähderaide