### PR TITLE
GVT-3608 Identify nodes and edges by their full content, not only hash

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/TopologyLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/TopologyLinking.kt
@@ -10,14 +10,14 @@ import fi.fta.geoviite.infra.tracklayout.LayoutNodeType.TRACK_BOUNDARY
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
-import fi.fta.geoviite.infra.tracklayout.NodeHash
+import fi.fta.geoviite.infra.tracklayout.NodeKey
 import fi.fta.geoviite.infra.tracklayout.NodePort
 import fi.fta.geoviite.infra.tracklayout.PlaceholderNode
 import fi.fta.geoviite.infra.tracklayout.SwitchLink
 import fi.fta.geoviite.infra.tracklayout.TrackBoundary
 
 data class NodeCombinations(
-    val replacements: Map<NodeHash, LayoutNode>,
+    val replacements: Map<NodeKey, LayoutNode>,
     val targetTracks: List<Pair<LocationTrack, LocationTrackGeometry>>,
 )
 
@@ -50,7 +50,7 @@ data class NodeTrackConnections(val node: DbLayoutNode, val trackVersions: Set<L
 
 fun mergeNodeConnections(connections: List<NodeReplacementTarget>): List<NodeReplacementTarget> =
     connections
-        .groupBy { c -> c.node.contentHash }
+        .groupBy { c -> c.node.contentKey }
         .map { (_, sameNodeConnections) ->
             NodeReplacementTarget(
                 node = sameNodeConnections.first().node,
@@ -62,17 +62,17 @@ fun resolveNodeCombinations(connections: List<NodeReplacementTarget>): NodeCombi
     val replacements = combineEligibleNodes(connections.map { c -> c.node })
     val replaced = connections.mapNotNull { c -> replacements[c.node]?.let { replacement -> c to replacement } }
     return NodeCombinations(
-        replaced.associate { (connection, replacement) -> connection.node.contentHash to replacement },
+        replaced.associate { (connection, replacement) -> connection.node.contentKey to replacement },
         replaced.flatMap { (connection, _) -> connection.tracks }.distinctBy { (t, _) -> t.id },
     )
 }
 
 fun mergeNodeCombinations(combinations: List<NodeCombinations>): NodeCombinations {
     val merged =
-        buildMap<NodeHash, LayoutNode> {
+        buildMap<NodeKey, LayoutNode> {
             combinations
                 .flatMap { r -> r.replacements.entries }
-                .forEach { (target: NodeHash, replacement: LayoutNode) ->
+                .forEach { (target: NodeKey, replacement: LayoutNode) ->
                     compute(target) { _, prev ->
                         prev?.also {
                             require(prev == replacement) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -266,8 +266,8 @@ constructor(
             "Duplicate tracks in changes to save: ${maybeChanged.map { (t,_) -> t.id }}"
         }
         val originalGeoms = original.map { (_, trackAndGeom) -> trackAndGeom.second }
-        val dbEdges = originalGeoms.flatMap { g -> g.edges }.associateBy { it.contentHash }
-        val dbNodes = originalGeoms.flatMap { g -> g.nodes }.associateBy { it.contentHash }
+        val dbEdges = originalGeoms.flatMap { g -> g.edges }.associateBy { it.contentKey }
+        val dbNodes = originalGeoms.flatMap { g -> g.nodes }.associateBy { it.contentKey }
 
         maybeChanged.forEach { (track, geometry) ->
             val id = track.id as IntId

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -316,17 +316,16 @@ class LayoutAlignmentDao(
 
     private fun saveEdges(
         edges: List<TmpLayoutEdge>,
-        savedNodes: Map<NodeHash, IntId<LayoutNode>>,
+        savedNodes: Map<NodeKey, IntId<LayoutNode>>,
         savedGeometries: Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>>,
     ): List<IntId<LayoutEdge>> {
         val startNodeIds =
             edges.map { edge ->
-                (edge.startNode.node as? DbLayoutNode)?.id
-                    ?: requireNotNull(savedNodes[edge.startNode.node.contentHash])
+                (edge.startNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.startNode.node.contentKey])
             }
         val endNodeIds =
             edges.map { edge ->
-                (edge.endNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.endNode.node.contentHash])
+                (edge.endNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.endNode.node.contentKey])
             }
         val sql =
             """
@@ -390,7 +389,7 @@ class LayoutAlignmentDao(
 
     private fun saveEdge(
         content: TmpLayoutEdge,
-        savedNodes: Map<NodeHash, IntId<LayoutNode>>,
+        savedNodes: Map<NodeKey, IntId<LayoutNode>>,
         savedGeometries: Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>>,
     ): IntId<LayoutEdge> = saveEdges(listOf(content), savedNodes, savedGeometries)[0]
 
@@ -453,7 +452,7 @@ class LayoutAlignmentDao(
         val savedNodes =
             tmpEdges
                 .flatMap { e -> listOfNotNull(e.startNode.node as? TmpLayoutNode, e.endNode.node as? TmpLayoutNode) }
-                .associateBy { it.contentHash }
+                .associateBy { it.contentKey }
                 .entries
                 .let { nodesByHash ->
                     val saved = saveNodes(nodesByHash.map { it.value })
@@ -466,7 +465,7 @@ class LayoutAlignmentDao(
 
         val savedEdges =
             tmpEdges
-                .associateBy { it.contentHash }
+                .associateBy { it.contentKey }
                 .entries
                 .let { edgesByHash ->
                     val saved = saveEdges(edgesByHash.map { it.value }, savedNodes, savedGeometries)
@@ -494,7 +493,7 @@ class LayoutAlignmentDao(
             ps.setInt(1, trackVersion.id.intValue)
             ps.setString(2, trackVersion.context.toSqlString())
             ps.setInt(3, trackVersion.version)
-            ps.setInt(4, ((edge as? DbLayoutEdge)?.id ?: requireNotNull(savedEdges[edge.contentHash])).intValue)
+            ps.setInt(4, ((edge as? DbLayoutEdge)?.id ?: requireNotNull(savedEdges[edge.contentKey])).intValue)
             ps.setInt(5, index)
             ps.setBigDecimal(6, roundTo6Decimals(m.min.distance))
         }
@@ -1468,7 +1467,7 @@ private fun createEdges(
                     endNode = edgeData.endNode.let { (id, port) -> getConnection(id, port) },
                     segments = createSegments(edgeData.segments, geometries),
                 )
-                .also { it.contentHash }
+                .also { it.contentKey }
         }
         .collect(Collectors.toList())
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -188,11 +188,11 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
     fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean = switchIds.contains(switchId)
 
     fun withDbComponents(
-        dbNodes: Map<NodeHash, DbLayoutNode>,
-        dbEdges: Map<EdgeHash, DbLayoutEdge>,
+        dbNodes: Map<NodeKey, DbLayoutNode>,
+        dbEdges: Map<EdgeKey, DbLayoutEdge>,
     ): LocationTrackGeometry =
         edges
-            .map { edge -> (edge as? DbLayoutEdge) ?: dbEdges[edge.contentHash] ?: edge.withDbNodes(dbNodes) }
+            .map { edge -> (edge as? DbLayoutEdge) ?: dbEdges[edge.contentKey] ?: edge.withDbNodes(dbNodes) }
             .let { newEdges -> if (newEdges == edges) this else TmpLocationTrackGeometry.of(newEdges, trackId) }
 
     fun withLocationTrackId(id: IntId<LocationTrack>): LocationTrackGeometry =
@@ -223,8 +223,8 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
             else -> TmpLocationTrackGeometry.of(combineEdges(edges.map { e -> e.withoutSwitch(switchId) }), trackId)
         }
 
-    fun withNodeReplacements(nodeSwaps: Map<NodeHash, LayoutNode>): LocationTrackGeometry =
-        this.takeIf { nodes.none { nodeSwaps.containsKey(it.contentHash) } }
+    fun withNodeReplacements(nodeSwaps: Map<NodeKey, LayoutNode>): LocationTrackGeometry =
+        this.takeIf { nodes.none { nodeSwaps.containsKey(it.contentKey) } }
             ?: TmpLocationTrackGeometry.of(processNodeReplacements(nodeSwaps, edges), trackId)
 
     fun getEdgeAtMOrThrow(m: LineM<LocationTrackM>): Pair<LayoutEdge, Range<LineM<LocationTrackM>>> {
@@ -256,7 +256,7 @@ fun calculateEdgeMValues(edges: List<LayoutEdge>): List<Range<LineM<LocationTrac
 
 fun verifyTrackGeometry(trackId: IntId<LocationTrack>?, edges: List<LayoutEdge>) {
     edges.zipWithNext().forEach { (prev, next) ->
-        require(prev.endNode.node.contentHash == next.startNode.node.contentHash) {
+        require(prev.endNode.node.contentKey == next.startNode.node.contentKey) {
             "Edges should be connected: prev=${prev.endNode} next=${next.startNode}"
         }
         require(prev.endNode.type == SWITCH) {
@@ -283,16 +283,16 @@ fun verifyTrackGeometry(trackId: IntId<LocationTrack>?, edges: List<LayoutEdge>)
             "Track geometry end node must have the correct track ID: trackId=$trackId trackBoundary=$boundary"
         }
     }
-    val nodes = mutableSetOf<NodeHash>()
+    val nodes = mutableSetOf<NodeKey>()
     edges
         .asSequence()
         .flatMapIndexed { i, edge -> listOfNotNull(edge.startNode.node.takeIf { i == 0 }, edge.endNode.node) }
         .filter { node -> node !is PlaceholderNode }
         .forEach { node ->
-            require(!nodes.contains(node.contentHash)) {
+            require(!nodes.contains(node.contentKey)) {
                 "Track geometry cannot contain the same node twice: trackId=$trackId node=$node"
             }
-            nodes.add(node.contentHash)
+            nodes.add(node.contentKey)
         }
 }
 
@@ -361,13 +361,24 @@ data class DbLocationTrackGeometry(
         get() = edges.lastOrNull()?.endNode
 }
 
-data class EdgeHash private constructor(val value: Int) {
+data class EdgeKey
+private constructor(
+    val hashValue: Int,
+    val start: NodeConnection,
+    val end: NodeConnection,
+    val segments: List<LayoutSegment>,
+) {
     companion object {
-        fun of(start: NodeConnection, end: NodeConnection, segments: List<LayoutSegment>): EdgeHash =
-            EdgeHash(Objects.hash(nodeConnectionHash(start), nodeConnectionHash(end), segmentsHash(segments)))
+        fun of(start: NodeConnection, end: NodeConnection, segments: List<LayoutSegment>): EdgeKey =
+            EdgeKey(
+                Objects.hash(nodeConnectionHash(start), nodeConnectionHash(end), segmentsHash(segments)),
+                start,
+                end,
+                segments,
+            )
 
         private fun nodeConnectionHash(nodeConnection: NodeConnection): Int =
-            Objects.hash(nodeConnection.portConnection, nodeConnection.node.contentHash)
+            Objects.hash(nodeConnection.portConnection, nodeConnection.node.contentKey)
 
         private fun segmentsHash(segments: List<LayoutSegment>): Int = Objects.hash(segments.map(::segmentHash))
 
@@ -412,7 +423,7 @@ sealed class LayoutEdge : IAlignment<EdgeM> {
         }
     }
 
-    @get:JsonIgnore val contentHash: EdgeHash by lazy { EdgeHash.of(startNode, endNode, segments) }
+    @get:JsonIgnore val contentKey: EdgeKey by lazy { EdgeKey.of(startNode, endNode, segments) }
 
     fun isSwitchInnerLink(): Boolean = startNode.switchIn?.id != null && startNode.switchIn?.id == endNode.switchIn?.id
 
@@ -431,12 +442,12 @@ sealed class LayoutEdge : IAlignment<EdgeM> {
             segments = segments,
         )
 
-    fun withDbNodes(dbNodes: Map<NodeHash, DbLayoutNode>): LayoutEdge {
+    fun withDbNodes(dbNodes: Map<NodeKey, DbLayoutNode>): LayoutEdge {
         val newStart =
-            startNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentHash]?.let(it::withDbNode) }
+            startNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentKey]?.let(it::withDbNode) }
                 ?: startNode
         val newEnd =
-            endNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentHash]?.let(it::withDbNode) }
+            endNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentKey]?.let(it::withDbNode) }
                 ?: endNode
         return if (newStart == startNode && newEnd == endNode) {
             this
@@ -655,9 +666,9 @@ enum class NodePortType {
         get() = if (this == A) B else A
 }
 
-data class NodeHash private constructor(val value: Int) {
+data class NodeKey private constructor(val hashValue: Int, val portA: NodePort, val portB: NodePort?) {
     companion object {
-        fun of(portA: NodePort, portB: NodePort?): NodeHash = NodeHash(Objects.hash(portA, portB))
+        fun of(portA: NodePort, portB: NodePort?): NodeKey = NodeKey(Objects.hash(portA, portB), portA, portB)
     }
 }
 
@@ -697,7 +708,7 @@ sealed class LayoutNode {
             inNodeOrder(link1, link2).let { (portA, portB) -> TmpTrackBoundaryNode(portA, portB) }
     }
 
-    @get:JsonIgnore val contentHash: NodeHash by lazy { NodeHash.of(portA, portB) }
+    @get:JsonIgnore val contentKey: NodeKey by lazy { NodeKey.of(portA, portB) }
 
     fun isSame(other: LayoutNode): Boolean = other.portA == portA && other.portB == portB
 }
@@ -820,7 +831,7 @@ fun combineEdges(edges: List<LayoutEdge>): List<LayoutEdge> {
         // Both edges agree there's a switch node between them
         else if (previous.endNode.type == SWITCH && next.startNode.type == SWITCH) {
             // Both edges agree on the switch content -> move on
-            if (next.startNode.node.contentHash == previous.endNode.node.contentHash) {
+            if (next.startNode.node.contentKey == previous.endNode.node.contentKey) {
                 combined.add(previous)
                 previous = next
             }
@@ -831,7 +842,7 @@ fun combineEdges(edges: List<LayoutEdge>): List<LayoutEdge> {
                     NodeConnection.switch(inner = previous.endNode.switchIn, outer = next.startNode.switchIn)
                 val startingNode =
                     NodeConnection.switch(inner = next.startNode.switchIn, outer = previous.endNode.switchIn)
-                require(endingNode.node.contentHash == startingNode.node.contentHash) {
+                require(endingNode.node.contentKey == startingNode.node.contentKey) {
                     "Failed to resolve dual-switch node: previous=$endingNode next=$startingNode"
                 }
                 combined.add(previous.withEndNode(endingNode))
@@ -865,7 +876,7 @@ fun combineEdges(edges: List<LayoutEdge>): List<LayoutEdge> {
 private fun verifyEdgeContent(edge: LayoutEdge) {
     val startNode = edge.startNode.node
     val endNode = edge.endNode.node
-    require(startNode is PlaceholderNode || startNode.contentHash != endNode.contentHash) {
+    require(startNode is PlaceholderNode || startNode.contentKey != endNode.contentKey) {
         "Start and end node must be different (edge cannot loop back on itself): start=$startNode end=$endNode"
     }
     require(edge.segments.isNotEmpty()) { "LayoutEdge must have at least one segment" }
@@ -921,50 +932,48 @@ private fun <T : NodePort> inNodeOrder(linkIn: T?, linkOut: T?): Pair<T, T?> {
     }
 }
 
-private fun processNodeReplacements(
-    replacements: Map<NodeHash, LayoutNode>,
-    edges: List<LayoutEdge>,
-): List<LayoutEdge> = buildList {
-    // This is notably stateful as each change is simpler to handle as an operation, but multiple
-    // may end up affecting the same edge due to replacements sometimes merging/splitting them.
-    // We maintain an edit window of 3 edges, where the middle one is the one being processed.
-    var previous: LayoutEdge? = null
-    var current: LayoutEdge? = edges.getOrNull(0)
-    var next: LayoutEdge? = edges.getOrNull(1)
-    var index = 0
-    while (current != null) {
-        // The replacement may result in the current edge getting merged with the next or previous
-        // one
-        val (editedPrevious, editedCurrent, editedNext) = replaceNodes(previous, current, next, replacements)
+private fun processNodeReplacements(nodes: Map<NodeKey, LayoutNode>, edges: List<LayoutEdge>): List<LayoutEdge> =
+    buildList {
+        // This is notably stateful as each change is simpler to handle as an operation, but multiple
+        // may end up affecting the same edge due to replacements sometimes merging/splitting them.
+        // We maintain an edit window of 3 edges, where the middle one is the one being processed.
+        var previous: LayoutEdge? = null
+        var current: LayoutEdge? = edges.getOrNull(0)
+        var next: LayoutEdge? = edges.getOrNull(1)
+        var index = 0
+        while (current != null) {
+            // The replacement may result in the current edge getting merged with the next or previous
+            // one
+            val (editedPrevious, editedCurrent, editedNext) = replaceNodes(previous, current, next, nodes)
 
-        // Move the edit-window forward, maintaining partially edited edges
-        index++
-        previous = editedCurrent ?: editedPrevious
-        current = editedNext
-        next = edges.getOrNull(index + 1)
+            // Move the edit-window forward, maintaining partially edited edges
+            index++
+            previous = editedCurrent ?: editedPrevious
+            current = editedNext
+            next = edges.getOrNull(index + 1)
 
-        // Store the edges that are done into the result list
-        if (current != null) {
-            // More yet to process -> add edges as they move out of the processing window
-            editedPrevious?.takeIf { it != previous }?.let(::add)
-        } else {
-            // We're done -> add result edges
-            editedPrevious?.let(::add)
-            editedCurrent?.let(::add)
+            // Store the edges that are done into the result list
+            if (current != null) {
+                // More yet to process -> add edges as they move out of the processing window
+                editedPrevious?.takeIf { it != previous }?.let(::add)
+            } else {
+                // We're done -> add result edges
+                editedPrevious?.let(::add)
+                editedCurrent?.let(::add)
+            }
         }
     }
-}
 
 private fun replaceNodes(
     previous: LayoutEdge?,
     current: LayoutEdge,
     next: LayoutEdge?,
-    replacements: Map<NodeHash, LayoutNode>,
+    replacements: Map<NodeKey, LayoutNode>,
 ): Triple<LayoutEdge?, LayoutEdge?, LayoutEdge?> {
-    val newStartNode = replacements[current.startNode.node.contentHash]
-    val newEndNode = replacements[current.endNode.node.contentHash]
-    val newStartHash = newStartNode?.contentHash ?: current.startNode.node.contentHash
-    val newEndHash = newEndNode?.contentHash ?: current.endNode.node.contentHash
+    val newStartNode = replacements[current.startNode.node.contentKey]
+    val newEndNode = replacements[current.endNode.node.contentKey]
+    val newStartHash = newStartNode?.contentKey ?: current.startNode.node.contentKey
+    val newEndHash = newEndNode?.contentKey ?: current.endNode.node.contentKey
     return when {
         newStartNode == null && newEndNode == null -> Triple(previous, current, next)
         // Special case where both ends would connect to the same node -> one of them needs to go

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
@@ -20,42 +20,39 @@ class LocationTrackGeometryTest {
         fun track124() = IntId<LocationTrack>(124)
 
         assertEquals(
-            TmpTrackBoundaryNode(track123(), START).contentHash,
-            TmpTrackBoundaryNode(track123(), START).contentHash,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
         )
         assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentHash,
-            TmpTrackBoundaryNode(track123(), START).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentKey,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
         )
         assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentHash,
-            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), START)).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentKey,
+            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), START)).contentKey,
         )
         assertNotEquals(
-            TmpTrackBoundaryNode(track123(), START).contentHash,
-            TmpTrackBoundaryNode(track124(), START).contentHash,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
+            TmpTrackBoundaryNode(track124(), START).contentKey,
         )
 
+        assertEquals(TmpTrackBoundaryNode(track123(), END).contentKey, TmpTrackBoundaryNode(track123(), END).contentKey)
         assertEquals(
-            TmpTrackBoundaryNode(track123(), END).contentHash,
-            TmpTrackBoundaryNode(track123(), END).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentKey,
+            TmpTrackBoundaryNode(track123(), END).contentKey,
         )
         assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentHash,
-            TmpTrackBoundaryNode(track123(), END).contentHash,
-        )
-        assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentHash,
-            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), END)).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentKey,
+            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), END)).contentKey,
         )
         assertNotEquals(
-            TmpTrackBoundaryNode(track123(), END).contentHash,
-            TmpTrackBoundaryNode(track124(), END).contentHash,
+            TmpTrackBoundaryNode(track123(), END).contentKey,
+            TmpTrackBoundaryNode(track124(), END).contentKey,
         )
 
         assertNotEquals(
-            TmpTrackBoundaryNode(track123(), START).contentHash,
-            TmpTrackBoundaryNode(track123(), END).contentHash,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
+            TmpTrackBoundaryNode(track123(), END).contentKey,
         )
     }
 
@@ -65,17 +62,14 @@ class LocationTrackGeometryTest {
         fun switch124Main1() = SwitchLink(IntId(124), MAIN, JointNumber(1))
         fun switch123Connection1() = SwitchLink(IntId(123), CONNECTION, JointNumber(1))
         fun switch123Main2() = SwitchLink(IntId(123), MAIN, JointNumber(2))
+        assertEquals(TmpSwitchNode(switch123Main1(), null).contentKey, TmpSwitchNode(switch123Main1(), null).contentKey)
         assertEquals(
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Main1(), null).contentHash,
+            DbSwitchNode(IntId(789), switch123Main1(), null).contentKey,
+            TmpSwitchNode(switch123Main1(), null).contentKey,
         )
         assertEquals(
-            DbSwitchNode(IntId(789), switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-        )
-        assertEquals(
-            DbSwitchNode(IntId(789), switch123Main1(), null).contentHash,
-            DbSwitchNode(IntId(987), switch123Main1(), null).contentHash,
+            DbSwitchNode(IntId(789), switch123Main1(), null).contentKey,
+            DbSwitchNode(IntId(987), switch123Main1(), null).contentKey,
         )
         assertNotEquals(
             TmpSwitchNode(switch123Main1(), switch124Main1()),
@@ -84,12 +78,12 @@ class LocationTrackGeometryTest {
         assertNotEquals(TmpSwitchNode(switch123Main1(), null), TmpSwitchNode(switch124Main1(), null))
         assertNotEquals(TmpSwitchNode(switch123Main1(), switch124Main1()), TmpSwitchNode(switch123Main1(), null))
         assertNotEquals(
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Connection1(), null).contentHash,
+            TmpSwitchNode(switch123Main1(), null).contentKey,
+            TmpSwitchNode(switch123Connection1(), null).contentKey,
         )
         assertNotEquals(
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Main2(), null).contentHash,
+            TmpSwitchNode(switch123Main1(), null).contentKey,
+            TmpSwitchNode(switch123Main2(), null).contentKey,
         )
     }
 
@@ -119,38 +113,38 @@ class LocationTrackGeometryTest {
 
         // Sanity check: we should get the same hashes despite recreating the edge
         assertEquals(
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
         )
         assertEquals(
-            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentHash,
+            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentKey,
         )
 
         // The actual verifications: different edges need different hashes
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode2(), trackNode2(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode2(), trackNode2(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(trackNode1(), switchNode1(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(trackNode1(), switchNode1(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments2()).contentHash,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments2()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode1(), switchNode2Reverse(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode1(), switchNode2Reverse(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode2Reverse(), switchNode1(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode2Reverse(), switchNode1(), segments1()).contentKey,
         )
     }
 
@@ -279,7 +273,7 @@ class LocationTrackGeometryTest {
 
         val result =
             geometry.withNodeReplacements(
-                mapOf(startNode.contentHash to startCombined, endNode.contentHash to endCombined)
+                mapOf(startNode.contentKey to startCombined, endNode.contentKey to endCombined)
             )
         assertEquals(listOf(startCombined, middleNode, endCombined), result.nodes)
     }
@@ -303,7 +297,7 @@ class LocationTrackGeometryTest {
 
         val result =
             geometry.withNodeReplacements(
-                mapOf(startNode.contentHash to startCombined, endNode.contentHash to endCombined)
+                mapOf(startNode.contentKey to startCombined, endNode.contentKey to endCombined)
             )
         assertEquals(listOf(startCombined, endCombined), result.nodes)
     }
@@ -331,7 +325,7 @@ class LocationTrackGeometryTest {
         val combined23 = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(node2.contentHash to combined23, node3.contentHash to combined23))
+            geometry.withNodeReplacements(mapOf(node2.contentKey to combined23, node3.contentKey to combined23))
         assertEquals(listOf(node1, combined23), result.nodes)
         assertMatches(
             trackGeometry(
@@ -370,7 +364,7 @@ class LocationTrackGeometryTest {
         val combined12 = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(node1.contentHash to combined12, node2.contentHash to combined12))
+            geometry.withNodeReplacements(mapOf(node1.contentKey to combined12, node2.contentKey to combined12))
         assertEquals(listOf(combined12, node3), result.nodes)
         assertMatches(
             trackGeometry(
@@ -415,7 +409,7 @@ class LocationTrackGeometryTest {
         val combined23 = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(node2.contentHash to combined23, node3.contentHash to combined23))
+            geometry.withNodeReplacements(mapOf(node2.contentKey to combined23, node3.contentKey to combined23))
         assertEquals(listOf(node1, combined23, node4), result.nodes)
         assertMatches(
             trackGeometry(
@@ -455,7 +449,7 @@ class LocationTrackGeometryTest {
         val combined = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(startNode.contentHash to combined, endNode.contentHash to combined))
+            geometry.withNodeReplacements(mapOf(startNode.contentKey to combined, endNode.contentKey to combined))
         assertEquals(geometry, result)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -44,8 +44,8 @@ private fun replaceEndWithTopoSwitch(
     switchId: IntId<LayoutSwitch>,
     jointNumber: JointNumber,
     jointRole: SwitchJointRole,
-): Pair<NodeHash, LayoutNode> =
-    geometry.edges.last().endNode.node.contentHash to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
+): Pair<NodeKey, LayoutNode> =
+    geometry.edges.last().endNode.node.contentKey to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
 
 fun removeTopologySwitchesFromLocationTrackAndUpdate(
     locationTrack: LocationTrack,
@@ -67,22 +67,22 @@ fun removeTopologySwitchesFromLocationTrackAndUpdate(
 private fun replaceTopologyStartWithTrackBoundary(
     geometry: LocationTrackGeometry,
     locationTrack: LocationTrack,
-): Pair<NodeHash, LayoutNode>? =
+): Pair<NodeKey, LayoutNode>? =
     geometry.edges.first().startNode.let { start ->
         if (start.switchOut == null) null
         else {
-            start.node.contentHash to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.START))
+            start.node.contentKey to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.START))
         }
     }
 
 private fun replaceTopologyEndWithTrackBoundary(
     geometry: LocationTrackGeometry,
     locationTrack: LocationTrack,
-): Pair<NodeHash, LayoutNode>? =
+): Pair<NodeKey, LayoutNode>? =
     geometry.edges.last().endNode.let { end ->
         if (end.switchOut == null) null
         else {
-            end.node.contentHash to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.END))
+            end.node.contentKey to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.END))
         }
     }
 
@@ -105,8 +105,8 @@ private fun replaceStartWithTopoSwitch(
     switchId: IntId<LayoutSwitch>,
     jointNumber: JointNumber,
     jointRole: SwitchJointRole,
-): Pair<NodeHash, LayoutNode> =
-    geometry.edges.first().startNode.node.contentHash to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
+): Pair<NodeKey, LayoutNode> =
+    geometry.edges.first().startNode.node.contentKey to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
 
 fun moveReferenceLineGeometryPointsAndUpdate(
     referenceLine: ReferenceLine,


### PR DESCRIPTION
NodeHash- ja EdgeHash-tyypit olivat pelkkiä 32-bittisiä hasheja, niissä ei riitä tilaa varmuudella tallentaa isoja muutosjoukkoja ja luottaa, ettei niin pienessä joukossa tapahdu törmäyksiä. Helpoin oikeaoppisehko korjaus on toimia tavallisen hashtable-periaatteen mukaan, ja lyödä olioon oikeasti sen koko identiteetin erottava sisältö, ei vain hashia.

Tässähän on kylläkin tavallisena vaarana, että koska edgellä voi olla paljon geometriaa, saatetaan tuhlata aikaa siihen, että sisällöltään saman olion yhtäsuuruutta itsensä kanssa tarkasteltaisiin jossain paikassa turhaan. En löytänyt tällaista paikkaa nykykoodista: Joka kohdassa oikeasti pitää piipertää sisältö geometrioineen kaikkineen, jotta oikeasti tiedetään että on kyse eri edgestä, tai varsinaiseen yhtäsuuruustarkistukseen menee vain samasta TmpLayoutEdgestä tehdyt EdgeKeyt, joiden equals() katsoo vaan että tämähän on vaan sama olio.