### PR TITLE
General: Improve error response logging

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -146,20 +146,13 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun getLocationTrack(locationTrackOid: RatkoOid<RatkoLocationTrack>): RatkoLocationTrack? {
         logger.integrationCall("getLocationTrack", "locationTrackOid" to locationTrackOid)
 
-        return getSpec(combinePaths(LOCATION_TRACK_LOCATIONS_PATH, locationTrackOid))
-            .defaultErrorHandler(
-                LOCATION,
-                FETCH_EXISTING,
-                combinePaths(LOCATION_TRACK_LOCATIONS_PATH, locationTrackOid),
-            )
-            .bodyToMono<String>()
-            .block(defaultBlockTimeout)
-            ?.let { response ->
-                ratkoJsonMapper.readTree(response).firstOrNull()?.let { locationTrackJsonNode ->
-                    replaceKmM(locationTrackJsonNode.get("nodecollection"))
-                    parseJsonNode<RatkoLocationTrack>(locationTrackJsonNode, "getLocationTrack")
-                }
+        return getWithJsonResponseBody(combinePaths(LOCATION_TRACK_LOCATIONS_PATH, locationTrackOid), LOCATION)?.let {
+            response ->
+            ratkoJsonMapper.readTree(response).firstOrNull()?.let { locationTrackJsonNode ->
+                replaceKmM(locationTrackJsonNode.get("nodecollection"))
+                parseJsonNode<RatkoLocationTrack>(locationTrackJsonNode, "getLocationTrack")
             }
+        }
     }
 
     fun updateLocationTrackProperties(locationTrack: RatkoLocationTrack, oid: Oid<LocationTrack>) {
@@ -325,7 +318,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun <T : RatkoAsset> newAsset(asset: RatkoAsset): RatkoOid<T>? {
         logger.integrationCall("newAsset", "asset" to asset)
 
-        return postForRawJson(ASSET_PATH, asset.withoutGeometries())
+        return postWithJsonResponseBody(ASSET_PATH, asset.withoutGeometries())
             ?.let { response -> ratkoJsonMapper.readTree(response).firstOrNull()?.get("id")?.textValue() }
             ?.let(::RatkoOid)
     }
@@ -349,20 +342,14 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun <T : RatkoAsset> getSwitchAsset(assetOid: RatkoOid<T>): RatkoSwitchAsset? {
         logger.integrationCall("getSwitchAsset", "assetOid" to assetOid)
 
-        return getSpec(combinePaths(ASSET_PATH, assetOid))
-            .defaultErrorHandler(PROPERTIES, FETCH_EXISTING, combinePaths(ASSET_PATH, assetOid))
-            .bodyToMono<String>()
-            .block(defaultBlockTimeout)
-            ?.let { response ->
-                ratkoJsonMapper.readTree(response).let { switchJsonNode ->
-                    switchJsonNode.get("assetGeoms")?.map { asset ->
-                        (asset as ObjectNode).replace("geometry", asset.get("geometryOriginal"))
-                    }
-
-                    switchJsonNode.get("locations")?.forEach { location -> replaceKmM(location.get("nodecollection")) }
-
-                    parseJsonNode<RatkoSwitchAsset>(switchJsonNode, "getSwitchAsset")
+        return getWithJsonResponseBody(combinePaths(ASSET_PATH, assetOid))
+            ?.let { response -> ratkoJsonMapper.readTree(response) }
+            ?.let { switchJsonNode ->
+                switchJsonNode.get("assetGeoms")?.forEach { asset ->
+                    (asset as ObjectNode).replace("geometry", asset.get("geometryOriginal"))
                 }
+                switchJsonNode.get("locations")?.forEach { location -> replaceKmM(location.get("nodecollection")) }
+                parseJsonNode<RatkoSwitchAsset>(switchJsonNode, "getSwitchAsset")
             }
     }
 
@@ -475,16 +462,12 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun getRouteNumber(routeNumberOid: RatkoOid<RatkoRouteNumber>): RatkoRouteNumber? {
         logger.integrationCall("getRouteNumber", "routeNumberOid" to routeNumberOid)
 
-        return getSpec(combinePaths(ROUTE_NUMBER_LOCATIONS_PATH, routeNumberOid))
-            .defaultErrorHandler(PROPERTIES, FETCH_EXISTING, combinePaths(ROUTE_NUMBER_LOCATIONS_PATH, routeNumberOid))
-            .bodyToMono<String>()
-            .block(defaultBlockTimeout)
-            ?.let { response ->
-                ratkoJsonMapper.readTree(response).let { routeNumberJsonNode ->
-                    replaceKmM(routeNumberJsonNode.get("nodecollection"))
-                    parseJsonNode<RatkoRouteNumber>(routeNumberJsonNode, "getRouteNumber")
-                }
+        return getWithJsonResponseBody(combinePaths(ROUTE_NUMBER_LOCATIONS_PATH, routeNumberOid))?.let { response ->
+            ratkoJsonMapper.readTree(response).let { routeNumberJsonNode ->
+                replaceKmM(routeNumberJsonNode.get("nodecollection"))
+                parseJsonNode<RatkoRouteNumber>(routeNumberJsonNode, "getRouteNumber")
             }
+        }
     }
 
     fun newRouteNumber(routeNumber: RatkoRouteNumber): RatkoOid<RatkoRouteNumber>? {
@@ -518,15 +501,16 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             logger.info("fetching operational points for page $pageNumber")
             val allAssetsInPage =
                 postWithResponseBody<RatkoOperationalPointAssetsResponse>(
-                    "$ASSET_PATH/search?fields=summary",
-                    mapOf(
-                        "assetType" to RatkoAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
-                        "pageNumber" to pageNumber++,
-                        "size" to 100,
-                        "sortOrder" to "ASC",
-                        "secondarySortOrder" to "ASC",
-                    ),
-                )?.assets ?: emptyList()
+                        "$ASSET_PATH/search?fields=summary",
+                        mapOf(
+                            "assetType" to RatkoAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
+                            "pageNumber" to pageNumber++,
+                            "size" to 100,
+                            "sortOrder" to "ASC",
+                            "secondarySortOrder" to "ASC",
+                        ),
+                    )
+                    ?.assets ?: emptyList()
             val validOperationalPointsInPage = allAssetsInPage.mapNotNull { parseAsset(it, logger) }
             allPoints.addAll(validOperationalPointsInPage)
         } while (allAssetsInPage.size == 100)
@@ -538,9 +522,10 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
         val bulkTransferId =
             postWithResponseBody<RatkoBulkTransferResponse>(
-                url = "$BULK_TRANSFER_PATH/start",
-                content = mapOf("this-is-something-that-should-be-defined" to "in-the-future"),
-            )?.id
+                    url = "$BULK_TRANSFER_PATH/start",
+                    content = mapOf("this-is-something-that-should-be-defined" to "in-the-future"),
+                )
+                ?.id
         checkNotNull(bulkTransferId) { "Received bulk transfer id was null" }
 
         // The state may also be received from the api regarding how it is created in Ratko's end.
@@ -616,14 +601,17 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         }
     }
 
-    private fun postForRawJson(url: String, content: Any): String? =
+    private fun postWithJsonResponseBody(url: String, content: Any): String? =
         postSpec(url, content)
             .defaultErrorHandler(PROPERTIES, CREATE, url, content)
             .bodyToMono<String>()
             .block(defaultBlockTimeout)
 
     private inline fun <reified TOut : Any> postWithResponseBody(url: String, content: Any): TOut? =
-        postForRawJson(url, content)?.let { parseJsonValue<TOut>(it, url) }
+        postWithJsonResponseBody(url, content)?.let { parseJsonValue<TOut>(it, url) }
+
+    private fun getWithJsonResponseBody(url: String, errorType: RatkoPushErrorType = PROPERTIES): String? =
+        getSpec(url).defaultErrorHandler(errorType, FETCH_EXISTING, url).bodyToMono<String>().block(defaultBlockTimeout)
 
     private fun putWithoutResponseBody(url: String, content: Any, errorType: RatkoPushErrorType = PROPERTIES) {
         putSpec(url, content)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -51,7 +51,6 @@ import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -64,6 +63,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 val defaultBlockTimeout: Duration = defaultResponseTimeout.plusMinutes(1L)
 
@@ -155,7 +155,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             ?.let { response ->
                 ratkoJsonMapper.readTree(response).firstOrNull()?.let { locationTrackJsonNode ->
                     replaceKmM(locationTrackJsonNode.get("nodecollection"))
-                    ratkoJsonMapper.treeToValue(locationTrackJsonNode, RatkoLocationTrack::class.java)
+                    parseJsonNode<RatkoLocationTrack>(locationTrackJsonNode, "getLocationTrack")
                 }
             }
     }
@@ -359,7 +359,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
                     switchJsonNode.get("locations")?.forEach { location -> replaceKmM(location.get("nodecollection")) }
 
-                    ratkoJsonMapper.treeToValue(switchJsonNode, RatkoSwitchAsset::class.java)
+                    parseJsonNode<RatkoSwitchAsset>(switchJsonNode, "getSwitchAsset")
                 }
             }
     }
@@ -480,8 +480,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             ?.let { response ->
                 ratkoJsonMapper.readTree(response).let { routeNumberJsonNode ->
                     replaceKmM(routeNumberJsonNode.get("nodecollection"))
-
-                    ratkoJsonMapper.treeToValue(routeNumberJsonNode, RatkoRouteNumber::class.java)
+                    parseJsonNode<RatkoRouteNumber>(routeNumberJsonNode, "getRouteNumber")
                 }
             }
     }
@@ -527,7 +526,9 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                     ),
                 ))
             val allAssetsInPage =
-                ratkoJsonMapper.readValue(body, RatkoOperationalPointAssetsResponse::class.java)?.assets ?: listOf()
+                body
+                    ?.let { parseJsonValue<RatkoOperationalPointAssetsResponse>(body, "fetchOperationalPoints") }
+                    ?.assets ?: emptyList()
             val validOperationalPointsInPage = allAssetsInPage.mapNotNull { parseAsset(it, logger) }
             allPoints.addAll(validOperationalPointsInPage)
         } while (allAssetsInPage.size == 100)
@@ -543,7 +544,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                 content = mapOf("this-is-something-that-should-be-defined" to "in-the-future"),
             )
 
-        val bulkTransferId = ratkoJsonMapper.readValue(body, RatkoBulkTransferResponse::class.java)?.id
+        val bulkTransferId = body?.let { parseJsonValue<RatkoBulkTransferResponse>(it, "startNewBulkTransfer") }?.id
         checkNotNull(bulkTransferId) { "Received bulk transfer id was null" }
 
         // The state may also be received from the api regarding how it is created in Ratko's end.
@@ -561,12 +562,10 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             }
             .block(defaultBlockTimeout)
             .let { response ->
-                val bulkTransferState =
-                    ratkoJsonMapper.readValue(response, RatkoBulkTransferResponse::class.java)?.state
-
+                val bulkTransferState = response?.let {
+                    parseJsonValue<RatkoBulkTransferResponse>(it, "pollBulkTransferState").state
+                }
                 checkNotNull(bulkTransferState) { "Received bulk transfer id was null!" }
-
-                bulkTransferState
             }
     }
 
@@ -592,6 +591,32 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                     point.put("kmM", RatkoTrackMeter(TrackMeter(km, m)).toString())
                 }
             }
+        }
+    }
+
+    private inline fun <reified T> parseJsonValue(json: String, context: String): T {
+        return try {
+            ratkoJsonMapper.readValue(json, T::class.java)
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to parse Ratko JSON response as ${T::class.simpleName} in $context: " +
+                    json.take(MAX_JSON_LOG_LENGTH),
+                e,
+            )
+            throw e
+        }
+    }
+
+    private inline fun <reified T> parseJsonNode(node: JsonNode, context: String): T {
+        return try {
+            ratkoJsonMapper.treeToValue(node, T::class.java)
+        } catch (e: Exception) {
+            logger.error(
+                "Failed to parse Ratko JSON node as ${T::class.simpleName} in $context: " +
+                    node.toString().take(MAX_JSON_LOG_LENGTH),
+                e,
+            )
+            throw e
         }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.jsonMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.treeToValue
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.MainBranchRatkoExternalId
@@ -323,7 +325,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun <T : RatkoAsset> newAsset(asset: RatkoAsset): RatkoOid<T>? {
         logger.integrationCall("newAsset", "asset" to asset)
 
-        return postWithResponseBody<String>(ASSET_PATH, asset.withoutGeometries())
+        return postForRawJson(ASSET_PATH, asset.withoutGeometries())
             ?.let { response -> ratkoJsonMapper.readTree(response).firstOrNull()?.get("id")?.textValue() }
             ?.let(::RatkoOid)
     }
@@ -514,8 +516,8 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         var pageNumber = 0
         do {
             logger.info("fetching operational points for page $pageNumber")
-            val body =
-                (postWithResponseBody<String>(
+            val allAssetsInPage =
+                postWithResponseBody<RatkoOperationalPointAssetsResponse>(
                     "$ASSET_PATH/search?fields=summary",
                     mapOf(
                         "assetType" to RatkoAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
@@ -524,11 +526,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                         "sortOrder" to "ASC",
                         "secondarySortOrder" to "ASC",
                     ),
-                ))
-            val allAssetsInPage =
-                body
-                    ?.let { parseJsonValue<RatkoOperationalPointAssetsResponse>(body, "fetchOperationalPoints") }
-                    ?.assets ?: emptyList()
+                )?.assets ?: emptyList()
             val validOperationalPointsInPage = allAssetsInPage.mapNotNull { parseAsset(it, logger) }
             allPoints.addAll(validOperationalPointsInPage)
         } while (allAssetsInPage.size == 100)
@@ -538,13 +536,11 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun startNewBulkTransfer(split: Split): Pair<IntId<BulkTransfer>, BulkTransferState> {
         logger.integrationCall("startNewBulkTransfer", "splitId" to split.id)
 
-        val body =
-            postWithResponseBody<String>(
+        val bulkTransferId =
+            postWithResponseBody<RatkoBulkTransferResponse>(
                 url = "$BULK_TRANSFER_PATH/start",
                 content = mapOf("this-is-something-that-should-be-defined" to "in-the-future"),
-            )
-
-        val bulkTransferId = body?.let { parseJsonValue<RatkoBulkTransferResponse>(it, "startNewBulkTransfer") }?.id
+            )?.id
         checkNotNull(bulkTransferId) { "Received bulk transfer id was null" }
 
         // The state may also be received from the api regarding how it is created in Ratko's end.
@@ -596,7 +592,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
     private inline fun <reified T> parseJsonValue(json: String, context: String): T {
         return try {
-            ratkoJsonMapper.readValue(json, T::class.java)
+            ratkoJsonMapper.readValue<T>(json)
         } catch (e: Exception) {
             logger.error(
                 "Failed to parse Ratko JSON response as ${T::class.simpleName} in $context: " +
@@ -609,7 +605,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
     private inline fun <reified T> parseJsonNode(node: JsonNode, context: String): T {
         return try {
-            ratkoJsonMapper.treeToValue(node, T::class.java)
+            ratkoJsonMapper.treeToValue<T>(node)
         } catch (e: Exception) {
             logger.error(
                 "Failed to parse Ratko JSON node as ${T::class.simpleName} in $context: " +
@@ -620,11 +616,14 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         }
     }
 
-    private inline fun <reified TOut : Any> postWithResponseBody(url: String, content: Any): TOut? =
+    private fun postForRawJson(url: String, content: Any): String? =
         postSpec(url, content)
             .defaultErrorHandler(PROPERTIES, CREATE, url, content)
-            .bodyToMono<TOut>()
+            .bodyToMono<String>()
             .block(defaultBlockTimeout)
+
+    private inline fun <reified TOut : Any> postWithResponseBody(url: String, content: Any): TOut? =
+        postForRawJson(url, content)?.let { parseJsonValue<TOut>(it, url) }
 
     private fun putWithoutResponseBody(url: String, content: Any, errorType: RatkoPushErrorType = PROPERTIES) {
         putSpec(url, content)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -500,17 +500,21 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         do {
             logger.info("fetching operational points for page $pageNumber")
             val allAssetsInPage =
-                postWithResponseBody<RatkoOperationalPointAssetsResponse>(
-                        "$ASSET_PATH/search?fields=summary",
-                        mapOf(
-                            "assetType" to RatkoAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
-                            "pageNumber" to pageNumber++,
-                            "size" to 100,
-                            "sortOrder" to "ASC",
-                            "secondarySortOrder" to "ASC",
-                        ),
-                    )
-                    ?.assets ?: emptyList()
+                requireNotNull(
+                    postWithResponseBody<RatkoOperationalPointAssetsResponse>(
+                            "$ASSET_PATH/search?fields=summary",
+                            mapOf(
+                                "assetType" to RatkoAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
+                                "pageNumber" to pageNumber++,
+                                "size" to 100,
+                                "sortOrder" to "ASC",
+                                "secondarySortOrder" to "ASC",
+                            ),
+                        )
+                        ?.assets
+                ) {
+                    "Failed to get operational points from Ratko (empty response)"
+                }
             val validOperationalPointsInPage = allAssetsInPage.mapNotNull { parseAsset(it, logger) }
             allPoints.addAll(validOperationalPointsInPage)
         } while (allAssetsInPage.size == 100)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -546,7 +546,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                 val bulkTransferState = response?.let {
                     parseJsonValue<RatkoBulkTransferResponse>(it, "pollBulkTransferState").state
                 }
-                checkNotNull(bulkTransferState) { "Received bulk transfer id was null!" }
+                checkNotNull(bulkTransferState) { "Received bulk transfer state was null!" }
             }
     }
 


### PR DESCRIPTION
Tehty helperit myös tulosten parsinnalle (joko json-puun osasta tai json-stringistä) niin että ne logittaa itse stringin jos parsinta failaa. Tämä otettu käyttöön parsintoihin.
Siirretty kaikille yhteiset osat ketjua (`getSpec` + `bodyToMono<String>` + `block`) helppereihin. 
Otettu sama pattern käyttöön myös paikkoihin jotka aiemmin nojasi `bodyToMono<SomeType>` rakenteisiin -> nyt otetaan tulos stringinä ja parsitaan yhteisellä funkkarilla.

Tämän ei pitäisi tehdä mitään toiminnallista muutosta vaan vaikuttaa vain logituksiin... mutta kuten copilot tuossa alla toteaa niin pari pientä muutosta sinne kuitenkin syntyy tuosta logiikan yhtenäistyksestä. Itse en näe niissä ongelmaa, sanokaa jos olette eri mieltä.