### PR TITLE
GVT-3608 Identify nodes and edges by their full content, not only hash

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/TopologyLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/TopologyLinking.kt
@@ -10,14 +10,14 @@ import fi.fta.geoviite.infra.tracklayout.LayoutNodeType.TRACK_BOUNDARY
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
-import fi.fta.geoviite.infra.tracklayout.NodeHash
+import fi.fta.geoviite.infra.tracklayout.NodeContentKey
 import fi.fta.geoviite.infra.tracklayout.NodePort
 import fi.fta.geoviite.infra.tracklayout.PlaceholderNode
 import fi.fta.geoviite.infra.tracklayout.SwitchLink
 import fi.fta.geoviite.infra.tracklayout.TrackBoundary
 
 data class NodeCombinations(
-    val replacements: Map<NodeHash, LayoutNode>,
+    val replacements: Map<NodeContentKey, LayoutNode>,
     val targetTracks: List<Pair<LocationTrack, LocationTrackGeometry>>,
 )
 
@@ -50,7 +50,7 @@ data class NodeTrackConnections(val node: DbLayoutNode, val trackVersions: Set<L
 
 fun mergeNodeConnections(connections: List<NodeReplacementTarget>): List<NodeReplacementTarget> =
     connections
-        .groupBy { c -> c.node.contentHash }
+        .groupBy { c -> c.node.contentKey }
         .map { (_, sameNodeConnections) ->
             NodeReplacementTarget(
                 node = sameNodeConnections.first().node,
@@ -62,17 +62,17 @@ fun resolveNodeCombinations(connections: List<NodeReplacementTarget>): NodeCombi
     val replacements = combineEligibleNodes(connections.map { c -> c.node })
     val replaced = connections.mapNotNull { c -> replacements[c.node]?.let { replacement -> c to replacement } }
     return NodeCombinations(
-        replaced.associate { (connection, replacement) -> connection.node.contentHash to replacement },
+        replaced.associate { (connection, replacement) -> connection.node.contentKey to replacement },
         replaced.flatMap { (connection, _) -> connection.tracks }.distinctBy { (t, _) -> t.id },
     )
 }
 
 fun mergeNodeCombinations(combinations: List<NodeCombinations>): NodeCombinations {
     val merged =
-        buildMap<NodeHash, LayoutNode> {
+        buildMap<NodeContentKey, LayoutNode> {
             combinations
                 .flatMap { r -> r.replacements.entries }
-                .forEach { (target: NodeHash, replacement: LayoutNode) ->
+                .forEach { (target: NodeContentKey, replacement: LayoutNode) ->
                     compute(target) { _, prev ->
                         prev?.also {
                             require(prev == replacement) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -266,8 +266,8 @@ constructor(
             "Duplicate tracks in changes to save: ${maybeChanged.map { (t,_) -> t.id }}"
         }
         val originalGeoms = original.map { (_, trackAndGeom) -> trackAndGeom.second }
-        val dbEdges = originalGeoms.flatMap { g -> g.edges }.associateBy { it.contentHash }
-        val dbNodes = originalGeoms.flatMap { g -> g.nodes }.associateBy { it.contentHash }
+        val dbEdges = originalGeoms.flatMap { g -> g.edges }.associateBy { it.contentKey }
+        val dbNodes = originalGeoms.flatMap { g -> g.nodes }.associateBy { it.contentKey }
 
         maybeChanged.forEach { (track, geometry) ->
             val id = track.id as IntId

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -316,17 +316,16 @@ class LayoutAlignmentDao(
 
     private fun saveEdges(
         edges: List<TmpLayoutEdge>,
-        savedNodes: Map<NodeHash, IntId<LayoutNode>>,
+        savedNodes: Map<NodeContentKey, IntId<LayoutNode>>,
         savedGeometries: Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>>,
     ): List<IntId<LayoutEdge>> {
         val startNodeIds =
             edges.map { edge ->
-                (edge.startNode.node as? DbLayoutNode)?.id
-                    ?: requireNotNull(savedNodes[edge.startNode.node.contentHash])
+                (edge.startNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.startNode.node.contentKey])
             }
         val endNodeIds =
             edges.map { edge ->
-                (edge.endNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.endNode.node.contentHash])
+                (edge.endNode.node as? DbLayoutNode)?.id ?: requireNotNull(savedNodes[edge.endNode.node.contentKey])
             }
         val sql =
             """
@@ -390,7 +389,7 @@ class LayoutAlignmentDao(
 
     private fun saveEdge(
         content: TmpLayoutEdge,
-        savedNodes: Map<NodeHash, IntId<LayoutNode>>,
+        savedNodes: Map<NodeContentKey, IntId<LayoutNode>>,
         savedGeometries: Map<StringId<SegmentGeometry>, IntId<SegmentGeometry>>,
     ): IntId<LayoutEdge> = saveEdges(listOf(content), savedNodes, savedGeometries)[0]
 
@@ -453,7 +452,7 @@ class LayoutAlignmentDao(
         val savedNodes =
             tmpEdges
                 .flatMap { e -> listOfNotNull(e.startNode.node as? TmpLayoutNode, e.endNode.node as? TmpLayoutNode) }
-                .associateBy { it.contentHash }
+                .associateBy { it.contentKey }
                 .entries
                 .let { nodesByHash ->
                     val saved = saveNodes(nodesByHash.map { it.value })
@@ -466,7 +465,7 @@ class LayoutAlignmentDao(
 
         val savedEdges =
             tmpEdges
-                .associateBy { it.contentHash }
+                .associateBy { it.contentKey }
                 .entries
                 .let { edgesByHash ->
                     val saved = saveEdges(edgesByHash.map { it.value }, savedNodes, savedGeometries)
@@ -494,7 +493,7 @@ class LayoutAlignmentDao(
             ps.setInt(1, trackVersion.id.intValue)
             ps.setString(2, trackVersion.context.toSqlString())
             ps.setInt(3, trackVersion.version)
-            ps.setInt(4, ((edge as? DbLayoutEdge)?.id ?: requireNotNull(savedEdges[edge.contentHash])).intValue)
+            ps.setInt(4, ((edge as? DbLayoutEdge)?.id ?: requireNotNull(savedEdges[edge.contentKey])).intValue)
             ps.setInt(5, index)
             ps.setBigDecimal(6, roundTo6Decimals(m.min.distance))
         }
@@ -1468,7 +1467,7 @@ private fun createEdges(
                     endNode = edgeData.endNode.let { (id, port) -> getConnection(id, port) },
                     segments = createSegments(edgeData.segments, geometries),
                 )
-                .also { it.contentHash }
+                .also { it.contentKey }
         }
         .collect(Collectors.toList())
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -389,6 +389,11 @@ data class SegmentGeometry(
     val id: DomainId<SegmentGeometry> = StringId(),
 ) : ISegmentGeometry, Loggable {
 
+    fun isSame(other: SegmentGeometry): Boolean =
+        resolution == other.resolution &&
+            segmentPoints.size == other.segmentPoints.size &&
+            segmentPoints.zip(other.segmentPoints) { a, b -> a.isSame(b) }.all { it }
+
     override val boundingBox: BoundingBox by lazy { boundingBoxAroundPoints(segmentPoints) }
 
     override val startDirection: Double by lazy { directionBetweenPoints(segmentPoints[0], segmentPoints[1]) }
@@ -525,6 +530,12 @@ data class LayoutSegment(
     override val sourceStartM: BigDecimal?,
     override val source: GeometrySource,
 ) : ISegmentGeometry by geometry, ISegment, Loggable {
+
+    fun isSame(other: LayoutSegment): Boolean =
+        sourceId == other.sourceId &&
+            sourceStartM == other.sourceStartM &&
+            source == other.source &&
+            geometry.isSame(other.geometry)
 
     companion object {
         const val SOURCE_START_M_SCALE = 6

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGeometry.kt
@@ -43,6 +43,7 @@ import fi.fta.geoviite.infra.math.pointInDirection
 import fi.fta.geoviite.infra.math.round
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.GENERATED
 import fi.fta.geoviite.infra.util.FileName
+import fi.fta.geoviite.infra.util.equalsBy
 import java.math.BigDecimal
 import java.time.Instant
 import kotlin.math.abs
@@ -390,9 +391,7 @@ data class SegmentGeometry(
 ) : ISegmentGeometry, Loggable {
 
     fun isSame(other: SegmentGeometry): Boolean =
-        resolution == other.resolution &&
-            segmentPoints.size == other.segmentPoints.size &&
-            segmentPoints.zip(other.segmentPoints) { a, b -> a.isSame(b) }.all { it }
+        resolution == other.resolution && segmentPoints.equalsBy(other.segmentPoints) { a, b -> a.isSame(b) }
 
     override val boundingBox: BoundingBox by lazy { boundingBoxAroundPoints(segmentPoints) }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -23,6 +23,7 @@ import fi.fta.geoviite.infra.tracklayout.TrackBoundaryType.END
 import fi.fta.geoviite.infra.tracklayout.TrackBoundaryType.START
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType.INNER
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType.OUTER
+import fi.fta.geoviite.infra.util.equalsBy
 import java.util.*
 import kotlin.math.PI
 import kotlin.math.abs
@@ -388,8 +389,7 @@ private constructor(
 
         return start.isSame(other.start) &&
             end.isSame(other.end) &&
-            segments.size == other.segments.size &&
-            segments.zip(other.segments) { a, b -> a.isSame(b) }.all { it }
+            segments.equalsBy(other.segments) { a, b -> a.isSame(b) }
     }
 
     override fun hashCode(): Int = nodesHash

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -394,7 +394,7 @@ private constructor(
 
     override fun hashCode(): Int = nodesHash
 
-    override fun toString(): String = "EdgeKey(nodesHash=$nodesHash, start=$start, end=$end, segments=$segments)"
+    override fun toString(): String = "EdgeContentKey(nodesHash=$nodesHash, start=$start, end=$end, segments=$segments)"
 }
 
 sealed class LayoutEdge : IAlignment<EdgeM> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -188,11 +188,11 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
     fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean = switchIds.contains(switchId)
 
     fun withDbComponents(
-        dbNodes: Map<NodeHash, DbLayoutNode>,
-        dbEdges: Map<EdgeHash, DbLayoutEdge>,
+        dbNodes: Map<NodeContentKey, DbLayoutNode>,
+        dbEdges: Map<EdgeContentKey, DbLayoutEdge>,
     ): LocationTrackGeometry =
         edges
-            .map { edge -> (edge as? DbLayoutEdge) ?: dbEdges[edge.contentHash] ?: edge.withDbNodes(dbNodes) }
+            .map { edge -> (edge as? DbLayoutEdge) ?: dbEdges[edge.contentKey] ?: edge.withDbNodes(dbNodes) }
             .let { newEdges -> if (newEdges == edges) this else TmpLocationTrackGeometry.of(newEdges, trackId) }
 
     fun withLocationTrackId(id: IntId<LocationTrack>): LocationTrackGeometry =
@@ -223,8 +223,8 @@ sealed class LocationTrackGeometry : IAlignment<LocationTrackM> {
             else -> TmpLocationTrackGeometry.of(combineEdges(edges.map { e -> e.withoutSwitch(switchId) }), trackId)
         }
 
-    fun withNodeReplacements(nodeSwaps: Map<NodeHash, LayoutNode>): LocationTrackGeometry =
-        this.takeIf { nodes.none { nodeSwaps.containsKey(it.contentHash) } }
+    fun withNodeReplacements(nodeSwaps: Map<NodeContentKey, LayoutNode>): LocationTrackGeometry =
+        this.takeIf { nodes.none { nodeSwaps.containsKey(it.contentKey) } }
             ?: TmpLocationTrackGeometry.of(processNodeReplacements(nodeSwaps, edges), trackId)
 
     fun getEdgeAtMOrThrow(m: LineM<LocationTrackM>): Pair<LayoutEdge, Range<LineM<LocationTrackM>>> {
@@ -256,7 +256,7 @@ fun calculateEdgeMValues(edges: List<LayoutEdge>): List<Range<LineM<LocationTrac
 
 fun verifyTrackGeometry(trackId: IntId<LocationTrack>?, edges: List<LayoutEdge>) {
     edges.zipWithNext().forEach { (prev, next) ->
-        require(prev.endNode.node.contentHash == next.startNode.node.contentHash) {
+        require(prev.endNode.node.contentKey == next.startNode.node.contentKey) {
             "Edges should be connected: prev=${prev.endNode} next=${next.startNode}"
         }
         require(prev.endNode.type == SWITCH) {
@@ -283,16 +283,16 @@ fun verifyTrackGeometry(trackId: IntId<LocationTrack>?, edges: List<LayoutEdge>)
             "Track geometry end node must have the correct track ID: trackId=$trackId trackBoundary=$boundary"
         }
     }
-    val nodes = mutableSetOf<NodeHash>()
+    val nodes = mutableSetOf<NodeContentKey>()
     edges
         .asSequence()
         .flatMapIndexed { i, edge -> listOfNotNull(edge.startNode.node.takeIf { i == 0 }, edge.endNode.node) }
         .filter { node -> node !is PlaceholderNode }
         .forEach { node ->
-            require(!nodes.contains(node.contentHash)) {
+            require(!nodes.contains(node.contentKey)) {
                 "Track geometry cannot contain the same node twice: trackId=$trackId node=$node"
             }
-            nodes.add(node.contentHash)
+            nodes.add(node.contentKey)
         }
 }
 
@@ -361,22 +361,40 @@ data class DbLocationTrackGeometry(
         get() = edges.lastOrNull()?.endNode
 }
 
-data class EdgeHash private constructor(val value: Int) {
+/**
+ * The content of an edge (its start and end node connections, and segments), with identity that survives a database
+ * roundtrip.
+ */
+class EdgeContentKey
+private constructor(
+    val nodesHash: Int,
+    val start: NodeConnection,
+    val end: NodeConnection,
+    val segments: List<LayoutSegment>,
+) {
     companion object {
-        fun of(start: NodeConnection, end: NodeConnection, segments: List<LayoutSegment>): EdgeHash =
-            EdgeHash(Objects.hash(nodeConnectionHash(start), nodeConnectionHash(end), segmentsHash(segments)))
+        fun of(start: NodeConnection, end: NodeConnection, segments: List<LayoutSegment>): EdgeContentKey =
+            EdgeContentKey(Objects.hash(nodeConnectionHash(start), nodeConnectionHash(end)), start, end, segments)
 
         private fun nodeConnectionHash(nodeConnection: NodeConnection): Int =
-            Objects.hash(nodeConnection.portConnection, nodeConnection.node.contentHash)
-
-        private fun segmentsHash(segments: List<LayoutSegment>): Int = Objects.hash(segments.map(::segmentHash))
-
-        // Note: the segment hash isn't similarly stable by content as node hash is:
-        // This can change after save & read. However, the db-function for inserting segments does
-        // normalize the hash and result in re-using any identical edge, so even at worst it's just
-        // an extra round-trip to the db.
-        private fun segmentHash(segment: LayoutSegment): Int = segment.hashCode()
+            Objects.hash(nodeConnection.portConnection, nodeConnection.node.contentKey)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as EdgeContentKey
+
+        return start.isSame(other.start) &&
+            end.isSame(other.end) &&
+            segments.size == other.segments.size &&
+            segments.zip(other.segments) { a, b -> a.isSame(b) }.all { it }
+    }
+
+    override fun hashCode(): Int = nodesHash
+
+    override fun toString(): String = "EdgeKey(nodesHash=$nodesHash, start=$start, end=$end, segments=$segments)"
 }
 
 sealed class LayoutEdge : IAlignment<EdgeM> {
@@ -412,7 +430,7 @@ sealed class LayoutEdge : IAlignment<EdgeM> {
         }
     }
 
-    @get:JsonIgnore val contentHash: EdgeHash by lazy { EdgeHash.of(startNode, endNode, segments) }
+    @get:JsonIgnore val contentKey: EdgeContentKey by lazy { EdgeContentKey.of(startNode, endNode, segments) }
 
     fun isSwitchInnerLink(): Boolean = startNode.switchIn?.id != null && startNode.switchIn?.id == endNode.switchIn?.id
 
@@ -431,12 +449,12 @@ sealed class LayoutEdge : IAlignment<EdgeM> {
             segments = segments,
         )
 
-    fun withDbNodes(dbNodes: Map<NodeHash, DbLayoutNode>): LayoutEdge {
+    fun withDbNodes(dbNodes: Map<NodeContentKey, DbLayoutNode>): LayoutEdge {
         val newStart =
-            startNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentHash]?.let(it::withDbNode) }
+            startNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentKey]?.let(it::withDbNode) }
                 ?: startNode
         val newEnd =
-            endNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentHash]?.let(it::withDbNode) }
+            endNode.let { it as? TmpNodeConnection }?.let { dbNodes[it.node.contentKey]?.let(it::withDbNode) }
                 ?: endNode
         return if (newStart == startNode && newEnd == endNode) {
             this
@@ -619,6 +637,8 @@ sealed class NodeConnection {
         }
 
     fun flipPort(): TmpNodeConnection = TmpNodeConnection(portConnection.opposite, node)
+
+    fun isSame(other: NodeConnection): Boolean = portConnection == other.portConnection && node.isSame(other.node)
 }
 
 data class DbNodeConnection(override val portConnection: NodePortType, override val node: DbLayoutNode) :
@@ -655,9 +675,9 @@ enum class NodePortType {
         get() = if (this == A) B else A
 }
 
-data class NodeHash private constructor(val value: Int) {
+data class NodeContentKey private constructor(val portA: NodePort, val portB: NodePort?) {
     companion object {
-        fun of(portA: NodePort, portB: NodePort?): NodeHash = NodeHash(Objects.hash(portA, portB))
+        fun of(portA: NodePort, portB: NodePort?): NodeContentKey = NodeContentKey(portA, portB)
     }
 }
 
@@ -697,7 +717,7 @@ sealed class LayoutNode {
             inNodeOrder(link1, link2).let { (portA, portB) -> TmpTrackBoundaryNode(portA, portB) }
     }
 
-    @get:JsonIgnore val contentHash: NodeHash by lazy { NodeHash.of(portA, portB) }
+    @get:JsonIgnore val contentKey: NodeContentKey by lazy { NodeContentKey.of(portA, portB) }
 
     fun isSame(other: LayoutNode): Boolean = other.portA == portA && other.portB == portB
 }
@@ -820,7 +840,7 @@ fun combineEdges(edges: List<LayoutEdge>): List<LayoutEdge> {
         // Both edges agree there's a switch node between them
         else if (previous.endNode.type == SWITCH && next.startNode.type == SWITCH) {
             // Both edges agree on the switch content -> move on
-            if (next.startNode.node.contentHash == previous.endNode.node.contentHash) {
+            if (next.startNode.node.contentKey == previous.endNode.node.contentKey) {
                 combined.add(previous)
                 previous = next
             }
@@ -831,7 +851,7 @@ fun combineEdges(edges: List<LayoutEdge>): List<LayoutEdge> {
                     NodeConnection.switch(inner = previous.endNode.switchIn, outer = next.startNode.switchIn)
                 val startingNode =
                     NodeConnection.switch(inner = next.startNode.switchIn, outer = previous.endNode.switchIn)
-                require(endingNode.node.contentHash == startingNode.node.contentHash) {
+                require(endingNode.node.contentKey == startingNode.node.contentKey) {
                     "Failed to resolve dual-switch node: previous=$endingNode next=$startingNode"
                 }
                 combined.add(previous.withEndNode(endingNode))
@@ -865,7 +885,7 @@ fun combineEdges(edges: List<LayoutEdge>): List<LayoutEdge> {
 private fun verifyEdgeContent(edge: LayoutEdge) {
     val startNode = edge.startNode.node
     val endNode = edge.endNode.node
-    require(startNode is PlaceholderNode || startNode.contentHash != endNode.contentHash) {
+    require(startNode is PlaceholderNode || startNode.contentKey != endNode.contentKey) {
         "Start and end node must be different (edge cannot loop back on itself): start=$startNode end=$endNode"
     }
     require(edge.segments.isNotEmpty()) { "LayoutEdge must have at least one segment" }
@@ -922,7 +942,7 @@ private fun <T : NodePort> inNodeOrder(linkIn: T?, linkOut: T?): Pair<T, T?> {
 }
 
 private fun processNodeReplacements(
-    replacements: Map<NodeHash, LayoutNode>,
+    replacements: Map<NodeContentKey, LayoutNode>,
     edges: List<LayoutEdge>,
 ): List<LayoutEdge> = buildList {
     // This is notably stateful as each change is simpler to handle as an operation, but multiple
@@ -959,16 +979,16 @@ private fun replaceNodes(
     previous: LayoutEdge?,
     current: LayoutEdge,
     next: LayoutEdge?,
-    replacements: Map<NodeHash, LayoutNode>,
+    replacements: Map<NodeContentKey, LayoutNode>,
 ): Triple<LayoutEdge?, LayoutEdge?, LayoutEdge?> {
-    val newStartNode = replacements[current.startNode.node.contentHash]
-    val newEndNode = replacements[current.endNode.node.contentHash]
-    val newStartHash = newStartNode?.contentHash ?: current.startNode.node.contentHash
-    val newEndHash = newEndNode?.contentHash ?: current.endNode.node.contentHash
+    val newStartNode = replacements[current.startNode.node.contentKey]
+    val newEndNode = replacements[current.endNode.node.contentKey]
+    val newStartKey = newStartNode?.contentKey ?: current.startNode.node.contentKey
+    val newEndKey = newEndNode?.contentKey ?: current.endNode.node.contentKey
     return when {
         newStartNode == null && newEndNode == null -> Triple(previous, current, next)
         // Special case where both ends would connect to the same node -> one of them needs to go
-        newStartHash == newEndHash ->
+        newStartKey == newEndKey ->
             mergeEdgeWithPeers(previous, current, next, requireNotNull(newStartNode ?: newEndNode))
         newStartNode == null -> Triple(previous, current.withEndNode(requireNotNull(newEndNode)), next)
         newEndNode == null -> Triple(previous, current.withStartNode(newStartNode), next)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/List.kt
@@ -66,6 +66,12 @@ fun <T, R> processSortedBy(list: List<T>, comparator: Comparator<T>, process: (l
     return rv as List<R>
 }
 
+fun <A, B> List<A>.equalsBy(other: List<B>, predicate: (A, B) -> Boolean): Boolean {
+    if (size != other.size) return false
+    for (i in indices) if (!predicate(this[i], other[i])) return false
+    return true
+}
+
 fun <T, R : Comparable<R>> getIndexRangeForRangeInOrderedList(
     things: List<T>,
     rangeStart: R,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.IndexedId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.MainLayoutContext
@@ -8,13 +9,16 @@ import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geography.CoordinateSystemName
+import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryProfile
 import fi.fta.geoviite.infra.geometry.VIPoint
 import fi.fta.geoviite.infra.geometry.geometryAlignment
+import fi.fta.geoviite.infra.geometry.geometryElements
 import fi.fta.geoviite.infra.geometry.infraModelFile
 import fi.fta.geoviite.infra.geometry.line
 import fi.fta.geoviite.infra.geometry.plan
+import fi.fta.geoviite.infra.geometry.testFile
 import fi.fta.geoviite.infra.inframodel.PlanElementName
 import fi.fta.geoviite.infra.linking.NodeTrackConnections
 import fi.fta.geoviite.infra.math.MultiPoint
@@ -27,6 +31,8 @@ import fi.fta.geoviite.infra.tracklayout.SwitchJointRole.CONNECTION
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole.MAIN
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole.MATH
 import fi.fta.geoviite.infra.util.getIntId
+import java.math.BigDecimal
+import kotlin.random.Random
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -470,6 +476,55 @@ constructor(
             ),
             alignmentDao.getNodeConnectionsNear(MainLayoutContext.draft, MultiPoint(track1End), 1.0),
         )
+    }
+
+    @Test
+    fun `database roundtrip maintains EdgeKey equality`() {
+        val trackNumber = mainOfficialContext.save(trackNumber()).id
+        val planVersion =
+            geometryDao.insertPlan(plan(alignments = listOf(geometryAlignment(geometryElements()))), testFile(), null)
+
+        val planAlignmentId = geometryDao.fetchPlan(planVersion).alignments[0].id as IntId<GeometryAlignment>
+        val geometry =
+            trackGeometryOfSegments(
+                // segments with diverse data
+                segment(Point(0.0, 0.0), Point(14.0, 15.0))
+                    .copy(
+                        sourceId = IndexedId(planAlignmentId.intValue, 0),
+                        // sourceStartMs have exactly 6 decimals in the schema, and we don't care about having other
+                        // numbers of decimals survive roundtrips
+                        sourceStartM = BigDecimal("123.534631"),
+                        source = PLAN,
+                    ),
+                segment(Point(14.0001, 14.9999), Point(15.0, 15.0)).copy(source = GENERATED),
+                segment(Point(15.0, 15.0), Point(18.0, 10.0)),
+                segment(Point(18.0, 10.0), Point(19.0, 10.0)).copy(sourceStartM = BigDecimal("0.000000")),
+            )
+        val track = mainOfficialContext.save(locationTrack(trackNumber), geometry).id
+        val geometryWithTrackId = geometry.withLocationTrackId(track)
+        val loadedGeometry = mainOfficialContext.fetchLocationTrackWithGeometry(track)!!.second
+        assertEquals(geometryWithTrackId.edges[0].contentKey, loadedGeometry.edges[0].contentKey)
+    }
+
+    @Test
+    fun `database roundtrip maintains EdgeKey equality for random segments`() {
+        val trackNumber = mainOfficialContext.save(trackNumber()).id
+
+        val rng = Random(123)
+
+        repeat(10 /*_000_000 */) {
+            val geometry =
+                trackGeometryOfSegments(
+                    segment(
+                        Point(rng.nextFloat() * 100.0, rng.nextFloat() * 100.0),
+                        Point(rng.nextFloat() * 100.0, rng.nextFloat() * 100.0),
+                    )
+                )
+            val track = mainOfficialContext.save(locationTrack(trackNumber), geometry).id
+            val geometryWithTrackId = geometry.withLocationTrackId(track)
+            val loadedGeometry = mainOfficialContext.fetchLocationTrackWithGeometry(track)!!.second
+            assertEquals(geometryWithTrackId.edges[0].contentKey, loadedGeometry.edges[0].contentKey)
+        }
     }
 
     fun edgesBetweenNodes(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 class LocationTrackGeometryTest {
 
     @Test
-    fun `Start & End node content hash works`() {
+    fun `Start & End node content key works`() {
         fun track123() = IntId<LocationTrack>(123)
         fun track124() = IntId<LocationTrack>(124)
 
@@ -57,7 +57,7 @@ class LocationTrackGeometryTest {
     }
 
     @Test
-    fun `Switch node content hash works`() {
+    fun `Switch node content key works`() {
         fun switch123Main1() = SwitchLink(IntId(123), MAIN, JointNumber(1))
         fun switch124Main1() = SwitchLink(IntId(124), MAIN, JointNumber(1))
         fun switch123Connection1() = SwitchLink(IntId(123), CONNECTION, JointNumber(1))
@@ -88,7 +88,7 @@ class LocationTrackGeometryTest {
     }
 
     @Test
-    fun `Edge content hash works`() {
+    fun `Edge content key works`() {
         fun switchNode1() = NodeConnection.switch(SwitchLink(IntId(1), MAIN, JointNumber(1)), null)
         fun switchNode2() =
             NodeConnection.switch(
@@ -111,7 +111,7 @@ class LocationTrackGeometryTest {
         fun segments1() = listOf(segment1)
         fun segments2() = listOf(segment1, segment2)
 
-        // Sanity check: we should get the same hashes despite recreating the edge
+        // Sanity check: we should get the same keys despite recreating the edge
         assertEquals(
             TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
             TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
@@ -121,7 +121,7 @@ class LocationTrackGeometryTest {
             TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentKey,
         )
 
-        // The actual verifications: different edges need different hashes
+        // The actual verifications: different edges need different keys
         assertNotEquals(
             TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
             TmpLayoutEdge(switchNode2(), trackNode2(), segments1()).contentKey,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometryTest.kt
@@ -20,42 +20,39 @@ class LocationTrackGeometryTest {
         fun track124() = IntId<LocationTrack>(124)
 
         assertEquals(
-            TmpTrackBoundaryNode(track123(), START).contentHash,
-            TmpTrackBoundaryNode(track123(), START).contentHash,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
         )
         assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentHash,
-            TmpTrackBoundaryNode(track123(), START).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentKey,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
         )
         assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentHash,
-            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), START)).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), START)).contentKey,
+            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), START)).contentKey,
         )
         assertNotEquals(
-            TmpTrackBoundaryNode(track123(), START).contentHash,
-            TmpTrackBoundaryNode(track124(), START).contentHash,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
+            TmpTrackBoundaryNode(track124(), START).contentKey,
         )
 
+        assertEquals(TmpTrackBoundaryNode(track123(), END).contentKey, TmpTrackBoundaryNode(track123(), END).contentKey)
         assertEquals(
-            TmpTrackBoundaryNode(track123(), END).contentHash,
-            TmpTrackBoundaryNode(track123(), END).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentKey,
+            TmpTrackBoundaryNode(track123(), END).contentKey,
         )
         assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentHash,
-            TmpTrackBoundaryNode(track123(), END).contentHash,
-        )
-        assertEquals(
-            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentHash,
-            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), END)).contentHash,
+            DbTrackBoundaryNode(IntId(456), TrackBoundary(track123(), END)).contentKey,
+            DbTrackBoundaryNode(IntId(654), TrackBoundary(track123(), END)).contentKey,
         )
         assertNotEquals(
-            TmpTrackBoundaryNode(track123(), END).contentHash,
-            TmpTrackBoundaryNode(track124(), END).contentHash,
+            TmpTrackBoundaryNode(track123(), END).contentKey,
+            TmpTrackBoundaryNode(track124(), END).contentKey,
         )
 
         assertNotEquals(
-            TmpTrackBoundaryNode(track123(), START).contentHash,
-            TmpTrackBoundaryNode(track123(), END).contentHash,
+            TmpTrackBoundaryNode(track123(), START).contentKey,
+            TmpTrackBoundaryNode(track123(), END).contentKey,
         )
     }
 
@@ -65,17 +62,14 @@ class LocationTrackGeometryTest {
         fun switch124Main1() = SwitchLink(IntId(124), MAIN, JointNumber(1))
         fun switch123Connection1() = SwitchLink(IntId(123), CONNECTION, JointNumber(1))
         fun switch123Main2() = SwitchLink(IntId(123), MAIN, JointNumber(2))
+        assertEquals(TmpSwitchNode(switch123Main1(), null).contentKey, TmpSwitchNode(switch123Main1(), null).contentKey)
         assertEquals(
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Main1(), null).contentHash,
+            DbSwitchNode(IntId(789), switch123Main1(), null).contentKey,
+            TmpSwitchNode(switch123Main1(), null).contentKey,
         )
         assertEquals(
-            DbSwitchNode(IntId(789), switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-        )
-        assertEquals(
-            DbSwitchNode(IntId(789), switch123Main1(), null).contentHash,
-            DbSwitchNode(IntId(987), switch123Main1(), null).contentHash,
+            DbSwitchNode(IntId(789), switch123Main1(), null).contentKey,
+            DbSwitchNode(IntId(987), switch123Main1(), null).contentKey,
         )
         assertNotEquals(
             TmpSwitchNode(switch123Main1(), switch124Main1()),
@@ -84,12 +78,12 @@ class LocationTrackGeometryTest {
         assertNotEquals(TmpSwitchNode(switch123Main1(), null), TmpSwitchNode(switch124Main1(), null))
         assertNotEquals(TmpSwitchNode(switch123Main1(), switch124Main1()), TmpSwitchNode(switch123Main1(), null))
         assertNotEquals(
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Connection1(), null).contentHash,
+            TmpSwitchNode(switch123Main1(), null).contentKey,
+            TmpSwitchNode(switch123Connection1(), null).contentKey,
         )
         assertNotEquals(
-            TmpSwitchNode(switch123Main1(), null).contentHash,
-            TmpSwitchNode(switch123Main2(), null).contentHash,
+            TmpSwitchNode(switch123Main1(), null).contentKey,
+            TmpSwitchNode(switch123Main2(), null).contentKey,
         )
     }
 
@@ -119,38 +113,38 @@ class LocationTrackGeometryTest {
 
         // Sanity check: we should get the same hashes despite recreating the edge
         assertEquals(
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
         )
         assertEquals(
-            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentHash,
+            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(trackNode1(), trackNode2(), segments1()).contentKey,
         )
 
         // The actual verifications: different edges need different hashes
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode2(), trackNode2(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode2(), trackNode2(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(trackNode1(), switchNode1(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(trackNode1(), switchNode1(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode1(), trackNode2(), segments2()).contentHash,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode1(), trackNode2(), segments2()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode1(), switchNode2Reverse(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode1(), switchNode2(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode1(), switchNode2Reverse(), segments1()).contentKey,
         )
         assertNotEquals(
-            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentHash,
-            TmpLayoutEdge(switchNode2Reverse(), switchNode1(), segments1()).contentHash,
+            TmpLayoutEdge(switchNode2(), switchNode1(), segments1()).contentKey,
+            TmpLayoutEdge(switchNode2Reverse(), switchNode1(), segments1()).contentKey,
         )
     }
 
@@ -279,7 +273,7 @@ class LocationTrackGeometryTest {
 
         val result =
             geometry.withNodeReplacements(
-                mapOf(startNode.contentHash to startCombined, endNode.contentHash to endCombined)
+                mapOf(startNode.contentKey to startCombined, endNode.contentKey to endCombined)
             )
         assertEquals(listOf(startCombined, middleNode, endCombined), result.nodes)
     }
@@ -303,7 +297,7 @@ class LocationTrackGeometryTest {
 
         val result =
             geometry.withNodeReplacements(
-                mapOf(startNode.contentHash to startCombined, endNode.contentHash to endCombined)
+                mapOf(startNode.contentKey to startCombined, endNode.contentKey to endCombined)
             )
         assertEquals(listOf(startCombined, endCombined), result.nodes)
     }
@@ -331,7 +325,7 @@ class LocationTrackGeometryTest {
         val combined23 = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(node2.contentHash to combined23, node3.contentHash to combined23))
+            geometry.withNodeReplacements(mapOf(node2.contentKey to combined23, node3.contentKey to combined23))
         assertEquals(listOf(node1, combined23), result.nodes)
         assertMatches(
             trackGeometry(
@@ -370,7 +364,7 @@ class LocationTrackGeometryTest {
         val combined12 = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(node1.contentHash to combined12, node2.contentHash to combined12))
+            geometry.withNodeReplacements(mapOf(node1.contentKey to combined12, node2.contentKey to combined12))
         assertEquals(listOf(combined12, node3), result.nodes)
         assertMatches(
             trackGeometry(
@@ -415,7 +409,7 @@ class LocationTrackGeometryTest {
         val combined23 = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(node2.contentHash to combined23, node3.contentHash to combined23))
+            geometry.withNodeReplacements(mapOf(node2.contentKey to combined23, node3.contentKey to combined23))
         assertEquals(listOf(node1, combined23, node4), result.nodes)
         assertMatches(
             trackGeometry(
@@ -455,7 +449,7 @@ class LocationTrackGeometryTest {
         val combined = TmpSwitchNode(switchLinkYV(IntId(1), 1), switchLinkYV(IntId(2), 1))
 
         val result =
-            geometry.withNodeReplacements(mapOf(startNode.contentHash to combined, endNode.contentHash to combined))
+            geometry.withNodeReplacements(mapOf(startNode.contentKey to combined, endNode.contentKey to combined))
         assertEquals(geometry, result)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -44,8 +44,8 @@ private fun replaceEndWithTopoSwitch(
     switchId: IntId<LayoutSwitch>,
     jointNumber: JointNumber,
     jointRole: SwitchJointRole,
-): Pair<NodeHash, LayoutNode> =
-    geometry.edges.last().endNode.node.contentHash to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
+): Pair<NodeContentKey, LayoutNode> =
+    geometry.edges.last().endNode.node.contentKey to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
 
 fun removeTopologySwitchesFromLocationTrackAndUpdate(
     locationTrack: LocationTrack,
@@ -67,22 +67,22 @@ fun removeTopologySwitchesFromLocationTrackAndUpdate(
 private fun replaceTopologyStartWithTrackBoundary(
     geometry: LocationTrackGeometry,
     locationTrack: LocationTrack,
-): Pair<NodeHash, LayoutNode>? =
+): Pair<NodeContentKey, LayoutNode>? =
     geometry.edges.first().startNode.let { start ->
         if (start.switchOut == null) null
         else {
-            start.node.contentHash to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.START))
+            start.node.contentKey to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.START))
         }
     }
 
 private fun replaceTopologyEndWithTrackBoundary(
     geometry: LocationTrackGeometry,
     locationTrack: LocationTrack,
-): Pair<NodeHash, LayoutNode>? =
+): Pair<NodeContentKey, LayoutNode>? =
     geometry.edges.last().endNode.let { end ->
         if (end.switchOut == null) null
         else {
-            end.node.contentHash to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.END))
+            end.node.contentKey to LayoutNode.of(TrackBoundary(locationTrack.id as IntId, TrackBoundaryType.END))
         }
     }
 
@@ -105,8 +105,8 @@ private fun replaceStartWithTopoSwitch(
     switchId: IntId<LayoutSwitch>,
     jointNumber: JointNumber,
     jointRole: SwitchJointRole,
-): Pair<NodeHash, LayoutNode> =
-    geometry.edges.first().startNode.node.contentHash to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
+): Pair<NodeContentKey, LayoutNode> =
+    geometry.edges.first().startNode.node.contentKey to LayoutNode.of(SwitchLink(switchId, jointRole, jointNumber))
 
 fun moveReferenceLineGeometryPointsAndUpdate(
     referenceLine: ReferenceLine,


### PR DESCRIPTION
Perinteistä syntymäpäiväongelman välttelyä.

Olkoonkin että näitä tyyppejä käytetään paikoissa, joissa käsiteltävien olioiden määrä taitaa olla yleensä enintään muutamissa tuhansissa. Aiemmassa tapauksessa reititysgraafissa, jossa hash-törmäyksiä näkyi käytännössä, olioita oli satoja tuhansia. Mutta todennäköisyys, että jossain kohdassa näillä oliomäärilläkin törmäiltäisiin, on riittävä että kyllä nämä pitää tehdä oikeaoppisesti koko sisällön vertailulla.

Toinen ehkä konseptina selkeämpi toteutusvaihtoehto olisi, että heitettäisiin nämä luokat kokonaan pois, ja toteutettaisiin vaan `LayoutNode#isSame` ja `LayoutEdge#isSame`-funktiot. Näiden luokkien käyttötarkoitushan on, että kun raiteelle on tehty jotain muutoksia, katsotaan, mitkä niistä oikeasti muuttivat jonkin noden tai edgen sisältöä, ja jätetään tallentamatta uusi versio olioista, jotka eivät oikeasti muuttuneet. Mutta koska raiteen muutokset voivat muuttaa sen edge-listan indeksejä, tämä sitten monimutkaistaisi kutsupaikkoja paljon.