### PR TITLE
GVT-3592: Ratkosta synkattujen toiminnallisten pisteiden ratkoversioviitteiden korjaaminen pisteiden poistossa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -64,7 +64,7 @@ constructor(
             }
 
         val nonDeletedVersions = latestRatkoVersions.filter { !it.deleted }
-        val layoutPointOids = upsertIdsForRatkoPoints(nonDeletedVersions)
+        val layoutPointOids = updateAndFetchRatkoOperationalPointOids(nonDeletedVersions)
         insertNewLayoutOperationalPoints(nonDeletedVersions, layoutPointOids, layoutPoints)
         updateExistingLayoutOperationalPoints(layoutPoints, layoutPointOids, ratkoPointsByOid)
     }
@@ -86,7 +86,7 @@ constructor(
             RatkoPushErrorAndDetails(errorWithAsset, publicationLogService.getPublicationDetails(publicationId))
         }
 
-    private fun upsertIdsForRatkoPoints(
+    private fun updateAndFetchRatkoOperationalPointOids(
         ratkoPointVersions: List<RatkoOperationalPointVersion>
     ): Map<IntId<OperationalPoint>, Oid<OperationalPoint>> {
         val existingIds = operationalPointDao.fetchExternalIds(LayoutBranch.main).mapValues { (_, extId) -> extId.oid }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -27,7 +27,6 @@ import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
 import fi.fta.geoviite.infra.tracklayout.OperationalPointOrigin
 import fi.fta.geoviite.infra.tracklayout.OperationalPointState
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
-import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.transaction.annotation.Transactional
@@ -139,11 +138,10 @@ constructor(
                 originalLayoutPointOids.contains(layoutPoint.id) &&
                 !ratkoPointsByOid.contains(originalLayoutPointOids[layoutPoint.id])
         }
-        val now = Instant.now()
         deleted.forEach { layoutPoint ->
             val ratkoVersionOfDeleted =
                 originalLayoutPointOids.getValue(layoutPoint.id as IntId).let {
-                    ratkoOperationalPointDao.fetchVersionAt(it.cast(), now)
+                    ratkoOperationalPointDao.fetchVersionAt(it.cast())
                 }
             operationalPointDao.save(
                 asMainDraft(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -27,6 +27,7 @@ import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
 import fi.fta.geoviite.infra.tracklayout.OperationalPointOrigin
 import fi.fta.geoviite.infra.tracklayout.OperationalPointState
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.transaction.annotation.Transactional
@@ -55,8 +56,9 @@ constructor(
     @Transactional
     fun updateLayoutPointsFromIntegrationTable() {
         val ratkoPointsWithVersions = ratkoOperationalPointDao.listWithVersions()
-        val ratkoPointsByOid =
-            ratkoPointsWithVersions.associateBy { (point) -> point.externalId.cast<OperationalPoint>() }
+        val ratkoPointsByOid = ratkoPointsWithVersions.associateBy { (point) ->
+            point.externalId.cast<OperationalPoint>()
+        }
         val layoutPoints =
             operationalPointDao.list(LayoutBranch.main.draft, true).filter { point ->
                 point.origin == OperationalPointOrigin.RATKO
@@ -132,14 +134,22 @@ constructor(
         originalLayoutPointOids: Map<IntId<OperationalPoint>, Oid<OperationalPoint>>,
         ratkoPointsByOid: Map<Oid<OperationalPoint>, Pair<RatkoOperationalPoint, Int>>,
     ): Set<IntId<OperationalPoint>> {
-        val deleted =
-            layoutPoints.filter { layoutPoint ->
-                layoutPoint.state != OperationalPointState.DELETED &&
-                    originalLayoutPointOids.contains(layoutPoint.id) &&
-                    !ratkoPointsByOid.contains(originalLayoutPointOids[layoutPoint.id])
-            }
+        val deleted = layoutPoints.filter { layoutPoint ->
+            layoutPoint.state != OperationalPointState.DELETED &&
+                originalLayoutPointOids.contains(layoutPoint.id) &&
+                !ratkoPointsByOid.contains(originalLayoutPointOids[layoutPoint.id])
+        }
+        val now = Instant.now()
         deleted.forEach { layoutPoint ->
-            operationalPointDao.save(asMainDraft(layoutPoint.copy(state = OperationalPointState.DELETED)))
+            val ratkoVersionOfDeleted =
+                originalLayoutPointOids.getValue(layoutPoint.id as IntId).let {
+                    ratkoOperationalPointDao.fetchVersionAt(it.cast(), now)
+                }
+            operationalPointDao.save(
+                asMainDraft(
+                    layoutPoint.copy(state = OperationalPointState.DELETED, ratkoVersion = ratkoVersionOfDeleted)
+                )
+            )
         }
         return deleted.map { it.id as IntId }.toSet()
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -111,34 +111,49 @@ constructor(
         layoutPointOids: Map<IntId<OperationalPoint>, Oid<OperationalPoint>>,
         ratkoPointsByOid: Map<Oid<OperationalPoint>, RatkoOperationalPointVersion>,
     ) {
-        layoutPoints.forEach { layoutPoint ->
-            val extId = layoutPointOids[layoutPoint.id as IntId] ?: return@forEach
-            val ratkoData = ratkoPointsByOid[extId] ?: return@forEach
-            if (ratkoData.version <= requireNotNull(layoutPoint.ratkoVersion)) return@forEach
-
-            when {
-                ratkoData.deleted && layoutPoint.state != OperationalPointState.DELETED -> {
-                    operationalPointDao.save(
-                        asMainDraft(
-                            layoutPoint.copy(state = OperationalPointState.DELETED, ratkoVersion = ratkoData.version)
+        layoutPoints
+            .mapNotNull { layoutPoint ->
+                layoutPointOids[layoutPoint.id as IntId]
+                    ?.let { extId -> extId to ratkoPointsByOid[extId] }
+                    ?.let { (extId, ratkoData) ->
+                        if (ratkoData != null) Triple(layoutPoint, extId, ratkoData) else null
+                    }
+            }
+            .forEach { (layoutPoint, extId, ratkoPointVersion) ->
+                when {
+                    // Deletion
+                    ratkoPointVersion.deleted && layoutPoint.state != OperationalPointState.DELETED -> {
+                        operationalPointDao.save(
+                            asMainDraft(
+                                layoutPoint.copy(
+                                    state = OperationalPointState.DELETED,
+                                    ratkoVersion = ratkoPointVersion.version,
+                                )
+                            )
                         )
-                    )
-                }
-                !ratkoData.deleted && layoutPoint.state == OperationalPointState.DELETED -> {
-                    operationalPointDao.save(
-                        asMainDraft(
-                            layoutPoint.copy(state = OperationalPointState.IN_USE, ratkoVersion = ratkoData.version)
+                    }
+                    // Restore
+                    !ratkoPointVersion.deleted && layoutPoint.state == OperationalPointState.DELETED -> {
+                        operationalPointDao.save(
+                            asMainDraft(
+                                layoutPoint.copy(
+                                    state = OperationalPointState.IN_USE,
+                                    ratkoVersion = ratkoPointVersion.version,
+                                )
+                            )
                         )
-                    )
-                }
-                !ratkoData.deleted && layoutPoint.state != OperationalPointState.DELETED -> {
-                    val savedRatkoPoint = ratkoOperationalPointDao.fetch(extId.cast(), layoutPoint.ratkoVersion)
-                    if (ratkoOperationalPointContentDiffers(ratkoData.point, savedRatkoPoint)) {
-                        operationalPointDao.save(asMainDraft(layoutPoint.copy(ratkoVersion = ratkoData.version)))
+                    }
+                    // Normal update
+                    layoutPoint.ratkoVersion != null -> {
+                        val savedRatkoPoint = ratkoOperationalPointDao.fetch(extId.cast(), layoutPoint.ratkoVersion)
+                        if (ratkoOperationalPointContentDiffers(ratkoPointVersion.point, savedRatkoPoint)) {
+                            operationalPointDao.save(
+                                asMainDraft(layoutPoint.copy(ratkoVersion = ratkoPointVersion.version))
+                            )
+                        }
                     }
                 }
             }
-        }
     }
 
     private fun ratkoOperationalPointContentDiffers(a: RatkoOperationalPoint, b: RatkoOperationalPoint) =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -116,7 +116,9 @@ constructor(
                 layoutPointOids[layoutPoint.id as IntId]
                     ?.let { extId -> extId to ratkoPointsByOid[extId] }
                     ?.let { (extId, ratkoData) ->
-                        if (ratkoData != null) Triple(layoutPoint, extId, ratkoData) else null
+                        if (ratkoData != null && layoutPoint.ratkoVersion != ratkoData.version)
+                            Triple(layoutPoint, extId, ratkoData)
+                        else null
                     }
             }
             .forEach { (layoutPoint, extId, ratkoPointVersion) ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -54,23 +54,19 @@ constructor(
 
     @Transactional
     fun updateLayoutPointsFromIntegrationTable() {
-        val ratkoPointsWithVersions = ratkoOperationalPointDao.listWithVersions()
-        val ratkoPointsByOid = ratkoPointsWithVersions.associateBy { (point) ->
-            point.externalId.cast<OperationalPoint>()
+        val latestRatkoVersions = ratkoOperationalPointDao.listLatestVersions()
+        val ratkoPointsByOid = latestRatkoVersions.associateBy { ratkoVersion ->
+            ratkoVersion.point.externalId.cast<OperationalPoint>()
         }
         val layoutPoints =
             operationalPointDao.list(LayoutBranch.main.draft, true).filter { point ->
                 point.origin == OperationalPointOrigin.RATKO
             }
 
-        val layoutPointOids = upsertIdsForRatkoPoints(ratkoPointsWithVersions)
-        upsertObjectsForRatkoPoints(ratkoPointsWithVersions, layoutPointOids, layoutPoints)
-        val deletedPoints = markRemovedPointsAsDeleted(layoutPoints, layoutPointOids, ratkoPointsByOid)
-        updatePossiblyUpdatedPoints(
-            layoutPoints.filterNot { deletedPoints.contains(it.id) },
-            layoutPointOids,
-            ratkoPointsByOid,
-        )
+        val nonDeletedVersions = latestRatkoVersions.filter { !it.deleted }
+        val layoutPointOids = upsertIdsForRatkoPoints(nonDeletedVersions)
+        insertNewLayoutOperationalPoints(nonDeletedVersions, layoutPointOids, layoutPoints)
+        updateExistingLayoutOperationalPoints(layoutPoints, layoutPointOids, ratkoPointsByOid)
     }
 
     @Transactional(readOnly = true)
@@ -91,12 +87,12 @@ constructor(
         }
 
     private fun upsertIdsForRatkoPoints(
-        ratkoPointsWithVersions: List<Pair<RatkoOperationalPoint, Int>>
+        ratkoPointVersions: List<RatkoOperationalPointVersion>
     ): Map<IntId<OperationalPoint>, Oid<OperationalPoint>> {
         val existingIds = operationalPointDao.fetchExternalIds(LayoutBranch.main).mapValues { (_, extId) -> extId.oid }
         val existingOidsSet = existingIds.values.toSet()
         val createdIds =
-            ratkoPointsWithVersions
+            ratkoPointVersions
                 .filter { (ratkoPoint) -> !existingOidsSet.contains(ratkoPoint.externalId.cast()) }
                 .associate { (ratkoPoint) ->
                     createOperationalPointIdForRatkoPoint(ratkoPoint) to ratkoPoint.externalId.cast<OperationalPoint>()
@@ -110,46 +106,39 @@ constructor(
         return id
     }
 
-    private fun updatePossiblyUpdatedPoints(
-        possiblyUpdatedPoints: List<OperationalPoint>,
+    private fun updateExistingLayoutOperationalPoints(
+        layoutPoints: List<OperationalPoint>,
         layoutPointOids: Map<IntId<OperationalPoint>, Oid<OperationalPoint>>,
-        ratkoPointsByOid: Map<Oid<OperationalPoint>, Pair<RatkoOperationalPoint, Int>>,
+        ratkoPointsByOid: Map<Oid<OperationalPoint>, RatkoOperationalPointVersion>,
     ) {
-        possiblyUpdatedPoints.forEach { layoutPoint ->
-            val extId = layoutPointOids.getValue(layoutPoint.id as IntId)
-            ratkoPointsByOid[extId]?.let { (currentRatkoPoint, currentRatkoPointVersion) ->
-                if (currentRatkoPointVersion > requireNotNull(layoutPoint.ratkoVersion)) {
+        layoutPoints.forEach { layoutPoint ->
+            val extId = layoutPointOids[layoutPoint.id as IntId] ?: return@forEach
+            val ratkoData = ratkoPointsByOid[extId] ?: return@forEach
+            if (ratkoData.version <= requireNotNull(layoutPoint.ratkoVersion)) return@forEach
+
+            when {
+                ratkoData.deleted && layoutPoint.state != OperationalPointState.DELETED -> {
+                    operationalPointDao.save(
+                        asMainDraft(
+                            layoutPoint.copy(state = OperationalPointState.DELETED, ratkoVersion = ratkoData.version)
+                        )
+                    )
+                }
+                !ratkoData.deleted && layoutPoint.state == OperationalPointState.DELETED -> {
+                    operationalPointDao.save(
+                        asMainDraft(
+                            layoutPoint.copy(state = OperationalPointState.IN_USE, ratkoVersion = ratkoData.version)
+                        )
+                    )
+                }
+                !ratkoData.deleted && layoutPoint.state != OperationalPointState.DELETED -> {
                     val savedRatkoPoint = ratkoOperationalPointDao.fetch(extId.cast(), layoutPoint.ratkoVersion)
-                    if (ratkoOperationalPointContentDiffers(currentRatkoPoint, savedRatkoPoint)) {
-                        operationalPointDao.save(asMainDraft(layoutPoint.copy(ratkoVersion = currentRatkoPointVersion)))
+                    if (ratkoOperationalPointContentDiffers(ratkoData.point, savedRatkoPoint)) {
+                        operationalPointDao.save(asMainDraft(layoutPoint.copy(ratkoVersion = ratkoData.version)))
                     }
                 }
             }
         }
-    }
-
-    private fun markRemovedPointsAsDeleted(
-        layoutPoints: List<OperationalPoint>,
-        originalLayoutPointOids: Map<IntId<OperationalPoint>, Oid<OperationalPoint>>,
-        ratkoPointsByOid: Map<Oid<OperationalPoint>, Pair<RatkoOperationalPoint, Int>>,
-    ): Set<IntId<OperationalPoint>> {
-        val deleted = layoutPoints.filter { layoutPoint ->
-            layoutPoint.state != OperationalPointState.DELETED &&
-                originalLayoutPointOids.contains(layoutPoint.id) &&
-                !ratkoPointsByOid.contains(originalLayoutPointOids[layoutPoint.id])
-        }
-        deleted.forEach { layoutPoint ->
-            val ratkoVersionOfDeleted =
-                originalLayoutPointOids.getValue(layoutPoint.id as IntId).let {
-                    ratkoOperationalPointDao.fetchVersionAt(it.cast())
-                }
-            operationalPointDao.save(
-                asMainDraft(
-                    layoutPoint.copy(state = OperationalPointState.DELETED, ratkoVersion = ratkoVersionOfDeleted)
-                )
-            )
-        }
-        return deleted.map { it.id as IntId }.toSet()
     }
 
     private fun ratkoOperationalPointContentDiffers(a: RatkoOperationalPoint, b: RatkoOperationalPoint) =
@@ -159,13 +148,13 @@ constructor(
             a.location != b.location ||
             a.uicCode != b.uicCode
 
-    private fun upsertObjectsForRatkoPoints(
-        ratkoPointsWithVersions: List<Pair<RatkoOperationalPoint, Int>>,
+    private fun insertNewLayoutOperationalPoints(
+        ratkoPointVersions: List<RatkoOperationalPointVersion>,
         layoutPointOids: Map<IntId<OperationalPoint>, Oid<OperationalPoint>>,
         layoutPoints: List<OperationalPoint>,
     ) {
         val layoutPointsByOid = layoutPointOids.entries.associate { (k, v) -> v to k }
-        ratkoPointsWithVersions.forEach { (ratkoPoint, ratkoPointVersion) ->
+        ratkoPointVersions.forEach { (ratkoPoint, ratkoPointVersion) ->
             val id = layoutPointsByOid[ratkoPoint.externalId.cast()]
             if (id != null && layoutPoints.none { layoutPoint -> layoutPoint.id == id }) {
                 operationalPointDao.insertRatkoPoint(id, ratkoPointVersion, OperationalPointState.IN_USE)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
@@ -16,6 +16,7 @@ import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
 import java.sql.ResultSet
+import java.sql.Timestamp
 import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
@@ -137,6 +138,25 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
                 .trimIndent()
 
         return jdbcTemplate.query(sql) { rs, _ -> toRatkoOperationalPoint(rs) to rs.getInt("version") }
+    }
+
+    @Transactional(readOnly = true)
+    fun fetchVersionAt(oid: Oid<RatkoOperationalPoint>, moment: Instant): Int {
+        val sql =
+            """
+            select version
+              from integrations.ratko_operational_point_version
+              where external_id = :oid
+                and :moment >= change_time
+                and (expiry_time is null or :moment < expiry_time)
+            """
+                .trimIndent()
+        return jdbcTemplate.queryOne(
+            sql,
+            mapOf("oid" to oid.toString(), "moment" to Timestamp.from(moment)),
+        ) { rs, _ ->
+            rs.getInt("version")
+        }
     }
 
     @Transactional(readOnly = true)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
@@ -141,19 +141,19 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
     }
 
     @Transactional(readOnly = true)
-    fun fetchVersionAt(oid: Oid<RatkoOperationalPoint>, moment: Instant): Int {
+    fun fetchVersionAt(oid: Oid<RatkoOperationalPoint>, moment: Instant? = null): Int {
         val sql =
             """
             select version
               from integrations.ratko_operational_point_version
               where external_id = :oid
-                and :moment >= change_time
-                and (expiry_time is null or :moment < expiry_time)
+                and coalesce(:moment, now()) >= change_time
+                and (expiry_time is null or coalesce(:moment, now()) < expiry_time)
             """
                 .trimIndent()
         return jdbcTemplate.queryOne(
             sql,
-            mapOf("oid" to oid.toString(), "moment" to Timestamp.from(moment)),
+            mapOf("oid" to oid.toString(), "moment" to moment?.let { Timestamp.from(it) }),
         ) { rs, _ ->
             rs.getInt("version")
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
@@ -16,12 +16,17 @@ import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
 import java.sql.ResultSet
-import java.sql.Timestamp
 import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+data class RatkoOperationalPointVersion(
+    val point: RatkoOperationalPoint,
+    val version: Int,
+    val deleted: Boolean,
+)
 
 fun toRatkoOperationalPoint(rs: ResultSet): RatkoOperationalPoint {
     return RatkoOperationalPoint(
@@ -120,7 +125,7 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
     }
 
     @Transactional(readOnly = true)
-    fun listWithVersions(): List<Pair<RatkoOperationalPoint, Int>> {
+    fun listLatestVersions(): List<RatkoOperationalPointVersion> {
         val sql =
             """
             select
@@ -132,30 +137,19 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
               postgis.st_x(location) as x,
               postgis.st_y(location) as y,
               track_number_id,
-              version
-              from integrations.ratko_operational_point
-            """
-                .trimIndent()
-
-        return jdbcTemplate.query(sql) { rs, _ -> toRatkoOperationalPoint(rs) to rs.getInt("version") }
-    }
-
-    @Transactional(readOnly = true)
-    fun fetchVersionAt(oid: Oid<RatkoOperationalPoint>, moment: Instant? = null): Int {
-        val sql =
-            """
-            select version
+              version,
+              deleted
               from integrations.ratko_operational_point_version
-              where external_id = :oid
-                and coalesce(:moment, now()) >= change_time
-                and (expiry_time is null or coalesce(:moment, now()) < expiry_time)
+              where expiry_time is null
             """
                 .trimIndent()
-        return jdbcTemplate.queryOne(
-            sql,
-            mapOf("oid" to oid.toString(), "moment" to moment?.let { Timestamp.from(it) }),
-        ) { rs, _ ->
-            rs.getInt("version")
+
+        return jdbcTemplate.query(sql) { rs, _ ->
+            RatkoOperationalPointVersion(
+                point = toRatkoOperationalPoint(rs),
+                version = rs.getInt("version"),
+                deleted = rs.getBoolean("deleted"),
+            )
         }
     }
 

--- a/infra/src/main/resources/db/migration/prod/V145__fix_deleted_op_ratko_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V145__fix_deleted_op_ratko_version.sql
@@ -8,6 +8,7 @@ set ratko_operational_point_version = ropv.version
   from layout.operational_point_external_id ext_id
     join integrations.ratko_operational_point_version ropv
          on ext_id.external_id = ropv.external_id
+           and ext_id.layout_context_id = 'main_official'
   where op.id = ext_id.id
     and op.origin = 'RATKO'
     and op.state = 'DELETED'
@@ -20,6 +21,7 @@ set ratko_operational_point_version = ropv.version
   from layout.operational_point_external_id ext_id
     join integrations.ratko_operational_point_version ropv
          on ext_id.external_id = ropv.external_id
+           and ext_id.layout_context_id = 'main_official'
   where opv.id = ext_id.id
     and opv.origin = 'RATKO'
     and opv.state = 'DELETED'

--- a/infra/src/main/resources/db/migration/prod/V145__fix_deleted_op_ratko_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V145__fix_deleted_op_ratko_version.sql
@@ -5,33 +5,27 @@ alter table layout.operational_point
 
 update layout.operational_point op
 set ratko_operational_point_version = ropv.version
-from layout.operational_point_external_id ext_id
-join integrations.ratko_operational_point_version ropv
-  on ext_id.external_id = ropv.external_id
-where op.id = ext_id.id
-  and ext_id.layout_context_id = 'main_official'
-  and op.draft = true
-  and op.design_id is null
-  and op.origin = 'RATKO'
-  and op.state = 'DELETED'
-  and op.change_time >= ropv.change_time
-  and (ropv.expiry_time is null or op.change_time < ropv.expiry_time)
-  and op.ratko_operational_point_version is distinct from ropv.version;
+  from layout.operational_point_external_id ext_id
+    join integrations.ratko_operational_point_version ropv
+         on ext_id.external_id = ropv.external_id
+  where op.id = ext_id.id
+    and op.origin = 'RATKO'
+    and op.state = 'DELETED'
+    and op.change_time >= ropv.change_time
+    and (ropv.expiry_time is null or op.change_time < ropv.expiry_time)
+    and op.ratko_operational_point_version is distinct from ropv.version;
 
 update layout.operational_point_version opv
 set ratko_operational_point_version = ropv.version
-from layout.operational_point_external_id ext_id
-join integrations.ratko_operational_point_version ropv
-  on ext_id.external_id = ropv.external_id
-where opv.id = ext_id.id
-  and ext_id.layout_context_id = 'main_official'
-  and opv.draft = true
-  and opv.design_id is null
-  and opv.origin = 'RATKO'
-  and opv.state = 'DELETED'
-  and opv.change_time >= ropv.change_time
-  and (ropv.expiry_time is null or opv.change_time < ropv.expiry_time)
-  and opv.ratko_operational_point_version is distinct from ropv.version;
+  from layout.operational_point_external_id ext_id
+    join integrations.ratko_operational_point_version ropv
+         on ext_id.external_id = ropv.external_id
+  where opv.id = ext_id.id
+    and opv.origin = 'RATKO'
+    and opv.state = 'DELETED'
+    and opv.change_time >= ropv.change_time
+    and (ropv.expiry_time is null or opv.change_time < ropv.expiry_time)
+    and opv.ratko_operational_point_version is distinct from ropv.version;
 
 alter table layout.operational_point
   enable trigger version_update_trigger;

--- a/infra/src/main/resources/db/migration/prod/V145__fix_deleted_op_ratko_version.sql
+++ b/infra/src/main/resources/db/migration/prod/V145__fix_deleted_op_ratko_version.sql
@@ -1,0 +1,39 @@
+alter table layout.operational_point
+  disable trigger version_update_trigger;
+alter table layout.operational_point
+  disable trigger version_row_trigger;
+
+update layout.operational_point op
+set ratko_operational_point_version = ropv.version
+from layout.operational_point_external_id ext_id
+join integrations.ratko_operational_point_version ropv
+  on ext_id.external_id = ropv.external_id
+where op.id = ext_id.id
+  and ext_id.layout_context_id = 'main_official'
+  and op.draft = true
+  and op.design_id is null
+  and op.origin = 'RATKO'
+  and op.state = 'DELETED'
+  and op.change_time >= ropv.change_time
+  and (ropv.expiry_time is null or op.change_time < ropv.expiry_time)
+  and op.ratko_operational_point_version is distinct from ropv.version;
+
+update layout.operational_point_version opv
+set ratko_operational_point_version = ropv.version
+from layout.operational_point_external_id ext_id
+join integrations.ratko_operational_point_version ropv
+  on ext_id.external_id = ropv.external_id
+where opv.id = ext_id.id
+  and ext_id.layout_context_id = 'main_official'
+  and opv.draft = true
+  and opv.design_id is null
+  and opv.origin = 'RATKO'
+  and opv.state = 'DELETED'
+  and opv.change_time >= ropv.change_time
+  and (ropv.expiry_time is null or opv.change_time < ropv.expiry_time)
+  and opv.ratko_operational_point_version is distinct from ropv.version;
+
+alter table layout.operational_point
+  enable trigger version_update_trigger;
+alter table layout.operational_point
+  enable trigger version_row_trigger;

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -1306,18 +1306,16 @@ constructor(
         ratkoService.updateOperationalPointsFromRatko()
         fakeRatko.hasOperationalPoints(listOf(turpeela.copy(name = OperationalPointName("Turpasauna")), liukuainen))
         ratkoService.updateOperationalPointsFromRatko()
-        assertTrue(
-            jdbc.queryOne(
-                """select deleted from integrations.ratko_operational_point_version where name = 'Kannustamo' and version = 2"""
-            ) { rs, _ ->
-                rs.getBoolean("deleted")
-            }
-        )
-        val pointsFromDatabase = ratkoOperationalPointDao.listWithVersions()
-        assertEquals(2, pointsFromDatabase.size)
+        val pointsFromDatabase = ratkoOperationalPointDao.listLatestVersions()
+        assertEquals(3, pointsFromDatabase.size)
+        val sortedPoints = pointsFromDatabase.sortedBy { it.point.name.toString() }
         assertEquals(
-            listOf("Liukuainen", "Turpasauna"),
-            pointsFromDatabase.map { (point) -> point.name.toString() }.sorted(),
+            listOf("Kannustamo", "Liukuainen", "Turpasauna"),
+            sortedPoints.map { it.point.name.toString() },
+        )
+        assertEquals(
+            listOf(true, false, false),
+            sortedPoints.map { it.deleted },
         )
         assertEquals(
             5,
@@ -1325,6 +1323,84 @@ constructor(
                 rs.getInt("c")
             },
         )
+    }
+
+    @Test
+    fun `listLatestVersions returns all points including deleted`() {
+        val trackNumberId =
+            trackNumberService
+                .saveDraft(LayoutBranch.main, trackNumber(testDBService.getUnusedTrackNumber(), draft = true))
+                .id
+        trackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, Oid("5.5.5.5.5"))
+        val alpha = ratkoOperationalPoint("1.2.3.4.1", "Alpha", trackNumberOid = "5.5.5.5.5")
+        val beta = ratkoOperationalPoint("1.2.3.4.2", "Beta", trackNumberOid = "5.5.5.5.5")
+        val gamma = ratkoOperationalPoint("1.2.3.4.3", "Gamma", trackNumberOid = "5.5.5.5.5")
+
+        ratkoOperationalPointDao.updateOperationalPoints(listOf(alpha, beta, gamma))
+
+        ratkoOperationalPointDao.listLatestVersions().sortedBy { it.point.name.toString() }.also { versions ->
+            assertEquals(3, versions.size)
+            assertEquals(listOf("Alpha", "Beta", "Gamma"), versions.map { it.point.name.toString() })
+            assertEquals(listOf(1, 1, 1), versions.map { it.version })
+            assertEquals(listOf(false, false, false), versions.map { it.deleted })
+        }
+
+        ratkoOperationalPointDao.updateOperationalPoints(listOf(alpha, gamma))
+
+        ratkoOperationalPointDao.listLatestVersions().sortedBy { it.point.name.toString() }.also { versions ->
+            assertEquals(3, versions.size)
+            assertEquals(listOf("Alpha", "Beta", "Gamma"), versions.map { it.point.name.toString() })
+            assertEquals(listOf(false, true, false), versions.map { it.deleted })
+            val betaVersion = versions.first { it.point.name.toString() == "Beta" }
+            assertEquals(2, betaVersion.version)
+        }
+    }
+
+    @Test
+    fun `deleted operational point is restored when recreated in Ratko`() {
+        val trackNumberId =
+            trackNumberService
+                .saveDraft(LayoutBranch.main, trackNumber(testDBService.getUnusedTrackNumber(), draft = true))
+                .id
+        trackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, Oid("5.5.5.5.5"))
+        val station = ratkoOperationalPoint("1.2.3.4.8", "Station", trackNumberOid = "5.5.5.5.5")
+
+        // Create the point
+        fakeRatko.hasOperationalPoints(listOf(station))
+        ratkoService.updateOperationalPointsFromRatko()
+
+        operationalPointDao.list(mainDraftContext.context, true)
+            .filter { it.origin == OperationalPointOrigin.RATKO }
+            .also { points ->
+                assertEquals(1, points.size)
+                assertEquals(OperationalPointState.IN_USE, points.first().state)
+                assertEquals(1, points.first().ratkoVersion)
+            }
+
+        // Delete the point
+        fakeRatko.hasOperationalPoints(emptyList())
+        ratkoService.updateOperationalPointsFromRatko()
+
+        operationalPointDao.list(mainDraftContext.context, true)
+            .filter { it.origin == OperationalPointOrigin.RATKO }
+            .also { points ->
+                assertEquals(1, points.size)
+                assertEquals(OperationalPointState.DELETED, points.first().state)
+                assertEquals(2, points.first().ratkoVersion)
+            }
+
+        // Recreate the point with different content
+        val recreatedStation = station.copy(name = OperationalPointName("Station Reborn"))
+        fakeRatko.hasOperationalPoints(listOf(recreatedStation))
+        ratkoService.updateOperationalPointsFromRatko()
+
+        operationalPointDao.list(mainDraftContext.context, true)
+            .filter { it.origin == OperationalPointOrigin.RATKO }
+            .also { points ->
+                assertEquals(1, points.size)
+                assertEquals(OperationalPointState.IN_USE, points.first().state)
+                assertEquals(3, points.first().ratkoVersion)
+            }
     }
 
     private data class OperationalPointComparison(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -838,8 +838,9 @@ constructor(
         )
     }
 
-    private fun sortRatkoSwitchLocationsByTrack(locations: List<RatkoAssetLocation>) =
-        locations.sortedBy { it.nodecollection.nodes.first().point.locationtrack.toString() }
+    private fun sortRatkoSwitchLocationsByTrack(locations: List<RatkoAssetLocation>) = locations.sortedBy {
+        it.nodecollection.nodes.first().point.locationtrack.toString()
+    }
 
     @Test
     fun removeLocationTrackWithSwitch() {
@@ -1331,6 +1332,7 @@ constructor(
         val draft: Boolean,
         val version: Int,
         val state: OperationalPointState,
+        val ratkoVersion: Int?,
     )
 
     private fun assertLayoutOperationalTableContent(expected: List<OperationalPointComparison>) =
@@ -1344,6 +1346,7 @@ constructor(
                         op.isDraft,
                         requireNotNull(op.version).version,
                         op.state,
+                        op.ratkoVersion,
                     )
                 }
                 .sortedBy { it.name },
@@ -1364,9 +1367,9 @@ constructor(
         ratkoService.updateOperationalPointsFromRatko()
         assertLayoutOperationalTableContent(
             listOf(
-                OperationalPointComparison("Kannustamo", true, 1, OperationalPointState.IN_USE),
-                OperationalPointComparison("Liukuainen", true, 1, OperationalPointState.IN_USE),
-                OperationalPointComparison("Turpeela", true, 1, OperationalPointState.IN_USE),
+                OperationalPointComparison("Kannustamo", true, 1, OperationalPointState.IN_USE, 1),
+                OperationalPointComparison("Liukuainen", true, 1, OperationalPointState.IN_USE, 1),
+                OperationalPointComparison("Turpeela", true, 1, OperationalPointState.IN_USE, 1),
             )
         )
 
@@ -1379,9 +1382,9 @@ constructor(
         // a deletion row in the version table, so draft versions get incremented an extra time
         assertLayoutOperationalTableContent(
             listOf(
-                OperationalPointComparison("Kannustamo", true, 3, OperationalPointState.DELETED),
-                OperationalPointComparison("Liukuainen", false, 1, OperationalPointState.IN_USE),
-                OperationalPointComparison("Turpasauna", true, 3, OperationalPointState.IN_USE),
+                OperationalPointComparison("Kannustamo", true, 3, OperationalPointState.DELETED, 2),
+                OperationalPointComparison("Liukuainen", false, 1, OperationalPointState.IN_USE, 1),
+                OperationalPointComparison("Turpasauna", true, 3, OperationalPointState.IN_USE, 2),
             )
         )
         operationalPointDao
@@ -1397,9 +1400,9 @@ constructor(
         // should have no updates now that the official state of everything matched the integration table already
         assertLayoutOperationalTableContent(
             listOf(
-                OperationalPointComparison("Kannustamo", false, 2, OperationalPointState.DELETED),
-                OperationalPointComparison("Liukuainen", false, 1, OperationalPointState.IN_USE),
-                OperationalPointComparison("Turpasauna", false, 2, OperationalPointState.IN_USE),
+                OperationalPointComparison("Kannustamo", false, 2, OperationalPointState.DELETED, 2),
+                OperationalPointComparison("Liukuainen", false, 1, OperationalPointState.IN_USE, 1),
+                OperationalPointComparison("Turpasauna", false, 2, OperationalPointState.IN_USE, 2),
             )
         )
     }


### PR DESCRIPTION
Aiemmin siis tilanteessa jossa Ratkosta synkattu toiminnallinen piste poistui synkan myötä ka. toiminnallisen pisteen kaikki muut arvot päivittyivät poistetun version mukaisiksi, mutta versioviite jäi osoittamaan viimeisimpään ei-poistettuun versioon. Tämä korjattu täällä, ja koska kannassa on myös aiempia Ratkosta synkattuja toiminnallisia pisteitä, niin myös lisätty migraatio joka korjaa niiden versioviitteet 