### PR TITLE
GVT-3601: Success-toastit jäävät näkyviin ikuisiksi ajoiksi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,7 +58,7 @@ updates:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "react-toastify"
-        versions: [ ">=11.0.5" ]
+        versions: [ "11.0.5" ]
     groups:
       toolchain:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,7 +58,7 @@ updates:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "react-toastify"
-        versions: [ "11.0.5" ]
+        versions: [ "11.1.0" ]
     groups:
       toolchain:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     ignore:
       - dependency-name: "org.seleniumhq*"
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types: [ "version-update:semver-major" ]
     groups:
       spring-boot:
         patterns:
@@ -56,7 +56,9 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "react-toastify"
+        versions: [ ">=11.0.5" ]
     groups:
       toolchain:
         patterns:

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,7 @@
                 "react-i18next": "^17.0.4",
                 "react-redux": "^9.2.0",
                 "react-router-dom": "^7.14.1",
-                "react-toastify": "^11.1.0",
+                "react-toastify": "~11.0.5",
                 "react-widgets": "^5.8.6",
                 "redux": "^5.0.1",
                 "redux-persist": "^6.0.0",
@@ -12140,9 +12140,9 @@
             }
         },
         "node_modules/react-toastify": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.1.0.tgz",
-            "integrity": "sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==",
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+            "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
             "license": "MIT",
             "dependencies": {
                 "clsx": "^2.1.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -67,7 +67,7 @@
         "react-i18next": "^17.0.4",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.14.1",
-        "react-toastify": "^11.1.0",
+        "react-toastify": "~11.0.5",
         "react-widgets": "^5.8.6",
         "redux": "^5.0.1",
         "redux-persist": "^6.0.0",

--- a/ui/src/geoviite-design-lib/snackbar/snackbar.tsx
+++ b/ui/src/geoviite-design-lib/snackbar/snackbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Id, toast, ToastOptions } from 'react-toastify/unstyled';
+import { Id, toast, ToastOptions } from 'react-toastify';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 import './snackbar.scss';
 import styles from './snackbar.scss';

--- a/ui/src/main/main.tsx
+++ b/ui/src/main/main.tsx
@@ -3,7 +3,7 @@ import 'i18n/config';
 import { Route, Routes } from 'react-router-dom';
 import styles from './main.module.scss';
 import { TrackLayoutContainer } from 'track-layout/track-layout-container';
-import { Slide, ToastContainer } from 'react-toastify/unstyled';
+import { Slide, ToastContainer } from 'react-toastify';
 import { I18nDemo } from 'i18n/i18n-demo';
 import { AppBar } from 'app-bar/app-bar';
 import { GeoviiteLibDemo } from 'geoviite-design-lib/demo/demo';


### PR DESCRIPTION
Bugi johtui siitä, että meidän tulisi ajaa react-toastifyta nykyään unstyled-moodissa, jossa `autoClose` bugaa. Tein asian tiimoilta react-toastifylle [bugiraportin](https://github.com/fkhadra/react-toastify/issues/1286), mutta siihen saakka kunnes he saavat (tai hän saa, kyseessä vaikuttaisi olevan yhden hengen projekti) sen korjattua niin tiputetaan paketin versio takaisin edelliseen toimivaan.