### PR TITLE
GVT-3602: Raiteen generoitu kuvaus julkaisulokin kenttäkohtaisiin muutoksiin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -729,6 +729,7 @@ data class LocationTrackChanges(
     val id: IntId<LocationTrack>,
     val name: Change<AlignmentName>,
     val namingScheme: Change<LocationTrackNamingScheme>,
+    val description: Change<FreeText>,
     val descriptionBase: Change<LocationTrackDescriptionBase>,
     val descriptionSuffix: Change<LocationTrackDescriptionSuffix>,
     val state: Change<LocationTrackState>,
@@ -821,8 +822,9 @@ data class SwitchChanges(
     private fun getTrackNumberJointLocation(
         trackNumberId: IntId<LayoutTrackNumber>,
         jointNumber: JointNumber,
-    ): Change<Point?> =
-        trackConnections.map { tracks -> getTrackNumberJointLocation(tracks, trackNumberId, jointNumber) }
+    ): Change<Point?> = trackConnections.map { tracks ->
+        getTrackNumberJointLocation(tracks, trackNumberId, jointNumber)
+    }
 
     private fun getTrackNumberJointLocation(
         tracks: List<SwitchLocationTrack>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -56,6 +56,7 @@ import fi.fta.geoviite.infra.tracklayout.OperationalPointState
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.getBboxOrNull
 import fi.fta.geoviite.infra.util.getBooleanOrNull
 import fi.fta.geoviite.infra.util.getChange
@@ -102,11 +103,11 @@ import fi.fta.geoviite.infra.util.getUicCodeOrNull
 import fi.fta.geoviite.infra.util.getUuid
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Timestamp
-import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -879,6 +880,8 @@ class PublicationDao(
               old_ltv.name as old_name,
               ltv.naming_scheme,
               old_ltv.naming_scheme as old_naming_scheme,
+              ltv.description,
+              old_ltv.description as old_description,
               ltv.description_base,
               old_ltv.description_base as old_description_base,
               ltv.description_suffix,
@@ -937,6 +940,7 @@ class PublicationDao(
                         name = rs.getChange("name") { rs.getString(it)?.let(::AlignmentName) },
                         namingScheme =
                             rs.getChange("naming_scheme") { rs.getEnumOrNull<LocationTrackNamingScheme>(it) },
+                        description = rs.getChange("description") { rs.getString(it)?.let(::FreeText) },
                         descriptionBase =
                             rs.getChange("description_base") { rs.getString(it)?.let(::LocationTrackDescriptionBase) },
                         descriptionSuffix =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -52,12 +52,12 @@ import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsFirstComparator
 import fi.fta.geoviite.infra.util.printCsv
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.ZoneId
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 
 const val DISTANCE_CHANGE_THRESHOLD = 0.0005
 
@@ -617,6 +617,7 @@ constructor(
                 null,
                 "LocationTrackType",
             ),
+            compareChangeValues(locationTrackChanges.description, { it }, PropKey("description")),
             compareChangeValues(locationTrackChanges.descriptionBase, { it }, PropKey("description-base")),
             compareChangeValues(
                 locationTrackChanges.descriptionSuffix,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -425,13 +425,14 @@ constructor(
             ) { _, _ ->
                 null
             }
-        assertEquals(6, diff.size)
+        assertEquals(7, diff.size)
         assertEquals("location-track", diff[0].propKey.key.toString())
         assertEquals("state", diff[1].propKey.key.toString())
         assertEquals("location-track-type", diff[2].propKey.key.toString())
-        assertEquals("description-base", diff[3].propKey.key.toString())
-        assertEquals("description-suffix", diff[4].propKey.key.toString())
-        assertEquals("duplicate-of", diff[5].propKey.key.toString())
+        assertEquals("description", diff[3].propKey.key.toString())
+        assertEquals("description-base", diff[4].propKey.key.toString())
+        assertEquals("description-suffix", diff[5].propKey.key.toString())
+        assertEquals("duplicate-of", diff[6].propKey.key.toString())
     }
 
     @Test
@@ -463,7 +464,7 @@ constructor(
                 locationTrackService.update(
                     LayoutBranch.main,
                     locationTrack.id,
-                    saveReq.copy(descriptionBase = LocationTrackDescriptionBase("TEST2")),
+                    saveReq.copy(type = LocationTrackType.CHORD),
                 )
             )
         publish(publicationService, locationTracks = listOf(updatedLocationTrack.id as IntId))
@@ -490,9 +491,9 @@ constructor(
                 null
             }
         assertEquals(1, diff.size)
-        assertEquals("description-base", diff[0].propKey.key.toString())
-        assertEquals(locationTrack.descriptionStructure.base, diff[0].value.oldValue)
-        assertEquals(updatedLocationTrack.descriptionStructure.base, diff[0].value.newValue)
+        assertEquals("location-track-type", diff[0].propKey.key.toString())
+        assertEquals(locationTrack.type, diff[0].value.oldValue)
+        assertEquals(updatedLocationTrack.type, diff[0].value.newValue)
     }
 
     @Test


### PR DESCRIPTION
Tiketillä oli hieman epäselvyyttä siitä miten kuvaus tulisi esittää julkaisulokissa. Päädyin seuraavaan:

- Kuvaus näytetään perusosan ja lisäosan yläpuolella (konsistentti nimen kanssa, jossa generoitu koko nimi näytetään osiensa yläpuolella)
- Kentän nimi on "Kuvaus"