### PR TITLE
General: Clean up Oid handling in ratko code

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/Oid.kt
@@ -21,8 +21,6 @@ data class Oid<T> @JsonCreator(mode = DELEGATING) constructor(private val value:
     }
 
     @JsonValue override fun toString(): String = value
-
-    fun <ToType> cast(): Oid<ToType> = Oid(value)
 }
 
 class RatkoExternalId<T>(val oid: Oid<T>, val planItemId: RatkoPlanItemId?)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -101,11 +101,11 @@ enum class RatkoConnectionStatus {
     NOT_CONFIGURED,
 }
 
-fun isFakeOID(oid: String): Boolean {
-    return oid.startsWith(FAKE_OID_PREFIX)
-}
+fun isFakeOID(oid: String): Boolean = oid.startsWith(FAKE_OID_PREFIX)
 
 fun <T> isFakeOID(oid: RatkoOid<T>): Boolean = isFakeOID(oid.toString())
+
+fun <T> isFakeOID(oid: Oid<T>): Boolean = isFakeOID(oid.toString())
 
 @Component
 @ConditionalOnBean(RatkoFakeOidGeneratorConfiguration::class)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -55,8 +55,7 @@ constructor(
     @Transactional
     fun updateLayoutPointsFromIntegrationTable() {
         val ratkoPointsWithVersions = ratkoOperationalPointDao.listWithVersions()
-        val ratkoPointsByOid =
-            ratkoPointsWithVersions.associateBy { (point) -> point.externalId.cast<OperationalPoint>() }
+        val ratkoPointsByOid = ratkoPointsWithVersions.associateBy { (point) -> point.externalId }
         val layoutPoints =
             operationalPointDao.list(LayoutBranch.main.draft, true).filter { point ->
                 point.origin == OperationalPointOrigin.RATKO
@@ -96,16 +95,16 @@ constructor(
         val existingOidsSet = existingIds.values.toSet()
         val createdIds =
             ratkoPointsWithVersions
-                .filter { (ratkoPoint) -> !existingOidsSet.contains(ratkoPoint.externalId.cast()) }
+                .filter { (ratkoPoint) -> !existingOidsSet.contains(ratkoPoint.externalId) }
                 .associate { (ratkoPoint) ->
-                    createOperationalPointIdForRatkoPoint(ratkoPoint) to ratkoPoint.externalId.cast<OperationalPoint>()
+                    createOperationalPointIdForRatkoPoint(ratkoPoint) to ratkoPoint.externalId
                 }
         return existingIds + createdIds
     }
 
     private fun createOperationalPointIdForRatkoPoint(point: RatkoOperationalPoint): IntId<OperationalPoint> {
         val id = operationalPointDao.createId()
-        operationalPointDao.insertExternalIdInExistingTransaction(LayoutBranch.main, id, point.externalId.cast())
+        operationalPointDao.insertExternalIdInExistingTransaction(LayoutBranch.main, id, point.externalId)
         return id
     }
 
@@ -118,7 +117,7 @@ constructor(
             val extId = layoutPointOids.getValue(layoutPoint.id as IntId)
             ratkoPointsByOid[extId]?.let { (currentRatkoPoint, currentRatkoPointVersion) ->
                 if (currentRatkoPointVersion > requireNotNull(layoutPoint.ratkoVersion)) {
-                    val savedRatkoPoint = ratkoOperationalPointDao.fetch(extId.cast(), layoutPoint.ratkoVersion)
+                    val savedRatkoPoint = ratkoOperationalPointDao.fetch(extId, layoutPoint.ratkoVersion)
                     if (ratkoOperationalPointContentDiffers(currentRatkoPoint, savedRatkoPoint)) {
                         operationalPointDao.save(asMainDraft(layoutPoint.copy(ratkoVersion = currentRatkoPointVersion)))
                     }
@@ -132,12 +131,11 @@ constructor(
         originalLayoutPointOids: Map<IntId<OperationalPoint>, Oid<OperationalPoint>>,
         ratkoPointsByOid: Map<Oid<OperationalPoint>, Pair<RatkoOperationalPoint, Int>>,
     ): Set<IntId<OperationalPoint>> {
-        val deleted =
-            layoutPoints.filter { layoutPoint ->
-                layoutPoint.state != OperationalPointState.DELETED &&
-                    originalLayoutPointOids.contains(layoutPoint.id) &&
-                    !ratkoPointsByOid.contains(originalLayoutPointOids[layoutPoint.id])
-            }
+        val deleted = layoutPoints.filter { layoutPoint ->
+            layoutPoint.state != OperationalPointState.DELETED &&
+                originalLayoutPointOids.contains(layoutPoint.id) &&
+                !ratkoPointsByOid.contains(originalLayoutPointOids[layoutPoint.id])
+        }
         deleted.forEach { layoutPoint ->
             operationalPointDao.save(asMainDraft(layoutPoint.copy(state = OperationalPointState.DELETED)))
         }
@@ -158,7 +156,7 @@ constructor(
     ) {
         val layoutPointsByOid = layoutPointOids.entries.associate { (k, v) -> v to k }
         ratkoPointsWithVersions.forEach { (ratkoPoint, ratkoPointVersion) ->
-            val id = layoutPointsByOid[ratkoPoint.externalId.cast()]
+            val id = layoutPointsByOid[ratkoPoint.externalId]
             if (id != null && layoutPoints.none { layoutPoint -> layoutPoint.id == id }) {
                 operationalPointDao.insertRatkoPoint(id, ratkoPointVersion, OperationalPointState.IN_USE)
             }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.ratko.model.RatkoOperationalPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoOperationalPointParse
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.OperationalPointAbbreviation
 import fi.fta.geoviite.infra.tracklayout.OperationalPointName
 import fi.fta.geoviite.infra.tracklayout.UicCode
@@ -15,12 +16,12 @@ import fi.fta.geoviite.infra.util.getOid
 import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
-import java.sql.ResultSet
-import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.sql.ResultSet
+import java.time.Instant
 
 fun toRatkoOperationalPoint(rs: ResultSet): RatkoOperationalPoint {
     return RatkoOperationalPoint(
@@ -49,7 +50,7 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
     private fun deleteRemovedPoints(newPoints: List<RatkoOperationalPointParse>) {
         val oldPointsIds =
             jdbcTemplate.query("""select external_id from integrations.ratko_operational_point""") { rs, _ ->
-                rs.getOid<RatkoOperationalPoint>("external_id")
+                rs.getOid<OperationalPoint>("external_id")
             }
         val newPointsIds = newPoints.map { point -> point.externalId }.toSet()
         jdbcTemplate.batchUpdate(
@@ -140,7 +141,7 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
     }
 
     @Transactional(readOnly = true)
-    fun fetch(oid: Oid<RatkoOperationalPoint>, version: Int): RatkoOperationalPoint {
+    fun fetch(oid: Oid<OperationalPoint>, version: Int): RatkoOperationalPoint {
         val sql =
             """
             select

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
@@ -3,9 +3,11 @@ package fi.fta.geoviite.infra.ratko.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 abstract class RatkoAsset(
@@ -41,7 +43,7 @@ data class RatkoMetadataAsset(
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class RatkoSwitchAsset(
-    val id: String?,
+    val id: Oid<LayoutSwitch>?,
     override val state: RatkoAssetState,
     override val properties: Collection<RatkoAssetProperty>,
     override val rowMetadata: RatkoMetadata = RatkoMetadata(),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoConversion.kt
@@ -193,14 +193,14 @@ fun convertToRatkoLocationTrack(
     locationTrackStateOverride: RatkoLocationTrackState? = null,
 ) =
     RatkoLocationTrack(
-        id = locationTrackExternalId?.oid?.toString(),
+        id = locationTrackExternalId?.oid,
         name = locationTrack.name.toString(),
         routenumber = trackNumberOid?.let(::RatkoOid),
         description = locationTrack.description.toString(),
         state = locationTrackStateOverride ?: mapToRatkoLocationTrackState(locationTrack.state),
         type = mapToRatkoLocationTrackType(locationTrack.type),
         nodecollection = nodeCollection,
-        duplicateOf = duplicateOfOid?.toString(),
+        duplicateOf = duplicateOfOid,
         topologicalConnectivity = mapToRatkoTopologicalConnectivityType(locationTrack.topologicalConnectivity),
         owner = owner.name.toString(),
         isPlanContext = locationTrackExternalId is DesignRatkoExternalId,
@@ -213,7 +213,7 @@ fun convertToRatkoRouteNumber(
     nodeCollection: RatkoNodes? = null,
 ) =
     RatkoRouteNumber(
-        id = trackNumberExternalId?.oid?.toString(),
+        id = trackNumberExternalId?.oid,
         name = trackNumber.number.toString(),
         description = trackNumber.description.toString(),
         state = mapToRatkoRouteNumberState(trackNumber.state),
@@ -317,7 +317,7 @@ fun convertToRatkoSwitch(
     existingRatkoSwitch: RatkoSwitchAsset? = null,
 ) =
     RatkoSwitchAsset(
-        id = layoutSwitchExternalId?.oid?.toString(),
+        id = layoutSwitchExternalId?.oid,
         state = mapToRatkoSwitchState(layoutSwitch.stateCategory, existingRatkoSwitch?.state),
         properties =
             listOf(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.ratko.model
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import fi.fta.geoviite.infra.common.MainBranchRatkoExternalId
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.publication.PublicationDetails
 import fi.fta.geoviite.infra.split.Split
@@ -13,7 +14,7 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class RatkoLocationTrack(
-    val id: String?,
+    val id: Oid<LocationTrack>?,
     val routenumber: RatkoOid<RatkoRouteNumber>?,
     val nodecollection: RatkoNodes?,
     val name: String,
@@ -21,7 +22,7 @@ data class RatkoLocationTrack(
     val type: RatkoLocationTrackType,
     val state: RatkoLocationTrackState,
     val rowMetadata: RatkoMetadata = RatkoMetadata(),
-    val duplicateOf: String?,
+    val duplicateOf: Oid<LocationTrack>?,
     val topologicalConnectivity: RatkoTopologicalConnectivityType,
     val owner: String?,
     val isPlanContext: Boolean,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
@@ -34,7 +34,7 @@ data class RatkoOperationalPointParse(
     override val uicCode: UicCode,
     override val type: OperationalPointRatoType,
     override val location: Point,
-    val trackNumberExternalId: Oid<RatkoRouteNumber>,
+    val trackNumberExternalId: Oid<LayoutTrackNumber>,
 ) : AbstractRatkoOperationalPoint(name, abbreviation, uicCode, type, location)
 
 data class RatkoOperationalPoint(
@@ -61,7 +61,7 @@ fun parseAsset(asset: RatkoOperationalPointAsset, logger: Logger): RatkoOperatio
     if (location == null) {
         logger.warn("operational point with id $externalId will be rejected: null location")
     }
-    val trackNumberExternalId: Oid<RatkoRouteNumber>? = soloPoint?.routenumber?.toString()?.let(::Oid)
+    val trackNumberExternalId: Oid<LayoutTrackNumber>? = soloPoint?.routenumber?.toString()?.let(::Oid)
     if (trackNumberExternalId == null) {
         logger.warn("operational point with id $externalId will be rejected: null trackNumberExternalId")
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoOperationalPointModel.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.OperationalPointAbbreviation
 import fi.fta.geoviite.infra.tracklayout.OperationalPointName
 import fi.fta.geoviite.infra.tracklayout.UicCode
@@ -27,7 +28,7 @@ abstract class AbstractRatkoOperationalPoint(
 )
 
 data class RatkoOperationalPointParse(
-    val externalId: Oid<RatkoOperationalPoint>,
+    val externalId: Oid<OperationalPoint>,
     override val name: OperationalPointName,
     override val abbreviation: OperationalPointAbbreviation,
     override val uicCode: UicCode,
@@ -37,7 +38,7 @@ data class RatkoOperationalPointParse(
 ) : AbstractRatkoOperationalPoint(name, abbreviation, uicCode, type, location)
 
 data class RatkoOperationalPoint(
-    val externalId: Oid<RatkoOperationalPoint>,
+    val externalId: Oid<OperationalPoint>,
     override val name: OperationalPointName,
     override val abbreviation: OperationalPointAbbreviation,
     override val uicCode: UicCode,
@@ -47,7 +48,7 @@ data class RatkoOperationalPoint(
 ) : AbstractRatkoOperationalPoint(name, abbreviation, uicCode, type, location)
 
 fun parseAsset(asset: RatkoOperationalPointAsset, logger: Logger): RatkoOperationalPointParse? {
-    val externalId = Oid<RatkoOperationalPoint>(asset.id)
+    val externalId = Oid<OperationalPoint>(asset.id)
     val type = asset.getEnumProperty<OperationalPointRatoType>("operational_point_type")
     val soloPoint =
         asset.locations
@@ -91,7 +92,7 @@ fun parseAsset(asset: RatkoOperationalPointAsset, logger: Logger): RatkoOperatio
 
 private fun getSanitizedName(
     asset: RatkoOperationalPointAsset,
-    externalId: Oid<RatkoOperationalPoint>,
+    externalId: Oid<OperationalPoint>,
     logger: Logger,
 ): OperationalPointName? {
     val name = asset.getStringProperty("name")
@@ -108,7 +109,7 @@ private fun getSanitizedName(
 
 private fun getSanitizedAbbreviation(
     asset: RatkoOperationalPointAsset,
-    externalId: Oid<RatkoOperationalPoint>,
+    externalId: Oid<OperationalPoint>,
     logger: Logger,
 ): OperationalPointAbbreviation? {
     val abbreviation = asset.getStringProperty("operational_point_abbreviation")
@@ -125,7 +126,7 @@ private fun getSanitizedAbbreviation(
 
 private fun getSanitizedUicCode(
     asset: RatkoOperationalPointAsset,
-    externalId: Oid<RatkoOperationalPoint>,
+    externalId: Oid<OperationalPoint>,
     logger: Logger,
 ): UicCode? {
     val uicCode = asset.getIntProperty("operational_point_code")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoRouteNumberModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoRouteNumberModel.kt
@@ -2,10 +2,12 @@ package fi.fta.geoviite.infra.ratko.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class RatkoRouteNumber(
-    val id: String?,
+    val id: Oid<LayoutTrackNumber>?,
     val nodecollection: RatkoNodes?,
     val name: String,
     val description: String,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -282,7 +282,7 @@ class FakeRatko(port: Int) {
             .filter { body -> body.length > 3 }
             .mapNotNull { body ->
                 val json = jsonMapper.readValue(body, RatkoRouteNumber::class.java)
-                if (json.id == oid.toString()) json else null
+                if (json.id == oid) json else null
             }
 
     fun acceptsNewBulkTransferGivingItId(bulkTransferId: IntId<BulkTransfer>) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoTestService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoTestService.kt
@@ -35,11 +35,7 @@ class RatkoTestService(
             )
             val pointIds: List<IntId<OperationalPoint>> = points.map { operationalPointDao.createId() }
             points.zip(pointIds).forEach { (point, pointId) ->
-                operationalPointDao.insertExternalIdInExistingTransaction(
-                    LayoutBranch.main,
-                    pointId,
-                    point.externalId.cast(),
-                )
+                operationalPointDao.insertExternalIdInExistingTransaction(LayoutBranch.main, pointId, point.externalId)
             }
             ratkoLocalService.updateLayoutPointsFromIntegrationTable()
             pointIds


### PR DESCRIPTION
Muutettu ratkon string-id kenttiä Oid-tyypiksi koska sen pitäisi olla kuitenkin yhteensopiva niin ulospäin mennessä kuin sisäänpäin tullessa.

Muutettu ratkon oid-tyyppien tyyppiargsit käyttämään geoviitteen tyyppejä, jotta saadaan ne yhteensopivaksi eikä tarvitse castailla. Eli ei `Oid<RatkoLocationTrack>` vaan `Oid<LocationTrack>`. Kuitenkin kyseessä on sama Oid, joten ei ole mitään syytä olla 2 eri oid-tyyppiä -> käytetään meidän käsitteen tyyppiä.

RatkoOid-tyyppiin puolestaan ei ole koskettu. Olisin halunnut poistaa sen kokonaan, mutta sillä näyttäisi olevan id-kenttä julkisena atribuuttina joten se taitaa kääntyä json:iin olioksi jossa tuo id ihan näkyy. Jätin sen nyt siis koskematta. Koska koko tyyppi on eri kuin Oid, sen sisältämällä oliotyypilläkään ei ole väliä -> annoin noiden olla.