### PR TITLE
Improve geocoding documentation

### DIFF
--- a/doc/geokoodaus.md
+++ b/doc/geokoodaus.md
@@ -67,10 +67,11 @@ Kullakin projektioviivalla on rataosoite. (Ekstrapoloiduilla ennen linjaa ja sen
 osoitteina pituusmittauslinjan alku- ja loppuosoite; ne ovat olemassa sitä varten, että käänteinen geokoodaus
 pystyy armahtamaan pienet laskentojen pyöristykset pituusmittauslinjan alku- ja loppupäissä.)
 
-Geokoodaus kumpaan tahansa suuntaan toimii konseptitasolla niin, että haetaan projektioviivaväli, jolla geokoodattava
-asia on, ja interpoloidaan tältä väliltä projektioviiva, joka osoittaa varsinaiseen geokoodattavaan asiaan.
-Projektioviivavälin voi käsittää viuhkamaisena muotona, josssa jos ollaan vaikkapa kohdassa 0.6, niin interpoloitu
-viiva:
+Geokoodaus kumpaan tahansa suuntaan toimii konseptitasolla niin, että haetaan se vierekkäisten projektioviivojen väli,
+jolla geokoodattava asia on, ja interpoloidaan tältä väliltä projektioviiva, joka osoittaa varsinaiseen geokoodattavaan
+asiaan. Projektioviivavälin voi käsittää viuhkamaisena muotona, jossa jos ollaan vaikkapa kohdassa 0.6, niin
+interpoloitu viiva kullekin kohdalle saadaan interpoloimalla lineaarisesti erikseen lähtöpiste (alun ja lopun
+projektioviivojen alkujen välisellä janalla), viivan kulma, ja osoite.:
 
 - Lähtee interpoloidulta pisteeltä 0.4 x välin alkuprojektion lähtöpiste, 0.6 x loppuprojektion lähtöpiste. Lähtöpisteet
   ovat pituusmittauslinjalla, mutta nämä interpoloidut pisteet eivät välttämättä ole.
@@ -80,6 +81,8 @@ viiva:
 
 Projektioviivavälit määrittävät tällä tavalla yksiselitteisesti osoitteen jokaiselle pisteelle, joka on mahdollista
 geokoodata pituusmittauslinjalle.
+
+![](images/geokoodaus_interpolaatio.svg)
 
 ### Geokoodaus raiteelle (osoitteesta raiteen koordinaateiksi)
 
@@ -99,6 +102,8 @@ Kun oikea projektioviivaväli tiedetään, oikean interpoloidun projektioviivan 
 tulos) löydetään hakemalla suora, jonka kulma on sama kuin projektioviivojen alkupisteiden välinen kulma, ja jolla
 haettava piste on: Tämä suora sitten leikkaa alku- ja loppuprojektioviivan, ja pisteen interpolaatioarvo on se kohta,
 millä etäisyydellä se on näiden leikkauspisteiden välillä.
+
+![](images/geokoodaus_kaanteinen.svg)
 
 ## Raiteen osoitepisteiden tuottaminen (RATKOn malli)
 

--- a/doc/images/geokoodaus_interpolaatio.svg
+++ b/doc/images/geokoodaus_interpolaatio.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="460" viewBox="0 0 800 460" font-family="Helvetica, Arial, sans-serif">
+  <rect width="800" height="460" fill="white"/>
+
+  <!-- Reference line as polyline (vertices roughly 1 m apart) -->
+  <polyline points="21,102 186,92 350,107 502,170 645,253" stroke="#333" stroke-width="2.5" fill="none"/>
+  <text x="80" y="78" font-size="13" fill="#333">pituusmittauslinja</text>
+
+  <!-- Upper (conceptual) extension of the projection-line interval -->
+  <polygon points="288,0 482,0 432,141 272,100" fill="#1976d2" fill-opacity="0.025"/>
+
+  <!-- Subtle highlight for the projection-line interval ("viuhka") -->
+  <polygon points="272,100 227,376 339,405 432,141" fill="#1976d2" fill-opacity="0.05"/>
+
+  <!-- Upper (conceptual) extensions of the projection lines -->
+  <line x1="288" y1="0" x2="272" y2="100" stroke="#1976d2" stroke-width="2.5" stroke-opacity="0.3"/>
+  <line x1="482" y1="0" x2="432" y2="141" stroke="#1976d2" stroke-width="2.5" stroke-opacity="0.3"/>
+
+  <!-- Two adjacent (known) projection lines L and R -->
+  <line x1="272" y1="100" x2="227" y2="376" stroke="#1976d2" stroke-width="2.5"/>
+  <line x1="432" y1="141" x2="339" y2="405" stroke="#1976d2" stroke-width="2.5"/>
+
+  <!-- Dashed segment connecting the two start points: where the interpolated start lies -->
+  <line x1="272" y1="100" x2="432" y2="141" stroke="#888" stroke-width="1" stroke-dasharray="4,3"/>
+
+  <!-- Upper (conceptual) extension of the interpolated projection line -->
+  <line x1="402" y1="0" x2="368" y2="125" stroke="#e65100" stroke-width="2.5" stroke-opacity="0.3"/>
+
+  <!-- Interpolated projection line I, drawn at proportion 0.6 from L toward R -->
+  <line x1="368" y1="125" x2="294" y2="395" stroke="#e65100" stroke-width="2.5"/>
+
+  <!-- Markers at start points -->
+  <circle cx="272" cy="100" r="5" fill="#1976d2"/>
+  <circle cx="432" cy="141" r="5" fill="#1976d2"/>
+  <circle cx="368" cy="125" r="5" fill="#e65100" stroke="white" stroke-width="1.5"/>
+
+  <!-- Labels -->
+  <text x="262" y="70" text-anchor="end" font-size="14" fill="#1976d2" font-weight="bold">L</text>
+  <text x="262" y="85" text-anchor="end" font-size="11" fill="#1976d2">0123</text>
+
+  <text x="450" y="117" font-size="14" fill="#1976d2" font-weight="bold">R</text>
+  <text x="450" y="132" font-size="11" fill="#1976d2">0124</text>
+
+  <text x="388" y="92" text-anchor="middle" font-size="14" fill="#e65100" font-weight="bold">I</text>
+  <text x="388" y="107" text-anchor="middle" font-size="11" fill="#e65100">0123.600</text>
+
+  <!-- Caption -->
+  <g transform="translate(80, 420)">
+    <text font-size="13" fill="#444">
+      <tspan x="0" dy="0">Rataosoitteen 0123.600 projektioviiva I saadaan interpoloimalla metripisteiden</tspan>
+      <tspan x="0" dy="18">projektioviivojen L ja R alkupiste ja kulma lineaarisesti suhteessa 0.4*L+0.6*R.</tspan>
+    </text>
+  </g>
+</svg>

--- a/doc/images/geokoodaus_kaanteinen.svg
+++ b/doc/images/geokoodaus_kaanteinen.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="460" viewBox="0 0 800 460" font-family="Helvetica, Arial, sans-serif">
+  <rect width="800" height="460" fill="white"/>
+
+  <!-- Reference line (same polyline as the forward-geocoding diagram) -->
+  <polyline points="21,102 186,92 350,107 502,170 645,253" stroke="#333" stroke-width="2.5" fill="none"/>
+  <text x="80" y="78" font-size="13" fill="#333">pituusmittauslinja</text>
+
+  <!-- Upper (conceptual) extension of the projection-line interval -->
+  <polygon points="288,0 482,0 432,141 272,100" fill="#1976d2" fill-opacity="0.025"/>
+
+  <!-- Subtle highlight for the projection-line interval -->
+  <polygon points="272,100 227,376 339,405 432,141" fill="#1976d2" fill-opacity="0.05"/>
+
+  <!-- Upper (conceptual) extensions of the projection lines -->
+  <line x1="288" y1="0" x2="272" y2="100" stroke="#1976d2" stroke-width="2.5" stroke-opacity="0.3"/>
+  <line x1="482" y1="0" x2="432" y2="141" stroke="#1976d2" stroke-width="2.5" stroke-opacity="0.3"/>
+
+  <!-- Two adjacent (known) projection lines L and R -->
+  <line x1="272" y1="100" x2="227" y2="376" stroke="#1976d2" stroke-width="2.5"/>
+  <line x1="432" y1="141" x2="339" y2="405" stroke="#1976d2" stroke-width="2.5"/>
+
+  <!-- Faint reference: line between L_start and R_start (parallel to the query line) -->
+  <line x1="272" y1="100" x2="432" y2="141" stroke="#888" stroke-width="1" stroke-dasharray="3,3" opacity="0.55"/>
+
+  <!-- Query line: through Q, in direction L_start → R_start, extending past both intersections -->
+  <line x1="200" y1="248" x2="420" y2="305" stroke="#2e7d32" stroke-width="2" stroke-dasharray="6,3"/>
+
+  <!-- Markers at L_start and R_start -->
+  <circle cx="272" cy="100" r="5" fill="#1976d2"/>
+  <circle cx="432" cy="141" r="5" fill="#1976d2"/>
+
+  <!-- Query coordinate Q -->
+  <circle cx="320" cy="280" r="6" fill="#2e7d32"/>
+
+  <!-- Intersection points of query line with L and R projections -->
+  <circle cx="246" cy="261" r="4.5" fill="white" stroke="#e65100" stroke-width="2.5"/>
+  <circle cx="378" cy="295" r="4.5" fill="white" stroke="#e65100" stroke-width="2.5"/>
+
+  <!-- Labels for L and R -->
+  <text x="262" y="70" text-anchor="end" font-size="14" fill="#1976d2" font-weight="bold">L</text>
+  <text x="262" y="85" text-anchor="end" font-size="11" fill="#1976d2">0123</text>
+
+  <text x="450" y="117" font-size="14" fill="#1976d2" font-weight="bold">R</text>
+  <text x="450" y="132" font-size="11" fill="#1976d2">0124</text>
+
+  <!-- Q label -->
+  <text x="332" y="285" font-size="14" fill="#2e7d32" font-weight="bold">Q</text>
+
+  <!-- Query line label -->
+  <text x="200" y="230" font-size="11" fill="#2e7d32" font-style="italic" transform="rotate(14.5 200 240)">kyselyviiva  (suunta L_start → R_start)</text>
+
+  <!-- Intersection labels -->
+  <text x="240" y="252" text-anchor="end" font-size="11" fill="#e65100">P_L</text>
+  <text x="386" y="295" font-size="11" fill="#e65100">P_R</text>
+
+  <!-- Caption -->
+  <g transform="translate(80, 420)">
+    <text font-size="13" fill="#444">
+      <tspan x="0" dy="0">Q on haettava koordinaatti. Kyselyviiva (vihreä) lähtee Q:sta suunnassa L_start → R_start.</tspan>
+      <tspan x="0" dy="18">Q:n suhteellinen sijainti leikkauspisteiden P_L ja P_R välissä antaa osoitteen (≈ 0123.6).</tspan>
+    </text>
+  </g>
+</svg>


### PR DESCRIPTION
Mietin Juusen kommenttia https://github.com/finnishtransportagency/geoviite/pull/2253#pullrequestreview-4096605613 että mitähän tälle tekisi, päädyin siihen että eiköhän asian saa selkeiten esitettyä kaaviokuvalla.

Github ei näemmä sitten enää tässä näkymässä osaa näyttää noita SVG-kuvia, vaikka pullaria valmistellessa osasi. Raakalinkit siis:

https://raw.githubusercontent.com/finnishtransportagency/geoviite/22b8b6dce7fa5b16623378b3ff6b4680792a4e00/doc/images/geokoodaus_interpolaatio.svg

https://raw.githubusercontent.com/finnishtransportagency/geoviite/22b8b6dce7fa5b16623378b3ff6b4680792a4e00/doc/images/geokoodaus_kaanteinen.svg