### PR TITLE
GVT-3606: Toiminnallisen pisteen tuominen suunnitelmasta luonnostilaan yliajaa Ratkosta synkatut muutokset

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
@@ -1,10 +1,12 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.GeoviiteOidDao
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
+import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.OidType
 import fi.fta.geoviite.infra.error.SavingFailureException
@@ -183,6 +185,24 @@ class OperationalPointService(
             }
             draftVersion
         }
+    }
+
+    override fun mergeToMainBranch(
+        fromBranch: DesignBranch,
+        id: IntId<OperationalPoint>,
+    ): LayoutRowVersion<OperationalPoint> {
+        val designBranchPoint = fetchAndCheckForMerging(fromBranch, id).first
+        val mainBranchPoint = dao.fetchVersion(MainLayoutContext.draft, id)?.let(operationalPointDao::fetch)
+        return dao.save(
+            asMainDraft(
+                // Handle all fields whose values reside in layout.operational_point but who are still controlled by
+                // Ratko sync. Ratko sync only runs in main, so use main draft's values for them
+                designBranchPoint.copy(
+                    ratkoVersion = mainBranchPoint?.ratkoVersion ?: mainBranchPoint?.ratkoVersion,
+                    state = mainBranchPoint?.state ?: designBranchPoint.state,
+                )
+            )
+        )
     }
 
     private fun clearOperationalPointReferences(branch: LayoutBranch, id: IntId<OperationalPoint>) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
@@ -193,13 +193,15 @@ class OperationalPointService(
     ): LayoutRowVersion<OperationalPoint> {
         val designBranchPoint = fetchAndCheckForMerging(fromBranch, id).first
         val mainBranchPoint = dao.fetchVersion(MainLayoutContext.draft, id)?.let(operationalPointDao::fetch)
+        val isRatkoPoint = mainBranchPoint?.origin == OperationalPointOrigin.RATKO
         return dao.save(
             asMainDraft(
-                // Handle all fields whose values reside in layout.operational_point but who are still controlled by
-                // Ratko sync. Ratko sync only runs in main, so use main draft's values for them
+                // If an operational point is synced from Ratko, its ratko version and state are handled by the Ratko
+                // sync. Ratko sync only runs in main, so that data should be used over whatever exists in the design.
+                // If the operational point is from Geoviite, we can just take the state info from the design branch.
                 designBranchPoint.copy(
-                    ratkoVersion = mainBranchPoint?.ratkoVersion ?: mainBranchPoint?.ratkoVersion,
-                    state = mainBranchPoint?.state ?: designBranchPoint.state,
+                    ratkoVersion = if (isRatkoPoint) mainBranchPoint.ratkoVersion else null,
+                    state = if (isRatkoPoint) mainBranchPoint.state else designBranchPoint.state,
                 )
             )
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -475,7 +475,7 @@ constructor(
         // Merge to main
         operationalPointService.mergeToMainBranch(designBranch, externalPointId)
 
-        // Make sure that the operational poin in main draft is an unholy union of the design point's user modifiable
+        // Make sure that the operational point in main draft is an unholy union of the design point's user modifiable
         // fields and the Ratko version's state and Ratko version
         val merged = mainDraftContext.fetch(externalPointId)
         assertNotNull(merged)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.tracklayout
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.DomainId
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.error.SavingFailureException
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
@@ -389,6 +390,58 @@ constructor(
         assertEquals(setOf(opId), trackAfter.operationalPointIds)
         val switchAfter = switchService.getOrThrow(mainDraftContext.context, switchVersion.id)
         assertEquals(opId, switchAfter.operationalPointId)
+    }
+
+    @Test
+    fun `mergeToMainBranch preserves ratkoVersion and state from existing main-draft for Ratko points`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(designBranch, PublicationState.OFFICIAL)
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+
+        val externalPointId =
+            ratkoTestService.setupRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", name = "ratko op"))[0]
+
+        testDBService.save(
+            operationalPoint(
+                contextData = createMainContext(externalPointId, false),
+                origin = OperationalPointOrigin.RATKO,
+                ratkoVersion = 1,
+                rinfType = OperationalPointRinfType.STATION,
+            )
+        )
+
+        designOfficialContext.moveFrom(
+            designDraftContext.save(
+                asDesignDraft(
+                    mainOfficialContext
+                        .fetch(externalPointId)!!
+                        .copy(rinfType = OperationalPointRinfType.FREIGHT_TERMINAL),
+                    designBranch.designId,
+                )
+            )
+        )
+
+        // Delete operational point from Ratko
+        ratkoTestService.updateRatkoOperationalPoints()
+        val mainDraftPointAfterDelete = mainDraftContext.fetch(externalPointId)!!
+        assertEquals(2, mainDraftPointAfterDelete.ratkoVersion)
+        assertEquals(OperationalPointState.DELETED, mainDraftPointAfterDelete.state)
+
+        // Make sure the operational point still exists in design
+        val designDraftAfterMainDelete = designDraftContext.fetch(externalPointId)!!
+        assertEquals(OperationalPointState.IN_USE, designDraftAfterMainDelete.state)
+        assertEquals(1, designDraftAfterMainDelete.ratkoVersion)
+
+        // Merge to main
+        operationalPointService.mergeToMainBranch(designBranch, externalPointId)
+
+        // Make sure that the operational poin in main draft is an unholy union of the design point's user modifiable
+        // fields and the Ratko version's state and Ratko version
+        val merged = mainDraftContext.fetch(externalPointId)
+        assertNotNull(merged)
+        assertEquals(OperationalPointRinfType.FREIGHT_TERMINAL, merged.rinfType)
+        assertEquals(OperationalPointState.DELETED, merged.state)
+        assertEquals(2, merged.ratkoVersion)
     }
 
     private fun internalPointSaveRequest(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -393,6 +393,46 @@ constructor(
     }
 
     @Test
+    fun `mergeToMainBranch syncs all fields from design branch for Geoviite points`() {
+        val designBranch = testDBService.createDesignBranch()
+        val designOfficialContext = testDBService.testContext(designBranch, PublicationState.OFFICIAL)
+        val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
+
+        val officialVersion =
+            mainOfficialContext.save(
+                operationalPoint(name = "original", state = OperationalPointState.IN_USE, draft = false)
+            )
+
+        mainDraftContext.save(
+            asMainDraft(mainOfficialContext.fetch(officialVersion.id)!!).copy(state = OperationalPointState.DELETED)
+        )
+
+        designOfficialContext.moveFrom(
+            designDraftContext.save(
+                asDesignDraft(
+                    mainOfficialContext
+                        .fetch(officialVersion.id)!!
+                        .copy(
+                            name = OperationalPointName("edited in design"),
+                            rinfType = OperationalPointRinfType.FREIGHT_TERMINAL,
+                            state = OperationalPointState.IN_USE,
+                        ),
+                    designBranch.designId,
+                )
+            )
+        )
+
+        operationalPointService.mergeToMainBranch(designBranch, officialVersion.id)
+
+        val merged = mainDraftContext.fetch(officialVersion.id)
+        assertNotNull(merged)
+        assertEquals("edited in design", merged.name.toString())
+        assertEquals(OperationalPointRinfType.FREIGHT_TERMINAL, merged.rinfType)
+        assertEquals(OperationalPointState.IN_USE, merged.state)
+        assertNull(merged.ratkoVersion)
+    }
+
+    @Test
     fun `mergeToMainBranch preserves ratkoVersion and state from existing main-draft for Ratko points`() {
         val designBranch = testDBService.createDesignBranch()
         val designOfficialContext = testDBService.testContext(designBranch, PublicationState.OFFICIAL)


### PR DESCRIPTION
Aiemmin toiminnallisen pisteen main-mergelle ei ollut minkäänlaista omaa erikoistusta. Tämä tarkoitti sitä, että main-mergessä main-draftissa aiemmin olemassaolleen pohjaolion kaikki kentät ylikirjoitettiin -- myös Ratkoversioviite ja tila, joita ei voi asettaa käsin ja jotka olivat oikein mainin versiolla. Korjattu tämä tekemällä erikoistus, joka kopioi Ratkosta synkatuille toiminnallisille pisteille Ratkoversioviitteen ja tilan mainin oliolta.