### PR TITLE
General: Fix ratko asset fetching in NOT_FOUND cases

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -615,7 +615,13 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         postWithJsonResponseBody(url, content)?.let { parseJsonValue<TOut>(it, url) }
 
     private fun getWithJsonResponseBody(url: String, errorType: RatkoPushErrorType = PROPERTIES): String? =
-        getSpec(url).defaultErrorHandler(errorType, FETCH_EXISTING, url).bodyToMono<String>().block(defaultBlockTimeout)
+        getSpec(url)
+            .defaultErrorHandler(errorType, FETCH_EXISTING, url)
+            .bodyToMono<String>()
+            .onErrorResume(WebClientResponseException::class.java) { ex ->
+                if (ex.statusCode == NOT_FOUND) Mono.empty() else Mono.error(ex)
+            }
+            .block(defaultBlockTimeout)
 
     private fun putWithoutResponseBody(url: String, content: Any, errorType: RatkoPushErrorType = PROPERTIES) {
         putSpec(url, content)
@@ -632,7 +638,13 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     }
 
     private fun deletePoints(url: String) {
-        deleteSpec(url).defaultErrorHandler(GEOMETRY, DELETE, url).toBodilessEntity().block(defaultBlockTimeout)
+        deleteSpec(url)
+            .defaultErrorHandler(GEOMETRY, DELETE, url)
+            .toBodilessEntity()
+            .onErrorResume(WebClientResponseException::class.java) { ex ->
+                if (ex.statusCode == NOT_FOUND) Mono.empty() else Mono.error(ex)
+            }
+            .block(defaultBlockTimeout)
     }
 
     private fun deleteSpec(url: String) = client.delete().uri(url).retrieve()
@@ -655,19 +667,18 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         requestBody: Any? = null,
     ) =
         onStatus(
-            { !it.is2xxSuccessful },
+            { status ->
+                !status.is2xxSuccessful &&
+                    !(status == NOT_FOUND && (operation == FETCH_EXISTING || operation == DELETE))
+            },
             { response ->
-                when (val status = response.statusCode()) {
-                    NOT_FOUND if (operation == FETCH_EXISTING || operation == DELETE) -> Mono.empty()
-                    else ->
-                        response.bodyToMono<String>().switchIfEmpty(Mono.just("")).flatMap { responseBody ->
-                            val request = getBodyJsonForLog(requestBody).take(MAX_JSON_LOG_LENGTH)
-                            val response = responseBody.take(MAX_JSON_LOG_LENGTH)
-                            logger.error(
-                                "Error during Ratko push: status=$status responseBody=$response requestUrl=\"$requestUrl\" requestBody=$request"
-                            )
-                            Mono.error(RatkoPushException(errorType, operation))
-                        }
+                response.bodyToMono<String>().switchIfEmpty(Mono.just("")).flatMap { responseBody ->
+                    val request = getBodyJsonForLog(requestBody).take(MAX_JSON_LOG_LENGTH)
+                    val truncatedResponse = responseBody.take(MAX_JSON_LOG_LENGTH)
+                    logger.error(
+                        "Error during Ratko push: status=${response.statusCode()} responseBody=$truncatedResponse requestUrl=\"$requestUrl\" requestBody=$request"
+                    )
+                    Mono.error(RatkoPushException(errorType, operation))
                 }
             },
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -549,7 +549,27 @@ class FakeRatko(port: Int) {
             )
             .also { logger.info("Binding $method $url, queryParams=$queryParams, body=$body") }
 
+    fun doesNotHaveRouteNumber(oid: String) {
+        get("/api/locations/v1.1/routenumber/$oid")
+            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Route number couldn't be found with the external id [$oid]")))
+    }
+
+    fun doesNotHaveLocationTrack(oid: String) {
+        get("/api/locations/v1.1/locationtracks/$oid")
+            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Location track couldn't be found with the external id [$oid]")))
+    }
+
+    fun doesNotHaveSwitch(oid: String) {
+        get("/api/assets/v1.2/$oid")
+            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Switch couldn't be found with the external id [$oid]")))
+    }
+
     private fun ok() = HttpResponse.response().withStatusCode(200)
+
+    private fun notFoundJson(body: Any) =
+        HttpResponse.response(jsonMapper.writeValueAsString(body))
+            .withStatusCode(404)
+            .withContentType(MediaType.APPLICATION_JSON)
 
     private fun okJson(body: Any) =
         HttpResponse.response(jsonMapper.writeValueAsString(body))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -564,6 +564,16 @@ class FakeRatko(port: Int) {
             .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Switch couldn't be found with the external id [$oid]")))
     }
 
+    fun doesNotHaveLocationTrackPoints(oid: String, km: String) {
+        delete("/api/infra/v1.0/points/$oid/$km")
+            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Points couldn't be found for location track [$oid] at km [$km]")))
+    }
+
+    fun doesNotHaveRouteNumberPoints(oid: String, km: String) {
+        delete("/api/infra/v1.0/routenumber/points/$oid/$km")
+            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Points couldn't be found for route number [$oid] at km [$km]")))
+    }
+
     private fun ok() = HttpResponse.response().withStatusCode(200)
 
     private fun notFoundJson(body: Any) =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.MainBranchRatkoExternalId
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
@@ -136,6 +137,22 @@ constructor(
         fakeRatko.doesNotHaveSwitch(oid)
         val result = ratkoClient.getSwitchAsset(RatkoOid(oid))
         assertNull(result)
+    }
+
+    @Test
+    fun `deleteLocationTrackPoints should not throw when points do not exist`() {
+        val oid = "1.2.3.4.5"
+        val km = "0042"
+        fakeRatko.doesNotHaveLocationTrackPoints(oid, km)
+        ratkoClient.deleteLocationTrackPoints(RatkoOid(oid), KmNumber(km))
+    }
+
+    @Test
+    fun `deleteRouteNumberPoints should not throw when points do not exist`() {
+        val oid = "1.2.3.4.5"
+        val km = "0042"
+        fakeRatko.doesNotHaveRouteNumberPoints(oid, km)
+        ratkoClient.deleteRouteNumberPoints(RatkoOid(oid), KmNumber(km))
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.switch
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -111,6 +112,30 @@ constructor(
 
         assertEquals(expectedBulkTransferId, receivedBulkTransferId)
         assertEquals(BulkTransferState.IN_PROGRESS, receivedBulkTransferState)
+    }
+
+    @Test
+    fun `getRouteNumber should return null when route number does not exist`() {
+        val oid = "1.2.3.4.5"
+        fakeRatko.doesNotHaveRouteNumber(oid)
+        val result = ratkoClient.getRouteNumber(RatkoOid(oid))
+        assertNull(result)
+    }
+
+    @Test
+    fun `getLocationTrack should return null when location track does not exist`() {
+        val oid = "1.2.3.4.5"
+        fakeRatko.doesNotHaveLocationTrack(oid)
+        val result = ratkoClient.getLocationTrack(RatkoOid(oid))
+        assertNull(result)
+    }
+
+    @Test
+    fun `getSwitchAsset should return null when switch does not exist`() {
+        val oid = "1.2.3.4.5"
+        fakeRatko.doesNotHaveSwitch(oid)
+        val result = ratkoClient.getSwitchAsset(RatkoOid(oid))
+        assertNull(result)
     }
 
     @Test


### PR DESCRIPTION
Geneerisessä virhekäsittelyssä tuli luotua bugi: errorhandlerin palautta Mono.empty() ei tyhjennä bodyä mihinkään joten sen jälkeen ajettava bodyToMono lukaisi edelleenkin sisällön ja yritti jäsentää sen. Lisätty testit + korjattu toteutus.