### PR TITLE
GVT-3448: Kiinteistörajat kartalle

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1573,6 +1573,7 @@
         "operational-points": "Toiminnalliset pisteet",
         "operational-point-areas": "Toiminnallisten pisteiden alueet",
         "signal-asset": "Ratkon opastimet",
+        "property-boundary": "Kiinteistörajat",
         "debug-1m": "Tasametripisteet",
         "debug-projection-lines": "Geokoodauksen projektioviivat",
         "debug": "Debug",

--- a/ui/src/map/layers/property-boundary-layer.ts
+++ b/ui/src/map/layers/property-boundary-layer.ts
@@ -11,18 +11,29 @@ import { BackgroundMapLayerSourceType } from 'map/layers/background-map-layer';
 
 type PropertyBoundaryStyle = {
     opacity: number;
-    strokeWidth: number;
+    style: Style;
 };
 
 const layerExtent = [-548576, 6291456, 1548576, 8388608];
+const PROPERTY_BORDER_COLOR = '#b40a14';
 const PROPERTY_BOUNDARY_STYLES: { [key in BackgroundMapLayerSourceType]: PropertyBoundaryStyle } = {
     ortokuva: {
         opacity: 0.8,
-        strokeWidth: 3,
+        style: new Style({
+            stroke: new Stroke({
+                width: 3,
+                color: PROPERTY_BORDER_COLOR,
+            }),
+        }),
     },
     taustakartta: {
         opacity: 0.5,
-        strokeWidth: 1,
+        style: new Style({
+            stroke: new Stroke({
+                width: 1,
+                color: PROPERTY_BORDER_COLOR,
+            }),
+        }),
     },
 };
 
@@ -36,12 +47,7 @@ const PROPERTY_BOUNDARY_LOCATIONS = 'KiinteistorajanSijaintitiedot';
 const styleFunc = (feature: FeatureLike, boundaryStyle: PropertyBoundaryStyle): Style | undefined =>
     // Only visibly draw actual property boundaries, not the other features in the same layer
     feature.getProperties()?.layer === PROPERTY_BOUNDARY_LOCATIONS
-        ? new Style({
-              stroke: new Stroke({
-                  width: boundaryStyle.strokeWidth,
-                  color: '#b40a14',
-              }),
-          })
+        ? boundaryStyle.style
         : undefined;
 
 function createLayer(

--- a/ui/src/map/layers/property-boundary-layer.ts
+++ b/ui/src/map/layers/property-boundary-layer.ts
@@ -55,8 +55,24 @@ function createLayer(
         extent: layerExtent,
         maxZoom: 12,
     });
-    source.on('tileloadstart', () => onLoadingData(true));
-    source.on(['tileloadend', 'tileloaderror'], () => onLoadingData(false));
+    let inFlightTileLoads = 0;
+
+    source.on('tileloadstart', () => {
+        inFlightTileLoads += 1;
+        if (inFlightTileLoads === 1) {
+            onLoadingData(true);
+        }
+    });
+    source.on(['tileloadend', 'tileloaderror'], () => {
+        if (inFlightTileLoads === 0) {
+            return;
+        }
+
+        inFlightTileLoads -= 1;
+        if (inFlightTileLoads === 0) {
+            onLoadingData(false);
+        }
+    });
 
     return new VectorTileLayer({
         source: source,

--- a/ui/src/map/layers/property-boundary-layer.ts
+++ b/ui/src/map/layers/property-boundary-layer.ts
@@ -1,0 +1,85 @@
+import { Tile } from 'ol/layer';
+import { MapLayer } from 'map/layers/utils/layer-model';
+import { LAYOUT_SRID } from 'track-layout/track-layout-model';
+import TileSource from 'ol/source/Tile';
+import MVT from 'ol/format/MVT';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
+import { Stroke, Style } from 'ol/style';
+import { FeatureLike } from 'ol/Feature';
+import { BackgroundMapLayerSourceType } from 'map/layers/background-map-layer';
+
+type PropertyBoundaryStyle = {
+    opacity: number;
+    strokeWidth: number;
+};
+
+const layerExtent = [-548576, 6291456, 1548576, 8388608];
+const PROPERTY_BOUNDARY_STYLES: { [key in BackgroundMapLayerSourceType]: PropertyBoundaryStyle } = {
+    ortokuva: {
+        opacity: 0.8,
+        strokeWidth: 3,
+    },
+    taustakartta: {
+        opacity: 0.5,
+        strokeWidth: 1,
+    },
+};
+
+const getPropertyBoundaryStyle = (orthoMapVisible: boolean) =>
+    orthoMapVisible
+        ? PROPERTY_BOUNDARY_STYLES['ortokuva']
+        : PROPERTY_BOUNDARY_STYLES['taustakartta'];
+
+const PROPERTY_BOUNDARY_LOCATIONS = 'KiinteistorajanSijaintitiedot';
+
+const styleFunc = (feature: FeatureLike, boundaryStyle: PropertyBoundaryStyle): Style | undefined =>
+    // Only visibly draw actual property boundaries, not the other features in the same layer
+    feature.getProperties()?.layer === PROPERTY_BOUNDARY_LOCATIONS
+        ? new Style({
+              stroke: new Stroke({
+                  width: boundaryStyle.strokeWidth,
+                  color: '#b40a14',
+              }),
+          })
+        : undefined;
+
+function createLayer(
+    onLoadingData: (loading: boolean) => void,
+    propertyBoundaryStyle: PropertyBoundaryStyle,
+) {
+    const source = new VectorTileSource({
+        format: new MVT(),
+        url: '/location-map/kiinteisto-avoin/tiles/wmts/1.0.0/kiinteistojaotus/default/v3/ETRS-TM35FIN/{z}/{y}/{x}.pbf',
+        projection: LAYOUT_SRID,
+        extent: layerExtent,
+        maxZoom: 12,
+    });
+    source.on('tileloadstart', () => onLoadingData(true));
+    source.on(['tileloadend', 'tileloaderror'], () => onLoadingData(false));
+
+    return new VectorTileLayer({
+        source: source,
+        renderMode: 'vector',
+        maxResolution: 4,
+        opacity: propertyBoundaryStyle.opacity,
+        style: (feature) => styleFunc(feature, propertyBoundaryStyle),
+    });
+}
+
+export function createPropertyBoundaryLayer(
+    existingOlLayer: Tile<TileSource>,
+    onLoadingData: (loading: boolean) => void,
+    orthoMapVisible: boolean,
+): MapLayer {
+    const layer =
+        !existingOlLayer || existingOlLayer?.get('orthoMapVisible') !== orthoMapVisible
+            ? createLayer(onLoadingData, getPropertyBoundaryStyle(orthoMapVisible))
+            : existingOlLayer;
+
+    layer.set('orthoMapVisible', orthoMapVisible);
+    return {
+        name: 'property-boundary-layer',
+        layer: layer,
+    };
+}

--- a/ui/src/map/layers/utils/layer-visibility-limits.ts
+++ b/ui/src/map/layers/utils/layer-visibility-limits.ts
@@ -9,6 +9,7 @@ export const HIGHLIGHTS_SHOW = 100.0;
 
 const mapLayerOrder: MapLayerName[] = [
     'background-map-layer',
+    'property-boundary-layer',
     'location-track-background-layer',
     'reference-line-background-layer',
     'operational-points-area-layer',

--- a/ui/src/map/map-model.ts
+++ b/ui/src/map/map-model.ts
@@ -61,6 +61,7 @@ export type MapLayerName =
     | 'deleted-publication-candidate-icon-layer'
     | 'debug-geometry-graph-layer'
     | 'signal-asset-layer'
+    | 'property-boundary-layer'
     | 'virtual-hide-signal-asset-layer';
 
 export type MapViewportSource = 'Map';
@@ -123,6 +124,7 @@ export type MapLayerMenuItemName =
     | 'operational-points'
     | 'operational-point-areas'
     | 'signal-asset'
+    | 'property-boundary'
     | 'debug-1m'
     | 'debug-projection-lines'
     | 'debug'

--- a/ui/src/map/map-store.ts
+++ b/ui/src/map/map-store.ts
@@ -127,6 +127,7 @@ const layerMenuItemMapLayers: Record<MapLayerMenuItemName, MapLayerName[]> = {
     'operational-points': ['operational-points-icon-layer', 'operational-points-badge-layer'],
     'operational-point-areas': ['operational-points-area-layer'],
     'signal-asset': ['signal-asset-layer'],
+    'property-boundary': ['property-boundary-layer'],
     'debug-1m': ['debug-1m-points-layer'],
     'debug-projection-lines': ['debug-projection-lines-layer'],
     'debug': ['debug-layer'],
@@ -187,6 +188,7 @@ export const initialMapState: Map = {
                 ],
             },
             { name: 'signal-asset', selected: false },
+            { name: 'property-boundary', selected: false },
         ],
         geometry: [
             { name: 'geometry-alignment', selected: true },

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -113,6 +113,7 @@ import { createOperationalPointsPlacingLayer } from 'map/layers/operational-poin
 import { createOperationalPointAreaLayer } from 'map/layers/operational-point/operational-points-area-layer';
 import { createOperationalPointBadgeLayer } from 'map/layers/operational-point/operational-points-badge-layer';
 import { createSignalAssetLayer } from 'map/layers/ratko/signal-asset-layer';
+import { createPropertyBoundaryLayer } from 'map/layers/property-boundary-layer';
 import { AlignmentLinkingClusterOverlay } from 'map/overlays/alignment-linking-cluster-overlay';
 import { OperationalPointClusterOverlay } from 'map/overlays/operational-point-cluster-overlay';
 import { RouteLocation, RouteLocations } from 'track-layout/track-layout-slice';
@@ -778,6 +779,12 @@ const MapView: React.FC<MapViewProps> = ({
                         return createSignalAssetLayer(
                             existingOlLayer as TileLayer<TileSource>,
                             (loading) => onLayerLoading(layerName, loading),
+                        );
+                    case 'property-boundary-layer':
+                        return createPropertyBoundaryLayer(
+                            existingOlLayer as TileLayer<TileSource>,
+                            (loading) => onLayerLoading(layerName, loading),
+                            visibleLayerNames.includes('orthographic-background-map-layer'),
                         );
                     case 'virtual-km-post-linking-layer': // Virtual map layers
                     case 'virtual-hide-geometry-layer':


### PR DESCRIPTION
Kiinteistörajoille oma karttataso. Toimii hyvin samaan tapaan kuin opastinten `SignalAssetLayer`, sillä erotuksella että datat haetaan MML:n API:sta taustakartan tyylisesti.

Alkuperäisestä speksistä poiketen ilmakuvakarttatason päällä ollessa kiinteistörajat piirretään erilaisella tyylillä (paksummat viivat, korkeampi opacity). Tämä tehdään kontrastin parantamiseksi, sillä ilmakuvassa on kaikenlaisia tummempiakin värejä kun taas taustakartta on pääosin vaalea.