### PR TITLE
Ad-hoc: Raiteiden nimi- ja kuvauskenttien parempi sanitointi splittausinfoboksissa

### DIFF
--- a/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
+++ b/ui/src/tool-panel/location-track/dialog/location-track-edit-dialog.tsx
@@ -296,7 +296,11 @@ export const LocationTrackEditDialog: React.FC<LocationTrackDialogProps> = (
         if (canSaveLocationTrack(state) && state.locationTrack) {
             const saveRequestWithSanitizedNameAndDescription = {
                 ...state.locationTrack,
-                ...locationTrackNameFieldsSanitized(state.locationTrack),
+                ...locationTrackNameFieldsSanitized(
+                    state.locationTrack.namingScheme,
+                    state.locationTrack.nameFreeText,
+                    state.locationTrack.nameSpecifier,
+                ),
                 descriptionBase: state.locationTrack.descriptionBase?.trim(),
             };
 

--- a/ui/src/tool-panel/location-track/splitting/confirm-split-dialog.tsx
+++ b/ui/src/tool-panel/location-track/splitting/confirm-split-dialog.tsx
@@ -38,12 +38,14 @@ export const ConfirmSplitDialog: React.FC<ConfirmSplitDialogProps> = ({
         target: FirstSplitTargetCandidate | SplitTargetCandidate,
         index: number,
     ): string {
-        if (target.suffixMode === 'NONE') return target.descriptionBase;
+        const descriptionBaseTrimmed = target.descriptionBase.trim();
+
+        if (target.suffixMode === 'NONE') return descriptionBaseTrimmed;
         const startSwitchNameParts = getSwitchNameParts(target.splitPoint, switches);
         const endSplitPointForTarget = allSplits[index + 1]?.splitPoint ?? endSplitPoint;
         const endSwitchNameParts = getSwitchNameParts(endSplitPointForTarget, switches);
         return formatTrackDescription(
-            target.descriptionBase,
+            descriptionBaseTrimmed,
             target.suffixMode,
             startSwitchNameParts,
             endSwitchNameParts,

--- a/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
+++ b/ui/src/tool-panel/location-track/splitting/location-track-split.tsx
@@ -297,16 +297,13 @@ const LocationTrackSplitM: React.FC<SplitProps> = ({
     const showNameSpecifierInput =
         split.namingScheme === LocationTrackNamingScheme.BETWEEN_OPERATIONAL_POINTS;
     const showFullName = !showFreeTextInput;
-    const showFullDescription = split.suffixMode !== 'NONE';
-    const fullDescription = showFullDescription
-        ? formatTrackDescription(
-              split.descriptionBase,
-              split.suffixMode,
-              startSwitchNameParts,
-              endSwitchNameParts,
-              t,
-          )
-        : undefined;
+    const fullDescription = formatTrackDescription(
+        split.descriptionBase,
+        split.suffixMode,
+        startSwitchNameParts,
+        endSwitchNameParts,
+        t,
+    );
 
     function updateName(
         namingScheme: LocationTrackNamingScheme,
@@ -624,25 +621,20 @@ const LocationTrackSplitM: React.FC<SplitProps> = ({
                             hasError={descriptionSuffixErrorsVisible}
                         />
                     </InfoboxField>
-                    {showFullDescription && (
-                        <InfoboxField
-                            className={
-                                styles['location-track-infobox__split-item-field-label--low']
-                            }
-                            label={t('tool-panel.location-track.splitting.full-description')}
-                            hasErrors={descriptionErrorsVisible}>
-                            <span
-                                className={createClassName(
-                                    styles['location-track-infobox__split-full-name'],
-                                    descriptionErrorsVisible &&
-                                        styles[
-                                            'location-track-infobox__split-full-name--has-errors'
-                                        ],
-                                )}>
-                                {fullDescription}
-                            </span>
-                        </InfoboxField>
-                    )}
+                    <InfoboxField
+                        className={styles['location-track-infobox__split-item-field-label--low']}
+                        label={t('tool-panel.location-track.splitting.full-description')}
+                        hasErrors={descriptionErrorsVisible}>
+                        <span
+                            className={createClassName(
+                                styles['location-track-infobox__split-full-name'],
+                                descriptionErrorsVisible &&
+                                    styles['location-track-infobox__split-full-name--has-errors'],
+                            )}>
+                            {fullDescription}
+                        </span>
+                    </InfoboxField>
+
                     {descriptionSuffixErrorsVisible && (
                         <InfoboxField
                             className={createClassName(

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -68,7 +68,7 @@ const splitToRequestTarget = (
             split.nameFreeText,
             split.nameSpecifier,
         ),
-        descriptionBase: split.descriptionBase?.trim() ?? '',
+        descriptionBase: split.descriptionBase.trim(),
         descriptionSuffix: split.suffixMode ?? 'NONE',
         duplicateTrack: duplicateTrack,
         startAtSwitchId:

--- a/ui/src/tool-panel/location-track/splitting/split-utils.ts
+++ b/ui/src/tool-panel/location-track/splitting/split-utils.ts
@@ -3,6 +3,7 @@ import {
     LayoutSwitch,
     LocationTrackDescriptionSuffixMode,
     LocationTrackId,
+    locationTrackNameFieldsSanitized,
     LocationTrackNamingScheme,
     SplitPoint,
     splitPointsAreSame,
@@ -62,9 +63,12 @@ const splitToRequestTarget = (
             : undefined;
     return {
         namingScheme: split.namingScheme,
-        nameFreeText: split.nameFreeText,
-        nameSpecifier: split.nameSpecifier,
-        descriptionBase: split.descriptionBase ?? '',
+        ...locationTrackNameFieldsSanitized(
+            split.namingScheme,
+            split.nameFreeText,
+            split.nameSpecifier,
+        ),
+        descriptionBase: split.descriptionBase?.trim() ?? '',
         descriptionSuffix: split.suffixMode ?? 'NONE',
         duplicateTrack: duplicateTrack,
         startAtSwitchId:

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -25,7 +25,7 @@ import {
 } from 'common/common-model';
 import { deduplicateById } from 'utils/array-utils';
 import { AlignmentPolyLine, GeometryAlignmentHeader } from './layout-map-api';
-import { GeometryPlanLinkStatus, LocationTrackSaveRequest } from 'linking/linking-model';
+import { GeometryPlanLinkStatus } from 'linking/linking-model';
 import { exhaustiveMatchingGuard, ifDefined } from 'utils/type-utils';
 import { Brand } from 'common/brand';
 import { isNilOrBlank } from 'utils/string-utils';
@@ -209,14 +209,14 @@ export function getNameSpecifier(
 }
 
 export const locationTrackNameFieldsSanitized = (
-    saveRequest: LocationTrackSaveRequest,
-): Pick<LocationTrackSaveRequest, 'nameFreeText' | 'nameSpecifier'> => {
-    const freeText = !isNilOrBlank(saveRequest.nameFreeText)
-        ? saveRequest.nameFreeText?.trim()
-        : undefined;
-    const specifier = saveRequest.nameSpecifier;
+    namingScheme: LocationTrackNamingScheme | undefined,
+    nameFreeText: string | undefined,
+    nameSpecifier: LocationTrackNameSpecifier | undefined,
+): { nameFreeText: string | undefined; nameSpecifier: LocationTrackNameSpecifier | undefined } => {
+    const freeText = !isNilOrBlank(nameFreeText) ? nameFreeText?.trim() : undefined;
+    const specifier = nameSpecifier;
 
-    switch (saveRequest.namingScheme) {
+    switch (namingScheme) {
         case LocationTrackNamingScheme.FREE_TEXT:
         case LocationTrackNamingScheme.WITHIN_OPERATIONAL_POINT:
             return {
@@ -241,7 +241,7 @@ export const locationTrackNameFieldsSanitized = (
         case undefined:
             throw Error('Naming scheme is mandatory for location track save request!');
         default:
-            return exhaustiveMatchingGuard(saveRequest.namingScheme);
+            return exhaustiveMatchingGuard(namingScheme);
     }
 };
 

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -239,7 +239,7 @@ export const locationTrackNameFieldsSanitized = (
                 nameSpecifier: undefined,
             };
         case undefined:
-            throw Error('Naming scheme is mandatory for location track save request!');
+            throw Error('Naming scheme is mandatory for location track.');
         default:
             return exhaustiveMatchingGuard(namingScheme);
     }


### PR DESCRIPTION
Aiemmin splittauksessa nimi- ja kuvauskenttien arvoja käytettiin sellaisenaan. Ne olisi kuitenkin hyvä sanitoida, ja mm. muokkausdialogissa niin tehdäänkin. Splittausta muutettu nyt niin, että myös siellä sanitoidaan nimet ja kuvaukset