### PR TITLE
GVT-3448 Retain property boundary layer across orthoMapVisible changes

### DIFF
--- a/ui/src/map/layers/property-boundary-layer.ts
+++ b/ui/src/map/layers/property-boundary-layer.ts
@@ -1,7 +1,5 @@
-import { Tile } from 'ol/layer';
 import { MapLayer } from 'map/layers/utils/layer-model';
 import { LAYOUT_SRID } from 'track-layout/track-layout-model';
-import TileSource from 'ol/source/Tile';
 import MVT from 'ol/format/MVT';
 import VectorTileLayer from 'ol/layer/VectorTile';
 import VectorTileSource from 'ol/source/VectorTile';
@@ -44,10 +42,7 @@ const styleFunc = (feature: FeatureLike, boundaryStyle: PropertyBoundaryStyle): 
           })
         : undefined;
 
-function createLayer(
-    onLoadingData: (loading: boolean) => void,
-    propertyBoundaryStyle: PropertyBoundaryStyle,
-) {
+function createLayer(onLoadingData: (loading: boolean) => void, opacity: number) {
     const source = new VectorTileSource({
         format: new MVT(),
         url: '/location-map/kiinteisto-avoin/tiles/wmts/1.0.0/kiinteistojaotus/default/v3/ETRS-TM35FIN/{z}/{y}/{x}.pbf',
@@ -62,22 +57,22 @@ function createLayer(
         source: source,
         renderMode: 'vector',
         maxResolution: 4,
-        opacity: propertyBoundaryStyle.opacity,
-        style: (feature) => styleFunc(feature, propertyBoundaryStyle),
+        opacity,
     });
 }
 
 export function createPropertyBoundaryLayer(
-    existingOlLayer: Tile<TileSource>,
+    existingOlLayer: VectorTileLayer<VectorTileSource<never>, never>,
     onLoadingData: (loading: boolean) => void,
     orthoMapVisible: boolean,
 ): MapLayer {
-    const layer =
-        !existingOlLayer || existingOlLayer?.get('orthoMapVisible') !== orthoMapVisible
-            ? createLayer(onLoadingData, getPropertyBoundaryStyle(orthoMapVisible))
-            : existingOlLayer;
+    const propertyBoundaryStyle = getPropertyBoundaryStyle(orthoMapVisible);
+    const layer = !existingOlLayer
+        ? createLayer(onLoadingData, propertyBoundaryStyle.opacity)
+        : existingOlLayer;
 
     layer.set('orthoMapVisible', orthoMapVisible);
+    layer.setStyle((feature) => styleFunc(feature, propertyBoundaryStyle));
     return {
         name: 'property-boundary-layer',
         layer: layer,

--- a/ui/src/map/layers/property-boundary-layer.ts
+++ b/ui/src/map/layers/property-boundary-layer.ts
@@ -62,7 +62,7 @@ function createLayer(onLoadingData: (loading: boolean) => void, opacity: number)
 }
 
 export function createPropertyBoundaryLayer(
-    existingOlLayer: VectorTileLayer<VectorTileSource<never>, never>,
+    existingOlLayer: VectorTileLayer<VectorTileSource<never>, never> | undefined,
     onLoadingData: (loading: boolean) => void,
     orthoMapVisible: boolean,
 ): MapLayer {
@@ -72,6 +72,7 @@ export function createPropertyBoundaryLayer(
         : existingOlLayer;
 
     layer.set('orthoMapVisible', orthoMapVisible);
+    layer.setOpacity(propertyBoundaryStyle.opacity);
     layer.setStyle((feature) => styleFunc(feature, propertyBoundaryStyle));
     return {
         name: 'property-boundary-layer',

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -1,3 +1,5 @@
+import type VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
 import React from 'react';
 import OlMap from 'ol/Map';
 import {
@@ -782,7 +784,7 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'property-boundary-layer':
                         return createPropertyBoundaryLayer(
-                            existingOlLayer as TileLayer<TileSource>,
+                            existingOlLayer as VectorTileLayer<VectorTileSource<never>, never>,
                             (loading) => onLayerLoading(layerName, loading),
                             visibleLayerNames.includes('orthographic-background-map-layer'),
                         );

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -1,5 +1,5 @@
 import type VectorTileLayer from 'ol/layer/VectorTile';
-import VectorTileSource from 'ol/source/VectorTile';
+import type VectorTileSource from 'ol/source/VectorTile';
 import React from 'react';
 import OlMap from 'ol/Map';
 import {
@@ -784,7 +784,9 @@ const MapView: React.FC<MapViewProps> = ({
                         );
                     case 'property-boundary-layer':
                         return createPropertyBoundaryLayer(
-                            existingOlLayer as VectorTileLayer<VectorTileSource<never>, never>,
+                            existingOlLayer as
+                                | VectorTileLayer<VectorTileSource<never>, never>
+                                | undefined,
                             (loading) => onLayerLoading(layerName, loading),
                             visibleLayerNames.includes('orthographic-background-map-layer'),
                         );


### PR DESCRIPTION
Tämä näyttää kylläkin vähän töhöltä kun ilmakuvakarttatason näyttämisessä/piilottamisessa on jokinlainen fade-in/out-häkkyrä, mutta tällä tasolla taas tyyli muuttuu välittömästi. Mutta on tämä ihan riittävän nätti näin.