### PR TITLE
General: IT test data-init refactor

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
@@ -12,7 +12,6 @@ import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.tracklayout.LayoutSegment
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
-import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
@@ -32,10 +31,10 @@ import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
-import java.util.*
 import org.junit.jupiter.api.Assertions.assertNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.util.*
 
 data class GeocodableTrack(
     val layoutContext: LayoutContext,
@@ -78,7 +77,6 @@ constructor(
     private val trackNumberDao: LayoutTrackNumberDao,
     private val referenceLineDao: ReferenceLineDao,
     private val locationTrackDao: LocationTrackDao,
-    private val switchDao: LayoutSwitchDao,
 ) : DBTestBase() {
 
     fun insertGeocodableTrack(
@@ -181,11 +179,10 @@ constructor(
             )
         val (trackNumberId, referenceLineId) =
             insertTrackNumberAndReferenceLine(layoutContext, segments = listOf(segment))
-        val trackIds =
-            joints.map { (start, end) ->
-                val geom = linkedTrackGeometry(savedSwitch, start.number, end.number, structure)
-                layoutContext.save(locationTrack(trackNumberId), geom).id
-            }
+        val trackIds = joints.map { (start, end) ->
+            val geom = linkedTrackGeometry(savedSwitch, start.number, end.number, structure)
+            layoutContext.save(locationTrack(trackNumberId), geom).id
+        }
 
         return SwitchAndTrackIds(
             switch = IdAndOid(switchId, layoutContext.generateOid(switchId)),

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
@@ -5,8 +5,6 @@ import fi.fta.geoviite.infra.TestLayoutContext
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
@@ -25,12 +23,14 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.linkedTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
+import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
-import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -81,7 +81,8 @@ constructor(
 
     fun insertGeocodableTrack(
         layoutContext: TestLayoutContext = mainOfficialContext,
-        trackNumberId: IntId<LayoutTrackNumber> = mainOfficialContext.createLayoutTrackNumber().id,
+        trackNumberId: IntId<LayoutTrackNumber> =
+            mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber())).first,
         referenceLineId: IntId<ReferenceLine>? = null,
         locationTrackName: String = "Test track-${UUID.randomUUID()}",
         locationTrackType: LocationTrackType = LocationTrackType.MAIN,
@@ -117,42 +118,6 @@ constructor(
         )
     }
 
-    fun insertTrackNumberAndReferenceLine(
-        layoutContext: TestLayoutContext,
-        trackNumberName: String = testDBService.getUnusedTrackNumber().value,
-        segments: List<LayoutSegment>,
-        startAddress: TrackMeter = TrackMeter.ZERO,
-    ): Pair<IntId<LayoutTrackNumber>, IntId<ReferenceLine>> {
-        val trackNumberId = layoutContext.createLayoutTrackNumber(TrackNumber(trackNumberName)).id
-
-        val referenceLine =
-            layoutContext.saveReferenceLine(
-                referenceLineAndGeometry(
-                    trackNumberId = trackNumberId,
-                    segments = segments,
-                    startAddress = startAddress,
-                )
-            )
-
-        return trackNumberId to referenceLine.id
-    }
-
-    fun insertTrackNumberAndReferenceLineWithOid(
-        layoutContext: TestLayoutContext,
-        trackNumberName: String = testDBService.getUnusedTrackNumber().value,
-        segments: List<LayoutSegment>,
-        startAddress: TrackMeter = TrackMeter.ZERO,
-    ): Triple<IntId<LayoutTrackNumber>, IntId<ReferenceLine>, Oid<LayoutTrackNumber>> {
-        val (trackNumberId, referenceLineId) =
-            insertTrackNumberAndReferenceLine(layoutContext, trackNumberName, segments, startAddress)
-        val oid =
-            someOid<LayoutTrackNumber>().also { oid ->
-                trackNumberDao.insertExternalId(trackNumberId, layoutContext.context.branch, oid)
-            }
-
-        return Triple(trackNumberId, referenceLineId, oid)
-    }
-
     data class IdAndOid<T>(val id: IntId<T>, val oid: Oid<T>)
 
     data class SwitchAndTrackIds(
@@ -177,8 +142,9 @@ constructor(
                 Point(allJoints.minOf { it.location.x }, allJoints.minOf { it.location.y }),
                 Point(allJoints.maxOf { it.location.x }, allJoints.maxOf { it.location.y }),
             )
-        val (trackNumberId, referenceLineId) =
-            insertTrackNumberAndReferenceLine(layoutContext, segments = listOf(segment))
+        val (trackNumberId, trackNumberOid) =
+            layoutContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = layoutContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
         val trackIds = joints.map { (start, end) ->
             val geom = linkedTrackGeometry(savedSwitch, start.number, end.number, structure)
             layoutContext.save(locationTrack(trackNumberId), geom).id
@@ -187,7 +153,7 @@ constructor(
         return SwitchAndTrackIds(
             switch = IdAndOid(switchId, layoutContext.generateOid(switchId)),
             tracks = trackIds.map { id -> IdAndOid(id, layoutContext.generateOid(id)) },
-            trackNumber = IdAndOid(trackNumberId, layoutContext.generateOid(trackNumberId)),
+            trackNumber = IdAndOid(trackNumberId, trackNumberOid),
             referenceLineId = referenceLineId,
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
@@ -3,18 +3,13 @@ package fi.fta.geoviite.api
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.TestLayoutContext
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.Publication
-import fi.fta.geoviite.infra.publication.PublicationDao
-import fi.fta.geoviite.infra.publication.PublicationTestSupportService
-import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
-import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutSegment
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
@@ -26,7 +21,6 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackOwner
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
-import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.linkedTrackGeometry
@@ -85,8 +79,6 @@ constructor(
     private val referenceLineDao: ReferenceLineDao,
     private val locationTrackDao: LocationTrackDao,
     private val switchDao: LayoutSwitchDao,
-    private val publicationTestSupportService: PublicationTestSupportService,
-    private val publicationDao: PublicationDao,
 ) : DBTestBase() {
 
     fun insertGeocodableTrack(
@@ -204,52 +196,10 @@ constructor(
     }
 
     fun publishInMain(switchAndTrackIds: List<SwitchAndTrackIds>): Publication =
-        publishInMain(
+        testDBService.publish(
             trackNumbers = switchAndTrackIds.map { it.trackNumber.id },
             referenceLines = switchAndTrackIds.map { it.referenceLineId },
             locationTracks = switchAndTrackIds.flatMap { it.tracks.map { track -> track.id } },
             switches = switchAndTrackIds.map { it.switch.id },
         )
-
-    fun publishInMain(
-        trackNumbers: List<IntId<LayoutTrackNumber>> = emptyList(),
-        referenceLines: List<IntId<ReferenceLine>> = emptyList(),
-        locationTracks: List<IntId<LocationTrack>> = emptyList(),
-        switches: List<IntId<LayoutSwitch>> = emptyList(),
-        kmPosts: List<IntId<LayoutKmPost>> = emptyList(),
-        operationalPoints: List<IntId<OperationalPoint>> = emptyList(),
-    ): Publication =
-        publishInBranch(
-            LayoutBranch.main,
-            trackNumbers = trackNumbers,
-            referenceLines = referenceLines,
-            locationTracks = locationTracks,
-            switches = switches,
-            kmPosts = kmPosts,
-            operationalPoints = operationalPoints,
-        )
-
-    fun publishInBranch(
-        branch: LayoutBranch,
-        trackNumbers: List<IntId<LayoutTrackNumber>> = emptyList(),
-        referenceLines: List<IntId<ReferenceLine>> = emptyList(),
-        locationTracks: List<IntId<LocationTrack>> = emptyList(),
-        switches: List<IntId<LayoutSwitch>> = emptyList(),
-        kmPosts: List<IntId<LayoutKmPost>> = emptyList(),
-        operationalPoints: List<IntId<OperationalPoint>> = emptyList(),
-    ): Publication {
-        return publicationTestSupportService
-            .publish(
-                branch,
-                publicationRequestIds(
-                    trackNumbers = trackNumbers,
-                    referenceLines = referenceLines,
-                    locationTracks = locationTracks,
-                    switches = switches,
-                    kmPosts = kmPosts,
-                    operationalPoints = operationalPoints,
-                ),
-            )
-            .let { summary -> publicationDao.getPublication(requireNotNull(summary.publicationId)) }
-    }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
@@ -3,28 +3,18 @@ package fi.fta.geoviite.api
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.TestLayoutContext
 import fi.fta.geoviite.infra.common.IntId
-import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
-import fi.fta.geoviite.infra.tracklayout.LayoutSegment
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
-import fi.fta.geoviite.infra.tracklayout.LocationTrackOwner
-import fi.fta.geoviite.infra.tracklayout.LocationTrackState
-import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
-import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.linkedTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.locationTrack
-import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLine
-import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switch
@@ -32,16 +22,7 @@ import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertNull
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import java.util.*
-
-data class GeocodableTrack(
-    val layoutContext: LayoutContext,
-    val trackNumber: LayoutTrackNumber,
-    val referenceLine: ReferenceLine,
-    val locationTrack: LocationTrack,
-)
 
 fun assertContainsErrorMessage(expectedErrorMessage: String, errorMessages: Any?, contextMessage: String = "") {
     assert((errorMessages as List<*>).contains(expectedErrorMessage)) {
@@ -71,52 +52,7 @@ private fun assertNullProperties(properties: Map<String, Any>, vararg propertyNa
 }
 
 @Service
-class ExtApiTestDataServiceV1
-@Autowired
-constructor(
-    private val trackNumberDao: LayoutTrackNumberDao,
-    private val referenceLineDao: ReferenceLineDao,
-    private val locationTrackDao: LocationTrackDao,
-) : DBTestBase() {
-
-    fun insertGeocodableTrack(
-        layoutContext: TestLayoutContext = mainOfficialContext,
-        trackNumberId: IntId<LayoutTrackNumber> =
-            mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber())).first,
-        referenceLineId: IntId<ReferenceLine>? = null,
-        locationTrackName: String = "Test track-${UUID.randomUUID()}",
-        locationTrackType: LocationTrackType = LocationTrackType.MAIN,
-        segments: List<LayoutSegment> = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))),
-        state: LocationTrackState = LocationTrackState.IN_USE,
-        owner: IntId<LocationTrackOwner> = IntId(1),
-    ): GeocodableTrack {
-        val usedReferenceLineId =
-            referenceLineId
-                ?: layoutContext
-                    .saveReferenceLine(referenceLineAndGeometry(trackNumberId = trackNumberId, segments = segments))
-                    .id
-
-        val locationTrackId =
-            layoutContext
-                .saveLocationTrack(
-                    locationTrackAndGeometry(
-                        trackNumberId = trackNumberId,
-                        name = locationTrackName,
-                        type = locationTrackType,
-                        segments = segments,
-                        state = state,
-                        ownerId = owner,
-                    )
-                )
-                .id
-
-        return GeocodableTrack(
-            layoutContext = layoutContext.context,
-            trackNumber = trackNumberDao.get(layoutContext.context, trackNumberId)!!,
-            referenceLine = referenceLineDao.get(layoutContext.context, usedReferenceLineId)!!,
-            locationTrack = locationTrackDao.get(layoutContext.context, locationTrackId)!!,
-        )
-    }
+class ExtApiTestDataServiceV1 : DBTestBase() {
 
     data class IdAndOid<T>(val id: IntId<T>, val oid: Oid<T>)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
@@ -45,7 +45,7 @@ data class GeocodableTrack(
 
 fun assertContainsErrorMessage(expectedErrorMessage: String, errorMessages: Any?, contextMessage: String = "") {
     assert((errorMessages as List<*>).contains(expectedErrorMessage)) {
-        "$expectedErrorMessage is not in the list of errors $contextMessage"
+        "$expectedErrorMessage is not in the list of errors ($errorMessages) $contextMessage"
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiTestDataService.kt
@@ -73,14 +73,17 @@ class ExtApiTestDataServiceV1 : DBTestBase() {
         val switchId = layoutContext.save(switch(structure.id, allJoints)).id
         val savedSwitch = layoutContext.fetch(switchId)!!
 
-        val segment =
-            segment(
-                Point(allJoints.minOf { it.location.x }, allJoints.minOf { it.location.y }),
-                Point(allJoints.maxOf { it.location.x }, allJoints.maxOf { it.location.y }),
-            )
         val (trackNumberId, trackNumberOid) =
             layoutContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
-        val referenceLineId = layoutContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
+        val rlGeometry =
+            referenceLineGeometry(
+                segment(
+                    Point(allJoints.minOf { it.location.x }, allJoints.minOf { it.location.y }),
+                    Point(allJoints.maxOf { it.location.x }, allJoints.maxOf { it.location.y }),
+                )
+            )
+        val referenceLineId = layoutContext.save(referenceLine(trackNumberId), rlGeometry).id
+
         val trackIds = joints.map { (start, end) ->
             val geom = linkedTrackGeometry(savedSwitch, start.number, end.number, structure)
             layoutContext.save(locationTrack(trackNumberId), geom).id

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.frameconverter.v1
 
-import fi.fta.geoviite.api.GeocodableTrack
 import fi.fta.geoviite.api.assertContainsErrorMessage
 import fi.fta.geoviite.api.assertNullDetailedProperties
 import fi.fta.geoviite.api.assertNullSimpleProperties
@@ -9,6 +8,7 @@ import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.TestLayoutContext
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
+import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.geocoding.GeocodingService
@@ -50,6 +50,13 @@ import kotlin.math.hypot
 import kotlin.test.assertEquals
 
 private const val API_TRACK_ADDRESSES: FrameConverterUrl = "/rata-vkm/v1/rataosoitteet"
+
+private data class GeocodableTrack(
+    val layoutContext: LayoutContext,
+    val trackNumber: LayoutTrackNumber,
+    val referenceLine: ReferenceLine,
+    val locationTrack: LocationTrack,
+)
 
 // Purposefully different data structure as the actual logic to imitate a user.
 private data class TestCoordinateToTrackAddressRequest(
@@ -324,10 +331,9 @@ constructor(
         // Purposefully uses the same segments for overlap in order to determine
         // that the filtering works based on the track number.
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        val tracks =
-            trackNumberIds.map { trackNumberId ->
-                insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
-            }
+        val tracks = trackNumberIds.map { trackNumberId ->
+            insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        }
 
         tracks.forEach { geocodableTrack ->
             val trackNumberName = geocodableTrack.trackNumber.number.toString()

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -24,8 +24,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
-import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
-import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
@@ -357,8 +356,8 @@ constructor(
             (0..2).map { _ ->
                 val name = "Test track-${UUID.randomUUID()}"
                 mainOfficialContext
-                    .saveAndFetch(locationTrack(trackNumberId, name = name), trackGeometryOfSegments(segments))
-                    .first
+                    .save(locationTrack(trackNumberId, name = name), trackGeometryOfSegments(segments))
+                    .let { mainOfficialContext.fetch(it.id) }
             }
 
         tracks.forEach { track ->
@@ -689,19 +688,14 @@ constructor(
     @Test
     fun `Reverse geocoded address should match the returned coordinate`() {
         val referenceLineSegments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        val trackNumberVersion =
-            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(referenceLineSegments))
-        val trackNumberId = trackNumberVersion.id
-        val trackNumber = trackNumberDao.fetch(trackNumberVersion)
+        val (trackNumber, trackNumberId) = mainOfficialContext.createTrackNumberAndId()
+        mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(referenceLineSegments))
 
         // Track is offset from the reference line and with a slightly different angle
         val trackStart = Point(-5.0, 1.0)
         val trackEnd = Point(5.0, 2.0)
-        val trackSegments = listOf(segment(trackStart, trackEnd))
-        val (track, _) =
-            mainOfficialContext.saveAndFetchLocationTrack(
-                locationTrackAndGeometry(trackNumberId, segments = trackSegments)
-            )
+        val trackGeometry = trackGeometryOfSegments(segment(trackStart, trackEnd))
+        val (track, _) = mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometry)
 
         // Seek a point that is offset from both the track and the reference line - perpendicular
         // from track point x=0 y=1.5
@@ -716,7 +710,7 @@ constructor(
         val featureCollection = api.fetchFeatureCollectionBatch(API_TRACK_ADDRESSES, request)
 
         val properties = featureCollection.features[0].properties!!
-        assertEquals(trackNumber.number.toString(), properties["ratanumero"])
+        assertEquals(trackNumber.toString(), properties["ratanumero"])
         assertEquals(track.name.toString(), properties["sijaintiraide"])
 
         // Verify that we got the expected coordinate
@@ -743,8 +737,7 @@ constructor(
     fun `Location track OID filter does not find any results when the location track OID does not match`() {
         val trackOid = Oid<LocationTrack>("000.000.000")
         val searchOid = Oid<LocationTrack>("111.111.111")
-        val trackVersion = mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
-        val trackId = trackVersion.id
+        val trackId = mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry()).id
 
         locationTrackDao.insertExternalId(trackId, mainOfficialContext.context.branch, trackOid)
 
@@ -757,15 +750,12 @@ constructor(
 
     @Test
     fun `Location track OID filter only finds tracks with the given location track OID`() {
-        val testOids = listOf<Oid<LocationTrack>>(someOid(), someOid())
-
-        testOids.forEach { oid ->
-            val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-            val trackVersion =
-                mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
-
-            locationTrackDao.insertExternalId(trackVersion.id, mainOfficialContext.context.branch, oid)
-        }
+        val testOids =
+            (0..1).map {
+                val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+                val id = mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments)).id
+                mainOfficialContext.generateOid(id)
+            }
 
         testOids.forEach { oid ->
             val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sijaintiraide_oid = oid.toString())
@@ -792,12 +782,9 @@ constructor(
 
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
 
-        mainOfficialContext.createLayoutTrackNumberWithOid(trackNumberOid).let { trackNumber ->
-            mainOfficialContext.saveReferenceLine(
-                referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
-            )
-
-            mainOfficialContext.save(locationTrack(trackNumber.id), trackGeometryOfSegments(segments))
+        mainOfficialContext.createLayoutTrackNumberWithOid(trackNumberOid).id.let { tnId ->
+            mainOfficialContext.save(referenceLine(tnId), referenceLineGeometry(segments))
+            mainOfficialContext.save(locationTrack(tnId), trackGeometryOfSegments(segments))
         }
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, ratanumero_oid = searchOid.toString())
@@ -816,12 +803,9 @@ constructor(
         val testOids = listOf<Oid<LayoutTrackNumber>>(someOid(), someOid())
 
         testOids.forEach { oid ->
-            val trackNumber = mainOfficialContext.createLayoutTrackNumberWithOid(oid)
-            mainOfficialContext.saveReferenceLine(
-                referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
-            )
-
-            mainOfficialContext.save(locationTrack(trackNumber.id), trackGeometryOfSegments(segments))
+            val tnId = mainOfficialContext.createLayoutTrackNumberWithOid(oid).id
+            mainOfficialContext.save(referenceLine(tnId), referenceLineGeometry(segments))
+            mainOfficialContext.save(locationTrack(tnId), trackGeometryOfSegments(segments))
         }
 
         testOids.forEach { oid ->
@@ -857,9 +841,8 @@ constructor(
     fun `Coordinate system argument is respected`() {
         // Helsinki Railway Station area: TM35FIN (385782.89, 6672277.83) ↔ WGS84 (24.9414003, 60.1713788)
         val trackStart = Point(385782.89, 6672277.83)
-        mainOfficialContext.createLocationTrackWithReferenceLine(
-            trackGeometryOfSegments(listOf(segment(trackStart, trackStart + Point(100.0, 100.0))))
-        )
+        val segment = segment(trackStart, trackStart + Point(100.0, 100.0))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segment))
 
         // With EPSG:4326: x/y in the request body are WGS84, and the response x/y are also WGS84
         val trackStartWgs84 = transformNonKKJCoordinate(LAYOUT_SRID, WGS_84_SRID, trackStart)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -5,10 +5,7 @@ import fi.fta.geoviite.api.assertNullDetailedProperties
 import fi.fta.geoviite.api.assertNullSimpleProperties
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
-import fi.fta.geoviite.infra.TestLayoutContext
-import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
-import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.geocoding.GeocodingService
@@ -18,23 +15,22 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.pointDistanceToLine
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
-import fi.fta.geoviite.infra.tracklayout.LayoutSegment
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
-import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
-import fi.fta.geoviite.infra.tracklayout.ReferenceLine
-import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
+import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
+import fi.fta.geoviite.infra.tracklayout.someTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -50,13 +46,6 @@ import kotlin.math.hypot
 import kotlin.test.assertEquals
 
 private const val API_TRACK_ADDRESSES: FrameConverterUrl = "/rata-vkm/v1/rataosoitteet"
-
-private data class GeocodableTrack(
-    val layoutContext: LayoutContext,
-    val trackNumber: LayoutTrackNumber,
-    val referenceLine: ReferenceLine,
-    val locationTrack: LocationTrack,
-)
 
 // Purposefully different data structure as the actual logic to imitate a user.
 private data class TestCoordinateToTrackAddressRequest(
@@ -79,8 +68,6 @@ class CoordinateToTrackAddressIT
 constructor(
     mockMvc: MockMvc,
     val trackNumberDao: LayoutTrackNumberDao,
-    val referenceLineDao: ReferenceLineDao,
-    val locationTrackService: LocationTrackService,
     val locationTrackDao: LocationTrackDao,
     val layoutKmPostDao: LayoutKmPostDao,
     val geocodingService: GeocodingService,
@@ -186,7 +173,8 @@ constructor(
 
     @Test
     fun `Valid multi request with some matches should succeed but return error features`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val requests =
             listOf(
@@ -214,7 +202,8 @@ constructor(
 
     @Test
     fun `Valid single request using request params should succeed`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val params = mapOf("x" to "0.0", "y" to "0.0")
         api.fetchFeatureCollectionSingle(API_TRACK_ADDRESSES, params)
@@ -222,7 +211,8 @@ constructor(
 
     @Test
     fun `Response feature should include identifier of the request if submitted`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val identifiers = listOf("some-identifier-${UUID.randomUUID()}", "some-identifier-${UUID.randomUUID()}")
 
@@ -240,7 +230,15 @@ constructor(
 
     @Test
     fun `Basic request should default to return feature with basic and detailed data`() {
-        val geocodableTrack = insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId =
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.MAIN),
+                trackGeometryOfSegments(segments),
+            )
 
         val yDifferenceToTargetLocation = 5.0
 
@@ -251,9 +249,9 @@ constructor(
                 "x" to 0.0,
                 "y" to 0.0,
                 "valimatka" to yDifferenceToTargetLocation,
-                "ratanumero" to geocodableTrack.trackNumber.number.toString(),
-                "sijaintiraide" to geocodableTrack.locationTrack.name.toString(),
-                "sijaintiraide_kuvaus" to geocodableTrack.locationTrack.description.toString(),
+                "ratanumero" to trackNumber.toString(),
+                "sijaintiraide" to track.name.toString(),
+                "sijaintiraide_kuvaus" to track.description.toString(),
                 "sijaintiraide_tyyppi" to "pääraide",
                 "ratakilometri" to 0,
                 "ratametri" to 10,
@@ -276,7 +274,8 @@ constructor(
 
     @Test
     fun `Request with all-false response data settings should succeed but not return any actual data`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0)
         val params =
@@ -299,7 +298,8 @@ constructor(
 
     @Test
     fun `Basic filtering with radius works`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val requestsToExpectedError =
             mapOf(
@@ -326,17 +326,18 @@ constructor(
 
     @Test
     fun `Filtering with track number works`() {
-        val trackNumberIds = (0..2).map { _ -> mainOfficialContext.createLayoutTrackNumber().id }
-
-        // Purposefully uses the same segments for overlap in order to determine
+        // Purposefully uses the same geometry for overlap in order to determine
         // that the filtering works based on the track number.
-        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
-        val tracks = trackNumberIds.map { trackNumberId ->
-            insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
-        }
+        val geometry = trackGeometryOfSegments(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        val tracks =
+            (0..2).map { _ ->
+                testDBService.getUnusedTrackNumber().also {
+                    mainOfficialContext.createLocationTrackWithReferenceLine(geometry, it)
+                }
+            }
 
-        tracks.forEach { geocodableTrack ->
-            val trackNumberName = geocodableTrack.trackNumber.number.toString()
+        tracks.forEach { trackNumber ->
+            val trackNumberName = trackNumber.toString()
 
             val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, ratanumero = trackNumberName)
             val featureCollection = api.fetchFeatureCollectionBatch(API_TRACK_ADDRESSES, request)
@@ -351,13 +352,17 @@ constructor(
         // Purposefully uses the same segments for overlap in order to determine
         // that the filtering works based on the location track name.
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        val trackNumberId = mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments)).id
         val tracks =
             (0..2).map { _ ->
-                insertGeocodableTrack(locationTrackName = "Test track-${UUID.randomUUID()}", segments = segments)
+                val name = "Test track-${UUID.randomUUID()}"
+                mainOfficialContext
+                    .saveAndFetch(locationTrack(trackNumberId, name = name), trackGeometryOfSegments(segments))
+                    .first
             }
 
-        tracks.forEach { geocodableTrack ->
-            val locationTrackName = geocodableTrack.locationTrack.name.toString()
+        tracks.forEach { track ->
+            val locationTrackName = track.name.toString()
 
             val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sijaintiraide = locationTrackName)
             val featureCollection = api.fetchFeatureCollectionBatch(API_TRACK_ADDRESSES, request)
@@ -372,9 +377,10 @@ constructor(
         // Purposefully uses the same segments for overlap in order to determine
         // that the filtering works based on the location track type.
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        val trackNumberId = mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments)).id
 
-        LocationTrackType.entries.forEach { locationTrackType ->
-            insertGeocodableTrack(segments = segments, locationTrackType = locationTrackType)
+        LocationTrackType.entries.forEach { type ->
+            mainOfficialContext.save(locationTrack(trackNumberId, type = type), trackGeometryOfSegments(segments))
         }
 
         listOf("pääraide", "sivuraide", "kujaraide", "turvaraide").forEach { trackType ->
@@ -388,7 +394,8 @@ constructor(
 
     @Test
     fun `Response output data can be set to only return basic feature data`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val yDifference = 1.0
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = yDifference)
@@ -413,7 +420,8 @@ constructor(
 
     @Test
     fun `Response output data can be set to only return feature geometry data`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))))
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 1.0)
         val params =
@@ -443,10 +451,14 @@ constructor(
 
     @Test
     fun `Response output data can be set to only return detailed feature data`() {
-        val geocodableTrack =
-            insertGeocodableTrack(
-                segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))),
-                locationTrackType = LocationTrackType.CHORD,
+        val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId =
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.CHORD),
+                trackGeometryOfSegments(segments),
             )
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 1.0)
@@ -469,9 +481,9 @@ constructor(
 
         assertNullSimpleProperties(properties)
 
-        assertEquals(geocodableTrack.trackNumber.number.toString(), properties["ratanumero"])
-        assertEquals(geocodableTrack.locationTrack.name.toString(), properties["sijaintiraide"])
-        assertEquals(geocodableTrack.locationTrack.description.toString(), properties["sijaintiraide_kuvaus"])
+        assertEquals(trackNumber.toString(), properties["ratanumero"])
+        assertEquals(track.name.toString(), properties["sijaintiraide"])
+        assertEquals(track.description.toString(), properties["sijaintiraide_kuvaus"])
         assertEquals("kujaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
         assertEquals(10, properties["ratametri"] as Int)
@@ -480,13 +492,14 @@ constructor(
 
     @Test
     fun `Response output data setting combination works`() {
-        val layoutContext = mainOfficialContext
-
-        val geocodableTrack =
-            insertGeocodableTrack(
-                layoutContext = layoutContext,
-                segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-                locationTrackType = LocationTrackType.TRAP,
+        val segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId =
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.TRAP),
+                trackGeometryOfSegments(segments),
             )
 
         val xPositionOnTrack = 3.0
@@ -521,9 +534,9 @@ constructor(
         assertEquals(yPositionOnTrack, ((properties["y"] as? Double)!!), 0.001)
         assertEquals(yDifference, ((properties["valimatka"] as? Double)!!), 0.001)
 
-        assertEquals(geocodableTrack.trackNumber.number.toString(), properties["ratanumero"])
-        assertEquals(geocodableTrack.locationTrack.name.toString(), properties["sijaintiraide"])
-        assertEquals(geocodableTrack.locationTrack.description.toString(), properties["sijaintiraide_kuvaus"])
+        assertEquals(trackNumber.toString(), properties["ratanumero"])
+        assertEquals(track.name.toString(), properties["sijaintiraide"])
+        assertEquals(track.description.toString(), properties["sijaintiraide_kuvaus"])
         assertEquals("turvaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
         assertEquals(xPositionOnTrack.toInt(), properties["ratametri"] as? Int)
@@ -532,14 +545,14 @@ constructor(
 
     @Test
     fun `Track km position is returned correctly`() {
-        val layoutContext = mainOfficialContext
-
-        val geocodableTrack =
-            insertGeocodableTrack(
-                layoutContext = layoutContext,
-                segments = listOf(segment(Point(0.0, 0.0), Point(3000.0, 0.0))),
-                locationTrackType = LocationTrackType.TRAP,
-            )
+        val segments = listOf(segment(Point(0.0, 0.0), Point(3000.0, 0.0)))
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId =
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+        mainOfficialContext.save(
+            locationTrack(trackNumberId, type = LocationTrackType.TRAP),
+            trackGeometryOfSegments(segments),
+        )
 
         val secondKmNumberXLocation = 2000.0 - 50
 
@@ -554,7 +567,7 @@ constructor(
         listOf(Point(900.0, 0.0), Point(secondKmNumberXLocation, 0.0))
             .mapIndexed { index, kmPostLocation ->
                 kmPost(
-                    trackNumberId = geocodableTrack.trackNumber.id as IntId,
+                    trackNumberId = trackNumberId,
                     km = KmNumber(index + 1),
                     gkLocation = kmPostGkLocation(kmPostLocation),
                     draft = false,
@@ -580,7 +593,7 @@ constructor(
 
     @Test
     fun `Search radius under supported range should result in an error`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sade = 0.9)
 
@@ -596,7 +609,7 @@ constructor(
 
     @Test
     fun `Search radius over supported range should result in an error`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sade = 1000.1)
 
@@ -612,7 +625,7 @@ constructor(
 
     @Test
     fun `Invalid location track type should result in an error`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sijaintiraide_tyyppi = "something")
 
@@ -628,7 +641,7 @@ constructor(
 
     @Test
     fun `Invalid location track name should result in an error`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sijaintiraide = "@")
 
@@ -641,7 +654,7 @@ constructor(
 
     @Test
     fun `Invalid track number should result in an error`() {
-        insertGeocodableTrack(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
 
         val request =
             TestCoordinateToTrackAddressRequest(
@@ -658,8 +671,9 @@ constructor(
 
     @Test
     fun `Deleted track is not found`() {
-        val track = insertGeocodableTrack(segments = listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
-        testDBService.update(track.locationTrack.version!!) { t -> t.copy(state = LocationTrackState.DELETED) }
+        val trackNumberId = mainOfficialContext.createTrackNumberAndReferenceLine().id
+        val trackVersion = mainOfficialContext.save(locationTrack(trackNumberId), someTrackGeometry())
+        testDBService.update(trackVersion) { t -> t.copy(state = LocationTrackState.DELETED) }
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0)
 
@@ -676,7 +690,7 @@ constructor(
     fun `Reverse geocoded address should match the returned coordinate`() {
         val referenceLineSegments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
         val trackNumberVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(referenceLineSegments))
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(referenceLineSegments))
         val trackNumberId = trackNumberVersion.id
         val trackNumber = trackNumberDao.fetch(trackNumberVersion)
 
@@ -729,13 +743,10 @@ constructor(
     fun `Location track OID filter does not find any results when the location track OID does not match`() {
         val trackOid = Oid<LocationTrack>("000.000.000")
         val searchOid = Oid<LocationTrack>("111.111.111")
-        val geocodableTrack = insertGeocodableTrack()
+        val trackVersion = mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry())
+        val trackId = trackVersion.id
 
-        locationTrackDao.insertExternalId(
-            geocodableTrack.locationTrack.id as IntId,
-            geocodableTrack.layoutContext.branch,
-            trackOid,
-        )
+        locationTrackDao.insertExternalId(trackId, mainOfficialContext.context.branch, trackOid)
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, sijaintiraide_oid = searchOid.toString())
         val featureCollection = api.fetchFeatureCollectionBatch(API_TRACK_ADDRESSES, request)
@@ -749,13 +760,11 @@ constructor(
         val testOids = listOf<Oid<LocationTrack>>(someOid(), someOid())
 
         testOids.forEach { oid ->
-            val geocodableTrack = insertGeocodableTrack()
+            val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
+            val trackVersion =
+                mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments))
 
-            locationTrackDao.insertExternalId(
-                geocodableTrack.locationTrack.id as IntId,
-                geocodableTrack.layoutContext.branch,
-                oid,
-            )
+            locationTrackDao.insertExternalId(trackVersion.id, mainOfficialContext.context.branch, oid)
         }
 
         testOids.forEach { oid ->
@@ -784,16 +793,11 @@ constructor(
         val segments = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0)))
 
         mainOfficialContext.createLayoutTrackNumberWithOid(trackNumberOid).let { trackNumber ->
-            val referenceLine =
-                mainOfficialContext.saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
-                )
-
-            insertGeocodableTrack(
-                trackNumberId = trackNumber.id,
-                segments = segments,
-                referenceLineId = referenceLine.id,
+            mainOfficialContext.saveReferenceLine(
+                referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
             )
+
+            mainOfficialContext.save(locationTrack(trackNumber.id), trackGeometryOfSegments(segments))
         }
 
         val request = TestCoordinateToTrackAddressRequest(x = 0.0, y = 0.0, ratanumero_oid = searchOid.toString())
@@ -813,16 +817,11 @@ constructor(
 
         testOids.forEach { oid ->
             val trackNumber = mainOfficialContext.createLayoutTrackNumberWithOid(oid)
-            val referenceLine =
-                mainOfficialContext.saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
-                )
-
-            insertGeocodableTrack(
-                trackNumberId = trackNumber.id,
-                segments = segments,
-                referenceLineId = referenceLine.id,
+            mainOfficialContext.saveReferenceLine(
+                referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
             )
+
+            mainOfficialContext.save(locationTrack(trackNumber.id), trackGeometryOfSegments(segments))
         }
 
         testOids.forEach { oid ->
@@ -858,7 +857,9 @@ constructor(
     fun `Coordinate system argument is respected`() {
         // Helsinki Railway Station area: TM35FIN (385782.89, 6672277.83) ↔ WGS84 (24.9414003, 60.1713788)
         val trackStart = Point(385782.89, 6672277.83)
-        insertGeocodableTrack(segments = listOf(segment(trackStart, trackStart + Point(100.0, 100.0))))
+        mainOfficialContext.createLocationTrackWithReferenceLine(
+            trackGeometryOfSegments(listOf(segment(trackStart, trackStart + Point(100.0, 100.0))))
+        )
 
         // With EPSG:4326: x/y in the request body are WGS84, and the response x/y are also WGS84
         val trackStartWgs84 = transformNonKKJCoordinate(LAYOUT_SRID, WGS_84_SRID, trackStart)
@@ -869,36 +870,5 @@ constructor(
         assertNull(wgs84Response.features[0].properties?.get("virheet"))
         assertEquals(trackStartWgs84.x, wgs84Response.features[0].properties?.get("x") as Double, 0.0000001)
         assertEquals(trackStartWgs84.y, wgs84Response.features[0].properties?.get("y") as Double, 0.0000001)
-    }
-
-    private fun insertGeocodableTrack(
-        layoutContext: TestLayoutContext = mainOfficialContext,
-        trackNumberId: IntId<LayoutTrackNumber> = mainOfficialContext.createLayoutTrackNumber().id,
-        locationTrackName: String = "Test location track",
-        locationTrackType: LocationTrackType = LocationTrackType.MAIN,
-        segments: List<LayoutSegment> = listOf(segment(Point(-10.0, 0.0), Point(10.0, 0.0))),
-        referenceLineId: IntId<ReferenceLine> =
-            layoutContext
-                .saveReferenceLine(referenceLineAndGeometry(trackNumberId = trackNumberId, segments = segments))
-                .id,
-    ): GeocodableTrack {
-        val locationTrackId =
-            layoutContext
-                .saveLocationTrack(
-                    locationTrackAndGeometry(
-                        trackNumberId = trackNumberId,
-                        name = locationTrackName,
-                        type = locationTrackType,
-                        segments = segments,
-                    )
-                )
-                .id
-
-        return GeocodableTrack(
-            layoutContext = layoutContext.context,
-            trackNumber = trackNumberDao.get(layoutContext.context, trackNumberId)!!,
-            referenceLine = referenceLineDao.get(layoutContext.context, referenceLineId)!!,
-            locationTrack = locationTrackDao.get(layoutContext.context, locationTrackId)!!,
-        )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -356,8 +356,8 @@ constructor(
             (0..2).map { _ ->
                 val name = "Test track-${UUID.randomUUID()}"
                 mainOfficialContext
-                    .save(locationTrack(trackNumberId, name = name), trackGeometryOfSegments(segments))
-                    .let { mainOfficialContext.fetch(it.id) }
+                    .saveAndFetch(locationTrack(trackNumberId, name = name), trackGeometryOfSegments(segments))
+                    .first
             }
 
         tracks.forEach { track ->
@@ -485,8 +485,8 @@ constructor(
         assertEquals(track.description.toString(), properties["sijaintiraide_kuvaus"])
         assertEquals("kujaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
-        assertEquals(10, properties["ratametri"] as Int)
-        assertEquals(0, properties["ratametri_desimaalit"] as Int)
+        assertEquals("10", properties["ratametri"])
+        assertEquals("0", properties["ratametri_desimaalit"])
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -485,8 +485,8 @@ constructor(
         assertEquals(track.description.toString(), properties["sijaintiraide_kuvaus"])
         assertEquals("kujaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
-        assertEquals("10", properties["ratametri"])
-        assertEquals("0", properties["ratametri_desimaalit"])
+        assertEquals(10, properties["ratametri"])
+        assertEquals(0, properties["ratametri_desimaalit"])
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -20,11 +20,14 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
+import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.someReferenceLineGeometry
+import fi.fta.geoviite.infra.tracklayout.someTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -95,9 +98,7 @@ constructor(
     @Test
     fun `Missing track kilometer in a request should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry(), trackNumber)
 
         val request = TestTrackAddressToCoordinateRequest(ratametri = 0, ratanumero = trackNumber.toString())
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
@@ -112,9 +113,7 @@ constructor(
     @Test
     fun `Track kilometer under range in a request should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry(), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(ratakilometri = -1, ratametri = 0, ratanumero = trackNumber.toString())
@@ -131,9 +130,7 @@ constructor(
     @Test
     fun `Track kilometer over range in a request should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry(), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(
@@ -154,9 +151,7 @@ constructor(
     @Test
     fun `Missing track meter in a request should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry(), trackNumber)
 
         val request = TestTrackAddressToCoordinateRequest(ratakilometri = 123, ratanumero = trackNumber.toString())
 
@@ -172,9 +167,7 @@ constructor(
     @Test
     fun `Track meter under range in a request should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry(), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(
@@ -195,9 +188,7 @@ constructor(
     @Test
     fun `Track meter over range in a request should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
+        mainOfficialContext.createLocationTrackWithReferenceLine(someTrackGeometry(), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(
@@ -475,11 +466,8 @@ constructor(
     @Test
     fun `Valid single request using request params should succeed`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments), trackNumber)
 
         val params = mapOf("ratanumero" to trackNumber.toString(), "ratakilometri" to "0", "ratametri" to "400")
 
@@ -518,15 +506,14 @@ constructor(
     @Test
     fun `Basic request should default to return feature with basic and detailed data`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        val geocodableTrack =
-            extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumberId,
-                segments = segments,
-                locationTrackType = LocationTrackType.SIDE,
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.SIDE),
+                trackGeometryOfSegments(segments),
             )
 
         val request =
@@ -539,9 +526,9 @@ constructor(
                 "x" to 400.0,
                 "y" to 0.0,
                 "valimatka" to 0.0,
-                "ratanumero" to geocodableTrack.trackNumber.number.toString(),
-                "sijaintiraide" to geocodableTrack.locationTrack.name.toString(),
-                "sijaintiraide_kuvaus" to geocodableTrack.locationTrack.description.toString(),
+                "ratanumero" to trackNumber.toString(),
+                "sijaintiraide" to track.name.toString(),
+                "sijaintiraide_kuvaus" to track.description.toString(),
                 "sijaintiraide_tyyppi" to "sivuraide",
                 "ratakilometri" to 0,
                 "ratametri" to 400,
@@ -563,11 +550,8 @@ constructor(
     @Test
     fun `Request with all-false response data settings should succeed but not return any actual data`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
@@ -594,11 +578,8 @@ constructor(
     @Test
     fun `Response output can be set to only return basic feature data`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
@@ -624,11 +605,8 @@ constructor(
     @Test
     fun `Response output can be set to only return geometry data`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments), trackNumber)
 
         val request =
             TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
@@ -662,15 +640,13 @@ constructor(
     @Test
     fun `Response output can be set to only return detailed feature data`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        val geocodableTrack =
-            extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumberId,
-                locationTrackType = LocationTrackType.CHORD,
-                segments = segments,
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.CHORD),
+                trackGeometryOfSegments(segments),
             )
 
         val request =
@@ -689,9 +665,9 @@ constructor(
 
         assertNullSimpleProperties(properties)
 
-        assertEquals(geocodableTrack.trackNumber.number.toString(), properties["ratanumero"])
-        assertEquals(geocodableTrack.locationTrack.name.toString(), properties["sijaintiraide"])
-        assertEquals(geocodableTrack.locationTrack.description.toString(), properties["sijaintiraide_kuvaus"])
+        assertEquals(trackNumber.toString(), properties["ratanumero"])
+        assertEquals(track.name.toString(), properties["sijaintiraide"])
+        assertEquals(track.description.toString(), properties["sijaintiraide_kuvaus"])
         assertEquals("kujaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
         assertEquals(300, properties["ratametri"] as Int)
@@ -701,15 +677,14 @@ constructor(
     @Test
     fun `Response output data setting combination works`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        val geocodableTrack =
-            extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumberId,
-                locationTrackType = LocationTrackType.TRAP,
-                segments = segments,
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.TRAP),
+                trackGeometryOfSegments(segments),
             )
 
         val request =
@@ -741,9 +716,9 @@ constructor(
         assertEquals(0.0, ((properties["y"] as? Double)!!), 0.001)
         assertEquals(0.0, ((properties["valimatka"] as? Double)!!), 0.001)
 
-        assertEquals(geocodableTrack.trackNumber.number.toString(), properties["ratanumero"])
-        assertEquals(geocodableTrack.locationTrack.name.toString(), properties["sijaintiraide"])
-        assertEquals(geocodableTrack.locationTrack.description.toString(), properties["sijaintiraide_kuvaus"])
+        assertEquals(trackNumber.toString(), properties["ratanumero"])
+        assertEquals(track.name.toString(), properties["sijaintiraide"])
+        assertEquals(track.description.toString(), properties["sijaintiraide_kuvaus"])
         assertEquals("turvaraide", properties["sijaintiraide_tyyppi"])
         assertEquals(0, properties["ratakilometri"])
         assertEquals(request.ratametri, properties["ratametri"] as? Int)
@@ -753,14 +728,13 @@ constructor(
     @Test
     fun `Invalid location track type should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumberId,
-            locationTrackType = LocationTrackType.CHORD,
-            segments = segments,
+        mainOfficialContext.save(
+            locationTrack(trackNumberId, type = LocationTrackType.CHORD),
+            trackGeometryOfSegments(segments),
         )
 
         val request =
@@ -784,14 +758,13 @@ constructor(
     @Test
     fun `Invalid location track name should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumberId,
-            locationTrackType = LocationTrackType.CHORD,
-            segments = segments,
+        mainOfficialContext.save(
+            locationTrack(trackNumberId, type = LocationTrackType.CHORD),
+            trackGeometryOfSegments(segments),
         )
 
         val request =
@@ -812,14 +785,13 @@ constructor(
     @Test
     fun `Invalid track number should result in an error`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumberId,
-            locationTrackType = LocationTrackType.CHORD,
-            segments = segments,
+        mainOfficialContext.save(
+            locationTrack(trackNumberId, type = LocationTrackType.CHORD),
+            trackGeometryOfSegments(segments),
         )
 
         val request =
@@ -839,14 +811,13 @@ constructor(
     @Test
     fun `track number should not be deleted`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber, state = LayoutState.DELETED)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber, state = LayoutState.DELETED)).id
+        mainOfficialContext.saveReferenceLine(referenceLine(trackNumberId) to referenceLineGeometry(segments))
 
-        extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumberId,
-            locationTrackType = LocationTrackType.CHORD,
-            segments = segments,
+        mainOfficialContext.save(
+            locationTrack(trackNumberId, type = LocationTrackType.CHORD),
+            trackGeometryOfSegments(segments),
         )
 
         val request =
@@ -862,16 +833,14 @@ constructor(
     @Test
     fun `location track should not be deleted`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        val locationTrack =
-            extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumberId,
-                locationTrackType = LocationTrackType.CHORD,
-                segments = segments,
-                state = LocationTrackState.DELETED,
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(
+                locationTrack(trackNumberId, type = LocationTrackType.CHORD, state = LocationTrackState.DELETED),
+                trackGeometryOfSegments(segments),
             )
 
         val request =
@@ -879,7 +848,7 @@ constructor(
                 ratanumero = trackNumber.toString(),
                 ratakilometri = 0,
                 ratametri = 275,
-                sijaintiraide = locationTrack.locationTrack.name.toString(),
+                sijaintiraide = track.name.toString(),
             )
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
@@ -1102,9 +1071,7 @@ constructor(
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments), trackNumber)
 
         val decimalSearchTests = listOf(0.0, 0.123, 0.400, 0.999)
 
@@ -1192,12 +1159,11 @@ constructor(
     @Test
     fun `Coordinate system argument is respected`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         // Helsinki Railway Station area: TM35FIN (385782.89, 6672277.83) ↔ WGS84 (24.9414003, 60.1713788)
         val trackStart = Point(385782.89, 6672277.83)
         val segments = listOf(segment(trackStart, trackStart + Point(100.0, 100.0)))
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
+        mainOfficialContext.createLocationTrackWithReferenceLine(trackGeometryOfSegments(segments), trackNumber)
 
         val trackStartWgs84 = transformNonKKJCoordinate(LAYOUT_SRID, WGS_84_SRID, trackStart)
         val request =

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -1,7 +1,6 @@
 package fi.fta.geoviite.api.frameconverter.v1
 
 import TestGeoJsonFeatureCollection
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.api.assertContainsErrorMessage
 import fi.fta.geoviite.api.assertNullDetailedProperties
 import fi.fta.geoviite.api.assertNullSimpleProperties
@@ -63,7 +62,6 @@ class TrackAddressToCoordinateIT
 @Autowired
 constructor(
     mockMvc: MockMvc,
-    val extTestDataService: ExtApiTestDataServiceV1,
     val locationTrackDao: LocationTrackDao,
     val locationTrackService: LocationTrackService,
 ) : DBTestBase() {
@@ -209,18 +207,13 @@ constructor(
     @Test
     fun `Location track filter should work`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val tracksUnderTest =
             (0..3).map { _ ->
-                extTestDataService.insertGeocodableTrack(
-                    trackNumberId = trackNumberId,
-                    referenceLineId = referenceLineId,
-                    segments = segments,
-                )
+                mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(segments)).first
             }
 
         tracksUnderTest.forEach { trackUnderTest ->
@@ -229,24 +222,23 @@ constructor(
                     ratakilometri = 0,
                     ratametri = 500,
                     ratanumero = trackNumber.toString(),
-                    sijaintiraide = trackUnderTest.locationTrack.name.toString(),
+                    sijaintiraide = trackUnderTest.name.toString(),
                 )
 
             val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
             val properties = featureCollection.features[0].properties
 
             assertSimpleFeatureCollection(featureCollection)
-            assertEquals(trackUnderTest.locationTrack.name.toString(), properties?.get("sijaintiraide"))
+            assertEquals(trackUnderTest.name.toString(), properties?.get("sijaintiraide"))
         }
     }
 
     @Test
     fun `Location track type filter should work`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val tracksUnderTest =
             listOf(
@@ -257,12 +249,10 @@ constructor(
                 )
                 .map { (locationTrackTypeName, locationTrackType) ->
                     val track =
-                        extTestDataService.insertGeocodableTrack(
-                            trackNumberId = trackNumberId,
-                            referenceLineId = referenceLineId,
-                            locationTrackType = locationTrackType,
-                            segments = segments,
-                        )
+                        mainOfficialContext.saveAndFetch(
+                            locationTrack(trackNumberId, type = locationTrackType),
+                            trackGeometryOfSegments(segments),
+                        ).first
 
                     locationTrackTypeName to track
                 }
@@ -281,7 +271,7 @@ constructor(
 
             assertSimpleFeatureCollection(featureCollection)
 
-            assertEquals(trackUnderTest.locationTrack.name.toString(), properties?.get("sijaintiraide"))
+            assertEquals(trackUnderTest.name.toString(), properties?.get("sijaintiraide"))
             assertEquals(locationTrackTypeName, properties?.get("sijaintiraide_tyyppi"))
         }
     }
@@ -310,11 +300,11 @@ constructor(
     @Test
     fun `Request matching multiple track addresses should return coordinates for all of them`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val referenceLineSegments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-        val referenceLineId =
-            mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(referenceLineSegments)).id
+        val trackNumberId =
+            mainOfficialContext
+                .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(referenceLineSegments), trackNumber)
+                .id
 
         val amountOfLocationTracks = 4
         val positionedTrackSegments =
@@ -323,12 +313,7 @@ constructor(
             }
 
         val tracksUnderTest = positionedTrackSegments.map { trackSegments ->
-            extTestDataService.insertGeocodableTrack(
-                layoutContext = mainOfficialContext,
-                trackNumberId = trackNumberId,
-                referenceLineId = referenceLineId,
-                segments = trackSegments,
-            )
+            mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(trackSegments)).first
         }
 
         val request =
@@ -337,7 +322,7 @@ constructor(
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
         assertEquals(amountOfLocationTracks, featureCollection.features.size)
 
-        val locationTrackNamesUnderTest = tracksUnderTest.map { track -> track.locationTrack.name.toString() }
+        val locationTrackNamesUnderTest = tracksUnderTest.map { track -> track.name.toString() }
         val locationTrackNamesReturned =
             featureCollection.features.map { feature -> feature.properties?.get("sijaintiraide") }
 
@@ -352,10 +337,10 @@ constructor(
     @Test
     fun `Request matching the address of some location tracks should succeed and return data only for the matches`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
-        val referenceLineId =
+        val refLineSegments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumberId =
             mainOfficialContext
-                .save(referenceLine(trackNumberId), referenceLineGeometry(segment(Point(0.0, 0.0), Point(1000.0, 0.0))))
+                .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(refLineSegments), trackNumber)
                 .id
 
         val tracksUnderTest =
@@ -367,12 +352,10 @@ constructor(
                     listOf(segment(Point(100.0, 0.0), Point(501.0, 0.0))), // Should be in the response
                 )
                 .map { trackSegments ->
-                    extTestDataService.insertGeocodableTrack(
-                        layoutContext = mainOfficialContext,
-                        trackNumberId = trackNumberId,
-                        referenceLineId = referenceLineId,
-                        segments = trackSegments,
-                    )
+                    mainOfficialContext.saveAndFetch(
+                        locationTrack(trackNumberId),
+                        trackGeometryOfSegments(trackSegments),
+                    ).first
                 }
 
         val request =
@@ -384,7 +367,7 @@ constructor(
         assertEquals(
             expected =
                 listOf(tracksUnderTest[0], tracksUnderTest[1], tracksUnderTest[4])
-                    .map { track -> track.locationTrack.name.toString() }
+                    .map { track -> track.name.toString() }
                     .toSet(),
             actual = featureCollection.features.map { f -> f.properties?.get("sijaintiraide") }.toSet(),
         )
@@ -393,24 +376,13 @@ constructor(
     @Test
     fun `Valid multi request with some matches should partially succeed`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val segments2 = listOf(segment(Point(0.0, 100.0), Point(1000.0, 100.0)))
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
-
-        extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumberId,
-            referenceLineId = referenceLineId,
-            segments = segments,
-        )
-
-        extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumberId,
-            referenceLineId = referenceLineId,
-            segments = segments2,
-        )
+        mainOfficialContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segments))
+        mainOfficialContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segments2))
 
         val requests =
             listOf(
@@ -868,19 +840,17 @@ constructor(
         val trackNumberNames =
             (0..3).map { trackNumberIndex ->
                 val trackNumber = testDBService.getUnusedTrackNumber()
-                val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-
-                val referenceLineId =
-                    mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
+                val trackNumberId =
+                    mainOfficialContext
+                        .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber)
+                        .id
 
                 // different numbers of overlapping location tracks on each track number, including
                 // 0
                 (0 until trackNumberIndex).map { i ->
-                    extTestDataService.insertGeocodableTrack(
-                        trackNumberId = trackNumberId,
-                        referenceLineId = referenceLineId,
-                        segments = segments,
-                        locationTrackName = "track $i",
+                    mainOfficialContext.save(
+                        locationTrack(trackNumberId, name = "track $i"),
+                        trackGeometryOfSegments(segments),
                     )
                 }
                 trackNumber.toString()
@@ -921,22 +891,11 @@ constructor(
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        extTestDataService
-            .insertGeocodableTrack(
-                trackNumberId = trackNumberId,
-                referenceLineId = referenceLineId,
-                segments = segments,
-            )
-            .let { geocodableTrack ->
-                locationTrackDao.insertExternalId(
-                    geocodableTrack.locationTrack.id as IntId,
-                    geocodableTrack.layoutContext.branch,
-                    testOid,
-                )
-            }
+        val (track, _) = mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(segments))
+        locationTrackDao.insertExternalId(track.id as IntId, mainOfficialContext.context.branch, testOid)
 
         val request =
             TestTrackAddressToCoordinateRequest(
@@ -962,23 +921,13 @@ constructor(
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
-        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
+        val trackNumberId =
+            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         testOids.forEach { oid ->
-            extTestDataService
-                .insertGeocodableTrack(
-                    trackNumberId = trackNumberId,
-                    referenceLineId = referenceLineId,
-                    segments = segments,
-                )
-                .let { geocodableTrack ->
-                    locationTrackDao.insertExternalId(
-                        geocodableTrack.locationTrack.id as IntId,
-                        geocodableTrack.layoutContext.branch,
-                        oid,
-                    )
-                }
+            val (track, _) =
+                mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(segments))
+            locationTrackDao.insertExternalId(track.id as IntId, mainOfficialContext.context.branch, oid)
         }
 
         testOids.forEach { oid ->
@@ -1005,14 +954,8 @@ constructor(
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         mainOfficialContext.createLayoutTrackNumberWithOid(trackNumberOid).also { trackNumber ->
-            val referenceLineId =
-                mainOfficialContext.save(referenceLine(trackNumber.id), referenceLineGeometry(segments)).id
-
-            extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumber.id,
-                referenceLineId = referenceLineId,
-                segments = segments,
-            )
+            mainOfficialContext.save(referenceLine(trackNumber.id), referenceLineGeometry(segments))
+            mainOfficialContext.save(locationTrack(trackNumber.id), trackGeometryOfSegments(segments))
         }
 
         val request =
@@ -1039,14 +982,8 @@ constructor(
 
         testOids.forEach { oid ->
             val trackNumber = mainOfficialContext.createLayoutTrackNumberWithOid(oid)
-            val referenceLineId =
-                mainOfficialContext.save(referenceLine(trackNumber.id), referenceLineGeometry(segments)).id
-
-            extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumber.id,
-                referenceLineId = referenceLineId,
-                segments = segments,
-            )
+            mainOfficialContext.save(referenceLine(trackNumber.id), referenceLineGeometry(segments))
+            mainOfficialContext.save(locationTrack(trackNumber.id), trackGeometryOfSegments(segments))
         }
 
         testOids.forEach { oid ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -22,7 +22,9 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
+import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.trackNumber
@@ -396,15 +398,14 @@ constructor(
                 )
                 .id
 
-        val tracksUnderTest =
-            positionedTrackSegments.map { trackSegments ->
-                extTestDataService.insertGeocodableTrack(
-                    layoutContext = layoutContext,
-                    trackNumberId = trackNumber.id as IntId,
-                    referenceLineId = referenceLineId,
-                    segments = trackSegments,
-                )
-            }
+        val tracksUnderTest = positionedTrackSegments.map { trackSegments ->
+            extTestDataService.insertGeocodableTrack(
+                layoutContext = layoutContext,
+                trackNumberId = trackNumber.id as IntId,
+                referenceLineId = referenceLineId,
+                segments = trackSegments,
+            )
+        }
 
         val request =
             TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 500, ratanumero = trackNumberName)
@@ -426,19 +427,11 @@ constructor(
 
     @Test
     fun `Request matching the address of some location tracks should succeed and return data only for the matches`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
-
-        val referenceLineSegments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val referenceLineId =
-            layoutContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id as IntId, segments = referenceLineSegments)
-                )
+            mainOfficialContext
+                .save(referenceLine(trackNumberId), referenceLineGeometry(segment(Point(0.0, 0.0), Point(1000.0, 0.0))))
                 .id
 
         val tracksUnderTest =
@@ -451,15 +444,15 @@ constructor(
                 )
                 .map { trackSegments ->
                     extTestDataService.insertGeocodableTrack(
-                        layoutContext = layoutContext,
-                        trackNumberId = trackNumber.id,
+                        layoutContext = mainOfficialContext,
+                        trackNumberId = trackNumberId,
                         referenceLineId = referenceLineId,
                         segments = trackSegments,
                     )
                 }
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 500, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 500, ratanumero = trackNumber.toString())
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
         assertEquals(3, featureCollection.features.size)
@@ -1075,15 +1068,14 @@ constructor(
                 trackNumberName
             }
 
-        val requests =
-            trackNumberNames.mapIndexed { index, trackNumberName ->
-                TestTrackAddressToCoordinateRequest(
-                    ratakilometri = 0,
-                    ratametri = 500,
-                    ratanumero = trackNumberName,
-                    tunniste = "req $index",
-                )
-            }
+        val requests = trackNumberNames.mapIndexed { index, trackNumberName ->
+            TestTrackAddressToCoordinateRequest(
+                ratakilometri = 0,
+                ratametri = 500,
+                ratanumero = trackNumberName,
+                tunniste = "req $index",
+            )
+        }
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, requests)
         val propertiess = featureCollection.features.map { it.properties!! }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -9,21 +9,18 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.geography.WGS_84_SRID
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType
 import fi.fta.geoviite.infra.tracklayout.referenceLine
-import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
@@ -64,7 +61,6 @@ class TrackAddressToCoordinateIT
 constructor(
     mockMvc: MockMvc,
     val extTestDataService: ExtApiTestDataServiceV1,
-    val layoutTrackNumberDao: LayoutTrackNumberDao,
     val locationTrackDao: LocationTrackDao,
     val locationTrackService: LocationTrackService,
 ) : DBTestBase() {
@@ -405,32 +401,22 @@ constructor(
 
     @Test
     fun `Valid multi request with some matches should partially succeed`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val segments2 = listOf(segment(Point(0.0, 100.0), Point(1000.0, 100.0)))
 
-        val referenceLineId =
-            layoutContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id as IntId, segments = segments)
-                )
-                .id
+        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
 
         extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumber.id as IntId,
+            trackNumberId = trackNumberId,
             referenceLineId = referenceLineId,
             segments = segments,
         )
 
         extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumber.id as IntId,
+            trackNumberId = trackNumberId,
             referenceLineId = referenceLineId,
             segments = segments2,
         )
@@ -442,7 +428,7 @@ constructor(
                     tunniste = "second-${UUID.randomUUID()}",
                     ratakilometri = 0,
                     ratametri = 1200,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                 ),
 
                 // Should match two tracks -> 2 result features.
@@ -450,7 +436,7 @@ constructor(
                     tunniste = "first-${UUID.randomUUID()}",
                     ratakilometri = 0,
                     ratametri = 500,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                 ),
 
                 // Shouldn't match any track numbers -> error feature.
@@ -488,31 +474,22 @@ constructor(
 
     @Test
     fun `Valid single request using request params should succeed`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId, segments = segments)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
 
-        val params = mapOf("ratanumero" to trackNumberName, "ratakilometri" to "0", "ratametri" to "400")
+        val params = mapOf("ratanumero" to trackNumber.toString(), "ratakilometri" to "0", "ratametri" to "400")
 
         api.fetchFeatureCollectionSingle(API_COORDINATES, params, HttpStatus.OK)
     }
 
     @Test
     fun `Response feature should include identifier of the request if submitted`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-            layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-        }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val identifiers = listOf("some-identifier-${UUID.randomUUID()}", "some-identifier-${UUID.randomUUID()}")
 
@@ -522,13 +499,13 @@ constructor(
                     tunniste = identifiers[0],
                     ratakilometri = 0,
                     ratametri = 500,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                 ),
                 TestTrackAddressToCoordinateRequest(
                     tunniste = identifiers[1],
                     ratakilometri = 0,
                     ratametri = 500,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                 ),
             )
 
@@ -540,25 +517,20 @@ constructor(
 
     @Test
     fun `Basic request should default to return feature with basic and detailed data`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val geocodableTrack =
             extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumber.id as IntId,
+                trackNumberId = trackNumberId,
                 segments = segments,
                 locationTrackType = LocationTrackType.SIDE,
             )
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 400)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
@@ -590,20 +562,15 @@ constructor(
 
     @Test
     fun `Request with all-false response data settings should succeed but not return any actual data`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId, segments = segments)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 400)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
 
         // The thingy under test.
         val params =
@@ -626,20 +593,15 @@ constructor(
 
     @Test
     fun `Response output can be set to only return basic feature data`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId, segments = segments)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 400)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
 
         // The thingy under test.
         val params = mapOf(RESPONSE_DETAILED_FEATURE_KEY to false)
@@ -661,20 +623,15 @@ constructor(
 
     @Test
     fun `Response output can be set to only return geometry data`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId, segments = segments)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 400)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 400)
 
         // The thingy under test.
         val params =
@@ -704,25 +661,20 @@ constructor(
 
     @Test
     fun `Response output can be set to only return detailed feature data`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val geocodableTrack =
             extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumber.id as IntId,
+                trackNumberId = trackNumberId,
                 locationTrackType = LocationTrackType.CHORD,
                 segments = segments,
             )
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 300)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 300)
 
         // The thingy under test.
         val params = mapOf(RESPONSE_BASIC_FEATURE_KEY to false)
@@ -748,25 +700,20 @@ constructor(
 
     @Test
     fun `Response output data setting combination works`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val geocodableTrack =
             extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumber.id as IntId,
+                trackNumberId = trackNumberId,
                 locationTrackType = LocationTrackType.TRAP,
                 segments = segments,
             )
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 275)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 275)
 
         // The thingy under test.
         val params =
@@ -805,25 +752,20 @@ constructor(
 
     @Test
     fun `Invalid location track type should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumber.id as IntId,
+            trackNumberId = trackNumberId,
             locationTrackType = LocationTrackType.CHORD,
             segments = segments,
         )
 
         val request =
             TestTrackAddressToCoordinateRequest(
-                ratanumero = trackNumberName,
+                ratanumero = trackNumber.toString(),
                 ratakilometri = 0,
                 ratametri = 275,
                 sijaintiraide_tyyppi = "something",
@@ -841,25 +783,20 @@ constructor(
 
     @Test
     fun `Invalid location track name should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumber.id as IntId,
+            trackNumberId = trackNumberId,
             locationTrackType = LocationTrackType.CHORD,
             segments = segments,
         )
 
         val request =
             TestTrackAddressToCoordinateRequest(
-                ratanumero = trackNumberName,
+                ratanumero = trackNumber.toString(),
                 ratakilometri = 0,
                 ratametri = 275,
                 sijaintiraide = "@",
@@ -874,18 +811,13 @@ constructor(
 
     @Test
     fun `Invalid track number should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumber.id as IntId,
+            trackNumberId = trackNumberId,
             locationTrackType = LocationTrackType.CHORD,
             segments = segments,
         )
@@ -906,25 +838,19 @@ constructor(
 
     @Test
     fun `track number should not be deleted`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName), state = LayoutState.DELETED)).id.let {
-                trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber, state = LayoutState.DELETED)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         extTestDataService.insertGeocodableTrack(
-            trackNumberId = trackNumber.id as IntId,
+            trackNumberId = trackNumberId,
             locationTrackType = LocationTrackType.CHORD,
             segments = segments,
         )
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 275)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 275)
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
@@ -935,19 +861,14 @@ constructor(
 
     @Test
     fun `location track should not be deleted`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val locationTrack =
             extTestDataService.insertGeocodableTrack(
-                trackNumberId = trackNumber.id as IntId,
+                trackNumberId = trackNumberId,
                 locationTrackType = LocationTrackType.CHORD,
                 segments = segments,
                 state = LocationTrackState.DELETED,
@@ -955,7 +876,7 @@ constructor(
 
         val request =
             TestTrackAddressToCoordinateRequest(
-                ratanumero = trackNumberName,
+                ratanumero = trackNumber.toString(),
                 ratakilometri = 0,
                 ratametri = 275,
                 sijaintiraide = locationTrack.locationTrack.name.toString(),
@@ -973,36 +894,27 @@ constructor(
 
     @Test
     fun `request batch can contain multiple track numbers`() {
-        val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         val trackNumberNames =
             (0..3).map { trackNumberIndex ->
-                val trackNumberName = testDBService.getUnusedTrackNumber().value
-                val trackNumber =
-                    layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                        layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-                    }
+                val trackNumber = testDBService.getUnusedTrackNumber()
+                val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
                 val referenceLineId =
-                    layoutContext
-                        .saveReferenceLine(
-                            referenceLineAndGeometry(trackNumberId = trackNumber.id as IntId, segments = segments)
-                        )
-                        .id
-                trackNumber to referenceLineId
+                    mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
 
                 // different numbers of overlapping location tracks on each track number, including
                 // 0
                 (0 until trackNumberIndex).map { i ->
                     extTestDataService.insertGeocodableTrack(
-                        trackNumberId = trackNumber.id as IntId,
+                        trackNumberId = trackNumberId,
                         referenceLineId = referenceLineId,
                         segments = segments,
                         locationTrackName = "track $i",
                     )
                 }
-                trackNumberName
+                trackNumber.toString()
             }
 
         val requests = trackNumberNames.mapIndexed { index, trackNumberName ->
@@ -1037,16 +949,14 @@ constructor(
         val testOid = Oid<LocationTrack>("000.000.000")
         val searchOid = Oid<LocationTrack>("111.111.111")
 
-        val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(layoutContext, trackNumberName, segments)
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
+        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
 
         extTestDataService
             .insertGeocodableTrack(
-                layoutContext = layoutContext,
                 trackNumberId = trackNumberId,
                 referenceLineId = referenceLineId,
                 segments = segments,
@@ -1063,7 +973,7 @@ constructor(
             TestTrackAddressToCoordinateRequest(
                 ratakilometri = 0,
                 ratametri = 500,
-                ratanumero = trackNumberName,
+                ratanumero = trackNumber.toString(),
                 sijaintiraide_oid = searchOid.toString(),
             )
 
@@ -1080,17 +990,15 @@ constructor(
     fun `Location track OID filter only finds tracks with the given location track OID`() {
         val testOids = listOf<Oid<LocationTrack>>(someOid(), someOid())
 
-        val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(layoutContext, trackNumberName, segments)
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
+        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
 
         testOids.forEach { oid ->
             extTestDataService
                 .insertGeocodableTrack(
-                    layoutContext = layoutContext,
                     trackNumberId = trackNumberId,
                     referenceLineId = referenceLineId,
                     segments = segments,
@@ -1109,7 +1017,7 @@ constructor(
                 TestTrackAddressToCoordinateRequest(
                     ratakilometri = 0,
                     ratametri = 500,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                     sijaintiraide_oid = oid.toString(),
                 )
 
@@ -1125,19 +1033,15 @@ constructor(
         val trackNumberOid = Oid<LayoutTrackNumber>("000.000.000")
         val searchOid = Oid<LayoutTrackNumber>("111.111.111")
 
-        val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         mainOfficialContext.createLayoutTrackNumberWithOid(trackNumberOid).also { trackNumber ->
-            val referenceLine =
-                mainOfficialContext.saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
-                )
+            val referenceLineId =
+                mainOfficialContext.save(referenceLine(trackNumber.id), referenceLineGeometry(segments)).id
 
             extTestDataService.insertGeocodableTrack(
-                layoutContext = layoutContext,
                 trackNumberId = trackNumber.id,
-                referenceLineId = referenceLine.id,
+                referenceLineId = referenceLineId,
                 segments = segments,
             )
         }
@@ -1162,20 +1066,16 @@ constructor(
     fun `Track number OID filter only finds tracks with the given track number OID`() {
         val testOids = listOf<Oid<LayoutTrackNumber>>(someOid(), someOid())
 
-        val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
         testOids.forEach { oid ->
             val trackNumber = mainOfficialContext.createLayoutTrackNumberWithOid(oid)
-            val referenceLine =
-                mainOfficialContext.saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id, segments = segments)
-                )
+            val referenceLineId =
+                mainOfficialContext.save(referenceLine(trackNumber.id), referenceLineGeometry(segments)).id
 
             extTestDataService.insertGeocodableTrack(
-                layoutContext = layoutContext,
                 trackNumberId = trackNumber.id,
-                referenceLineId = referenceLine.id,
+                referenceLineId = referenceLineId,
                 segments = segments,
             )
         }
@@ -1199,16 +1099,12 @@ constructor(
             val ratametri: Double? = null,
         ) : FrameConverterTestRequest()
 
-        val layoutContext = mainOfficialContext
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
 
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId, segments = segments)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
 
         val decimalSearchTests = listOf(0.0, 0.123, 0.400, 0.999)
 
@@ -1217,7 +1113,7 @@ constructor(
                 TestTrackAddressToCoordinateRequestWithDoubleAddress(
                     ratakilometri = 0,
                     ratametri = 500.0 + testDecimals,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                 )
 
             val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
@@ -1295,22 +1191,17 @@ constructor(
 
     @Test
     fun `Coordinate system argument is respected`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         // Helsinki Railway Station area: TM35FIN (385782.89, 6672277.83) ↔ WGS84 (24.9414003, 60.1713788)
         val trackStart = Point(385782.89, 6672277.83)
         val segments = listOf(segment(trackStart, trackStart + Point(100.0, 100.0)))
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId, segments = segments)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId, segments = segments)
 
         val trackStartWgs84 = transformNonKKJCoordinate(LAYOUT_SRID, WGS_84_SRID, trackStart)
         val request =
-            TestTrackAddressToCoordinateRequest(ratanumero = trackNumberName, ratakilometri = 0, ratametri = 0)
+            TestTrackAddressToCoordinateRequest(ratanumero = trackNumber.toString(), ratakilometri = 0, ratametri = 0)
 
         api.fetchFeatureCollectionBatch(API_COORDINATES, request).also { defaultResponse ->
             assertNull(defaultResponse.features[0].properties?.get("virheet"))

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -27,6 +27,7 @@ import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
+import fi.fta.geoviite.infra.tracklayout.someReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -97,17 +98,12 @@ constructor(
 
     @Test
     fun `Missing track kilometer in a request should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId)
-
-        val request = TestTrackAddressToCoordinateRequest(ratametri = 0, ratanumero = trackNumberName)
+        val request = TestTrackAddressToCoordinateRequest(ratametri = 0, ratanumero = trackNumber.toString())
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
         assertSimpleFeatureCollection(featureCollection)
@@ -117,69 +113,56 @@ constructor(
         )
     }
 
-    /* TODO Enable after GVT-2757?
     @Test
     fun `Track kilometer under range in a request should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        val trackNumber =
-            layoutTrackNumberDao.insert(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
-
-        frameConverterTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = -1, ratametri = 0, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(ratakilometri = -1, ratametri = 0, ratanumero = trackNumber.toString())
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
         assertSimpleFeatureCollection(featureCollection)
-        assertEquals(
+        assertContainsErrorMessage(
             "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen).",
             featureCollection.features[0].properties?.get("virheet"),
         )
-    } */
+    }
 
-    /* TODO Enable after GVT-2757?
     @Test
     fun `Track kilometer over range in a request should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        val trackNumber =
-            layoutTrackNumberDao.insert(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
-
-        frameConverterTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = 10000, ratametri = 0, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(
+                ratakilometri = 10000,
+                ratametri = 0,
+                ratanumero = trackNumber.toString(),
+            )
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
         assertSimpleFeatureCollection(featureCollection)
-        assertEquals(
-            "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen)",
+        assertContainsErrorMessage(
+            "Pyyntö sisälsi virheellisen rataosoitteen (eli ratakilometri+ratametri yhdistelmä oli virheellinen).",
             featureCollection.features[0].properties?.get("virheet"),
         )
-    } */
+    }
 
     @Test
     fun `Missing track meter in a request should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
 
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId)
-
-        val request = TestTrackAddressToCoordinateRequest(ratakilometri = 123, ratanumero = trackNumberName)
+        val request = TestTrackAddressToCoordinateRequest(ratakilometri = 123, ratanumero = trackNumber.toString())
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
@@ -192,18 +175,17 @@ constructor(
 
     @Test
     fun `Track meter under range in a request should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = 123, ratametri = -10001, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(
+                ratakilometri = 123,
+                ratametri = -10001,
+                ratanumero = trackNumber.toString(),
+            )
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
@@ -216,18 +198,17 @@ constructor(
 
     @Test
     fun `Track meter over range in a request should result in an error`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
-
-        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumber.id as IntId)
+        extTestDataService.insertGeocodableTrack(trackNumberId = trackNumberId)
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = 123, ratametri = 10000, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(
+                ratakilometri = 123,
+                ratametri = 10000,
+                ratanumero = trackNumber.toString(),
+            )
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
 
@@ -240,26 +221,16 @@ constructor(
 
     @Test
     fun `Location track filter should work`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
+
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
-
-        val referenceLineId =
-            layoutContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id as IntId, segments = segments)
-                )
-                .id
+        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
 
         val tracksUnderTest =
             (0..3).map { _ ->
                 extTestDataService.insertGeocodableTrack(
-                    trackNumberId = trackNumber.id as IntId,
+                    trackNumberId = trackNumberId,
                     referenceLineId = referenceLineId,
                     segments = segments,
                 )
@@ -270,7 +241,7 @@ constructor(
                 TestTrackAddressToCoordinateRequest(
                     ratakilometri = 0,
                     ratametri = 500,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                     sijaintiraide = trackUnderTest.locationTrack.name.toString(),
                 )
 
@@ -284,22 +255,11 @@ constructor(
 
     @Test
     fun `Location track type filter should work`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
-
-        val referenceLineId =
-            layoutContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id as IntId, segments = segments)
-                )
-                .id
+        val referenceLineId = mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(segments)).id
 
         val tracksUnderTest =
             listOf(
@@ -311,7 +271,7 @@ constructor(
                 .map { (locationTrackTypeName, locationTrackType) ->
                     val track =
                         extTestDataService.insertGeocodableTrack(
-                            trackNumberId = trackNumber.id as IntId,
+                            trackNumberId = trackNumberId,
                             referenceLineId = referenceLineId,
                             locationTrackType = locationTrackType,
                             segments = segments,
@@ -325,7 +285,7 @@ constructor(
                 TestTrackAddressToCoordinateRequest(
                     ratakilometri = 0,
                     ratametri = 500,
-                    ratanumero = trackNumberName,
+                    ratanumero = trackNumber.toString(),
                     sijaintiraide_tyyppi = locationTrackTypeName,
                 )
 
@@ -341,27 +301,14 @@ constructor(
 
     @Test
     fun `Request with matching track number but without any matching tracks should succeed but return error feature`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
         // Valid track number which can be geocoded, but no location tracks use it.
-        layoutTrackNumberDao
-            .save(trackNumber(TrackNumber(trackNumberName)))
-            .id
-            .let { trackNumberId -> layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!! }
-            .let { trackNumber ->
-                layoutContext
-                    .saveReferenceLine(
-                        referenceLineAndGeometry(
-                            trackNumberId = trackNumber.id as IntId,
-                            segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0))),
-                        )
-                    )
-                    .id
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        mainOfficialContext.save(trackNumber(trackNumber)).also { tn ->
+            mainOfficialContext.save(referenceLine(tn.id), someReferenceLineGeometry()).id
+        }
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 0, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 0, ratanumero = trackNumber.toString())
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
         val properties = featureCollection.features[0].properties
@@ -375,15 +322,12 @@ constructor(
 
     @Test
     fun `Request matching multiple track addresses should return coordinates for all of them`() {
-        val layoutContext = mainOfficialContext
-        val trackNumberName = testDBService.getUnusedTrackNumber().value
-
-        val trackNumber =
-            layoutTrackNumberDao.save(trackNumber(TrackNumber(trackNumberName))).id.let { trackNumberId ->
-                layoutTrackNumberDao.get(layoutContext.context, trackNumberId)!!
-            }
+        val trackNumber = testDBService.getUnusedTrackNumber()
+        val trackNumberId = mainOfficialContext.save(trackNumber(trackNumber)).id
 
         val referenceLineSegments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
+        val referenceLineId =
+            mainOfficialContext.save(referenceLine(trackNumberId), referenceLineGeometry(referenceLineSegments)).id
 
         val amountOfLocationTracks = 4
         val positionedTrackSegments =
@@ -391,24 +335,17 @@ constructor(
                 listOf(segment(Point(0.0, index * 100.0), Point(1000.0, index * 100.0)))
             }
 
-        val referenceLineId =
-            layoutContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId = trackNumber.id as IntId, segments = referenceLineSegments)
-                )
-                .id
-
         val tracksUnderTest = positionedTrackSegments.map { trackSegments ->
             extTestDataService.insertGeocodableTrack(
-                layoutContext = layoutContext,
-                trackNumberId = trackNumber.id as IntId,
+                layoutContext = mainOfficialContext,
+                trackNumberId = trackNumberId,
                 referenceLineId = referenceLineId,
                 segments = trackSegments,
             )
         }
 
         val request =
-            TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 500, ratanumero = trackNumberName)
+            TestTrackAddressToCoordinateRequest(ratakilometri = 0, ratametri = 500, ratanumero = trackNumber.toString())
 
         val featureCollection = api.fetchFeatureCollectionBatch(API_COORDINATES, request)
         assertEquals(amountOfLocationTracks, featureCollection.features.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -28,6 +28,10 @@ import fi.fta.geoviite.infra.tracklayout.someReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.someTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,10 +40,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 private const val API_COORDINATES: FrameConverterUrl = "/rata-vkm/v1/koordinaatit"
 
@@ -60,11 +60,8 @@ private data class TestTrackAddressToCoordinateRequest(
 @AutoConfigureMockMvc
 class TrackAddressToCoordinateIT
 @Autowired
-constructor(
-    mockMvc: MockMvc,
-    val locationTrackDao: LocationTrackDao,
-    val locationTrackService: LocationTrackService,
-) : DBTestBase() {
+constructor(mockMvc: MockMvc, val locationTrackDao: LocationTrackDao, val locationTrackService: LocationTrackService) :
+    DBTestBase() {
 
     private val api = FrameConverterTestApiService(mockMvc)
 
@@ -209,7 +206,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val tracksUnderTest =
             (0..3).map { _ ->
@@ -238,7 +235,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val tracksUnderTest =
             listOf(
@@ -249,10 +246,12 @@ constructor(
                 )
                 .map { (locationTrackTypeName, locationTrackType) ->
                     val track =
-                        mainOfficialContext.saveAndFetch(
-                            locationTrack(trackNumberId, type = locationTrackType),
-                            trackGeometryOfSegments(segments),
-                        ).first
+                        mainOfficialContext
+                            .saveAndFetch(
+                                locationTrack(trackNumberId, type = locationTrackType),
+                                trackGeometryOfSegments(segments),
+                            )
+                            .first
 
                     locationTrackTypeName to track
                 }
@@ -303,7 +302,7 @@ constructor(
         val referenceLineSegments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(referenceLineSegments), trackNumber)
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(referenceLineSegments), trackNumber)
                 .id
 
         val amountOfLocationTracks = 4
@@ -340,7 +339,7 @@ constructor(
         val refLineSegments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(refLineSegments), trackNumber)
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(refLineSegments), trackNumber)
                 .id
 
         val tracksUnderTest =
@@ -352,10 +351,9 @@ constructor(
                     listOf(segment(Point(100.0, 0.0), Point(501.0, 0.0))), // Should be in the response
                 )
                 .map { trackSegments ->
-                    mainOfficialContext.saveAndFetch(
-                        locationTrack(trackNumberId),
-                        trackGeometryOfSegments(trackSegments),
-                    ).first
+                    mainOfficialContext
+                        .saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(trackSegments))
+                        .first
                 }
 
         val request =
@@ -379,7 +377,7 @@ constructor(
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val segments2 = listOf(segment(Point(0.0, 100.0), Point(1000.0, 100.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         mainOfficialContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segments))
         mainOfficialContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segments2))
@@ -480,7 +478,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val (track, _) =
             mainOfficialContext.saveAndFetch(
@@ -614,7 +612,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
         val (track, _) =
             mainOfficialContext.saveAndFetch(
                 locationTrack(trackNumberId, type = LocationTrackType.CHORD),
@@ -651,7 +649,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val (track, _) =
             mainOfficialContext.saveAndFetch(
@@ -702,7 +700,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         mainOfficialContext.save(
             locationTrack(trackNumberId, type = LocationTrackType.CHORD),
@@ -732,7 +730,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         mainOfficialContext.save(
             locationTrack(trackNumberId, type = LocationTrackType.CHORD),
@@ -759,7 +757,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         mainOfficialContext.save(
             locationTrack(trackNumberId, type = LocationTrackType.CHORD),
@@ -807,7 +805,7 @@ constructor(
         val trackNumber = testDBService.getUnusedTrackNumber()
         val segments = listOf(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         val (track, _) =
             mainOfficialContext.saveAndFetch(
@@ -842,7 +840,7 @@ constructor(
                 val trackNumber = testDBService.getUnusedTrackNumber()
                 val trackNumberId =
                     mainOfficialContext
-                        .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber)
+                        .createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber)
                         .id
 
                 // different numbers of overlapping location tracks on each track number, including
@@ -892,9 +890,10 @@ constructor(
 
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
-        val (track, _) = mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(segments))
+        val (track, _) =
+            mainOfficialContext.saveAndFetch(locationTrack(trackNumberId), trackGeometryOfSegments(segments))
         locationTrackDao.insertExternalId(track.id as IntId, mainOfficialContext.context.branch, testOid)
 
         val request =
@@ -922,7 +921,7 @@ constructor(
 
         val trackNumber = testDBService.getUnusedTrackNumber()
         val trackNumberId =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
+            mainOfficialContext.createTrackNumberAndReferenceLine(referenceLineGeometry(segments), trackNumber).id
 
         testOids.forEach { oid ->
             val (track, _) =

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
@@ -11,17 +11,13 @@ import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
-import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
-import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
-import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.util.FreeText
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -41,7 +37,6 @@ class ExtLocationTrackCollectionIT
 @Autowired
 constructor(
     mockMvc: MockMvc,
-    private val layoutTrackNumberService: LayoutTrackNumberService,
     private val locationTrackService: LocationTrackService,
     private val extTestDataService: ExtApiTestDataServiceV1,
 ) : DBTestBase() {
@@ -60,17 +55,12 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
         val tracks =
-            listOf(1, 2, 3)
-                .map { _ -> mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id }
-                .map { trackId ->
-                    trackId to
-                        someOid<LocationTrack>().also { oid ->
-                            locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-                        }
-                }
+            listOf(1, 2, 3).map { _ ->
+                mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
+            }
 
         testDBService.publish(
             trackNumbers = listOf(trackNumberId),
@@ -95,27 +85,15 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
         val officialTracks =
-            listOf(1, 2, 3)
-                .map { index ->
-                    mainDraftContext
-                        .saveLocationTrack(
-                            locationTrackAndGeometry(
-                                trackNumberId,
-                                segment,
-                                description = "official description $index",
-                            )
-                        )
-                        .id
-                }
-                .map { trackId ->
-                    trackId to
-                        someOid<LocationTrack>().also { oid ->
-                            locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-                        }
-                }
+            listOf(1, 2, 3).map { index ->
+                mainDraftContext.saveWithOid(
+                    locationTrack(trackNumberId, description = "official description $index"),
+                    trackGeometryOfSegments(segment),
+                )
+            }
 
         val newestPublication =
             testDBService.publish(
@@ -138,11 +116,10 @@ constructor(
                 )
             }
 
-        mainDraftContext
-            .saveLocationTrack(
-                locationTrackAndGeometry(trackNumberId, segment, description = "some draft-only track description")
-            )
-            .id
+        mainDraftContext.save(
+            locationTrack(trackNumberId, description = "some draft-only track description"),
+            trackGeometryOfSegments(segment),
+        )
 
         val response = api.locationTrackCollection.get()
 
@@ -168,19 +145,15 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         val tracksToPublications =
             listOf(1, 2, 3).map { totalAmountOfLocationTracks ->
-                val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
+                val (trackId, trackOid) =
+                    mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
                 val publication = testDBService.publish(locationTracks = listOf(trackId))
-
-                val trackOid =
-                    someOid<LocationTrack>().also { oid ->
-                        locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-                    }
 
                 Triple(totalAmountOfLocationTracks, trackOid, publication)
             }
@@ -211,13 +184,10 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
-        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
-        val trackOid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-            }
+        val (trackId, trackOid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
         val publication =
             testDBService.publish(
@@ -255,14 +225,13 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
-        val deletedTrackId =
-            mainDraftContext
-                .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = LocationTrackState.DELETED))
-                .id
-
-        locationTrackService.insertExternalId(LayoutBranch.main, deletedTrackId, someOid())
+        val (deletedTrackId, _) =
+            mainDraftContext.saveWithOid(
+                locationTrack(trackNumberId, state = LocationTrackState.DELETED),
+                trackGeometryOfSegments(segment),
+            )
 
         testDBService.publish(
             trackNumbers = listOf(trackNumberId),
@@ -281,20 +250,17 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
         val tracks =
             LocationTrackState.entries
                 .filter { it != LocationTrackState.DELETED }
                 .map { state ->
-                    val trackId =
-                        mainDraftContext
-                            .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
-                            .id
-                    val trackOid =
-                        someOid<LocationTrack>().also { oid ->
-                            locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-                        }
+                    val (trackId, trackOid) =
+                        mainDraftContext.saveWithOid(
+                            locationTrack(trackNumberId, state = state),
+                            trackGeometryOfSegments(segment),
+                        )
 
                     trackOid to trackId
                 }
@@ -322,16 +288,13 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
         val allTracks =
             listOf(1, 2, 3, 4).map { _ ->
-                val trackVersion = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
+                val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-                val oid =
-                    someOid<LocationTrack>().also { oid ->
-                        locationTrackService.insertExternalId(LayoutBranch.main, trackVersion.id, oid)
-                    }
+                val oid = mainDraftContext.generateOid(trackVersion.id)
 
                 val (track, geometry) = locationTrackService.getWithGeometry(trackVersion)
 
@@ -348,7 +311,7 @@ constructor(
         val modifiedDescription = "this is a modified description, previous publication uuid=${initialPublication.uuid}"
         val modifiedTracks =
             listOf(allTracks[1], allTracks[2]).map { (oid, track, geometry) ->
-                mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+                mainDraftContext.save(track.copy(description = FreeText(modifiedDescription)), geometry)
 
                 oid to track.id as IntId
             }
@@ -373,18 +336,9 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val trackGeom = trackGeometryOfSegments(segment(Point(20.0, 0.0), Point(40.0, 0.0)))
-        val (trackId1, trackOid1) =
-            mainDraftContext.save(locationTrack(trackNumberId1), trackGeom).id.let {
-                it to mainDraftContext.generateOid(it)
-            }
-        val (trackId2, trackOid2) =
-            mainDraftContext.save(locationTrack(trackNumberId1), trackGeom).id.let {
-                it to mainDraftContext.generateOid(it)
-            }
-        val (trackId3, _) =
-            mainDraftContext.save(locationTrack(trackNumberId2), trackGeom).id.let {
-                it to mainDraftContext.generateOid(it)
-            }
+        val (trackId1, trackOid1) = mainDraftContext.saveWithOid(locationTrack(trackNumberId1), trackGeom)
+        val (trackId2, trackOid2) = mainDraftContext.saveWithOid(locationTrack(trackNumberId1), trackGeom)
+        val (trackId3, _) = mainDraftContext.saveWithOid(locationTrack(trackNumberId2), trackGeom)
 
         val basePublication =
             testDBService.publish(
@@ -450,15 +404,14 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
         val tracks =
             LocationTrackState.entries.map { state ->
-                val trackId =
-                    mainDraftContext
-                        .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
-                        .id
-                trackId to mainDraftContext.generateOid(trackId)
+                mainDraftContext.saveWithOid(
+                    locationTrack(trackNumberId, state = state),
+                    trackGeometryOfSegments(segment),
+                )
             }
 
         val initialPublication =
@@ -496,14 +449,11 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
-        val trackVersion = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
+        val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
         val trackId = trackVersion.id
-        val trackOid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-            }
+        val trackOid = mainDraftContext.generateOid(trackId)
 
         val publicationStart =
             testDBService.publish(
@@ -545,14 +495,11 @@ constructor(
         val (trackNumberId, referenceLineId) =
             extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
 
-        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
+        mainDraftContext.generateOid(trackNumberId)
 
-        val trackVersion = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
+        val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
         val trackId = trackVersion.id
-        val trackOid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-            }
+        val trackOid = mainDraftContext.generateOid(trackId)
 
         val publicationStart =
             testDBService.publish(
@@ -588,14 +535,16 @@ constructor(
         val (otherTnId, otherRlId, _) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        val matchingTrackId =
-            mainDraftContext
-                .saveLocationTrack(locationTrackAndGeometry(matchingTnId, segment, name = "MATCHING TRACK"))
-                .id
-        val matchingOid = testDBService.generateOid(matchingTrackId, LayoutBranch.main)
-        val otherTrackId =
-            mainDraftContext.saveLocationTrack(locationTrackAndGeometry(otherTnId, segment, name = "OTHER TRACK")).id
-        testDBService.generateOid(otherTrackId, LayoutBranch.main)
+        val (matchingTrackId, matchingOid) =
+            mainDraftContext.saveWithOid(
+                locationTrack(matchingTnId, name = "MATCHING TRACK"),
+                trackGeometryOfSegments(segment),
+            )
+        val (otherTrackId, _) =
+            mainDraftContext.saveWithOid(
+                locationTrack(otherTnId, name = "OTHER TRACK"),
+                trackGeometryOfSegments(segment),
+            )
 
         testDBService.publish(
             trackNumbers = listOf(matchingTnId, otherTnId),
@@ -627,18 +576,16 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val matchingTrackVersion =
-            mainDraftContext.saveLocationTrack(locationTrackAndGeometry(matchingTnId, segment, name = "MATCHING TRACK"))
+            mainDraftContext.save(
+                locationTrack(matchingTnId, name = "MATCHING TRACK"),
+                trackGeometryOfSegments(segment),
+            )
         val matchingTrackId = matchingTrackVersion.id
-        val matchingOid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, matchingTrackId, oid)
-            }
+        val matchingOid = mainDraftContext.generateOid(matchingTrackId)
         val otherTrackVersion =
-            mainDraftContext.saveLocationTrack(locationTrackAndGeometry(otherTnId, segment, name = "OTHER TRACK"))
+            mainDraftContext.save(locationTrack(otherTnId, name = "OTHER TRACK"), trackGeometryOfSegments(segment))
         val otherTrackId = otherTrackVersion.id
-        someOid<LocationTrack>().also { oid ->
-            locationTrackService.insertExternalId(LayoutBranch.main, otherTrackId, oid)
-        }
+        mainDraftContext.generateOid(otherTrackId)
 
         val fromPublication =
             testDBService

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
@@ -72,20 +72,20 @@ constructor(
                         }
                 }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = tracks.map { (id, _) -> id },
         )
 
-        val newestButEmptyPublication = extTestDataService.publishInMain()
+        val newestButEmptyPublication = testDBService.publish()
         val response = api.locationTrackCollection.get()
 
         assertEquals(newestButEmptyPublication.uuid.toString(), response.rataverkon_versio)
         assertEquals(tracks.size, response.sijaintiraiteet.size)
 
         val responseOids = response.sijaintiraiteet.map { track -> track.sijaintiraide_oid }
-        tracks.forEach { (id, oid) -> assertTrue(oid.toString() in responseOids) }
+        tracks.forEach { (_, oid) -> assertTrue(oid.toString() in responseOids) }
     }
 
     @Test
@@ -118,16 +118,15 @@ constructor(
                 }
 
         val newestPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = officialTracks.map { (id, _) -> id },
             )
 
-        val tracksBeforeModifications =
-            officialTracks.map { (id, oid) ->
-                oid to locationTrackService.getWithGeometryOrThrow(MainLayoutContext.official, id)
-            }
+        val tracksBeforeModifications = officialTracks.map { (id, oid) ->
+            oid to locationTrackService.getWithGeometryOrThrow(MainLayoutContext.official, id)
+        }
 
         tracksBeforeModifications
             .map { (_, trackAndGeometry) -> trackAndGeometry }
@@ -171,12 +170,12 @@ constructor(
 
         layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
 
-        extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+        testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         val tracksToPublications =
             listOf(1, 2, 3).map { totalAmountOfLocationTracks ->
                 val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
-                val publication = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+                val publication = testDBService.publish(locationTracks = listOf(trackId))
 
                 val trackOid =
                     someOid<LocationTrack>().also { oid ->
@@ -221,7 +220,7 @@ constructor(
             }
 
         val publication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -265,7 +264,7 @@ constructor(
 
         locationTrackService.insertExternalId(LayoutBranch.main, deletedTrackId, someOid())
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(deletedTrackId),
@@ -300,7 +299,7 @@ constructor(
                     trackOid to trackId
                 }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = tracks.map { (_, id) -> id },
@@ -340,7 +339,7 @@ constructor(
             }
 
         val initialPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = allTracks.map { (_, track, _) -> track.id as IntId },
@@ -354,11 +353,15 @@ constructor(
                 oid to track.id as IntId
             }
 
-        val secondPublication = extTestDataService.publishInMain(locationTracks = modifiedTracks.map { (_, id) -> id })
-        val response = api.locationTrackCollection.getModified("alkuversio" to initialPublication.uuid.toString())
-
+        val secondPublication = testDBService.publish(locationTracks = modifiedTracks.map { (_, id) -> id })
+        val response = api.locationTrackCollection.getModifiedSince(initialPublication.uuid)
         assertEquals(modifiedTracks.size, response.sijaintiraiteet.size)
+        assertEquals(secondPublication.uuid.toString(), response.loppuversio)
         response.sijaintiraiteet.forEach { track -> assertEquals(modifiedDescription, track.kuvaus) }
+        assertEquals(
+            response,
+            api.locationTrackCollection.getModifiedBetween(initialPublication.uuid, secondPublication.uuid),
+        )
     }
 
     @Test
@@ -384,7 +387,7 @@ constructor(
             }
 
         val basePublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId1, trackNumberId2),
                 referenceLines = listOf(referenceLineId1, referenceLineId2),
                 locationTracks = listOf(trackId1, trackId2, trackId3),
@@ -399,7 +402,7 @@ constructor(
             mainOfficialContext.fetch(referenceLineId1)!!.copy(startAddress = TrackMeter("0001+0010.000")),
             referenceLineGeometry(segment),
         )
-        val rlPublication = extTestDataService.publishInMain(referenceLines = listOf(referenceLineId1))
+        val rlPublication = testDBService.publish(referenceLines = listOf(referenceLineId1))
         getTracksByTrackNumberOids(trackNumberOid1).forEach { track ->
             assertEquals("0001+0030.000", track.alkusijainti?.rataosoite)
         }
@@ -416,7 +419,7 @@ constructor(
         initUser()
         val kmpId =
             mainDraftContext.save(kmPost(trackNumberId1, KmNumber(4), gkLocation = kmPostGkLocation(10.0, 0.0))).id
-        val kmpPublication = extTestDataService.publishInMain(kmPosts = listOf(kmpId))
+        val kmpPublication = testDBService.publish(kmPosts = listOf(kmpId))
         getTracksByTrackNumberOids(trackNumberOid1).forEach { track ->
             assertEquals("0004+0010.000", track.alkusijainti?.rataosoite)
         }
@@ -449,35 +452,28 @@ constructor(
 
         layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumberId, someOid())
 
-        val initialTracks =
+        val tracks =
             LocationTrackState.entries.map { state ->
-                val trackVersion =
-                    mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
-                val oid =
-                    someOid<LocationTrack>().also { oid ->
-                        locationTrackService.insertExternalId(LayoutBranch.main, trackVersion.id, oid)
-                    }
-
-                val (track, geometry) = locationTrackService.getWithGeometry(trackVersion)
-
-                Triple(oid, track, geometry)
+                val trackId =
+                    mainDraftContext
+                        .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
+                        .id
+                trackId to mainDraftContext.generateOid(trackId)
             }
 
         val initialPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
-                locationTracks = initialTracks.map { (_, track, _) -> track.id as IntId },
+                locationTracks = tracks.map { (id, _) -> id },
             )
 
         val modifiedTrackDescription = "this is a modified track from publicationUuid=${initialPublication.uuid}"
-        val modifiedTracks =
-            initialTracks.map { (oid, track, geometry) ->
-                mainDraftContext.save(track.copy(description = FreeText(modifiedTrackDescription)))
-                oid to track.id as IntId
-            }
+        tracks.forEach { (id, _) ->
+            mainDraftContext.mutate(id) { track -> track.copy(description = FreeText(modifiedTrackDescription)) }
+        }
 
-        val secondPublication = extTestDataService.publishInMain(locationTracks = modifiedTracks.map { (_, id) -> id })
+        val secondPublication = testDBService.publish(locationTracks = tracks.map { (id, _) -> id })
 
         val response =
             api.locationTrackCollection.getModified(
@@ -485,7 +481,7 @@ constructor(
                 "loppuversio" to secondPublication.uuid.toString(),
             )
 
-        assertEquals(modifiedTracks.size, response.sijaintiraiteet.size)
+        assertEquals(tracks.size, response.sijaintiraiteet.size)
         response.sijaintiraiteet.forEach { track -> assertEquals(modifiedTrackDescription, track.kuvaus) }
     }
 
@@ -493,7 +489,7 @@ constructor(
     fun `Location track modifications listing respects start & end track layout version arguments`() {
         // Create an initial publication which should not be in any of the following responses.
         // This verifies that the api does not always use the first publication as the comparison base.
-        extTestDataService.publishInMain()
+        testDBService.publish()
 
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
@@ -510,7 +506,7 @@ constructor(
             }
 
         val publicationStart =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -521,11 +517,11 @@ constructor(
             mainDraftContext.save(track.copy(description = FreeText(modifiedDescription)), geometry)
         }
 
-        val publicationEnd = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publicationEnd = testDBService.publish(locationTracks = listOf(trackId))
 
         // Create a publication after the last one which should not be used either.
         // This verifies that the api does not always use the last publication as the comparison target.
-        extTestDataService.publishInMain()
+        testDBService.publish()
 
         val response =
             api.locationTrackCollection.getModified(
@@ -559,7 +555,7 @@ constructor(
             }
 
         val publicationStart =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -570,7 +566,7 @@ constructor(
             mainDraftContext.save(track.copy(description = FreeText(modifiedDescription)), geometry)
         }
 
-        val publicationEnd = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publicationEnd = testDBService.publish(locationTracks = listOf(trackId))
 
         val response = api.locationTrackCollection.getModified("alkuversio" to publicationStart.uuid.toString())
 
@@ -601,7 +597,7 @@ constructor(
             mainDraftContext.saveLocationTrack(locationTrackAndGeometry(otherTnId, segment, name = "OTHER TRACK")).id
         testDBService.generateOid(otherTrackId, LayoutBranch.main)
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(matchingTnId, otherTnId),
             referenceLines = listOf(matchingRlId, otherRlId),
             locationTracks = listOf(matchingTrackId, otherTrackId),
@@ -645,8 +641,8 @@ constructor(
         }
 
         val fromPublication =
-            extTestDataService
-                .publishInMain(
+            testDBService
+                .publish(
                     trackNumbers = listOf(matchingTnId, otherTnId),
                     referenceLines = listOf(matchingRlId, otherRlId),
                     locationTracks = listOf(matchingTrackId, otherTrackId),
@@ -659,7 +655,7 @@ constructor(
         locationTrackService.getWithGeometry(otherTrackVersion).let { (track, geometry) ->
             mainDraftContext.save(track.copy(description = FreeText("changed other")), geometry)
         }
-        extTestDataService.publishInMain(locationTracks = listOf(matchingTrackId, otherTrackId))
+        testDBService.publish(locationTracks = listOf(matchingTrackId, otherTrackId))
 
         // TrackNumber OID match (exact)
         api.locationTrackCollection

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.IntId
@@ -16,9 +15,11 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FreeText
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -35,11 +36,7 @@ import org.springframework.test.web.servlet.MockMvc
 @AutoConfigureMockMvc
 class ExtLocationTrackCollectionIT
 @Autowired
-constructor(
-    mockMvc: MockMvc,
-    private val locationTrackService: LocationTrackService,
-    private val extTestDataService: ExtApiTestDataServiceV1,
-) : DBTestBase() {
+constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackService) : DBTestBase() {
 
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
@@ -52,10 +49,8 @@ constructor(
     fun `Newest location track listing is returned by default`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val tracks =
             listOf(1, 2, 3).map { _ ->
@@ -82,10 +77,8 @@ constructor(
     fun `Newest location track listing does not contain draft tracks`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val officialTracks =
             listOf(1, 2, 3).map { index ->
@@ -142,10 +135,8 @@ constructor(
     fun `Location track listing respects the track layout version argument`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -181,10 +172,8 @@ constructor(
 
         val segment = segment(helsinkiRailwayStationTm35Fin, helsinkiRailwayStationTm35FinPlus10000)
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val (trackId, trackOid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
@@ -222,10 +211,8 @@ constructor(
     fun `Location track listing should not contain deleted tracks`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val (deletedTrackId, _) =
             mainDraftContext.saveWithOid(
@@ -247,10 +234,8 @@ constructor(
     fun `Location track listing should contain all but deleted tracks`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val tracks =
             LocationTrackState.entries
@@ -285,10 +270,8 @@ constructor(
     fun `Location track modifications listing only lists modified location tracks`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val allTracks =
             listOf(1, 2, 3, 4).map { _ ->
@@ -330,10 +313,12 @@ constructor(
     @Test
     fun `Location track modifications listing lists tracks with calculated changes`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId1, referenceLineId1, trackNumberOid1) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
-        val (trackNumberId2, referenceLineId2, trackNumberOid2) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId1, trackNumberOid1) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId1 = mainDraftContext.save(referenceLine(trackNumberId1), referenceLineGeometry(segment)).id
+        val (trackNumberId2, trackNumberOid2) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId2 = mainDraftContext.save(referenceLine(trackNumberId2), referenceLineGeometry(segment)).id
 
         val trackGeom = trackGeometryOfSegments(segment(Point(20.0, 0.0), Point(40.0, 0.0)))
         val (trackId1, trackOid1) = mainDraftContext.saveWithOid(locationTrack(trackNumberId1), trackGeom)
@@ -401,10 +386,8 @@ constructor(
     fun `Location track modifications listing contains tracks in all states (including deleted)`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val tracks =
             LocationTrackState.entries.map { state ->
@@ -446,10 +429,8 @@ constructor(
 
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
         val trackId = trackVersion.id
@@ -492,10 +473,8 @@ constructor(
     fun `Location track modifications listing uses the newest track layout version if end version is not supplied`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId) =
-            extTestDataService.insertTrackNumberAndReferenceLine(mainDraftContext, segments = listOf(segment))
-
-        mainDraftContext.generateOid(trackNumberId)
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
         val trackId = trackVersion.id
@@ -530,10 +509,11 @@ constructor(
     fun `Location track collection is filtered by track number OID & track name`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (matchingTnId, matchingRlId, matchingTnOid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
-        val (otherTnId, otherRlId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (matchingTnId, matchingTnOid) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val matchingRlId = mainDraftContext.save(referenceLine(matchingTnId), referenceLineGeometry(segment)).id
+        val (otherTnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val otherRlId = mainDraftContext.save(referenceLine(otherTnId), referenceLineGeometry(segment)).id
 
         val (matchingTrackId, matchingOid) =
             mainDraftContext.saveWithOid(
@@ -570,10 +550,11 @@ constructor(
     fun `Location track change-list is filtered by track number OID & track name`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (matchingTnId, matchingRlId, matchingTnOid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
-        val (otherTnId, otherRlId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (matchingTnId, matchingTnOid) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val matchingRlId = mainDraftContext.save(referenceLine(matchingTnId), referenceLineGeometry(segment)).id
+        val (otherTnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val otherRlId = mainDraftContext.save(referenceLine(otherTnId), referenceLineGeometry(segment)).id
 
         val matchingTrackVersion =
             mainDraftContext.save(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
@@ -69,7 +69,7 @@ constructor(
             }
 
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(track.id as IntId),
@@ -89,36 +89,32 @@ constructor(
         val (trackNumberId, referenceLineId, _) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        val (track, geometry) =
-            mainDraftContext
-                .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
-                .let(locationTrackService::getWithGeometry)
+        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
 
         val oid =
             someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, track.id as IntId, oid)
+                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
             }
 
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
-                locationTracks = listOf(track.id as IntId),
+                locationTracks = listOf(trackId),
             )
 
-        val publication2 = extTestDataService.publishInMain()
+        val publication2 = testDBService.publish()
 
         val modifiedDescription = "modified description after publication=${publication1.uuid}"
-        mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+        mainDraftContext.mutate(trackId) { track -> track.copy(description = FreeText(modifiedDescription)) }
 
-        val publication3 = extTestDataService.publishInMain(locationTracks = listOf(track.id))
+        val publication3 = testDBService.publish(locationTracks = listOf(trackId))
 
         val responses =
             listOf(publication1, publication2, publication3).map { publication ->
-                val response = api.locationTracks.get(oid, "rataverkon_versio" to publication.uuid.toString())
-                assertEquals(publication.uuid.toString(), response.rataverkon_versio)
-
-                response
+                api.locationTracks.get(oid, "rataverkon_versio" to publication.uuid.toString()).also {
+                    assertEquals(publication.uuid.toString(), it.rataverkon_versio)
+                }
             }
 
         assertNotEquals(modifiedDescription, responses[0].sijaintiraide.kuvaus)
@@ -150,7 +146,7 @@ constructor(
                 locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
             }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -183,7 +179,7 @@ constructor(
         val oid = mainDraftContext.generateOid(trackId)
 
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -198,7 +194,7 @@ constructor(
         initUser()
         mainDraftContext.fetch(trackId).also { track -> mainDraftContext.save(track!!, newGeometry) }
 
-        val publication2 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication2 = testDBService.publish(locationTracks = listOf(trackId))
         api.locationTrackGeometry.get(oid).also { response ->
             assertEquals(publication2.uuid.toString(), response.rataverkon_versio)
             assertGeometryMatches(response, oid, "0001+0110.000", "0001+0190.000", newGeometry, 81)
@@ -240,7 +236,7 @@ constructor(
                 locationTrackService.insertExternalId(LayoutBranch.main, track.id, oid)
             }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(track.id),
@@ -282,7 +278,7 @@ constructor(
                 locationTrackService.insertExternalId(LayoutBranch.main, track.id, oid)
             }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(track.id),
@@ -324,7 +320,7 @@ constructor(
                 Triple(trackOid, trackId, state)
             }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = tracks.map { (_, id, _) -> id },
@@ -360,7 +356,7 @@ constructor(
             }
 
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = tracks.map { (_, track, _) -> track.id as IntId },
@@ -371,8 +367,7 @@ constructor(
             mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
         }
 
-        val publication2 =
-            extTestDataService.publishInMain(locationTracks = tracks.map { (_, track, _) -> track.id as IntId })
+        val publication2 = testDBService.publish(locationTracks = tracks.map { (_, track, _) -> track.id as IntId })
 
         tracks.forEach { (oid, track, _) ->
             val response =
@@ -400,7 +395,7 @@ constructor(
         val trackOid = mainDraftContext.generateOid(trackId)
 
         val basePublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 locationTracks = listOf(trackId),
@@ -413,7 +408,7 @@ constructor(
             mainOfficialContext.fetch(rlId)!!.copy(startAddress = TrackMeter("0001+0010.000")),
             rlGeom,
         )
-        val rlPublication = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val rlPublication = testDBService.publish(referenceLines = listOf(rlId))
         assertEquals("0001+0030.000", getExtLocationTrack(trackOid).alkusijainti?.rataosoite)
         api.locationTracks.getModifiedBetween(trackOid, basePublication.uuid, rlPublication.uuid).also { mod ->
             assertEquals("0001+0030.000", mod.sijaintiraide.alkusijainti?.rataosoite)
@@ -422,7 +417,7 @@ constructor(
 
         initUser()
         val kmpId = mainDraftContext.save(kmPost(tnId, KmNumber(4), gkLocation = kmPostGkLocation(10.0, 0.0))).id
-        val kmpPublication = extTestDataService.publishInMain(kmPosts = listOf(kmpId))
+        val kmpPublication = testDBService.publish(kmPosts = listOf(kmpId))
         assertEquals("0004+0010.000", getExtLocationTrack(trackOid).alkusijainti?.rataosoite)
 
         api.locationTracks.getModifiedBetween(trackOid, basePublication.uuid, kmpPublication.uuid).also { mod ->
@@ -448,7 +443,7 @@ constructor(
         val oid = mainDraftContext.generateOid(trackId)
 
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -460,7 +455,7 @@ constructor(
 
         initUser()
         mainDraftContext.mutate(trackId) { track -> track.copy(state = LocationTrackState.DELETED) }
-        val publication2 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication2 = testDBService.publish(locationTracks = listOf(trackId))
 
         api.locationTrackGeometry.assertDoesntExist(oid)
         api.locationTrackGeometry.assertDoesntExistAtVersion(oid, publication2.uuid)
@@ -480,7 +475,7 @@ constructor(
         val trackId = mainDraftContext.save(locationTrack(tnId), trackGeom).id
         val trackOid = mainDraftContext.generateOid(trackId)
         val initPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 locationTracks = listOf(trackId),
@@ -498,7 +493,7 @@ constructor(
         initUser()
         val (origTrack, origGeom) = mainDraftContext.fetchLocationTrackWithGeometry(trackId)!!
         mainDraftContext.saveLocationTrack(origTrack.copy(state = LocationTrackState.DELETED) to origGeom)
-        val deletePublication = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val deletePublication = testDBService.publish(locationTracks = listOf(trackId))
 
         api.locationTracks.get(trackOid).also { track ->
             assertEquals(startWithoutAddress, track.sijaintiraide.alkusijainti)
@@ -523,10 +518,7 @@ constructor(
                 startAddress = TrackMeter("0001+0100.000"),
             )
         val publication0 =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(trackNumberId),
-                referenceLines = listOf(referenceLineId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         // Publication 1 adds a new track
         val geometry1 =
@@ -538,7 +530,7 @@ constructor(
         val trackId = mainDraftContext.save(locationTrack(trackNumberId), geometry1).id
         val oid = mainDraftContext.generateOid(trackId)
 
-        val publication1 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication1 = testDBService.publish(locationTracks = listOf(trackId))
 
         api.locationTrackGeometry.get(oid).also { response ->
             assertEquals(publication1.uuid.toString(), response.rataverkon_versio)
@@ -572,7 +564,7 @@ constructor(
             )
         initUser()
         mainDraftContext.save(mainDraftContext.fetch(trackId)!!, geometry2)
-        val publication2 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication2 = testDBService.publish(locationTracks = listOf(trackId))
 
         api.locationTrackGeometry.get(oid).also { response ->
             assertEquals(publication2.uuid.toString(), response.rataverkon_versio)
@@ -620,7 +612,7 @@ constructor(
         // Publication 3 removes the geometry
         initUser()
         mainDraftContext.save(mainDraftContext.fetch(trackId)!!.copy(state = LocationTrackState.DELETED), geometry2)
-        val publication3 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication3 = testDBService.publish(locationTracks = listOf(trackId))
 
         api.locationTrackGeometry.assertNoModificationSince(oid, publication3.uuid)
 
@@ -652,7 +644,7 @@ constructor(
         val oid = mainDraftContext.generateOid(trackId)
 
         val basePub =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 locationTracks = listOf(trackId),
@@ -668,7 +660,7 @@ constructor(
             mainOfficialContext.fetch(rlId)!!.copy(startAddress = TrackMeter("0001+0010.000")),
             rlGeom,
         )
-        val rlPub = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val rlPub = testDBService.publish(referenceLines = listOf(rlId))
         api.locationTrackGeometry.get(oid).osoitevali!!.also { interval ->
             assertEquals("0001+0030.000", interval.alkuosoite)
             assertEquals("0001+0050.000", interval.loppuosoite)
@@ -691,7 +683,7 @@ constructor(
 
         initUser()
         val kmpId = mainDraftContext.save(kmPost(tnId, KmNumber(4), gkLocation = kmPostGkLocation(30.0, 0.0))).id
-        val kmpPub = extTestDataService.publishInMain(kmPosts = listOf(kmpId))
+        val kmpPub = testDBService.publish(kmPosts = listOf(kmpId))
 
         api.locationTrackGeometry.get(oid).osoitevali!!.also { interval ->
             assertEquals("0001+0030.000", interval.alkuosoite)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
@@ -5,7 +5,6 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
-import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -20,11 +19,9 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.locationTrack
-import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
-import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.util.FreeText
@@ -58,25 +55,19 @@ constructor(
         val (trackNumberId, referenceLineId, _) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        val (track, geometry) =
-            mainDraftContext
-                .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
-                .let(locationTrackService::getWithGeometry)
-
-        val oid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, track.id as IntId, oid)
-            }
+        val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
+        val oid = mainDraftContext.generateOid(trackVersion.id)
+        val (track, geometry) = locationTrackService.getWithGeometry(trackVersion)
 
         val publication1 =
             testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
-                locationTracks = listOf(track.id as IntId),
+                locationTracks = listOf(trackVersion.id),
             )
 
         val modifiedDescription = "modified description after publication=${publication1.uuid}"
-        mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+        mainDraftContext.save(track.copy(description = FreeText(modifiedDescription)), geometry)
 
         val responseAfterCreatingDraftTrack = api.locationTracks.get(oid)
         assertEquals(publication1.uuid.toString(), responseAfterCreatingDraftTrack.rataverkon_versio)
@@ -89,12 +80,8 @@ constructor(
         val (trackNumberId, referenceLineId, _) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
-
-        val oid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-            }
+        val (trackId, oid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
         val publication1 =
             testDBService.publish(
@@ -140,11 +127,8 @@ constructor(
         val (trackNumberId, referenceLineId, _) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
-        val oid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-            }
+        val (trackId, oid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
         testDBService.publish(
             trackNumbers = listOf(trackNumberId),
@@ -175,8 +159,7 @@ constructor(
             )
 
         val geometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
-        val trackId = mainDraftContext.save(locationTrack(trackNumberId), geometry).id
-        val oid = mainDraftContext.generateOid(trackId)
+        val (trackId, oid) = mainDraftContext.saveWithOid(locationTrack(trackNumberId), geometry)
 
         val publication1 =
             testDBService.publish(
@@ -230,16 +213,13 @@ constructor(
                 startAddress = TrackMeter(KmNumber(0), startM.toBigDecimal()),
             )
 
-        val track = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
-        val oid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, track.id, oid)
-            }
+        val (trackId, oid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
         testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
-            locationTracks = listOf(track.id),
+            locationTracks = listOf(trackId),
         )
 
         Resolution.entries
@@ -272,16 +252,13 @@ constructor(
                 startAddress = TrackMeter(KmNumber("0000"), startM.toBigDecimal()),
             )
 
-        val track = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment))
-        val oid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, track.id, oid)
-            }
+        val (trackId, oid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
         testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
-            locationTracks = listOf(track.id),
+            locationTracks = listOf(trackId),
         )
 
         Resolution.entries
@@ -307,15 +284,11 @@ constructor(
 
         val tracks =
             LocationTrackState.entries.map { state ->
-                val trackId =
-                    mainDraftContext
-                        .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
-                        .id
-
-                val trackOid =
-                    someOid<LocationTrack>().also { oid ->
-                        locationTrackService.insertExternalId(LayoutBranch.main, trackId, oid)
-                    }
+                val (trackId, trackOid) =
+                    mainDraftContext.saveWithOid(
+                        locationTrack(trackNumberId, state = state),
+                        trackGeometryOfSegments(segment),
+                    )
 
                 Triple(trackOid, trackId, state)
             }
@@ -342,15 +315,10 @@ constructor(
 
         val tracks =
             LocationTrackState.entries.map { state ->
-                val (track, geometry) =
-                    mainDraftContext
-                        .saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment, state = state))
-                        .let(locationTrackService::getWithGeometry)
-
-                val trackOid =
-                    someOid<LocationTrack>().also { oid ->
-                        locationTrackService.insertExternalId(LayoutBranch.main, track.id as IntId, oid)
-                    }
+                val trackVersion =
+                    mainDraftContext.save(locationTrack(trackNumberId, state = state), trackGeometryOfSegments(segment))
+                val trackOid = mainDraftContext.generateOid(trackVersion.id)
+                val (track, geometry) = locationTrackService.getWithGeometry(trackVersion)
 
                 Triple(trackOid, track, geometry)
             }
@@ -364,7 +332,7 @@ constructor(
 
         val modifiedDescription = "this is a modified location track after publication=${publication1.uuid}"
         tracks.forEach { (_, track, geometry) ->
-            mainDraftContext.saveLocationTrack(track.copy(description = FreeText(modifiedDescription)) to geometry)
+            mainDraftContext.save(track.copy(description = FreeText(modifiedDescription)), geometry)
         }
 
         val publication2 = testDBService.publish(locationTracks = tracks.map { (_, track, _) -> track.id as IntId })
@@ -391,8 +359,7 @@ constructor(
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
         val trackGeom = trackGeometryOfSegments(segment(Point(20.0, 0.0), Point(40.0, 0.0)))
-        val trackId = mainDraftContext.save(locationTrack(tnId), trackGeom).id
-        val trackOid = mainDraftContext.generateOid(trackId)
+        val (trackId, trackOid) = mainDraftContext.saveWithOid(locationTrack(tnId), trackGeom)
 
         val basePublication =
             testDBService.publish(
@@ -439,8 +406,8 @@ constructor(
                 segments = listOf(segment),
                 startAddress = TrackMeter("0001+0100.000"),
             )
-        val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
-        val oid = mainDraftContext.generateOid(trackId)
+        val (trackId, oid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
         val publication1 =
             testDBService.publish(
@@ -472,8 +439,7 @@ constructor(
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
         val trackGeom = trackGeometryOfSegments(segment(Point(10.0, 0.0), Point(90.0, 0.0)))
-        val trackId = mainDraftContext.save(locationTrack(tnId), trackGeom).id
-        val trackOid = mainDraftContext.generateOid(trackId)
+        val (trackId, trackOid) = mainDraftContext.saveWithOid(locationTrack(tnId), trackGeom)
         val initPublication =
             testDBService.publish(
                 trackNumbers = listOf(tnId),
@@ -492,7 +458,7 @@ constructor(
 
         initUser()
         val (origTrack, origGeom) = mainDraftContext.fetchLocationTrackWithGeometry(trackId)!!
-        mainDraftContext.saveLocationTrack(origTrack.copy(state = LocationTrackState.DELETED) to origGeom)
+        mainDraftContext.save(origTrack.copy(state = LocationTrackState.DELETED), origGeom)
         val deletePublication = testDBService.publish(locationTracks = listOf(trackId))
 
         api.locationTracks.get(trackOid).also { track ->
@@ -527,8 +493,7 @@ constructor(
                 segment(Point(40.0, 0.0), Point(60.0, 0.0)),
                 segment(Point(60.0, 0.0), Point(80.0, 0.0)),
             )
-        val trackId = mainDraftContext.save(locationTrack(trackNumberId), geometry1).id
-        val oid = mainDraftContext.generateOid(trackId)
+        val (trackId, oid) = mainDraftContext.saveWithOid(locationTrack(trackNumberId), geometry1)
 
         val publication1 = testDBService.publish(locationTracks = listOf(trackId))
 
@@ -640,8 +605,7 @@ constructor(
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
         val trackGeom = trackGeometryOfSegments(segment(Point(20.0, 0.0), Point(40.0, 0.0)))
-        val trackId = mainDraftContext.save(locationTrack(tnId), trackGeom).id
-        val oid = mainDraftContext.generateOid(trackId)
+        val (trackId, oid) = mainDraftContext.saveWithOid(locationTrack(tnId), trackGeom)
 
         val basePub =
             testDBService.publish(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.IntId
@@ -23,6 +22,7 @@ import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.util.FreeText
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -42,18 +42,14 @@ const val COORDINATE_DELTA = 0.001
 @AutoConfigureMockMvc
 class ExtLocationTrackIT
 @Autowired
-constructor(
-    mockMvc: MockMvc,
-    private val locationTrackService: LocationTrackService,
-    private val extTestDataService: ExtApiTestDataServiceV1,
-) : DBTestBase() {
+constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackService) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @Test
     fun `Newest official location track is returned by default`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val trackVersion = mainDraftContext.save(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
         val oid = mainDraftContext.generateOid(trackVersion.id)
@@ -77,8 +73,8 @@ constructor(
     @Test
     fun `Location track api respects the track layout version argument`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
@@ -124,8 +120,8 @@ constructor(
 
         val segment = segment(helsinkiRailwayStationTm35Fin, helsinkiRailwayStationTm35FinPlus10000)
 
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
@@ -151,12 +147,14 @@ constructor(
 
     @Test
     fun `Official geometry is returned at correct track layout version state`() {
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
-                startAddress = TrackMeter("0001+0100.000"),
-            )
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(
+                    referenceLine(trackNumberId, startAddress = TrackMeter("0001+0100.000")),
+                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
+                )
+                .id
 
         val geometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val (trackId, oid) = mainDraftContext.saveWithOid(locationTrack(trackNumberId), geometry)
@@ -206,12 +204,14 @@ constructor(
                 HelsinkiTestData.HKI_BASE_POINT + Point(0.0, endM - startM),
                 startM,
             )
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment),
-                startAddress = TrackMeter(KmNumber(0), startM.toBigDecimal()),
-            )
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(
+                    referenceLine(trackNumberId, startAddress = TrackMeter(KmNumber(0), startM.toBigDecimal())),
+                    referenceLineGeometry(segment),
+                )
+                .id
 
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
@@ -245,12 +245,14 @@ constructor(
                 HelsinkiTestData.HKI_BASE_POINT + Point(0.0, endM - startM),
                 startM,
             )
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment),
-                startAddress = TrackMeter(KmNumber("0000"), startM.toBigDecimal()),
-            )
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(
+                    referenceLine(trackNumberId, startAddress = TrackMeter(KmNumber("0000"), startM.toBigDecimal())),
+                    referenceLineGeometry(segment),
+                )
+                .id
 
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
@@ -279,8 +281,8 @@ constructor(
     @Test
     fun `Location track api should return track information regardless of its state`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val tracks =
             LocationTrackState.entries.map { state ->
@@ -310,8 +312,8 @@ constructor(
     @Test
     fun `Location track modifications api should return track information regardless of its state`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val tracks =
             LocationTrackState.entries.map { state ->
@@ -353,8 +355,7 @@ constructor(
 
     @Test
     fun `Location track modification API should show modifications for calculated change`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
-        mainDraftContext.generateOid(tnId)
+        val (tnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
@@ -400,12 +401,14 @@ constructor(
     @Test
     fun `Deleted tracks don't have geometry`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment),
-                startAddress = TrackMeter("0001+0100.000"),
-            )
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(
+                    referenceLine(trackNumberId, startAddress = TrackMeter("0001+0100.000")),
+                    referenceLineGeometry(segment),
+                )
+                .id
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
@@ -433,8 +436,7 @@ constructor(
 
     @Test
     fun `Deleted tracks have no addresses exposed through the API`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
-        mainDraftContext.generateOid(tnId)
+        val (tnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
@@ -477,12 +479,14 @@ constructor(
 
     @Test
     fun `Geometry modifications show correct diffs`() {
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
-                startAddress = TrackMeter("0001+0100.000"),
-            )
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(
+                    referenceLine(trackNumberId, startAddress = TrackMeter("0001+0100.000")),
+                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
+                )
+                .id
         val publication0 =
             testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -599,8 +603,7 @@ constructor(
 
     @Test
     fun `Geometry modifications API shows calculated changes correctly`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
-        mainDraftContext.generateOid(tnId)
+        val (tnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.ElevationMeasurementMethod
@@ -71,11 +70,7 @@ import java.math.BigDecimal
 @AutoConfigureMockMvc
 class ExtLocationTrackProfileIT
 @Autowired
-constructor(
-    mockMvc: MockMvc,
-    private val extTestDataService: ExtApiTestDataServiceV1,
-    private val heightTriangleDao: HeightTriangleDao,
-) : DBTestBase() {
+constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) : DBTestBase() {
 
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
@@ -114,21 +109,21 @@ constructor(
 
         // Publication 1: track with plan-linked profile
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
             )
 
         // Publication 2: empty publish — no changes to the track
-        val publication2 = extTestDataService.publishInMain()
+        val publication2 = testDBService.publish()
 
         // Publication 3: re-save the track with unlinked segments (removes profile)
         val (track, geometry) = mainDraftContext.fetchLocationTrackWithGeometry(trackId)!!
         val unlinkedGeometry =
             trackGeometryOfSegments(geometry.segments.map { it.copy(sourceId = null, sourceStartM = null) })
         mainDraftContext.save(track, unlinkedGeometry)
-        val publication3 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication3 = testDBService.publish(locationTracks = listOf(trackId))
 
         // --- Profile endpoint assertions ---
 
@@ -227,7 +222,7 @@ constructor(
                 trackGeometryOfElements(plan.alignments[0].elements),
             )
         val publication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -314,7 +309,7 @@ constructor(
         val (trackNumberId, referenceLineId) = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -346,7 +341,7 @@ constructor(
         val (trackNumberId, referenceLineId) = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -377,7 +372,7 @@ constructor(
         val (trackNumberId, referenceLineId) = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -421,7 +416,7 @@ constructor(
         val (trackNumberId, referenceLineId) = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -502,7 +497,7 @@ constructor(
                     segment(toSegmentPoints(to3DMPoints(points2)), sourceId = sourceElement2.id, sourceStartM = 0.0),
                 ),
             )
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -598,7 +593,7 @@ constructor(
                     segment(toSegmentPoints(to3DMPoints(points2)), sourceId = sourceElement2.id, sourceStartM = 0.0),
                 ),
             )
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -619,7 +614,7 @@ constructor(
     }
 
     @Test
-    fun `suunnitelman_korkeusasema maps TOP_OF_SLEEPER to Korkeusviiva and TOP_OF_RAIL to Kiskon selkä`() {
+    fun `suunnitelman_korkeusasema is reported correctly in the API`() {
         val sleeperPlan =
             insertPlan(
                 listOf(profileAlignment()),
@@ -637,7 +632,7 @@ constructor(
         val (railTrackId, railOid) =
             mainDraftContext.saveWithOid(locationTrack(railTrackNumberId), trackGeometryOfElements(railElements))
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(sleeperTrackNumberId, railTrackNumberId),
             referenceLines = listOf(sleeperRefLineId, railRefLineId),
             locationTracks = listOf(sleeperTrackId, railTrackId),
@@ -662,7 +657,7 @@ constructor(
             mainDraftContext.saveReferenceLine(referenceLineAndGeometry(trackNumberId, refLineSegment)).id
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(refLineSegment))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -708,7 +703,7 @@ constructor(
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements1))
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(referenceLineId),
                 locationTracks = listOf(trackId),
@@ -739,7 +734,7 @@ constructor(
         val elements2 = plan2.alignments[0].elements
         val (track, _) = mainDraftContext.fetchLocationTrackWithGeometry(trackId)!!
         mainDraftContext.save(track, trackGeometryOfElements(elements2))
-        val publication2 = extTestDataService.publishInMain(locationTracks = listOf(trackId))
+        val publication2 = testDBService.publish(locationTracks = listOf(trackId))
 
         // Changes endpoint should report the modification
         val response = api.locationTrackProfile.getModifiedBetween(oid, publication1.uuid, publication2.uuid)
@@ -815,9 +810,11 @@ constructor(
             point.korkeus_n2000,
             "$label N2000 height",
         )
-        assertEquals(expectedAddress, point.sijainti?.rataosoite, "$label track address")
-        assertEquals(expectedLocation.x, point.sijainti?.x!!, LAYOUT_COORDINATE_DELTA, "$label X coordinate")
-        assertEquals(expectedLocation.y, point.sijainti?.y!!, LAYOUT_COORDINATE_DELTA, "$label Y coordinate")
+        point.sijainti!!.also {
+            assertEquals(expectedAddress, it.rataosoite, "$label track address")
+            assertEquals(expectedLocation.x, it.x, LAYOUT_COORDINATE_DELTA, "$label X coordinate")
+            assertEquals(expectedLocation.y, it.y, LAYOUT_COORDINATE_DELTA, "$label Y coordinate")
+        }
     }
 
     private fun assertLinearSection(
@@ -890,7 +887,7 @@ constructor(
         val (trackNumberId, referenceLineId) = insertTrackNumberWithReferenceLine(elements, FIN_GK25_SRID)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements, FIN_GK25_SRID))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -901,14 +898,20 @@ constructor(
 
         // Compute expected LAYOUT_SRID location by transforming the GK25 PVI point
         val expectedPvi = transformNonKKJCoordinate(FIN_GK25_SRID, LAYOUT_SRID, gk25Pvi)
-        val expectedStart = transformNonKKJCoordinate(FIN_GK25_SRID, LAYOUT_SRID, gk25Start)
-        val expectedEnd = transformNonKKJCoordinate(FIN_GK25_SRID, LAYOUT_SRID, gk25End)
         assertEquals(expectedPvi.x, location.x, LAYOUT_COORDINATE_DELTA)
         assertEquals(expectedPvi.y, location.y, LAYOUT_COORDINATE_DELTA)
-        assertTrue(pviPoint.pyoristyksen_alku.sijainti!!.x in expectedStart.x..expectedPvi.x)
-        assertTrue(pviPoint.pyoristyksen_alku.sijainti!!.y in expectedStart.y..expectedPvi.y)
-        assertTrue(pviPoint.pyoristyksen_loppu.sijainti!!.x in expectedPvi.x..expectedEnd.x)
-        assertTrue(pviPoint.pyoristyksen_loppu.sijainti!!.y in expectedPvi.y..expectedEnd.y)
+
+        val expectedStart = transformNonKKJCoordinate(FIN_GK25_SRID, LAYOUT_SRID, gk25Start)
+        pviPoint.pyoristyksen_alku.sijainti!!.also {
+            assertTrue(it.x in expectedStart.x..expectedPvi.x)
+            assertTrue(it.y in expectedStart.y..expectedPvi.y)
+        }
+
+        val expectedEnd = transformNonKKJCoordinate(FIN_GK25_SRID, LAYOUT_SRID, gk25End)
+        pviPoint.pyoristyksen_loppu.sijainti!!.also {
+            assertTrue(it.x in expectedPvi.x..expectedEnd.x)
+            assertTrue(it.y in expectedPvi.y..expectedEnd.y)
+        }
 
         assertEquals(pviHeight.toString(), pviPoint.taite.korkeus_alkuperainen)
         assertEquals(pviHeight.toString(), pviPoint.taite.korkeus_n2000)
@@ -948,7 +951,7 @@ constructor(
         val (trackNumberId, referenceLineId) = insertTrackNumberWithReferenceLine(elements, FIN_GK25_SRID)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements, FIN_GK25_SRID))
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileIT.kt
@@ -44,13 +44,15 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.locationTrack
-import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometryOfElements
+import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.to3DMPoints
 import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfElements
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FileName
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -476,12 +478,10 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
             )
         val sourceElement1 = plan1.alignments[0].elements[0]
         val sourceElement2 = plan2.alignments[0].elements[0]
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val referenceLineId =
             mainDraftContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId, segment(Point(0.0, 0.0), Point(0.0, 2000.0)))
-                )
+                .save(referenceLine(trackNumberId), referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 2000.0))))
                 .id
 
         // Segment 1 (0..600) linked to plan1, gap (600..800) unlinked, segment 2 (800..1400) linked to plan2
@@ -575,12 +575,10 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         // Segment 2 linked to plan2's second element (stations 500-1000, contains curve at 550)
         val sourceElement1 = plan1.alignments[0].elements[0]
         val sourceElement2 = plan2.alignments[0].elements[1]
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val referenceLineId =
             mainDraftContext
-                .saveReferenceLine(
-                    referenceLineAndGeometry(trackNumberId, segment(Point(0.0, 0.0), Point(0.0, 1000.0)))
-                )
+                .save(referenceLine(trackNumberId), referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 1000.0))))
                 .id
 
         val points1 = (0..500).map { Point(0.0, it.toDouble()) }
@@ -652,9 +650,9 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
     @Test
     fun `Location track with no vertical geometry returns 200 with no PVI points`() {
         val refLineSegment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val referenceLineId =
-            mainDraftContext.saveReferenceLine(referenceLineAndGeometry(trackNumberId, refLineSegment)).id
+            mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(refLineSegment)).id
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(refLineSegment))
         testDBService.publish(
@@ -846,7 +844,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         elements: List<GeometryElement>,
         planSrid: Srid = LAYOUT_SRID,
     ): Pair<IntId<LayoutTrackNumber>, IntId<ReferenceLine>> {
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val referenceLineId =
             mainDraftContext
                 .saveReferenceLine(referenceLineAndGeometryOfElements(trackNumberId, elements, planSrid = planSrid))

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
@@ -25,6 +25,7 @@ import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -363,30 +364,23 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
         val (opId, opOid) = mainDraftContext.saveWithOid(operationalPoint(location = Point(5.0, 0.0)))
 
         // Create track number and reference line
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
         val rlId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         // Create switch linked to operational point
         val structure = switchStructureYV60_300_1_9()
-        val switchId =
-            mainDraftContext
-                .save(
-                    switch(structure.id, joints = listOf(switchJoint(1, Point(0.0, 0.0))))
-                        .copy(operationalPointId = opId)
-                )
-                .id
-        val switchOid = mainDraftContext.generateOid(switchId)
+        val (switchId, switchOid) =
+            mainDraftContext.saveWithOid(
+                switch(structure.id, joints = listOf(switchJoint(1, Point(0.0, 0.0)))).copy(operationalPointId = opId)
+            )
 
         // Create track linked to operational point
-        val trackId =
-            mainDraftContext
-                .save(
-                    locationTrack(trackNumberId).copy(operationalPointIds = setOf(opId)),
-                    trackGeometryOfSegments(segment),
-                )
-                .id
-        val trackOid = mainDraftContext.generateOid(trackId)
+        val (trackId, trackOid) =
+            mainDraftContext.saveWithOid(
+                locationTrack(trackNumberId).copy(operationalPointIds = setOf(opId)),
+                trackGeometryOfSegments(segment),
+            )
 
         testDBService.publish(
             operationalPoints = listOf(opId),
@@ -416,17 +410,14 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
         // Phase 1: Create and link a switch to the operational point (calculated change)
         initUser()
         val structure = switchStructureYV60_300_1_9()
-        val switchId =
-            mainDraftContext
-                .save(
-                    switch(
-                            structure.id,
-                            joints = listOf(switchJoint(1, Point(0.0, 0.0)), switchJoint(2, Point(10.0, 0.0))),
-                        )
-                        .copy(operationalPointId = opId)
+        val (switchId, _) =
+            mainDraftContext.saveWithOid(
+                switch(
+                    structure.id,
+                    joints = listOf(switchJoint(1, Point(0.0, 0.0)), switchJoint(2, Point(10.0, 0.0))),
+                    operationalPointId = opId,
                 )
-                .id
-        mainDraftContext.generateOid(switchId)
+            )
 
         val switchPublication = testDBService.publish(switches = listOf(switchId))
 
@@ -446,20 +437,17 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
         // Phase 2: Create and link a location track to the operational point (calculated change)
         initUser()
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlId =
             mainDraftContext
                 .save(referenceLine(trackNumberId), referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
                 .id
 
-        val trackId =
-            mainDraftContext
-                .save(
-                    locationTrack(trackNumberId).copy(operationalPointIds = setOf(opId)),
-                    trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
-                )
-                .id
-        mainDraftContext.generateOid(trackId)
+        val (trackId, _) =
+            mainDraftContext.saveWithOid(
+                locationTrack(trackNumberId).copy(operationalPointIds = setOf(opId)),
+                trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
+            )
 
         val trackPublication =
             testDBService.publish(
@@ -521,8 +509,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
     fun `Operational point collection is filtered by name`() {
         val (matchingOpId, matchingOpOid) = mainDraftContext.saveWithOid(operationalPoint(name = "OP MATCHING 001"))
 
-        val otherOpId = mainDraftContext.save(operationalPoint(name = "OP OTHER 999")).id
-        mainDraftContext.generateOid(otherOpId)
+        val (otherOpId, _) = mainDraftContext.saveWithOid(operationalPoint(name = "OP OTHER 999"))
 
         testDBService.publish(operationalPoints = listOf(matchingOpId, otherOpId))
 
@@ -539,8 +526,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
     fun `Operational point change-list is filtered by name`() {
         val (matchingOpId, matchingOpOid) = mainDraftContext.saveWithOid(operationalPoint(name = "OP MATCHING 001"))
 
-        val otherOpId = mainDraftContext.save(operationalPoint(name = "OP OTHER 999")).id
-        mainDraftContext.generateOid(otherOpId)
+        val (otherOpId, _) = mainDraftContext.saveWithOid(operationalPoint(name = "OP OTHER 999"))
 
         val fromPublication = testDBService.publish(operationalPoints = listOf(matchingOpId, otherOpId)).uuid
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.AlignmentName
@@ -42,9 +41,7 @@ import kotlin.random.Random
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
 @AutoConfigureMockMvc
-class ExtOperationalPointIT
-@Autowired
-constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServiceV1) : DBTestBase() {
+class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -66,7 +63,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         val op2Oid = mainDraftContext.generateOid(op2Id)
 
-        val baseVersion = extTestDataService.publishInMain(operationalPoints = listOf(op1Id, op2Id)).uuid
+        val baseVersion = testDBService.publish(operationalPoints = listOf(op1Id, op2Id)).uuid
 
         val op1BeforeUpdate = mainOfficialContext.fetch(op1Id)!!
         val op2BeforeUpdate = mainOfficialContext.fetch(op2Id)!!
@@ -78,7 +75,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         // Update op1
         initUser()
         mainDraftContext.mutate(op1Id) { op -> op.copy(name = op.name.copy(value = "${op.name}-EDIT")) }
-        val updatedVersion = extTestDataService.publishInMain(operationalPoints = listOf(op1Id)).uuid
+        val updatedVersion = testDBService.publish(operationalPoints = listOf(op1Id)).uuid
         val op1AfterUpdate = mainOfficialContext.fetch(op1Id)!!
         assertNotEquals(op1BeforeUpdate, op1AfterUpdate)
         assertEquals(op2BeforeUpdate, mainOfficialContext.fetch(op2Id)!!)
@@ -106,7 +103,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val op2Oid = mainDraftContext.generateOid(op2Id)
 
         // Only publish op1 at first
-        val baseVersion = extTestDataService.publishInMain(operationalPoints = listOf(op1Id)).uuid
+        val baseVersion = testDBService.publish(operationalPoints = listOf(op1Id)).uuid
         val op1Published = mainOfficialContext.fetch(op1Id)!!
 
         // API should only show published op1, not draft op2
@@ -115,7 +112,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         // Publish op2
         initUser()
-        val updateVersion = extTestDataService.publishInMain(operationalPoints = listOf(op2Id)).uuid
+        val updateVersion = testDBService.publish(operationalPoints = listOf(op2Id)).uuid
         val op2Published = mainOfficialContext.fetch(op2Id)!!
 
         // Both should now be visible
@@ -134,14 +131,14 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         val oid = mainDraftContext.generateOid(opId)
 
-        val baseVersion = extTestDataService.publishInMain(operationalPoints = listOf(opId)).uuid
+        val baseVersion = testDBService.publish(operationalPoints = listOf(opId)).uuid
         val baseOp = mainOfficialContext.fetch(opId)!!.also { assertEquals(OperationalPointState.IN_USE, it.state) }
         assertLatestStateInApi(baseVersion, oid to baseOp)
 
         // Delete the operational point
         initUser()
         mainDraftContext.mutate(opId) { op -> op.copy(state = OperationalPointState.DELETED) }
-        val deletedVersion = extTestDataService.publishInMain(operationalPoints = listOf(opId)).uuid
+        val deletedVersion = testDBService.publish(operationalPoints = listOf(opId)).uuid
         val deletedOp = mainOfficialContext.fetch(opId)!!.also { assertEquals(OperationalPointState.DELETED, it.state) }
 
         // Single fetch should return the deleted point
@@ -171,7 +168,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         val op2Oid = mainDraftContext.generateOid(op2Id)
 
-        val baseVersion = extTestDataService.publishInMain(operationalPoints = listOf(op1Id, op2Id)).uuid
+        val baseVersion = testDBService.publish(operationalPoints = listOf(op1Id, op2Id)).uuid
 
         // First publication -> no changes (verify as both since and between fetches)
         assertChangesSince(baseVersion, baseVersion, listOf(op1Oid, op2Oid), emptyList())
@@ -186,7 +183,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         val op3Oid = mainDraftContext.generateOid(op3Id)
 
-        val update1Version = extTestDataService.publishInMain(operationalPoints = listOf(op2Id, op3Id)).uuid
+        val update1Version = testDBService.publish(operationalPoints = listOf(op2Id, op3Id)).uuid
         val op2Update1 = mainOfficialContext.fetch(op2Id)!!
         val op3Update1 = mainOfficialContext.fetch(op3Id)!!
 
@@ -207,7 +204,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         // Update op2 again
         initUser()
         mainDraftContext.mutate(op2Id) { op -> op.copy(name = op.name.copy(value = "${op.name}2")) }
-        val update2Version = extTestDataService.publishInMain(operationalPoints = listOf(op2Id)).uuid
+        val update2Version = testDBService.publish(operationalPoints = listOf(op2Id)).uuid
         val op2Update2 = mainOfficialContext.fetch(op2Id)!!
 
         // Changes since base version: op1 unchanged, op2 changed twice, op3 added
@@ -245,7 +242,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         val oid = mainDraftContext.generateOid(opId)
 
-        val publication = extTestDataService.publishInMain(operationalPoints = listOf(opId))
+        val publication = testDBService.publish(operationalPoints = listOf(opId))
 
         // Query for changes with same version
         api.operationalPoint.assertNoModificationBetween(oid, publication.uuid, publication.uuid)
@@ -296,9 +293,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         // Publish all operational points
         val publication =
-            extTestDataService.publishInMain(
-                operationalPoints = testOperationalPoints.map { (_, op) -> op.id as IntId }
-            )
+            testDBService.publish(operationalPoints = testOperationalPoints.map { (_, op) -> op.id as IntId })
 
         // Verify single fetch API returns correct data for all variations
         testOperationalPoints.forEach { (oid, op) ->
@@ -332,7 +327,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val opId = mainDraftContext.save(operationalPoint(location = location3067)).id
         val oid = mainDraftContext.generateOid(opId)
 
-        extTestDataService.publishInMain(operationalPoints = listOf(opId))
+        testDBService.publish(operationalPoints = listOf(opId))
 
         // Default EPSG:3067
         api.operationalPoint.get(oid).let { response ->
@@ -366,7 +361,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val opId = mainDraftContext.save(operationalPoint(polygon = polygon, location = Point(50.0, 25.0))).id
         val oid = mainDraftContext.generateOid(opId)
 
-        extTestDataService.publishInMain(operationalPoints = listOf(opId))
+        testDBService.publish(operationalPoints = listOf(opId))
 
         val response = api.operationalPoint.get(oid)
         assertPolygonMatches(polygon, response.toiminnallinen_piste.alue)
@@ -410,7 +405,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         val trackOid = mainDraftContext.generateOid(trackId)
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             operationalPoints = listOf(opId),
             switches = listOf(switchId),
             locationTracks = listOf(trackId),
@@ -430,7 +425,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val opId = mainDraftContext.save(operationalPoint(location = Point(5.0, 0.0))).id
         val opOid = mainDraftContext.generateOid(opId)
 
-        val basePublication = extTestDataService.publishInMain(operationalPoints = listOf(opId))
+        val basePublication = testDBService.publish(operationalPoints = listOf(opId))
 
         // Verify no changes initially
         api.operationalPoint.assertNoModificationSince(opOid, basePublication.uuid)
@@ -451,7 +446,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
                 .id
         mainDraftContext.generateOid(switchId)
 
-        val switchPublication = extTestDataService.publishInMain(switches = listOf(switchId))
+        val switchPublication = testDBService.publish(switches = listOf(switchId))
 
         // Operational point should show as changed even though it wasn't directly edited
         val switchModification = api.operationalPoint.getModifiedSince(opOid, basePublication.uuid)
@@ -485,7 +480,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         mainDraftContext.generateOid(trackId)
 
         val trackPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 locationTracks = listOf(trackId),
                 trackNumbers = listOf(trackNumberId),
                 referenceLines = listOf(rlId),
@@ -512,7 +507,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         mainDraftContext.mutate(trackId) { track -> track.copy(name = AlignmentName("${track.name}-EDIT")) }
 
         val trivialChangePublication =
-            extTestDataService.publishInMain(switches = listOf(switchId), locationTracks = listOf(trackId))
+            testDBService.publish(switches = listOf(switchId), locationTracks = listOf(trackId))
 
         // Operational point should NOT show as changed since references didn't change
         api.operationalPoint.assertNoModificationSince(opOid, trackPublication.uuid)
@@ -548,7 +543,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val otherOpId = mainDraftContext.save(operationalPoint(name = "OP OTHER 999")).id
         mainDraftContext.generateOid(otherOpId)
 
-        extTestDataService.publishInMain(operationalPoints = listOf(matchingOpId, otherOpId))
+        testDBService.publish(operationalPoints = listOf(matchingOpId, otherOpId))
 
         api.operationalPointCollection.get(OPERATIONAL_POINT_NAME to "OP MATCHING 001").also { response ->
             assertEquals(listOf(matchingOpOid), getOids(response.toiminnalliset_pisteet))
@@ -567,12 +562,12 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val otherOpId = mainDraftContext.save(operationalPoint(name = "OP OTHER 999")).id
         mainDraftContext.generateOid(otherOpId)
 
-        val fromPublication = extTestDataService.publishInMain(operationalPoints = listOf(matchingOpId, otherOpId)).uuid
+        val fromPublication = testDBService.publish(operationalPoints = listOf(matchingOpId, otherOpId)).uuid
 
         initUser()
         mainDraftContext.mutate(matchingOpId) { op -> op.copy(name = OperationalPointName("${op.name}-EDIT")) }
         mainDraftContext.mutate(otherOpId) { op -> op.copy(name = OperationalPointName("${op.name}-EDIT")) }
-        extTestDataService.publishInMain(operationalPoints = listOf(matchingOpId, otherOpId))
+        testDBService.publish(operationalPoints = listOf(matchingOpId, otherOpId))
 
         api.operationalPointCollection
             .getModifiedSince(fromPublication, OPERATIONAL_POINT_NAME to "OP MATCHING 001")
@@ -584,8 +579,9 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         }
     }
 
-    private fun getOids(ops: List<ExtTestOperationalPointV1>): List<Oid<OperationalPoint>> =
-        ops.map { Oid(it.toiminnallinen_piste_oid) }
+    private fun getOids(ops: List<ExtTestOperationalPointV1>): List<Oid<OperationalPoint>> = ops.map {
+        Oid(it.toiminnallinen_piste_oid)
+    }
 
     private fun assertPolygonMatches(expected: Polygon, actual: ExtTestPolygonV1?) {
         assertNotNull(actual)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
@@ -51,17 +51,15 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point APIs should return correct object versions`() {
-        val op1Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 1", abbreviation = "TP1", location = Point(0.5, 0.5)))
-                .id
-        val op1Oid = mainDraftContext.generateOid(op1Id)
+        val (op1Id, op1Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 1", abbreviation = "TP1", location = Point(0.5, 0.5))
+            )
 
-        val op2Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 2", abbreviation = "TP2", location = Point(10.5, 10.5)))
-                .id
-        val op2Oid = mainDraftContext.generateOid(op2Id)
+        val (op2Id, op2Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 2", abbreviation = "TP2", location = Point(10.5, 10.5))
+            )
 
         val baseVersion = testDBService.publish(operationalPoints = listOf(op1Id, op2Id)).uuid
 
@@ -90,17 +88,15 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point API does not contain draft objects or changes`() {
-        val op1Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 1", abbreviation = "TP1", location = Point(0.5, 0.5)))
-                .id
-        val op1Oid = mainDraftContext.generateOid(op1Id)
+        val (op1Id, op1Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 1", abbreviation = "TP1", location = Point(0.5, 0.5))
+            )
 
-        val op2Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 2", abbreviation = "TP2", location = Point(10.5, 10.5)))
-                .id
-        val op2Oid = mainDraftContext.generateOid(op2Id)
+        val (op2Id, op2Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 2", abbreviation = "TP2", location = Point(10.5, 10.5))
+            )
 
         // Only publish op1 at first
         val baseVersion = testDBService.publish(operationalPoints = listOf(op1Id)).uuid
@@ -125,11 +121,10 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Deleted operational point should be returned in single-fetch API but not collection API`() {
-        val opId =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point", abbreviation = "TP", location = Point(0.5, 0.5)))
-                .id
-        val oid = mainDraftContext.generateOid(opId)
+        val (opId, oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point", abbreviation = "TP", location = Point(0.5, 0.5))
+            )
 
         val baseVersion = testDBService.publish(operationalPoints = listOf(opId)).uuid
         val baseOp = mainOfficialContext.fetch(opId)!!.also { assertEquals(OperationalPointState.IN_USE, it.state) }
@@ -156,17 +151,15 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point modification APIs should return correct versions`() {
-        val op1Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 1", abbreviation = "TP1", location = Point(0.5, 0.5)))
-                .id
-        val op1Oid = mainDraftContext.generateOid(op1Id)
+        val (op1Id, op1Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 1", abbreviation = "TP1", location = Point(0.5, 0.5))
+            )
 
-        val op2Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 2", abbreviation = "TP2", location = Point(10.5, 10.5)))
-                .id
-        val op2Oid = mainDraftContext.generateOid(op2Id)
+        val (op2Id, op2Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 2", abbreviation = "TP2", location = Point(10.5, 10.5))
+            )
 
         val baseVersion = testDBService.publish(operationalPoints = listOf(op1Id, op2Id)).uuid
 
@@ -177,11 +170,10 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
         // Update op2 and add op3
         initUser()
         mainDraftContext.mutate(op2Id) { op -> op.copy(name = op.name.copy(value = "${op.name}-EDIT")) }
-        val op3Id =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point 3", abbreviation = "TP3", location = Point(20.5, 20.5)))
-                .id
-        val op3Oid = mainDraftContext.generateOid(op3Id)
+        val (op3Id, op3Oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point 3", abbreviation = "TP3", location = Point(20.5, 20.5))
+            )
 
         val update1Version = testDBService.publish(operationalPoints = listOf(op2Id, op3Id)).uuid
         val op2Update1 = mainOfficialContext.fetch(op2Id)!!
@@ -236,11 +228,10 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point API returns no changes when versions are the same`() {
-        val opId =
-            mainDraftContext
-                .save(operationalPoint(name = "Test Point", abbreviation = "TP", location = Point(0.5, 0.5)))
-                .id
-        val oid = mainDraftContext.generateOid(opId)
+        val (opId, oid) =
+            mainDraftContext.saveWithOid(
+                operationalPoint(name = "Test Point", abbreviation = "TP", location = Point(0.5, 0.5))
+            )
 
         val publication = testDBService.publish(operationalPoints = listOf(opId))
 
@@ -255,39 +246,33 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
         // Test all RINF type variations
         OperationalPointRinfType.entries.forEach { rinfType ->
-            val opId = mainDraftContext.save(operationalPoint(rinfType = rinfType)).id
-            val oid = mainDraftContext.generateOid(opId)
+            val (opId, oid) = mainDraftContext.saveWithOid(operationalPoint(rinfType = rinfType))
             testOperationalPoints.add(oid to mainDraftContext.fetch(opId)!!)
         }
 
         // Test all RATO type variations
         OperationalPointRatoType.entries.forEach { ratoType ->
-            val opId = mainDraftContext.save(operationalPoint(rinfType = null).copy(ratoType = ratoType)).id
-            val oid = mainDraftContext.generateOid(opId)
+            val (opId, oid) = mainDraftContext.saveWithOid(operationalPoint(rinfType = null).copy(ratoType = ratoType))
             testOperationalPoints.add(oid to mainDraftContext.fetch(opId)!!)
         }
 
         // Test all state variations
         OperationalPointState.entries.forEach { state ->
-            val opId = mainDraftContext.save(operationalPoint(state = state)).id
-            val oid = mainDraftContext.generateOid(opId)
+            val (opId, oid) = mainDraftContext.saveWithOid(operationalPoint(state = state))
             testOperationalPoints.add(oid to mainDraftContext.fetch(opId)!!)
         }
 
         // Test other fields with random values
         repeat(3) {
-            val opId =
-                mainDraftContext
-                    .save(
-                        operationalPoint(
-                            name = randomString(),
-                            abbreviation = randomString(),
-                            uicCode = randomNumericString(),
-                            location = Point(randomDouble(), randomDouble()),
-                        )
+            val (opId, oid) =
+                mainDraftContext.saveWithOid(
+                    operationalPoint(
+                        name = randomString(),
+                        abbreviation = randomString(),
+                        uicCode = randomNumericString(),
+                        location = Point(randomDouble(), randomDouble()),
                     )
-                    .id
-            val oid = mainDraftContext.generateOid(opId)
+                )
             testOperationalPoints.add(oid to mainDraftContext.fetch(opId)!!)
         }
 
@@ -324,8 +309,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
         val location3067 = Point(385782.89, 6672277.83)
         val location4326 = Point(24.9414003, 60.1713788)
 
-        val opId = mainDraftContext.save(operationalPoint(location = location3067)).id
-        val oid = mainDraftContext.generateOid(opId)
+        val (opId, oid) = mainDraftContext.saveWithOid(operationalPoint(location = location3067))
 
         testDBService.publish(operationalPoints = listOf(opId))
 
@@ -358,8 +342,8 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
         val polygon =
             Polygon(listOf(Point(0.0, 0.0), Point(100.0, 0.0), Point(100.0, 50.0), Point(0.0, 50.0), Point(0.0, 0.0)))
 
-        val opId = mainDraftContext.save(operationalPoint(polygon = polygon, location = Point(50.0, 25.0))).id
-        val oid = mainDraftContext.generateOid(opId)
+        val (opId, oid) =
+            mainDraftContext.saveWithOid(operationalPoint(polygon = polygon, location = Point(50.0, 25.0)))
 
         testDBService.publish(operationalPoints = listOf(opId))
 
@@ -376,8 +360,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point with tracks and switches shows associations correctly`() {
-        val opId = mainDraftContext.save(operationalPoint(location = Point(5.0, 0.0))).id
-        val opOid = mainDraftContext.generateOid(opId)
+        val (opId, opOid) = mainDraftContext.saveWithOid(operationalPoint(location = Point(5.0, 0.0)))
 
         // Create track number and reference line
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id
@@ -422,8 +405,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point shows as changed when track or switch is linked to it`() {
-        val opId = mainDraftContext.save(operationalPoint(location = Point(5.0, 0.0))).id
-        val opOid = mainDraftContext.generateOid(opId)
+        val (opId, opOid) = mainDraftContext.saveWithOid(operationalPoint(location = Point(5.0, 0.0)))
 
         val basePublication = testDBService.publish(operationalPoints = listOf(opId))
 
@@ -537,8 +519,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point collection is filtered by name`() {
-        val matchingOpId = mainDraftContext.save(operationalPoint(name = "OP MATCHING 001")).id
-        val matchingOpOid = mainDraftContext.generateOid(matchingOpId)
+        val (matchingOpId, matchingOpOid) = mainDraftContext.saveWithOid(operationalPoint(name = "OP MATCHING 001"))
 
         val otherOpId = mainDraftContext.save(operationalPoint(name = "OP OTHER 999")).id
         mainDraftContext.generateOid(otherOpId)
@@ -556,8 +537,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
 
     @Test
     fun `Operational point change-list is filtered by name`() {
-        val matchingOpId = mainDraftContext.save(operationalPoint(name = "OP MATCHING 001")).id
-        val matchingOpOid = mainDraftContext.generateOid(matchingOpId)
+        val (matchingOpId, matchingOpOid) = mainDraftContext.saveWithOid(operationalPoint(name = "OP MATCHING 001"))
 
         val otherOpId = mainDraftContext.save(operationalPoint(name = "OP OTHER 999")).id
         mainDraftContext.generateOid(otherOpId)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtStationLinkIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtStationLinkIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.TestLayoutContext
@@ -37,9 +36,7 @@ import org.springframework.test.web.servlet.MockMvc
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
 @AutoConfigureMockMvc
-class ExtStationLinkIT
-@Autowired
-constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServiceV1) : DBTestBase() {
+class ExtStationLinkIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -49,7 +46,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
     @Test
     fun `Station links API returns correct object versions`() {
-        val baseVersion = extTestDataService.publishInMain().uuid
+        val baseVersion = testDBService.publish().uuid
         val baseResponse =
             api.stationLinkCollection.get().also { response ->
                 assertEquals(baseVersion.toString(), response.rataverkon_versio)
@@ -72,8 +69,8 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
             createConnectionTrack(mainDraftContext, tnId, switch1Id, switch2Id, Point(45.0, 5.0), Point(155.0, 5.0))
 
         val version1 =
-            extTestDataService
-                .publishInMain(
+            testDBService
+                .publish(
                     operationalPoints = listOf(op1Id, op2Id),
                     switches = listOf(switch1Id, switch2Id),
                     locationTracks = listOf(track1Id),
@@ -103,7 +100,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val (track2Id, track2Oid) =
             createConnectionTrack(mainDraftContext, tnId, switch1Id, switch2Id, Point(45.0, 0.0), Point(155.0, 10.0))
 
-        val updatedVersion = extTestDataService.publishInMain(locationTracks = listOf(track2Id)).uuid
+        val updatedVersion = testDBService.publish(locationTracks = listOf(track2Id)).uuid
 
         // Verify updated state shows both tracks
         api.stationLinkCollection.get().also { response ->
@@ -138,8 +135,8 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val switch2Id = mainDraftContext.save(switch(operationalPointId = op2Id)).id
 
         val baseVersion =
-            extTestDataService
-                .publishInMain(operationalPoints = listOf(op1Id, op2Id), switches = listOf(switch1Id, switch2Id))
+            testDBService
+                .publish(operationalPoints = listOf(op1Id, op2Id), switches = listOf(switch1Id, switch2Id))
                 .uuid
 
         api.stationLinkCollection.get().also { response ->
@@ -158,7 +155,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         }
 
         initUser() // Re-initUser after the API calls (thread context reset)
-        extTestDataService.publishInMain(locationTracks = listOf(trackId)).uuid
+        testDBService.publish(locationTracks = listOf(trackId)).uuid
 
         // Now the link should appear
         api.stationLinkCollection.get().also { response ->
@@ -187,7 +184,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val (trackId, trackOid) =
             createConnectionTrack(mainOfficialContext, tnId, switch1Id, switch2Id, Point(45.0, 1.0), Point(155.0, 1.0))
 
-        val baseVersion = extTestDataService.publishInMain().uuid
+        val baseVersion = testDBService.publish().uuid
 
         // Verify link exists
         api.stationLinkCollection.get().also { response ->
@@ -204,7 +201,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         initUser() // Re-initUser after the API calls (thread context reset)
         mainDraftContext.mutate(trackId) { track -> track.copy(state = LocationTrackState.DELETED) }
-        val deletedVersion = extTestDataService.publishInMain(locationTracks = listOf(trackId)).uuid
+        val deletedVersion = testDBService.publish(locationTracks = listOf(trackId)).uuid
 
         // Link should no longer appear
         api.stationLinkCollection.get().also { response ->
@@ -243,7 +240,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val (_, tn2TrackOid) =
             createConnectionTrack(mainOfficialContext, tn2Id, switch1Id, switch2Id, Point(45.0, 0.0), Point(155.0, 0.0))
 
-        val layoutVersion = extTestDataService.publishInMain().uuid
+        val layoutVersion = testDBService.publish().uuid
 
         // Verify API returns separate link objects for each track number
         api.stationLinkCollection.get().also { response ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtStationLinkIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtStationLinkIT.kt
@@ -299,7 +299,7 @@ class ExtStationLinkIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase() {
     ): Triple<IntId<LayoutTrackNumber>, Oid<LayoutTrackNumber>, TrackNumber> =
         testDBService.getUnusedTrackNumber().let { trackNumber ->
             val geometry = referenceLineGeometry(segment(start, end))
-            val tnId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(geometry, trackNumber).id
+            val tnId = mainOfficialContext.createTrackNumberAndReferenceLine(geometry, trackNumber).id
             val tnOid = mainOfficialContext.generateOid(tnId)
             return Triple(tnId, tnOid, trackNumber)
         }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
@@ -280,8 +280,8 @@ constructor(
         val joint2 = switchJoint(2, Point(10.0, 0.0))
         val joint3 = switchJoint(3, Point(10.0, 5.0))
         val structure = switchStructureYV60_300_1_9()
-        val switchId = mainDraftContext.save(switch(structure.id, joints = listOf(joint1, joint2, joint3))).id
-        val switchOid = mainDraftContext.generateOid(switchId)
+        val (switchId, switchOid) =
+            mainDraftContext.saveWithOid(switch(structure.id, joints = listOf(joint1, joint2, joint3)))
         val switch = mainDraftContext.fetch(switchId)!!
 
         val segment1to2 = segment(joint1.location, joint2.location)
@@ -292,8 +292,7 @@ constructor(
                 segments = listOf(segment1to2),
             )
         val track1Geom = linkedTrackGeometry(switch, joint1.number, joint2.number, structure)
-        val track1Id = mainDraftContext.save(locationTrack(tn1Id), track1Geom).id
-        val track1Oid = mainDraftContext.generateOid(track1Id)
+        val (track1Id, track1Oid) = mainDraftContext.saveWithOid(locationTrack(tn1Id), track1Geom)
 
         // Intentionally offset track 2 & it's reference line a bit: the link points be the points-on-track
         val segment1to3 = segment(joint1.location + 0.5, joint3.location + 0.5)
@@ -311,8 +310,7 @@ constructor(
                     endInnerSwitch = switchLinkYV(switchId, 3),
                 )
             )
-        val track2Id = mainDraftContext.save(locationTrack(tn2Id), track2Geom).id
-        val track2Oid = mainDraftContext.generateOid(track2Id)
+        val (track2Id, track2Oid) = mainDraftContext.saveWithOid(locationTrack(tn2Id), track2Geom)
 
         testDBService.publish(
             switches = listOf(switchId),
@@ -342,14 +340,14 @@ constructor(
 
         val s1Joint1 = switchJoint(1, Point(0.0, 0.0))
         val s1Joint2 = switchJoint(2, Point(10.0, 0.0))
-        val switch1Id = mainDraftContext.save(switch(structure.id, joints = listOf(s1Joint1, s1Joint2))).id
-        val switch1Oid = mainDraftContext.generateOid(switch1Id)
+        val (switch1Id, switch1Oid) =
+            mainDraftContext.saveWithOid(switch(structure.id, joints = listOf(s1Joint1, s1Joint2)))
         val switch1 = mainDraftContext.fetch(switch1Id)!!
 
         val s2Joint1 = switchJoint(1, Point(0.0, 0.0))
         val s2Joint2 = switchJoint(2, Point(10.0, 0.0))
-        val switch2Id = mainDraftContext.save(switch(structure.id, joints = listOf(s2Joint1, s2Joint2))).id
-        val switch2Oid = mainDraftContext.generateOid(switch2Id)
+        val (switch2Id, switch2Oid) =
+            mainDraftContext.saveWithOid(switch(structure.id, joints = listOf(s2Joint1, s2Joint2)))
         val switch2 = mainDraftContext.fetch(switch2Id)!!
 
         val (tn1Id, rl1Id) =
@@ -369,8 +367,7 @@ constructor(
                 segments = listOf(segment(s2Joint1.location, s2Joint2.location)),
             )
         val track2Geom = linkedTrackGeometry(switch2, s2Joint1.number, s2Joint2.number, structure)
-        val track2Id = mainDraftContext.save(locationTrack(tn2Id), track2Geom).id
-        val track2Oid = mainDraftContext.generateOid(track2Id)
+        val (track2Id, track2Oid) = mainDraftContext.saveWithOid(locationTrack(tn2Id), track2Geom)
 
         val baseVersion =
             testDBService

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
@@ -24,12 +24,15 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.linkedTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.referenceLine
+import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -285,23 +288,21 @@ constructor(
         val switch = mainDraftContext.fetch(switchId)!!
 
         val segment1to2 = segment(joint1.location, joint2.location)
-        val (tn1Id, rl1Id) =
-            extTestDataService.insertTrackNumberAndReferenceLine(
-                mainDraftContext,
-                startAddress = TrackMeter("0001+0100.000"),
-                segments = listOf(segment1to2),
-            )
+        val (tn1Id, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val rl1Id = mainDraftContext.save(
+            referenceLine(tn1Id, startAddress = TrackMeter("0001+0100.000")),
+            referenceLineGeometry(segment1to2),
+        ).id
         val track1Geom = linkedTrackGeometry(switch, joint1.number, joint2.number, structure)
         val (track1Id, track1Oid) = mainDraftContext.saveWithOid(locationTrack(tn1Id), track1Geom)
 
         // Intentionally offset track 2 & it's reference line a bit: the link points be the points-on-track
         val segment1to3 = segment(joint1.location + 0.5, joint3.location + 0.5)
-        val (tn2Id, rl2Id) =
-            extTestDataService.insertTrackNumberAndReferenceLine(
-                mainDraftContext,
-                startAddress = TrackMeter("0002+0200.000"),
-                segments = listOf(segment1to3),
-            )
+        val (tn2Id, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val rl2Id = mainDraftContext.save(
+            referenceLine(tn2Id, startAddress = TrackMeter("0002+0200.000")),
+            referenceLineGeometry(segment1to3),
+        ).id
         val track2Geom =
             trackGeometry(
                 edge(
@@ -350,22 +351,20 @@ constructor(
             mainDraftContext.saveWithOid(switch(structure.id, joints = listOf(s2Joint1, s2Joint2)))
         val switch2 = mainDraftContext.fetch(switch2Id)!!
 
-        val (tn1Id, rl1Id) =
-            extTestDataService.insertTrackNumberAndReferenceLine(
-                mainDraftContext,
-                startAddress = TrackMeter("0001+0100.000"),
-                segments = listOf(segment(s1Joint1.location, s1Joint2.location)),
-            )
+        val (tn1Id, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val rl1Id = mainDraftContext.save(
+            referenceLine(tn1Id, startAddress = TrackMeter("0001+0100.000")),
+            referenceLineGeometry(segment(s1Joint1.location, s1Joint2.location)),
+        ).id
         val track1Geom = linkedTrackGeometry(switch1, s1Joint1.number, s1Joint2.number, structure)
         val track1Id = mainDraftContext.save(locationTrack(tn1Id), track1Geom).id
         mainDraftContext.generateOid(track1Id)
 
-        val (tn2Id, rl2Id) =
-            extTestDataService.insertTrackNumberAndReferenceLine(
-                mainDraftContext,
-                startAddress = TrackMeter("0002+0200.000"),
-                segments = listOf(segment(s2Joint1.location, s2Joint2.location)),
-            )
+        val (tn2Id, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val rl2Id = mainDraftContext.save(
+            referenceLine(tn2Id, startAddress = TrackMeter("0002+0200.000")),
+            referenceLineGeometry(segment(s2Joint1.location, s2Joint2.location)),
+        ).id
         val track2Geom = linkedTrackGeometry(switch2, s2Joint1.number, s2Joint2.number, structure)
         val (track2Id, track2Oid) = mainDraftContext.saveWithOid(locationTrack(tn2Id), track2Geom)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
@@ -85,7 +85,7 @@ constructor(
         // Update switch 1
         initUser()
         mainDraftContext.mutate(switch1.switch.id) { s -> s.copy(name = SwitchName(s.name.toString() + "-EDIT")) }
-        val updatedVersion = extTestDataService.publishInMain(switches = listOf(switch1.switch.id)).uuid
+        val updatedVersion = testDBService.publish(switches = listOf(switch1.switch.id)).uuid
         val switch1AfterUpdate = mainOfficialContext.fetch(switch1.switch.id)!!
         assertNotEquals(switch1BeforeUpdate, switch1AfterUpdate)
         assertEquals(switch2BeforeUpdate, mainOfficialContext.fetch(switch2.switch.id)!!)
@@ -128,7 +128,7 @@ constructor(
         // Update both, but now only publish switch 2 (wasn't published before)
         mainDraftContext.mutate(switch1Id) { s -> s.copy(name = SwitchName(s.name.toString() + "-EDIT1")) }
         mainDraftContext.mutate(switch2Id) { s -> s.copy(name = SwitchName(s.name.toString() + "-EDIT2")) }
-        val updatedVersion = extTestDataService.publishInMain(switches = listOf(switch2.switch.id)).uuid
+        val updatedVersion = testDBService.publish(switches = listOf(switch2.switch.id)).uuid
 
         assertEquals(switch1Base, mainOfficialContext.fetch(switch1Id))
         val switch2Updated = mainOfficialContext.fetch(switch2Id)!!
@@ -161,8 +161,8 @@ constructor(
         mainDraftContext.mutate(switch.switch.id) { s -> s.copy(stateCategory = LayoutStateCategory.NOT_EXISTING) }
 
         val deletedVersion =
-            extTestDataService
-                .publishInMain(switches = listOf(switch.switch.id), locationTracks = switch.tracks.map { it.id })
+            testDBService
+                .publish(switches = listOf(switch.switch.id), locationTracks = switch.tracks.map { it.id })
                 .uuid
         val deletedSwitch =
             mainOfficialContext.fetch(id)!!.also { assertEquals(LayoutStateCategory.NOT_EXISTING, it.stateCategory) }
@@ -206,8 +206,8 @@ constructor(
             )
         val (switch3Id, switch3Oid) = switch3.switch
         val update1Version =
-            extTestDataService
-                .publishInMain(
+            testDBService
+                .publish(
                     switches = listOf(switch2Id, switch3Id),
                     locationTracks = switch3.tracks.map { it.id },
                     trackNumbers = listOf(switch3.trackNumber.id),
@@ -234,7 +234,7 @@ constructor(
         // Update switch 2 again
         initUser()
         mainDraftContext.mutate(switch2.switch.id) { s -> s.copy(name = SwitchName(s.name.toString() + "-EDIT2")) }
-        val update2Version = extTestDataService.publishInMain(switches = listOf(switch2Id)).uuid
+        val update2Version = testDBService.publish(switches = listOf(switch2Id)).uuid
         val switch2Update2 = mainOfficialContext.fetch(switch2.switch.id)!!
 
         // Changes since base version: s1 unchanged, s2 changed twice, s3 added
@@ -314,7 +314,7 @@ constructor(
         val track2Id = mainDraftContext.save(locationTrack(tn2Id), track2Geom).id
         val track2Oid = mainDraftContext.generateOid(track2Id)
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             switches = listOf(switchId),
             locationTracks = listOf(track1Id, track2Id),
             trackNumbers = listOf(tn1Id, tn2Id),
@@ -373,8 +373,8 @@ constructor(
         val track2Oid = mainDraftContext.generateOid(track2Id)
 
         val baseVersion =
-            extTestDataService
-                .publishInMain(
+            testDBService
+                .publish(
                     switches = listOf(switch1Id, switch2Id),
                     locationTracks = listOf(track1Id, track2Id),
                     trackNumbers = listOf(tn1Id, tn2Id),
@@ -399,7 +399,7 @@ constructor(
         // Update reference line 2 start -> should produce calculated change for track 2, affecting switch2 links
         initUser()
         mainDraftContext.mutate(rl2Id) { rl -> rl.copy(startAddress = TrackMeter("0003+0300.000")) }
-        val updateVersion = extTestDataService.publishInMain(referenceLines = listOf(rl2Id)).uuid
+        val updateVersion = testDBService.publish(referenceLines = listOf(rl2Id)).uuid
 
         // Different track number -> should not affect switch1
         api.switch.assertNoModificationSince(switch1Oid, baseVersion)
@@ -494,7 +494,7 @@ constructor(
 
         initUser()
         mainDraftContext.mutate(switch.tracks[0].id) { lt -> lt.copy(state = LocationTrackState.DELETED) }
-        val updateVersion = extTestDataService.publishInMain(locationTracks = switch.tracks.map { it.id }).uuid
+        val updateVersion = testDBService.publish(locationTracks = switch.tracks.map { it.id }).uuid
 
         api.switch.get(switchOid).let { response ->
             assertEquals(updateVersion.toString(), response.rataverkon_versio)
@@ -521,7 +521,7 @@ constructor(
 
         initUser()
         mainDraftContext.mutate(switch.tracks[0].id) { lt -> lt.copy(state = LocationTrackState.DELETED) }
-        val updateVersion = extTestDataService.publishInMain(locationTracks = switch.tracks.map { it.id }).uuid
+        val updateVersion = testDBService.publish(locationTracks = switch.tracks.map { it.id }).uuid
 
         api.switch.getModifiedSince(switchOid, baseVersion).let { response ->
             assertEquals(baseVersion.toString(), response.alkuversio)
@@ -583,7 +583,7 @@ constructor(
             s.copy(stateCategory = LayoutStateCategory.NOT_EXISTING)
         }
         mainDraftContext.mutate(otherSwitch.switch.id) { s -> s.copy(stateCategory = LayoutStateCategory.NOT_EXISTING) }
-        extTestDataService.publishInMain(switches = listOf(matchingSwitch.switch.id, otherSwitch.switch.id))
+        testDBService.publish(switches = listOf(matchingSwitch.switch.id, otherSwitch.switch.id))
 
         api.switchCollection.getModifiedSince(fromPublication, SWITCH_NAME to "VMATCH").also { response ->
             assertEquals(listOf(matchingOid.toString()), response.vaihteet.map { it.vaihde_oid })
@@ -720,7 +720,7 @@ constructor(
             actual.turvavaihde,
         )
 
-        assertEquals(switchLibrary.getSwitchOwner(switch.ownerId)!!.name.toString(), actual.omistaja)
+        assertEquals(switchLibrary.getSwitchOwner(switch.ownerId).name.toString(), actual.omistaja)
 
         val structure = switchLibrary.getSwitchStructure(switch.switchStructureId)
         assertEquals(structure.type.toString(), actual.tyyppi)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
@@ -3,7 +3,6 @@ import fi.fta.geoviite.api.tracklayout.v1.COORDINATE_SYSTEM
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackLayoutTestApiService
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
-import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
@@ -19,10 +18,8 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.locationTrack
-import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.operationalPoint
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometryOfElements
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -30,6 +27,7 @@ import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfElements
+import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -46,7 +44,6 @@ class ExtTestTrackLayoutV1IT
 @Autowired
 constructor(
     mockMvc: MockMvc,
-    private val locationTrackService: LocationTrackService,
     private val extTestDataService: ExtApiTestDataServiceV1,
     private val publicationService: PublicationService,
 ) : DBTestBase() {
@@ -550,9 +547,8 @@ constructor(
         val trackNumberId = mainDraftContext.createLayoutTrackNumber().id.also { mainDraftContext.generateOid(it) }
         val referenceLineId =
             mainDraftContext.saveReferenceLine(referenceLineAndGeometryOfElements(trackNumberId, elements)).id
-        val trackId =
-            mainDraftContext.saveLocationTrack(locationTrack(trackNumberId) to trackGeometryOfElements(elements)).id
-        val oid = mainDraftContext.generateOid(trackId)
+        val (trackId, oid) =
+            mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
 
         testDBService.publish(
             trackNumbers = listOf(trackNumberId),
@@ -571,9 +567,8 @@ constructor(
 
         val tracks =
             listOf(1, 2, 3).map { _ ->
-                val trackId = mainDraftContext.saveLocationTrack(locationTrackAndGeometry(trackNumberId, segment)).id
-                locationTrackService.insertExternalId(LayoutBranch.main, trackId, someOid())
-
+                val (trackId, _) =
+                    mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
                 trackId
             }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
@@ -151,7 +151,7 @@ constructor(
     fun `Ext api asset endpoints should return HTTP 400 if the OID is invalid format`() {
         val invalidOid = "asd"
         val expectedStatus = HttpStatus.BAD_REQUEST
-        val validButEmptyPublication = extTestDataService.publishInMain()
+        val validButEmptyPublication = testDBService.publish()
 
         errorTests.forEach { (_, apiCall) -> apiCall(invalidOid, emptyArray(), expectedStatus) }
         modificationErrorTests.forEach { (_, apiCall) ->
@@ -163,7 +163,7 @@ constructor(
     fun `Ext api asset endpoints should return HTTP 404 if the OID is not found`() {
         val expectedStatus = HttpStatus.NOT_FOUND
         val nonExistingOid = someOid<Nothing>().toString()
-        val validButEmptyPublication = extTestDataService.publishInMain()
+        val validButEmptyPublication = testDBService.publish()
 
         errorTests.forEach { (_, apiCall) -> apiCall(nonExistingOid, emptyArray(), expectedStatus) }
         modificationErrorTests.forEach { (_, apiCall) ->
@@ -215,8 +215,8 @@ constructor(
 
     @Test
     fun `Ext api asset modification endpoints should return HTTP 400 if the start and end track layout versions are in the incorrect order`() {
-        val startPublication = extTestDataService.publishInMain()
-        val endPublication = extTestDataService.publishInMain()
+        val startPublication = testDBService.publish()
+        val endPublication = testDBService.publish()
         val expectedStatus = HttpStatus.BAD_REQUEST
 
         modificationErrorTests
@@ -235,7 +235,7 @@ constructor(
 
     @Test
     fun `Ext api asset modification endpoints should return HTTP 404 if either the start or end track layout version is not found`() {
-        val emptyButExistingPublication = extTestDataService.publishInMain()
+        val emptyButExistingPublication = testDBService.publish()
         val validButNonExistingUuid = "00000000-0000-0000-0000-000000000000"
 
         val expectedStatus = HttpStatus.NOT_FOUND
@@ -258,7 +258,7 @@ constructor(
     @Test
     fun `Ext api asset endpoints should return HTTP 204 when the asset does not exist in the specified track layout version`() {
         val expectedStatus = HttpStatus.NO_CONTENT
-        val validButEmptyPublication = extTestDataService.publishInMain()
+        val validButEmptyPublication = testDBService.publish()
 
         noContentTests
             .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
@@ -284,8 +284,8 @@ constructor(
     @Test
     fun `Ext api asset modification endpoints should return HTTP 204 when the asset does not exist between track layout versions`() {
         val expectedStatus = HttpStatus.NO_CONTENT
-        val firstPublication = extTestDataService.publishInMain()
-        val secondPublication = extTestDataService.publishInMain()
+        val firstPublication = testDBService.publish()
+        val secondPublication = testDBService.publish()
 
         noContentModificationTests
             .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
@@ -305,7 +305,7 @@ constructor(
 
     @Test
     fun `Ext api asset modification endpoints should return HTTP 200 when the asset has been created after the start track layout version`() {
-        val validButEmptyPublication = extTestDataService.publishInMain()
+        val validButEmptyPublication = testDBService.publish()
 
         modificationSuccessTests
             .map { (oidSetup, apiCall) -> oidSetup() to apiCall }
@@ -324,7 +324,7 @@ constructor(
                 val publicationAfterSetup =
                     publicationService.getPublicationByUuidOrLatest(LayoutBranchType.MAIN, publicationUuid = null)
                 initUser()
-                val publicationWithNoChanges = extTestDataService.publishInMain()
+                val publicationWithNoChanges = testDBService.publish()
 
                 apiCall(
                     oid,
@@ -340,7 +340,7 @@ constructor(
     @Test
     fun `Ext api asset collection modification endpoints should return HTTP 404 if either start or end track layout version is not found`() {
         val nonExistingTrackLayoutVersion = "00000000-0000-0000-0000-000000000000"
-        val emptyButRealPublication = extTestDataService.publishInMain()
+        val emptyButRealPublication = testDBService.publish()
 
         collectionModificationErrorTests.forEach { apiCall ->
             apiCall(arrayOf("alkuversio" to nonExistingTrackLayoutVersion), HttpStatus.NOT_FOUND)
@@ -368,7 +368,7 @@ constructor(
     @Test
     fun `Ext api asset collection modification endpoints should return HTTP 400 if the start or end track layout versions is in invalid format`() {
         val invalidTrackLayoutVersion = "asd"
-        val emptyButRealPublication = extTestDataService.publishInMain()
+        val emptyButRealPublication = testDBService.publish()
 
         collectionModificationErrorTests.forEach { apiCall ->
             apiCall(arrayOf("alkuversio" to invalidTrackLayoutVersion), HttpStatus.BAD_REQUEST)
@@ -395,8 +395,8 @@ constructor(
 
     @Test
     fun `Ext api asset collection modification endpoints should return HTTP 400 if the start and end track layout versions are in the incorrect order`() {
-        val startPublication = extTestDataService.publishInMain()
-        val endPublication = extTestDataService.publishInMain()
+        val startPublication = testDBService.publish()
+        val endPublication = testDBService.publish()
 
         collectionModificationErrorTests.forEach { apiCall ->
             apiCall(
@@ -418,7 +418,7 @@ constructor(
 
     @Test
     fun `Ext api asset collection endpoints should return HTTP 404 if the track layout version is not found`() {
-        extTestDataService.publishInMain() // Purposefully a publication so that it does not answer based on this
+        testDBService.publish() // Purposefully a publication so that it does not answer based on this
 
         collectionErrorTests.forEach { apiCall ->
             apiCall(arrayOf("rataverkon_versio" to "00000000-0000-0000-0000-000000000000"), HttpStatus.NOT_FOUND)
@@ -428,7 +428,7 @@ constructor(
     @Test
     fun `Ext api asset collection modification endpoints should return HTTP 204 when there are no modifications`() {
         val lastContentPublication = collectionNoContentTests.map { (setupCollection, _) -> setupCollection() }.last()
-        val lastButEmptyPublication = extTestDataService.publishInMain()
+        val lastButEmptyPublication = testDBService.publish()
 
         collectionNoContentTests.forEach { (_, apiCall) ->
             apiCall(
@@ -505,7 +505,7 @@ constructor(
         val (trackNumberId, referenceLineId, oid) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+        testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         return oid
     }
@@ -524,7 +524,7 @@ constructor(
                 trackNumberId to referenceLineId
             }
 
-        return extTestDataService.publishInMain(
+        return testDBService.publish(
             trackNumbers = trackNumbersAndReferenceLines.map { it.first },
             referenceLines = trackNumbersAndReferenceLines.map { it.second },
         )
@@ -554,7 +554,7 @@ constructor(
             mainDraftContext.saveLocationTrack(locationTrack(trackNumberId) to trackGeometryOfElements(elements)).id
         val oid = mainDraftContext.generateOid(trackId)
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = listOf(trackId),
@@ -577,7 +577,7 @@ constructor(
                 trackId
             }
 
-        return extTestDataService.publishInMain(
+        return testDBService.publish(
             trackNumbers = listOf(trackNumberId),
             referenceLines = listOf(referenceLineId),
             locationTracks = tracks,
@@ -615,7 +615,7 @@ constructor(
                 .id
         val oid = mainDraftContext.generateOid(opId)
 
-        extTestDataService.publishInMain(operationalPoints = listOf(opId))
+        testDBService.publish(operationalPoints = listOf(opId))
 
         return oid
     }
@@ -635,6 +635,6 @@ constructor(
                     .also { opId -> mainDraftContext.generateOid(opId) }
             }
 
-        return extTestDataService.publishInMain(operationalPoints = ops)
+        return testDBService.publish(operationalPoints = ops)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
@@ -21,13 +21,16 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.operationalPoint
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometryOfElements
+import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfElements
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -499,8 +502,8 @@ constructor(
 
     private fun setupValidTrackNumber(): Oid<LayoutTrackNumber> {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, oid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, oid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -512,11 +515,9 @@ constructor(
 
         val trackNumbersAndReferenceLines =
             listOf(1, 2, 3).map { _ ->
-                val (trackNumberId, referenceLineId, _) =
-                    extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                        mainDraftContext,
-                        segments = listOf(segment),
-                    )
+                val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                val referenceLineId =
+                    mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
                 trackNumberId to referenceLineId
             }
@@ -544,7 +545,7 @@ constructor(
             )
         val elements = plan.alignments[0].elements
 
-        val trackNumberId = mainDraftContext.createLayoutTrackNumber().id.also { mainDraftContext.generateOid(it) }
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val referenceLineId =
             mainDraftContext.saveReferenceLine(referenceLineAndGeometryOfElements(trackNumberId, elements)).id
         val (trackId, oid) =
@@ -562,8 +563,8 @@ constructor(
     private fun setupValidLocationTrackCollection(): Publication {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val tracks =
             listOf(1, 2, 3).map { _ ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.CREATE_NEW
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.REPLACE_DUPLICATE
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.REPLACE_DUPLICATE_PARTIAL
@@ -37,13 +36,8 @@ import org.springframework.test.web.servlet.MockMvc
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
 @AutoConfigureMockMvc
-class ExtTrackBoundaryChangeIT
-@Autowired
-constructor(
-    mockMvc: MockMvc,
-    private val extTestDataService: ExtApiTestDataServiceV1,
-    private val splitService: SplitService,
-) : DBTestBase() {
+class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private val splitService: SplitService) :
+    DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -131,7 +125,7 @@ constructor(
 
         // Base publication before the split
         val basePublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 locationTracks = listOf(sourceId, target2Id, target3Id),
@@ -154,7 +148,7 @@ constructor(
 
         // Publication for the split should carry the new boundary changes
         val splitPublication =
-            extTestDataService.publishInMain(locationTracks = split.locationTracks, switches = split.relinkedSwitches)
+            testDBService.publish(locationTracks = split.locationTracks, switches = split.relinkedSwitches)
 
         // Verify results
         api.trackBoundaryCollection.getModifiedBetween(basePublication.uuid, splitPublication.uuid).let { response ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -87,8 +87,8 @@ class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private 
                     startOuterSwitch = switchLinkYV(switch2Id, 2),
                 ),
             )
-        val sourceId = mainDraftContext.save(locationTrack(tnId, name = "SourceTrack"), sourceTrackGeom).id
-        val sourceOid = mainDraftContext.generateOid(sourceId)
+        val (sourceId, sourceOid) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "SourceTrack"), sourceTrackGeom)
 
         // Split target tracks:
 
@@ -115,13 +115,13 @@ class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private 
                     endInnerSwitch = switchLinkYV(switch2Id, 2),
                 ),
             )
-        val target2Id = mainDraftContext.save(locationTrack(tnId, name = "PartialDuplicate"), target2Geom).id
-        val target2Oid = mainDraftContext.generateOid(target2Id)
+        val (target2Id, target2Oid) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "PartialDuplicate"), target2Geom)
 
         // Third target is a duplicate to be fully overridden: original geom doesn't matter
         val target3Geom = trackGeometryOfSegments(segment(Point(10.0, 10.0), Point(20.0, 10.0)))
-        val target3Id = mainDraftContext.save(locationTrack(tnId, name = "FullDuplicate"), target3Geom).id
-        val target3Oid = mainDraftContext.generateOid(target3Id)
+        val (target3Id, target3Oid) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "FullDuplicate"), target3Geom)
 
         // Base publication before the split
         val basePublication =

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -24,6 +24,7 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -48,8 +49,7 @@ class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private 
     @Test
     fun `LocationTrack split shows up a boundary change`() {
         val tn = testDBService.getUnusedTrackNumber()
-        val tnId = mainDraftContext.createLayoutTrackNumber(tn).id
-        val tnOid = mainDraftContext.generateOid(tnId)
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(tn))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutVersionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutVersionIT.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,7 +36,7 @@ class ExtTrackLayoutVersionIT @Autowired constructor(mockMvc: MockMvc) : DBTestB
         api.trackLayoutVersionCollection.getWithEmptyBody(httpStatus = HttpStatus.NO_CONTENT)
 
         initUser()
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0001.000")), rlGeom).id
         val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
@@ -78,7 +79,7 @@ class ExtTrackLayoutVersionIT @Autowired constructor(mockMvc: MockMvc) : DBTestB
 
     @Test
     fun `Track layout version modifications should be returned correctly`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0001.000")), rlGeom).id
         val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
@@ -126,7 +127,7 @@ class ExtTrackLayoutVersionIT @Autowired constructor(mockMvc: MockMvc) : DBTestB
 
     @Test
     fun `Design publications should not be returned`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0001.000")), rlGeom).id
         val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutVersionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutVersionIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.PublicationState
@@ -23,9 +22,7 @@ import org.springframework.test.web.servlet.MockMvc
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
 @AutoConfigureMockMvc
-class ExtTrackLayoutVersionIT
-@Autowired
-constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServiceV1) : DBTestBase() {
+class ExtTrackLayoutVersionIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -41,7 +38,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val tnId = mainDraftContext.createLayoutTrackNumber().id
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0001.000")), rlGeom).id
-        val publication1 = extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
         assertMatches(publication1, api.trackLayoutVersionLatest.get())
         assertMatches(publication1, api.trackLayoutVersion.get(publication1.uuid))
@@ -53,7 +50,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         initUser()
         mainDraftContext.mutate(rlId) { rl -> rl.copy(startAddress = TrackMeter("0001+0002.000")) }
-        val publication2 = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val publication2 = testDBService.publish(referenceLines = listOf(rlId))
 
         assertMatches(publication2, api.trackLayoutVersionLatest.get())
         assertMatches(publication1, api.trackLayoutVersion.get(publication1.uuid))
@@ -66,7 +63,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         initUser()
         mainDraftContext.mutate(rlId) { rl -> rl.copy(startAddress = TrackMeter("0001+0003.000")) }
-        val publication3 = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val publication3 = testDBService.publish(referenceLines = listOf(rlId))
 
         assertMatches(publication3, api.trackLayoutVersionLatest.get())
         assertMatches(publication1, api.trackLayoutVersion.get(publication1.uuid))
@@ -84,13 +81,13 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val tnId = mainDraftContext.createLayoutTrackNumber().id
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0001.000")), rlGeom).id
-        val publication1 = extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
         api.trackLayoutVersionCollection.assertNoModificationSince(publication1.uuid)
 
         initUser()
         mainDraftContext.mutate(rlId) { rl -> rl.copy(startAddress = TrackMeter("0001+0002.000")) }
-        val publication2 = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val publication2 = testDBService.publish(referenceLines = listOf(rlId))
 
         api.trackLayoutVersionCollection.getModifiedSince(publication1.uuid).let { result ->
             assertEquals(publication1.uuid.toString(), result.alkuversio)
@@ -105,7 +102,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         initUser()
         mainDraftContext.mutate(rlId) { rl -> rl.copy(startAddress = TrackMeter("0001+0003.000")) }
-        val publication3 = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val publication3 = testDBService.publish(referenceLines = listOf(rlId))
 
         api.trackLayoutVersionCollection.getModifiedSince(publication1.uuid).let { result ->
             assertEquals(publication1.uuid.toString(), result.alkuversio)
@@ -132,7 +129,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val tnId = mainDraftContext.createLayoutTrackNumber().id
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0001.000")), rlGeom).id
-        val publication1 = extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
         api.trackLayoutVersionCollection.assertNoModificationSince(publication1.uuid)
 
@@ -140,7 +137,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val designBranch = testDBService.createDesignBranch()
         val designCtx = testDBService.testContext(designBranch, PublicationState.DRAFT)
         designCtx.mutate(rlId) { rl -> rl.copy(startAddress = TrackMeter("0001+0002.000")) }
-        val designPublication = extTestDataService.publishInBranch(designBranch, referenceLines = listOf(rlId))
+        val designPublication = testDBService.publish(designBranch, referenceLines = listOf(rlId))
 
         api.trackLayoutVersionCollection.assertNoModificationSince(publication1.uuid)
         api.trackLayoutVersion.getWithExpectedError(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
@@ -57,12 +57,12 @@ constructor(
                 )
             }
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = trackNumbers.map { (trackNumberId, _, _) -> trackNumberId },
             referenceLines = trackNumbers.map { (_, referenceLineId, _) -> referenceLineId },
         )
 
-        val newestButEmptyPublication = extTestDataService.publishInMain()
+        val newestButEmptyPublication = testDBService.publish()
         val response = api.trackNumberCollection.get()
 
         assertEquals(newestButEmptyPublication.uuid.toString(), response.rataverkon_versio)
@@ -85,7 +85,7 @@ constructor(
             }
 
         val newestPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = officialTrackNumbers.map { it.first },
                 referenceLines = officialTrackNumbers.map { it.second },
             )
@@ -133,7 +133,7 @@ constructor(
                     )
 
                 val publication =
-                    extTestDataService.publishInMain(
+                    testDBService.publish(
                         trackNumbers = listOf(trackNumberId),
                         referenceLines = listOf(referenceLineId),
                     )
@@ -165,7 +165,7 @@ constructor(
         val (trackNumberId, referenceLineId, _) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+        testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         tests.forEach { (epsgCode, expectedStart, expectedEnd) ->
             val response = api.trackNumberCollection.get("koordinaatisto" to epsgCode)
@@ -201,7 +201,7 @@ constructor(
             }
 
         val initialPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = allTrackNumbers.map { (_, trackNumber, _) -> trackNumber.id as IntId },
                 referenceLines = allTrackNumbers.map { (_, _, referenceLineId) -> referenceLineId },
             )
@@ -216,8 +216,7 @@ constructor(
                 oid to trackNumber.id as IntId
             }
 
-        val secondPublication =
-            extTestDataService.publishInMain(trackNumbers = modifiedTrackNumbers.map { (_, id) -> id })
+        val secondPublication = testDBService.publish(trackNumbers = modifiedTrackNumbers.map { (_, id) -> id })
 
         val response = api.trackNumberCollection.getModified("alkuversio" to initialPublication.uuid.toString())
 
@@ -246,7 +245,7 @@ constructor(
             }
 
         val initialPublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = trackNumbers.map { (trackNumber, _) -> trackNumber.id as IntId },
                 referenceLines = trackNumbers.map { (_, referenceLineId) -> referenceLineId },
             )
@@ -257,9 +256,7 @@ constructor(
             .forEach { (trackNumber, newState) -> mainDraftContext.saveTrackNumber(trackNumber.copy(state = newState)) }
 
         val secondPublication =
-            extTestDataService.publishInMain(
-                trackNumbers = trackNumbers.map { (trackNumber, _) -> trackNumber.id as IntId }
-            )
+            testDBService.publish(trackNumbers = trackNumbers.map { (trackNumber, _) -> trackNumber.id as IntId })
 
         val response = api.trackNumberCollection.getModified("alkuversio" to initialPublication.uuid.toString())
 
@@ -268,7 +265,7 @@ constructor(
 
     @Test
     fun `Track number modification listing respects start & end track layout version arguments`() {
-        extTestDataService.publishInMain() // Purposeful empty publication which should not be in any of the responses
+        testDBService.publish() // Purposeful empty publication which should not be in any of the responses
 
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
@@ -276,10 +273,7 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val publicationStart =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(trackNumberId),
-                referenceLines = listOf(referenceLineId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         val modifiedDescription = "modified description after publication ${publicationStart.uuid}"
         layoutTrackNumberService.get(MainLayoutContext.official, trackNumberId).let(::requireNotNull).let { trackNumber
@@ -287,10 +281,10 @@ constructor(
             mainDraftContext.save(trackNumber.copy(description = TrackNumberDescription(modifiedDescription)))
         }
 
-        val publicationEnd = extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId))
+        val publicationEnd = testDBService.publish(trackNumbers = listOf(trackNumberId))
 
         // Publish one more time, this should also not be in the response
-        extTestDataService.publishInMain()
+        testDBService.publish()
 
         val response =
             api.trackNumberCollection.getModified(
@@ -313,10 +307,7 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val publicationStart =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(trackNumberId),
-                referenceLines = listOf(referenceLineId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         val modifiedDescription = "modified description after publication ${publicationStart.uuid}"
         layoutTrackNumberService.get(MainLayoutContext.official, trackNumberId).let(::requireNotNull).let { trackNumber
@@ -324,7 +315,7 @@ constructor(
             mainDraftContext.save(trackNumber.copy(description = TrackNumberDescription(modifiedDescription)))
         }
 
-        val publicationEnd = extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId))
+        val publicationEnd = testDBService.publish(trackNumbers = listOf(trackNumberId))
 
         val response = api.trackNumberCollection.getModified("alkuversio" to publicationStart.uuid.toString())
 
@@ -344,7 +335,7 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val basePublication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(trackNumberId1, trackNumberId2),
                 referenceLines = listOf(referenceLineId1, referenceLineId2),
             )
@@ -356,7 +347,7 @@ constructor(
             mainOfficialContext.fetch(referenceLineId1)!!.copy(startAddress = TrackMeter("0001+0010.000")),
             referenceLineGeometry(segment),
         )
-        val rlPublication = extTestDataService.publishInMain(referenceLines = listOf(referenceLineId1))
+        val rlPublication = testDBService.publish(referenceLines = listOf(referenceLineId1))
         assertAddressRange(getExtTrackNumberInCollection(trackNumberOid1)!!, "0001+0010.000", "0001+0020.000")
         api.trackNumberCollection.getModifiedBetween(basePublication.uuid, rlPublication.uuid).let { mods ->
             assertEquals(listOf(trackNumberOid1.toString()), mods.ratanumerot.map { it.ratanumero_oid })
@@ -367,7 +358,7 @@ constructor(
         initUser()
         val kmpId =
             mainDraftContext.save(kmPost(trackNumberId1, KmNumber(4), gkLocation = kmPostGkLocation(5.0, 0.0))).id
-        val kmpPublication = extTestDataService.publishInMain(kmPosts = listOf(kmpId))
+        val kmpPublication = testDBService.publish(kmPosts = listOf(kmpId))
         assertAddressRange(getExtTrackNumberInCollection(trackNumberOid1)!!, "0001+0010.000", "0004+0005.000")
         api.trackNumberCollection.getModifiedBetween(rlPublication.uuid, kmpPublication.uuid).let { mods ->
             assertEquals(listOf(trackNumberOid1.toString()), mods.ratanumerot.map { it.ratanumero_oid })
@@ -404,7 +395,7 @@ constructor(
                 segments = listOf(someSegment()),
             )
 
-        extTestDataService.publishInMain(
+        testDBService.publish(
             trackNumbers = listOf(matchingId, otherId),
             referenceLines = listOf(matchingRefId, otherRefId),
         )
@@ -433,11 +424,8 @@ constructor(
             )
 
         val fromPublication =
-            extTestDataService
-                .publishInMain(
-                    trackNumbers = listOf(matchingId, otherId),
-                    referenceLines = listOf(matchingRefId, otherRefId),
-                )
+            testDBService
+                .publish(trackNumbers = listOf(matchingId, otherId), referenceLines = listOf(matchingRefId, otherRefId))
                 .uuid
 
         layoutTrackNumberService.get(MainLayoutContext.official, matchingId).let(::requireNotNull).also { tn ->
@@ -447,7 +435,7 @@ constructor(
             mainDraftContext.saveTrackNumber(tn.copy(description = TrackNumberDescription("changed")))
         }
 
-        extTestDataService.publishInMain(trackNumbers = listOf(matchingId, otherId))
+        testDBService.publish(trackNumbers = listOf(matchingId, otherId))
 
         api.trackNumberCollection.getModifiedSince(fromPublication, TRACK_NUMBER to "001 MATCHING").also { response ->
             assertEquals(listOf(matchingOid.toString()), response.ratanumerot.map { it.ratanumero_oid })

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.IntId
@@ -8,6 +7,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LayoutState
@@ -15,11 +15,12 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
+import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someSegment
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -33,11 +34,7 @@ import org.springframework.test.web.servlet.MockMvc
 @AutoConfigureMockMvc
 class ExtTrackNumberCollectionIT
 @Autowired
-constructor(
-    mockMvc: MockMvc,
-    private val layoutTrackNumberService: LayoutTrackNumberService,
-    private val extTestDataService: ExtApiTestDataServiceV1,
-) : DBTestBase() {
+constructor(mockMvc: MockMvc, private val layoutTrackNumberService: LayoutTrackNumberService) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -51,10 +48,11 @@ constructor(
 
         val trackNumbers =
             listOf(1, 2, 3).map { _ ->
-                extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                    mainDraftContext,
-                    segments = listOf(segment),
-                )
+                val (trackNumberId, trackNumberOid) =
+                    mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                val referenceLineId =
+                    mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
+                Triple(trackNumberId, referenceLineId, trackNumberOid)
             }
 
         testDBService.publish(
@@ -67,9 +65,10 @@ constructor(
 
         assertEquals(newestButEmptyPublication.uuid.toString(), response.rataverkon_versio)
         assertEquals(trackNumbers.size, response.ratanumerot.size)
-
-        val responseOids = response.ratanumerot.map { trackNumber -> trackNumber.ratanumero_oid }
-        trackNumbers.forEach { (_, _, oid) -> assertTrue(oid.toString() in responseOids) }
+        assertEquals(
+            trackNumbers.map { it.third.toString() }.toSet(),
+            response.ratanumerot.map { it.ratanumero_oid }.toSet(),
+        )
     }
 
     @Test
@@ -78,10 +77,11 @@ constructor(
 
         val officialTrackNumbers =
             listOf(1, 2, 3).map { _ ->
-                extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                    mainDraftContext,
-                    segments = listOf(segment),
-                )
+                val (trackNumberId, trackNumberOid) =
+                    mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                val referenceLineId =
+                    mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
+                Triple(trackNumberId, referenceLineId, trackNumberOid)
             }
 
         val newestPublication =
@@ -101,7 +101,8 @@ constructor(
         }
 
         // Also save an additional draft track
-        extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (draftTrackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        mainDraftContext.save(referenceLine(draftTrackNumberId), referenceLineGeometry(segment))
 
         val response = api.trackNumberCollection.get()
         assertEquals(newestPublication.uuid.toString(), response.rataverkon_versio)
@@ -126,11 +127,9 @@ constructor(
 
         val expectedAmountToPublications =
             listOf(1, 2, 3).map { totalAmountOfTrackNumbers ->
-                val (trackNumberId, referenceLineId, _) =
-                    extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                        mainDraftContext,
-                        segments = listOf(segment),
-                    )
+                val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                val referenceLineId =
+                    mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
                 val publication =
                     testDBService.publish(
@@ -162,8 +161,8 @@ constructor(
 
         val segment = segment(helsinkiRailwayStationTm35Fin, helsinkiRailwayStationTm35FinPlus10000)
 
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -188,11 +187,10 @@ constructor(
 
         val allTrackNumbers =
             listOf(1, 2, 3, 4).map { _ ->
-                val (trackNumberId, referenceLineId, oid) =
-                    extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                        mainDraftContext,
-                        segments = listOf(segment),
-                    )
+                val (trackNumberId, oid) =
+                    mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                val referenceLineId =
+                    mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
                 val trackNumber =
                     layoutTrackNumberService.get(MainLayoutContext.draft, trackNumberId).let(::requireNotNull)
@@ -232,11 +230,9 @@ constructor(
 
         val trackNumbers =
             LayoutState.entries.map { _ ->
-                val (trackNumberId, referenceLineId, _) =
-                    extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                        mainDraftContext,
-                        segments = listOf(segment),
-                    )
+                val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                val referenceLineId =
+                    mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
                 val trackNumber =
                     layoutTrackNumberService.get(MainLayoutContext.draft, trackNumberId).let(::requireNotNull)
@@ -269,8 +265,8 @@ constructor(
 
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val publicationStart =
             testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
@@ -303,8 +299,8 @@ constructor(
     fun `Track number modification listing should use the newest track layout version if end version is not supplied`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
-        val (trackNumberId, referenceLineId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, _) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val publicationStart =
             testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
@@ -329,10 +325,12 @@ constructor(
     @Test
     fun `Track number modifications listing lists track numbers with calculated changes`() {
         val segment = segment(Point(0.0, 0.0), Point(10.0, 0.0))
-        val (trackNumberId1, referenceLineId1, trackNumberOid1) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
-        val (trackNumberId2, referenceLineId2, trackNumberOid2) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId1, trackNumberOid1) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId1 = mainDraftContext.save(referenceLine(trackNumberId1), referenceLineGeometry(segment)).id
+        val (trackNumberId2, trackNumberOid2) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId2 = mainDraftContext.save(referenceLine(trackNumberId2), referenceLineGeometry(segment)).id
 
         val basePublication =
             testDBService.publish(
@@ -382,18 +380,10 @@ constructor(
 
     @Test
     fun `Track number collection is filtered by track number name`() {
-        val (matchingId, matchingRefId, matchingOid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                trackNumberName = "001 MATCHING",
-                segments = listOf(someSegment()),
-            )
-        val (otherId, otherRefId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                trackNumberName = "999 OTHER",
-                segments = listOf(someSegment()),
-            )
+        val (matchingId, matchingOid) = mainDraftContext.saveWithOid(trackNumber(TrackNumber("001 MATCHING")))
+        val matchingRefId = mainDraftContext.save(referenceLine(matchingId), referenceLineGeometry(someSegment())).id
+        val (otherId, _) = mainDraftContext.saveWithOid(trackNumber(TrackNumber("999 OTHER")))
+        val otherRefId = mainDraftContext.save(referenceLine(otherId), referenceLineGeometry(someSegment())).id
 
         testDBService.publish(
             trackNumbers = listOf(matchingId, otherId),
@@ -410,18 +400,10 @@ constructor(
 
     @Test
     fun `Track number change-list is filtered by track number name`() {
-        val (matchingId, matchingRefId, matchingOid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                trackNumberName = "001 MATCHING",
-                segments = listOf(someSegment()),
-            )
-        val (otherId, otherRefId, _) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                trackNumberName = "999 OTHER",
-                segments = listOf(someSegment()),
-            )
+        val (matchingId, matchingOid) = mainDraftContext.saveWithOid(trackNumber(TrackNumber("001 MATCHING")))
+        val matchingRefId = mainDraftContext.save(referenceLine(matchingId), referenceLineGeometry(someSegment())).id
+        val (otherId, _) = mainDraftContext.saveWithOid(trackNumber(TrackNumber("999 OTHER")))
+        val otherRefId = mainDraftContext.save(referenceLine(otherId), referenceLineGeometry(someSegment())).id
 
         val fromPublication =
             testDBService

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
@@ -214,7 +214,7 @@ constructor(mockMvc: MockMvc, private val layoutTrackNumberService: LayoutTrackN
                 oid to trackNumber.id as IntId
             }
 
-        val secondPublication = testDBService.publish(trackNumbers = modifiedTrackNumbers.map { (_, id) -> id })
+        testDBService.publish(trackNumbers = modifiedTrackNumbers.map { (_, id) -> id })
 
         val response = api.trackNumberCollection.getModified("alkuversio" to initialPublication.uuid.toString())
 
@@ -251,8 +251,7 @@ constructor(mockMvc: MockMvc, private val layoutTrackNumberService: LayoutTrackN
             .zip(LayoutState.entries)
             .forEach { (trackNumber, newState) -> mainDraftContext.saveTrackNumber(trackNumber.copy(state = newState)) }
 
-        val secondPublication =
-            testDBService.publish(trackNumbers = trackNumbers.map { (trackNumber, _) -> trackNumber.id as IntId })
+        testDBService.publish(trackNumbers = trackNumbers.map { (trackNumber, _) -> trackNumber.id as IntId })
 
         val response = api.trackNumberCollection.getModified("alkuversio" to initialPublication.uuid.toString())
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
@@ -3,14 +3,11 @@ package fi.fta.geoviite.api.tracklayout.v1
 import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
-import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
-import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
 import fi.fta.geoviite.infra.geocoding.Resolution
 import fi.fta.geoviite.infra.math.Point
@@ -19,7 +16,6 @@ import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
@@ -27,7 +23,7 @@ import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineAndGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
-import fi.fta.geoviite.infra.tracklayout.someOid
+import fi.fta.geoviite.infra.tracklayout.someReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -50,7 +46,6 @@ constructor(
     mockMvc: MockMvc,
     private val extTestDataService: ExtApiTestDataServiceV1,
     private val layoutTrackNumberDao: LayoutTrackNumberDao,
-    private val layoutTrackNumberService: LayoutTrackNumberService,
 ) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
@@ -66,10 +61,7 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val publication1 =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(trackNumberId),
-                referenceLines = listOf(referenceLineId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         val modifiedDescription = "modified description after publication ${publication1.uuid}"
         val trackNumber = layoutTrackNumberDao.getOrThrow(MainLayoutContext.official, trackNumberId)
@@ -87,18 +79,15 @@ constructor(
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
         val publication1 =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(trackNumberId),
-                referenceLines = listOf(referenceLineId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
-        val publication2 = extTestDataService.publishInMain()
+        val publication2 = testDBService.publish()
 
         val modifiedDescription = "modified description after publication ${publication1.uuid}"
         val trackNumber = layoutTrackNumberDao.getOrThrow(MainLayoutContext.official, trackNumberId)
         mainDraftContext.saveTrackNumber(trackNumber.copy(description = TrackNumberDescription(modifiedDescription)))
 
-        val publication3 = extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId))
+        val publication3 = testDBService.publish(trackNumbers = listOf(trackNumberId))
 
         val responses =
             listOf(publication1, publication2, publication3).map { publication ->
@@ -131,7 +120,7 @@ constructor(
         val (trackNumberId, referenceLineId, oid) =
             extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
 
-        extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+        testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         tests.forEach { (epsgCode, expectedStart, expectedEnd) ->
             val response = api.trackNumbers.get(oid, "koordinaatisto" to epsgCode)
@@ -153,7 +142,7 @@ constructor(
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0100.000")), geometry).id
         val tnOid = mainDraftContext.generateOid(tnId)
 
-        val publication1 = extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
         api.trackNumberGeometry.get(tnOid).also { response ->
             assertEquals(publication1.uuid.toString(), response.rataverkon_versio)
@@ -165,7 +154,7 @@ constructor(
         mainDraftContext.fetch(rlId).also { rl ->
             mainDraftContext.save(rl!!.copy(startAddress = TrackMeter("0001+0200.000")), newGeometry)
         }
-        val publication2 = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val publication2 = testDBService.publish(referenceLines = listOf(rlId))
 
         api.trackNumberGeometry.get(tnOid).also { response ->
             assertEquals(publication2.uuid.toString(), response.rataverkon_versio)
@@ -185,29 +174,16 @@ constructor(
 
     @Test
     fun `Track number api should return track number information regardless of its state`() {
-        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-
         val trackNumbers =
-            LayoutState.entries.mapIndexed { index, state ->
-                val trackNumber =
+            LayoutState.entries.map { state ->
+                val tnId =
                     mainDraftContext
-                        .saveTrackNumber(trackNumber(TrackNumber("30$index"), state = state))
-                        .let(layoutTrackNumberDao::fetch)
-
-                val referenceLineId =
-                    mainDraftContext.saveReferenceLine(referenceLineAndGeometry(trackNumber.id as IntId, segment)).id
-
-                extTestDataService.publishInMain(
-                    trackNumbers = listOf(trackNumber.id as IntId),
-                    referenceLines = listOf(referenceLineId),
-                )
-
-                val oid =
-                    someOid<LayoutTrackNumber>().also { oid ->
-                        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumber.id, oid)
-                    }
-
-                oid to state
+                        .saveTrackNumber(trackNumber(testDBService.getUnusedTrackNumber(), state = state))
+                        .id
+                val tnOid = mainDraftContext.generateOid(tnId)
+                val referenceLineId = mainDraftContext.saveReferenceLine(referenceLineAndGeometry(tnId)).id
+                testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(referenceLineId))
+                tnOid to state
             }
 
         trackNumbers.forEach { (oid, state) ->
@@ -220,45 +196,32 @@ constructor(
 
     @Test
     fun `Track number modifications api should return track number regardless of its state`() {
-        val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
         val trackNumbers =
-            LayoutState.entries.mapIndexed { index, state ->
-                val trackNumber =
+            LayoutState.entries.map { state ->
+                val id =
                     mainDraftContext
-                        .saveTrackNumber(trackNumber(TrackNumber("30$index"), state = state))
-                        .let(layoutTrackNumberDao::fetch)
-
-                val referenceLineId =
-                    mainDraftContext.saveReferenceLine(referenceLineAndGeometry(trackNumber.id as IntId, segment)).id
-
-                extTestDataService.publishInMain(referenceLines = listOf(referenceLineId))
-
-                val oid =
-                    someOid<LayoutTrackNumber>().also { oid ->
-                        layoutTrackNumberService.insertExternalId(LayoutBranch.main, trackNumber.id, oid)
-                    }
-
-                Triple(oid, trackNumber, state)
+                        .saveTrackNumber(trackNumber(testDBService.getUnusedTrackNumber(), state = state))
+                        .id
+                Triple(id, mainDraftContext.generateOid(id), state)
             }
 
         val publication1 =
-            extTestDataService.publishInMain(
-                trackNumbers = trackNumbers.map { (_, trackNumber, _) -> trackNumber.id as IntId }
+            testDBService.publish(
+                trackNumbers = trackNumbers.map { (id, _, _) -> id },
+                referenceLines =
+                    trackNumbers.map { (id, _, _) ->
+                        mainDraftContext.save(referenceLine(id), someReferenceLineGeometry()).id
+                    },
             )
 
         val modifiedDescription = "modified description after publication ${publication1.uuid}"
-        trackNumbers.forEach { (_, trackNumber, _) ->
-            mainDraftContext.saveTrackNumber(
-                trackNumber.copy(description = TrackNumberDescription(modifiedDescription))
-            )
+        trackNumbers.forEach { (id, _, _) ->
+            mainDraftContext.mutate(id) { tn -> tn.copy(description = TrackNumberDescription(modifiedDescription)) }
         }
 
-        val publication2 =
-            extTestDataService.publishInMain(
-                trackNumbers = trackNumbers.map { (_, trackNumber, _) -> trackNumber.id as IntId }
-            )
+        val publication2 = testDBService.publish(trackNumbers = trackNumbers.map { (id, _, _) -> id })
 
-        trackNumbers.forEach { (oid, trackNumber, _) ->
+        trackNumbers.forEach { (_, oid, state) ->
             val response =
                 api.trackNumbers.getModified(
                     oid,
@@ -268,7 +231,7 @@ constructor(
 
             assertEquals(oid.toString(), response.ratanumero.ratanumero_oid)
             assertEquals(modifiedDescription, response.ratanumero.kuvaus)
-            assertExtLayoutState(trackNumber.state, response.ratanumero.tila)
+            assertExtLayoutState(state, response.ratanumero.tila)
         }
     }
 
@@ -291,7 +254,7 @@ constructor(
                 startAddress = TrackMeter(KmNumber("0000"), startM.toBigDecimal()),
             )
 
-        extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+        testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         Resolution.entries
             .map { it.meters }
@@ -323,7 +286,7 @@ constructor(
                 startAddress = intervalStartAddress,
             )
 
-        extTestDataService.publishInMain(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
+        testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
         Resolution.entries
             .map { it.meters }
@@ -347,15 +310,14 @@ constructor(
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
-        val basePublication =
-            extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val basePublication = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
         getExtTrackNumber(tnOid).also { assertAddressRange(it, "0000+0000.000", "0000+0010.000") }
         api.trackNumbers.assertNoModificationSince(tnOid, basePublication.uuid)
 
         initUser()
         val newStart = TrackMeter("0001+0010.000")
         mainDraftContext.save(mainOfficialContext.fetch(rlId)!!.copy(startAddress = newStart), rlGeom)
-        val rlPublication = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val rlPublication = testDBService.publish(referenceLines = listOf(rlId))
         assertAddressRange(getExtTrackNumber(tnOid), "0001+0010.000", "0001+0020.000")
         api.trackNumbers.getModifiedBetween(tnOid, basePublication.uuid, rlPublication.uuid).also { mod ->
             assertAddressRange(mod.ratanumero, "0001+0010.000", "0001+0020.000")
@@ -364,7 +326,7 @@ constructor(
 
         initUser()
         val kmpId = mainDraftContext.save(kmPost(tnId, KmNumber(4), gkLocation = kmPostGkLocation(5.0, 0.0))).id
-        val kmpPublication = extTestDataService.publishInMain(kmPosts = listOf(kmpId))
+        val kmpPublication = testDBService.publish(kmPosts = listOf(kmpId))
         assertAddressRange(getExtTrackNumber(tnOid), "0001+0010.000", "0004+0005.000")
         api.trackNumbers.getModifiedBetween(tnOid, rlPublication.uuid, kmpPublication.uuid).also { mod ->
             assertAddressRange(mod.ratanumero, "0001+0010.000", "0004+0005.000")
@@ -389,7 +351,7 @@ constructor(
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0100.000")), geometry).id
         val tnOid = mainDraftContext.generateOid(tnId)
 
-        val publication1 = extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
         api.trackNumberGeometry.get(tnOid).also { response ->
             assertEquals(publication1.uuid.toString(), response.rataverkon_versio)
@@ -397,7 +359,7 @@ constructor(
 
         initUser()
         mainDraftContext.mutate(tnId) { tn -> tn.copy(state = LayoutState.DELETED) }
-        val publication2 = extTestDataService.publishInMain(trackNumbers = listOf(tnId))
+        val publication2 = testDBService.publish(trackNumbers = listOf(tnId))
 
         api.trackNumberGeometry.assertDoesntExist(tnOid)
         api.trackNumberGeometry.assertDoesntExistAtVersion(tnOid, publication2.uuid)
@@ -417,8 +379,7 @@ constructor(
         val endWithAddress = ExtTestAddressPointV1(100.0, 0.0, "0000+0100.000")
         val endWithoutAddress = ExtTestAddressPointV1(100.0, 0.0, null)
 
-        val initPublication =
-            extTestDataService.publishInMain(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
+        val initPublication = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
         api.trackNumbers.get(tnOid).also { tn ->
             assertEquals(startWithAddress, tn.ratanumero.alkusijainti)
@@ -427,7 +388,7 @@ constructor(
 
         initUser()
         mainDraftContext.save(mainDraftContext.fetch(tnId)!!.copy(state = LayoutState.DELETED))
-        val deletePublication = extTestDataService.publishInMain(trackNumbers = listOf(tnId))
+        val deletePublication = testDBService.publish(trackNumbers = listOf(tnId))
 
         api.trackNumbers.get(tnOid).also { tn ->
             assertEquals(startWithoutAddress, tn.ratanumero.alkusijainti)
@@ -452,9 +413,7 @@ constructor(
                 .createLayoutTrackNumber()
                 .id
                 .let { tnId -> tnId to mainDraftContext.save(referenceLine(tnId)).id }
-                .let { (tn, rl) ->
-                    extTestDataService.publishInMain(trackNumbers = listOf(tn), referenceLines = listOf(rl))
-                }
+                .let { (tn, rl) -> testDBService.publish(trackNumbers = listOf(tn), referenceLines = listOf(rl)) }
 
         // Publication 1 adds a new track number
         val tnId = mainDraftContext.createLayoutTrackNumber().id
@@ -466,7 +425,7 @@ constructor(
         val kmp2Id = mainDraftContext.save(kmPost(tnId, KmNumber(3), gkLocation = kmPostGkLocation(65.0, 0.0))).id
         val tnOid = mainDraftContext.generateOid(tnId)
         val publication1 =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 kmPosts = listOf(kmp1Id, kmp2Id),
@@ -504,7 +463,7 @@ constructor(
             )
         initUser()
         mainDraftContext.save(mainDraftContext.fetch(rlId)!!, alignment2)
-        val publication2 = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val publication2 = testDBService.publish(referenceLines = listOf(rlId))
 
         api.trackNumberGeometry.get(tnOid).also { response ->
             assertEquals(publication2.uuid.toString(), response.rataverkon_versio)
@@ -570,7 +529,7 @@ constructor(
         // Publication 3 removes the geometry
         initUser()
         mainDraftContext.save(mainDraftContext.fetch(tnId)!!.copy(state = LayoutState.DELETED))
-        val publication3 = extTestDataService.publishInMain(trackNumbers = listOf(tnId))
+        val publication3 = testDBService.publish(trackNumbers = listOf(tnId))
 
         api.trackNumberGeometry.assertNoModificationSince(tnOid, publication3.uuid)
         // Modifications since 2 show the state-2 address range emptied
@@ -597,7 +556,7 @@ constructor(
         val tnOid = mainDraftContext.generateOid(tnId)
 
         val basePub =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 kmPosts = listOf(kmp1Id, kmp2Id),
@@ -613,7 +572,7 @@ constructor(
             mainOfficialContext.fetch(rlId)!!.copy(startAddress = TrackMeter("0001+0010.000")),
             geometry,
         )
-        val rlPub = extTestDataService.publishInMain(referenceLines = listOf(rlId))
+        val rlPub = testDBService.publish(referenceLines = listOf(rlId))
         api.trackNumberGeometry.get(tnOid).osoitevali!!.also { interval ->
             assertEquals("0001+0010.000", interval.alkuosoite)
             assertEquals("0004+0035.000", interval.loppuosoite)
@@ -636,7 +595,7 @@ constructor(
 
         initUser()
         val kmpId = mainDraftContext.save(kmPost(tnId, KmNumber(3), gkLocation = kmPostGkLocation(30.0, 0.0))).id
-        val kmpPub = extTestDataService.publishInMain(kmPosts = listOf(kmpId))
+        val kmpPub = testDBService.publish(kmPosts = listOf(kmpId))
 
         api.trackNumberGeometry.get(tnOid).osoitevali!!.also { interval ->
             assertEquals("0001+0010.000", interval.alkuosoite)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
@@ -176,11 +176,8 @@ constructor(
     fun `Track number api should return track number information regardless of its state`() {
         val trackNumbers =
             LayoutState.entries.map { state ->
-                val tnId =
-                    mainDraftContext
-                        .saveTrackNumber(trackNumber(testDBService.getUnusedTrackNumber(), state = state))
-                        .id
-                val tnOid = mainDraftContext.generateOid(tnId)
+                val (tnId, tnOid) =
+                    mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber(), state = state))
                 val referenceLineId = mainDraftContext.saveReferenceLine(referenceLineAndGeometry(tnId)).id
                 testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(referenceLineId))
                 tnOid to state
@@ -198,11 +195,9 @@ constructor(
     fun `Track number modifications api should return track number regardless of its state`() {
         val trackNumbers =
             LayoutState.entries.map { state ->
-                val id =
-                    mainDraftContext
-                        .saveTrackNumber(trackNumber(testDBService.getUnusedTrackNumber(), state = state))
-                        .id
-                Triple(id, mainDraftContext.generateOid(id), state)
+                val (id, oid) =
+                    mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber(), state = state))
+                Triple(id, oid, state)
             }
 
         val publication1 =

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.KmNumber
@@ -42,11 +41,7 @@ import org.springframework.test.web.servlet.MockMvc
 @AutoConfigureMockMvc
 class ExtTrackNumberIT
 @Autowired
-constructor(
-    mockMvc: MockMvc,
-    private val extTestDataService: ExtApiTestDataServiceV1,
-    private val layoutTrackNumberDao: LayoutTrackNumberDao,
-) : DBTestBase() {
+constructor(mockMvc: MockMvc, private val layoutTrackNumberDao: LayoutTrackNumberDao) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -57,8 +52,8 @@ constructor(
     @Test
     fun `Newest official track number is returned by default`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, oid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, oid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val publication1 =
             testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
@@ -75,8 +70,8 @@ constructor(
     @Test
     fun `Track number api respects the track layout version argument`() {
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
-        val (trackNumberId, referenceLineId, oid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, oid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         val publication1 =
             testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
@@ -117,8 +112,8 @@ constructor(
 
         val segment = segment(helsinkiRailwayStationTm35Fin, helsinkiRailwayStationTm35FinPlus10000)
 
-        val (trackNumberId, referenceLineId, oid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(mainDraftContext, segments = listOf(segment))
+        val (trackNumberId, oid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId = mainDraftContext.save(referenceLine(trackNumberId), referenceLineGeometry(segment)).id
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -137,10 +132,9 @@ constructor(
 
     @Test
     fun `Official geometry is returned at correct track layout version state`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val geometry = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0100.000")), geometry).id
-        val tnOid = mainDraftContext.generateOid(tnId)
 
         val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
@@ -242,12 +236,14 @@ constructor(
                 HelsinkiTestData.HKI_BASE_POINT + Point(endM - startM, 0.0),
                 startM,
             )
-        val (trackNumberId, referenceLineId, oid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment),
-                startAddress = TrackMeter(KmNumber("0000"), startM.toBigDecimal()),
-            )
+        val (trackNumberId, oid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(
+                    referenceLine(trackNumberId, startAddress = TrackMeter(KmNumber("0000"), startM.toBigDecimal())),
+                    referenceLineGeometry(segment),
+                )
+                .id
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -274,12 +270,11 @@ constructor(
                 HelsinkiTestData.HKI_BASE_POINT + Point(0.0, endM - startM),
                 startM,
             )
-        val (trackNumberId, referenceLineId, oid) =
-            extTestDataService.insertTrackNumberAndReferenceLineWithOid(
-                mainDraftContext,
-                segments = listOf(segment),
-                startAddress = intervalStartAddress,
-            )
+        val (trackNumberId, oid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineId =
+            mainDraftContext
+                .save(referenceLine(trackNumberId, startAddress = intervalStartAddress), referenceLineGeometry(segment))
+                .id
 
         testDBService.publish(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineId))
 
@@ -300,8 +295,7 @@ constructor(
 
     @Test
     fun `Track number modification API should show modifications for calculated change`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val tnOid = mainDraftContext.generateOid(tnId)
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
 
@@ -341,10 +335,9 @@ constructor(
 
     @Test
     fun `Deleted track numbers don't have geometry`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val geometry = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0100.000")), geometry).id
-        val tnOid = mainDraftContext.generateOid(tnId)
 
         val publication1 = testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId))
 
@@ -365,8 +358,7 @@ constructor(
 
     @Test
     fun `Deleted track numbers have no addresses exposed through the API`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val tnOid = mainDraftContext.generateOid(tnId)
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
         val startWithAddress = ExtTestAddressPointV1(0.0, 0.0, "0000+0000.000")
@@ -405,20 +397,18 @@ constructor(
         // Add "some" publication to have a baseline version for queries prior to the track number creation
         val publication0 =
             mainDraftContext
-                .createLayoutTrackNumber()
-                .id
-                .let { tnId -> tnId to mainDraftContext.save(referenceLine(tnId)).id }
+                .saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+                .let { (tnId, _) -> tnId to mainDraftContext.save(referenceLine(tnId)).id }
                 .let { (tn, rl) -> testDBService.publish(trackNumbers = listOf(tn), referenceLines = listOf(rl)) }
 
         // Publication 1 adds a new track number
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val alignment1 = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         // Straight reference line initially
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0100.000")), alignment1).id
         // Use km-posts to reset address calculation, as otherwise any change would change the geometry until the end
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(2), gkLocation = kmPostGkLocation(15.0, 0.0))).id
         val kmp2Id = mainDraftContext.save(kmPost(tnId, KmNumber(3), gkLocation = kmPostGkLocation(65.0, 0.0))).id
-        val tnOid = mainDraftContext.generateOid(tnId)
         val publication1 =
             testDBService.publish(
                 trackNumbers = listOf(tnId),
@@ -543,12 +533,11 @@ constructor(
 
     @Test
     fun `Geometry modifications API shows calculated changes correctly`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val geometry = referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter("0001+0100.000")), geometry).id
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(2), gkLocation = kmPostGkLocation(15.0, 0.0))).id
         val kmp2Id = mainDraftContext.save(kmPost(tnId, KmNumber(4), gkLocation = kmPostGkLocation(65.0, 0.0))).id
-        val tnOid = mainDraftContext.generateOid(tnId)
 
         val basePub =
             testDBService.publish(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmsIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmsIT.kt
@@ -1,6 +1,5 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
-import fi.fta.geoviite.api.ExtApiTestDataServiceV1
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
 import fi.fta.geoviite.infra.common.KmNumber
@@ -16,8 +15,6 @@ import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
-import java.math.BigDecimal
-import kotlin.math.abs
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -30,13 +27,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import java.math.BigDecimal
+import kotlin.math.abs
 
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
 @AutoConfigureMockMvc
-class ExtTrackNumberKmsIT
-@Autowired
-constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServiceV1) : DBTestBase() {
+class ExtTrackNumberKmsIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -65,7 +62,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
             mainDraftContext.save(kmPost(tnId, KmNumber(16), gkLocation = kmPostGkLocation(600.0, 0.0, true))).id
 
         val publication =
-            extTestDataService.publishInMain(
+            testDBService.publish(
                 trackNumbers = listOf(tnId),
                 referenceLines = listOf(rlId),
                 kmPosts = listOf(kmp13Id, kmp14Id, deletedKmp15Id, kmp16Id),
@@ -134,11 +131,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(1), gkLocation = kmPostGkLocation(1500.0, 1002.0))).id
 
         val publication =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(tnId),
-                referenceLines = listOf(rlId),
-                kmPosts = listOf(kmp1Id),
-            )
+            testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId), kmPosts = listOf(kmp1Id))
         val response = api.trackNumberKms.get(tnOid, COORDINATE_SYSTEM to "EPSG:4326")
         assertEquals(publication.uuid.toString(), response.rataverkon_versio)
         assertEquals(Srid(4326).toString(), response.koordinaatisto)
@@ -183,11 +176,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter.ZERO), rlGeom).id
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(1), gkLocation = kmPostGkLocation(500.0, 0.0))).id
         val basePublication =
-            extTestDataService.publishInMain(
-                trackNumbers = listOf(tnId),
-                referenceLines = listOf(rlId),
-                kmPosts = listOf(kmp1Id),
-            )
+            testDBService.publish(trackNumbers = listOf(tnId), referenceLines = listOf(rlId), kmPosts = listOf(kmp1Id))
 
         api.trackNumberKms.get(tnOid).also { response ->
             assertEquals(basePublication.uuid.toString(), response.rataverkon_versio)
@@ -203,7 +192,7 @@ constructor(mockMvc: MockMvc, private val extTestDataService: ExtApiTestDataServ
 
         initUser()
         mainDraftContext.mutate(tnId) { tn -> tn.copy(state = LayoutState.DELETED) }
-        val deletePublication = extTestDataService.publishInMain(trackNumbers = listOf(tnId))
+        val deletePublication = testDBService.publish(trackNumbers = listOf(tnId))
         api.trackNumberKms.getWithEmptyBody(tnOid, httpStatus = HttpStatus.NO_CONTENT)
         api.trackNumberKms.assertDoesntExist(tnOid)
         assertNull(

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmsIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmsIT.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.trackNumber
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -44,8 +45,7 @@ class ExtTrackNumberKmsIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase(
     @Test
     fun `Track number kms API should return correct kms`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val tnId = mainDraftContext.createLayoutTrackNumber(trackNumber).id
-        val tnOid = mainDraftContext.generateOid(tnId)
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(trackNumber))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter(10, 100)), rlGeom).id
         val kmp13Id =
@@ -124,8 +124,7 @@ class ExtTrackNumberKmsIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase(
     @Test
     fun `Track number kms API respects the coordinate system argument`() {
         val trackNumber = testDBService.getUnusedTrackNumber()
-        val tnId = mainDraftContext.createLayoutTrackNumber(trackNumber).id
-        val tnOid = mainDraftContext.generateOid(tnId)
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(trackNumber))
         val rlGeom = referenceLineGeometry(segment(Point(1000.0, 1000.0), Point(2000.0, 1000.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter.ZERO), rlGeom).id
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(1), gkLocation = kmPostGkLocation(1500.0, 1002.0))).id
@@ -170,8 +169,7 @@ class ExtTrackNumberKmsIT @Autowired constructor(mockMvc: MockMvc) : DBTestBase(
 
     @Test
     fun `A deleted track number has no kms`() {
-        val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val tnOid = mainDraftContext.generateOid(tnId)
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
         val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(1000.0, 0.0)))
         val rlId = mainDraftContext.save(referenceLine(tnId, startAddress = TrackMeter.ZERO), rlGeom).id
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(1), gkLocation = kmPostGkLocation(500.0, 0.0))).id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -8,7 +8,6 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.Oid
-import fi.fta.geoviite.infra.integration.CalculatedChangesService
 import fi.fta.geoviite.infra.common.ProjectName
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
@@ -21,9 +20,10 @@ import fi.fta.geoviite.infra.geometry.Author
 import fi.fta.geoviite.infra.geometry.CompanyName
 import fi.fta.geoviite.infra.geometry.GeometryDao
 import fi.fta.geoviite.infra.geometry.GeometryPlan
-import fi.fta.geoviite.infra.inframodel.InfraModelFile
 import fi.fta.geoviite.infra.geometry.Project
 import fi.fta.geoviite.infra.geometry.project
+import fi.fta.geoviite.infra.inframodel.InfraModelFile
+import fi.fta.geoviite.infra.integration.CalculatedChangesService
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationCause
@@ -86,10 +86,10 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.setUser
-import java.time.Instant
-import kotlin.reflect.KClass
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.Instant
+import kotlin.reflect.KClass
 
 interface TestDB {
     val jdbc: NamedParameterJdbcTemplate
@@ -462,10 +462,7 @@ class TestDBService(
         )
     }
 
-    fun savePlan(
-        plan: GeometryPlan,
-        file: InfraModelFile = InfraModelFile(plan.fileName, "<a></a>"),
-    ): GeometryPlan {
+    fun savePlan(plan: GeometryPlan, file: InfraModelFile = InfraModelFile(plan.fileName, "<a></a>")): GeometryPlan {
         val planVersion = geometryDao.insertPlan(plan, file, null)
         return geometryDao.fetchPlan(planVersion)
     }
@@ -547,8 +544,10 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
     inline fun <reified T : LayoutAsset<T>> generateOid(id: IntId<T>): Oid<T> =
         testService.generateOid(id, context.branch)
 
-    fun saveWithOid(asset: LocationTrack, geometry: LocationTrackGeometry): Pair<IntId<LocationTrack>, Oid<LocationTrack>> =
-        save(asset, geometry).id.let { id -> id to generateOid(id) }
+    fun saveWithOid(
+        asset: LocationTrack,
+        geometry: LocationTrackGeometry,
+    ): Pair<IntId<LocationTrack>, Oid<LocationTrack>> = save(asset, geometry).id.let { id -> id to generateOid(id) }
 
     fun saveWithOid(asset: LayoutSwitch): Pair<IntId<LayoutSwitch>, Oid<LayoutSwitch>> =
         save(asset).id.let { id -> id to generateOid(id) }
@@ -664,8 +663,12 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
         return save(locationTrack(createLayoutTrackNumber().id), geometry)
     }
 
-    fun createLocationTrackWithReferenceLine(geometry: LocationTrackGeometry): LayoutRowVersion<LocationTrack> {
-        val trackNumberId = createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments)).id
+    fun createLocationTrackWithReferenceLine(
+        geometry: LocationTrackGeometry,
+        trackNumber: TrackNumber = testService.getUnusedTrackNumber(),
+    ): LayoutRowVersion<LocationTrack> {
+        val trackNumberId =
+            createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments), trackNumber).id
         return save(locationTrack(trackNumberId), geometry)
     }
 
@@ -723,24 +726,23 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
                     )
                 )
                 .id
-        val innerTrackIds =
-            alignmentJointPositions.map { jointPositions ->
-                save(
-                        locationTrack(createLayoutTrackNumber().id),
-                        trackGeometry(
-                            combineEdges(
-                                jointPositions.zipWithNext().map { (from, to) ->
-                                    edge(
-                                        startInnerSwitch = switchLinkYV(switchId, from.first.intValue),
-                                        endInnerSwitch = switchLinkYV(switchId, to.first.intValue),
-                                        segments = listOf(segment(toSegmentPoints(from.second, to.second))),
-                                    )
-                                }
-                            )
-                        ),
-                    )
-                    .id
-            }
+        val innerTrackIds = alignmentJointPositions.map { jointPositions ->
+            save(
+                    locationTrack(createLayoutTrackNumber().id),
+                    trackGeometry(
+                        combineEdges(
+                            jointPositions.zipWithNext().map { (from, to) ->
+                                edge(
+                                    startInnerSwitch = switchLinkYV(switchId, from.first.intValue),
+                                    endInnerSwitch = switchLinkYV(switchId, to.first.intValue),
+                                    segments = listOf(segment(toSegmentPoints(from.second, to.second))),
+                                )
+                            }
+                        )
+                    ),
+                )
+                .id
+        }
         return switchId to innerTrackIds
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -8,6 +8,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.integration.CalculatedChangesService
 import fi.fta.geoviite.infra.common.ProjectName
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
@@ -28,6 +29,9 @@ import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationCause
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.publication.PublicationMessage
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.publicationRequest
+import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.tracklayout.DbLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.DesignAssetState
@@ -143,6 +147,8 @@ class TestDBService(
     override val operationalPointDao: OperationalPointDao,
     private val layoutDesignDao: LayoutDesignDao,
     private val publicationDao: PublicationDao,
+    private val publicationService: PublicationService,
+    private val calculatedChangesService: CalculatedChangesService,
 ) : TestDB {
 
     override val jdbc by lazy { jdbcTemplate ?: error("JDBC not initialized") }
@@ -462,6 +468,45 @@ class TestDBService(
     ): GeometryPlan {
         val planVersion = geometryDao.insertPlan(plan, file, null)
         return geometryDao.fetchPlan(planVersion)
+    }
+
+    fun publish(
+        branch: LayoutBranch = LayoutBranch.main,
+        trackNumbers: List<IntId<LayoutTrackNumber>> = emptyList(),
+        referenceLines: List<IntId<ReferenceLine>> = emptyList(),
+        locationTracks: List<IntId<LocationTrack>> = emptyList(),
+        switches: List<IntId<LayoutSwitch>> = emptyList(),
+        kmPosts: List<IntId<LayoutKmPost>> = emptyList(),
+        operationalPoints: List<IntId<OperationalPoint>> = emptyList(),
+    ): Publication {
+        val requestIds =
+            publicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts, operationalPoints)
+        val versions = publicationService.getValidationVersions(branch, requestIds)
+        val calculatedChanges = calculatedChangesService.getCalculatedChanges(versions)
+        val result =
+            publicationService.publishChanges(
+                branch,
+                versions,
+                calculatedChanges,
+                PublicationMessage.of("test"),
+                PublicationCause.MANUAL,
+            )
+        return publicationDao.getPublication(requireNotNull(result.publicationId))
+    }
+
+    fun publishAndValidate(
+        branch: LayoutBranch = LayoutBranch.main,
+        trackNumbers: List<IntId<LayoutTrackNumber>> = emptyList(),
+        referenceLines: List<IntId<ReferenceLine>> = emptyList(),
+        locationTracks: List<IntId<LocationTrack>> = emptyList(),
+        switches: List<IntId<LayoutSwitch>> = emptyList(),
+        kmPosts: List<IntId<LayoutKmPost>> = emptyList(),
+        operationalPoints: List<IntId<OperationalPoint>> = emptyList(),
+    ): Publication {
+        val request =
+            publicationRequest(trackNumbers, locationTracks, referenceLines, switches, kmPosts, operationalPoints)
+        val result = publicationService.publishManualPublication(branch, request)
+        return publicationDao.getPublication(requireNotNull(result.publicationId))
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -86,10 +86,10 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.setUser
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 import kotlin.reflect.KClass
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.transaction.support.TransactionTemplate
 
 interface TestDB {
     val jdbc: NamedParameterJdbcTemplate
@@ -667,12 +667,11 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
         geometry: LocationTrackGeometry,
         trackNumber: TrackNumber = testService.getUnusedTrackNumber(),
     ): LayoutRowVersion<LocationTrack> {
-        val trackNumberId =
-            createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments), trackNumber).id
+        val trackNumberId = createTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments), trackNumber).id
         return save(locationTrack(trackNumberId), geometry)
     }
 
-    fun createLayoutTrackNumberAndReferenceLine(
+    fun createTrackNumberAndReferenceLine(
         referenceLineGeometry: ReferenceLineGeometry = referenceLineGeometry(),
         trackNumber: TrackNumber = testService.getUnusedTrackNumber(),
         startAddress: TrackMeter = TrackMeter.ZERO,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -71,6 +70,11 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -80,11 +84,6 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1282,7 +1281,7 @@ constructor(
         )
         val kmPost = mainOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(3.0, 0.0))).id
         val switch = mainOfficialContext.save(switch(joints = listOf(switchJoint(1, Point(7.0, 0.0))))).id
-        val locationTrack =
+        val trackId =
             mainOfficialContext
                 .save(
                     locationTrack(trackNumber),
@@ -1298,14 +1297,14 @@ constructor(
         val designBranch = testDBService.createDesignBranch()
         val designDraftContext = testDBService.testContext(designBranch, PublicationState.DRAFT)
         designDraftContext.save(mainOfficialContext.fetch(switch)!!)
-        designDraftContext.save(mainOfficialContext.fetch(locationTrack)!!)
+        designDraftContext.save(mainOfficialContext.fetch(trackId)!!)
         publicationTestSupportService.publish(
             designBranch,
-            publicationRequestIds(switches = listOf(switch), locationTracks = listOf(locationTrack)),
+            publicationRequestIds(switches = listOf(switch), locationTracks = listOf(trackId)),
         )
-        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
-        switchDao.insertExternalId(switch, designBranch, Oid("2.3.4.5.6"))
-        layoutTrackNumberDao.insertExternalId(trackNumber, designBranch, Oid("3.4.5.6.7"))
+        val locationTrackOid = testDBService.generateOid(trackId, designBranch)
+        testDBService.generateOid(switch, designBranch)
+        val trackNumberOid = testDBService.generateOid(trackNumber, designBranch)
 
         moveKmPostLocation(mainOfficialContext.fetch(kmPost)!!, Point(5.0, 0.0), kmPostService)
 
@@ -1324,7 +1323,7 @@ constructor(
             changes.trackNumberChanges,
         )
         assertEquals(
-            listOf(LocationTrackChange(locationTrack, setOf(KmNumber(0), KmNumber(1)), false, true)),
+            listOf(LocationTrackChange(trackId, setOf(KmNumber(0), KmNumber(1)), false, true)),
             changes.locationTrackChanges,
         )
         val expectedSwitchJointChange =
@@ -1333,10 +1332,10 @@ constructor(
                 false,
                 TrackMeter(KmNumber(1), BigDecimal("2.000")),
                 Point(7.0, 0.0),
-                locationTrack,
-                Oid("1.2.3.4.5"),
+                trackId,
+                locationTrackOid,
                 trackNumber,
-                Oid("3.4.5.6.7"),
+                trackNumberOid,
             )
         assertEquals(listOf(SwitchChange(switch, listOf(expectedSwitchJointChange))), changes.switchChanges)
     }
@@ -1404,9 +1403,9 @@ constructor(
             designBranch,
             publicationRequestIds(switches = listOf(switch), locationTracks = listOf(locationTrack)),
         )
-        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
-        switchDao.insertExternalId(switch, designBranch, Oid("2.3.4.5.6"))
-        layoutTrackNumberDao.insertExternalId(trackNumber, designBranch, Oid("3.4.5.6.7"))
+        val locationTrackOid = testDBService.generateOid(locationTrack, designBranch)
+        testDBService.generateOid(switch, designBranch)
+        val trackNumberOid = testDBService.generateOid(trackNumber, designBranch)
 
         moveKmPostLocation(mainOfficialContext.fetch(kmPost)!!, Point(5.0, 0.0), kmPostService)
 
@@ -1435,9 +1434,9 @@ constructor(
                 TrackMeter(KmNumber(1), BigDecimal("2.000")),
                 Point(7.0, 0.0),
                 locationTrack,
-                Oid("1.2.3.4.5"),
+                locationTrackOid,
                 trackNumber,
-                Oid("3.4.5.6.7"),
+                trackNumberOid,
             )
         assertEquals(listOf(SwitchChange(switch, listOf(expectedSwitchJointChange))), changes.switchChanges)
     }
@@ -1486,9 +1485,9 @@ constructor(
                 kmPosts = listOf(kmPost),
             ),
         )
-        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
-        switchDao.insertExternalId(switch, designBranch, Oid("2.3.4.5.6"))
-        layoutTrackNumberDao.insertExternalId(trackNumber, designBranch, Oid("3.4.5.6.7"))
+        testDBService.generateOid(locationTrack, designBranch)
+        testDBService.generateOid(switch, designBranch)
+        testDBService.generateOid(trackNumber, designBranch)
 
         moveKmPostLocation(mainOfficialContext.fetch(kmPost)!!, Point(5.0, 0.0), kmPostService)
 
@@ -1684,19 +1683,18 @@ constructor(
             layoutTrackNumberDao.fetch(
                 layoutTrackNumberDao.save(trackNumber(TrackNumber("TEST TN $sequence"), draft = false))
             )
-        val kmPosts =
-            kmPostData.map { (kmNumber, location) ->
-                layoutKmPostDao.fetch(
-                    layoutKmPostDao.save(
-                        kmPost(
-                            trackNumberId = trackNumber.id as IntId,
-                            km = kmNumber,
-                            gkLocation = kmPostGkLocation(refPoint + location),
-                            draft = false,
-                        )
+        val kmPosts = kmPostData.map { (kmNumber, location) ->
+            layoutKmPostDao.fetch(
+                layoutKmPostDao.save(
+                    kmPost(
+                        trackNumberId = trackNumber.id as IntId,
+                        km = kmNumber,
+                        gkLocation = kmPostGkLocation(refPoint + location),
+                        draft = false,
                     )
                 )
-            }
+            )
+        }
         val referenceLineGeometryVersion =
             layoutAlignmentDao.insert(
                 referenceLineGeometry(
@@ -1718,54 +1716,50 @@ constructor(
             )
 
         var locationTrackSequence = 0
-        val locationTracksAndGeometries =
-            locationTrackData.map { line ->
-                locationTrackService.getWithGeometry(
-                    locationTrackDao.save(
-                        locationTrack(
-                            trackNumberId = trackNumber.id as IntId,
-                            name = "TEST LocTr $sequence ${locationTrackSequence++}",
-                            draft = false,
-                        ),
-                        trackGeometryOfSegments(segments(refPoint + line.start, refPoint + line.end, 10.0)),
-                    )
+        val locationTracksAndGeometries = locationTrackData.map { line ->
+            locationTrackService.getWithGeometry(
+                locationTrackDao.save(
+                    locationTrack(
+                        trackNumberId = trackNumber.id as IntId,
+                        name = "TEST LocTr $sequence ${locationTrackSequence++}",
+                        draft = false,
+                    ),
+                    trackGeometryOfSegments(segments(refPoint + line.start, refPoint + line.end, 10.0)),
                 )
-            }
+            )
+        }
 
-        val switches =
-            switchData.map { switch ->
-                linkTestSwitch(
-                    refPoint + switch.location,
-                    locationTracksAndGeometries[switch.locationTrackIndexA],
-                    locationTracksAndGeometries[switch.locationTrackIndexB],
-                    switch.name,
-                )
-            }
+        val switches = switchData.map { switch ->
+            linkTestSwitch(
+                refPoint + switch.location,
+                locationTracksAndGeometries[switch.locationTrackIndexA],
+                locationTracksAndGeometries[switch.locationTrackIndexB],
+                switch.name,
+            )
+        }
 
-        val publishedLocationTracksAndGeometries =
-            locationTracksAndGeometries.map { (locationTrack, _) ->
-                val id = locationTrack.id as IntId
-                val rowVersion = locationTrackDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-                val (edited, editedGeometry) = locationTrackService.getWithGeometry(rowVersion)
-                if (edited.isDraft) {
-                    val publicationResponse = locationTrackService.publish(LayoutBranch.main, rowVersion).published
-                    locationTrackService.getWithGeometry(publicationResponse)
-                } else {
-                    edited to editedGeometry
-                }
+        val publishedLocationTracksAndGeometries = locationTracksAndGeometries.map { (locationTrack, _) ->
+            val id = locationTrack.id as IntId
+            val rowVersion = locationTrackDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+            val (edited, editedGeometry) = locationTrackService.getWithGeometry(rowVersion)
+            if (edited.isDraft) {
+                val publicationResponse = locationTrackService.publish(LayoutBranch.main, rowVersion).published
+                locationTrackService.getWithGeometry(publicationResponse)
+            } else {
+                edited to editedGeometry
             }
-        val publishedSwitches =
-            switches.map { switch ->
-                val id = switch.id as IntId
-                val rowVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-                val edited = switchDao.fetch(rowVersion)
-                if (edited.isDraft) {
-                    val publicationResponse = switchService.publish(LayoutBranch.main, rowVersion).published
-                    switchDao.fetch(publicationResponse)
-                } else {
-                    edited
-                }
+        }
+        val publishedSwitches = switches.map { switch ->
+            val id = switch.id as IntId
+            val rowVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+            val edited = switchDao.fetch(rowVersion)
+            if (edited.isDraft) {
+                val publicationResponse = switchService.publish(LayoutBranch.main, rowVersion).published
+                switchDao.fetch(publicationResponse)
+            } else {
+                edited
             }
+        }
 
         return TestData(
             trackNumber = trackNumber,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
@@ -923,16 +923,15 @@ constructor(
             name = SwitchName(name),
         )
 
-    private fun shiftTrack(template: List<LayoutSegment>, shiftVector: Point) =
-        template.map { segment -> shiftSegmentGeometry(segment, shiftVector) }
+    private fun shiftTrack(template: List<LayoutSegment>, shiftVector: Point) = template.map { segment ->
+        shiftSegmentGeometry(segment, shiftVector)
+    }
 
     @Test
     fun `validateRelinkingTrack relinks okay cases and gives validation errors about bad ones`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(150.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(150.0, 0.0))))
                 .id
 
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
@@ -1073,9 +1072,7 @@ constructor(
     fun `relinkTrack and validateRelinkingTrack find nearby switches`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
 
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
@@ -1123,9 +1120,7 @@ constructor(
     fun `validateRelinkingTrack warns about switches getting unlinked`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
 
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
@@ -1242,9 +1237,7 @@ constructor(
     fun `re-linking switch cleans up previous references consistently`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
         val (templateSwitch, templateTrackSections) =
@@ -1314,9 +1307,7 @@ constructor(
     fun `re-linking switch cleans up topological connections`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
         val (templateSwitch, templateTrackSections) =
@@ -1370,9 +1361,7 @@ constructor(
     fun `relinking with head-to-head linked YV switches with initially unlinked through track`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
         val leftSwitch =
@@ -1554,9 +1543,7 @@ constructor(
     fun `relinking removes misplaced topological switch link`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "RR54-4x1:9" }!!
         val (templateSwitch, templateTrackSections) =
@@ -1926,9 +1913,7 @@ constructor(
         Triple<IntId<LocationTrack>, IntId<LocationTrack>, IntId<LayoutSwitch>> {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         // switch structure YV60_300_1_9_O's rightmost joints are at x-coords:
         // - 34.430 (through track)
@@ -2033,9 +2018,7 @@ constructor(
     fun `relinkTrack does not relink unrelated tracks`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
         val switchToRelink =
@@ -2149,9 +2132,7 @@ constructor(
     fun `relinkTrack connects track outward topologically`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(200.0, 0.0))))
                 .id
         val switchStructure = switchLibraryService.getSwitchStructures().find { it.type.typeName == "YV60-300-1:9-O" }!!
         val startSwitch =
@@ -2516,12 +2497,11 @@ constructor(
     ): List<Pair<LocationTrack, LocationTrackGeometry>> {
         val fittedSwitchLocationTrackIds =
             fittedSwitch.joints.flatMap { joint -> joint.matches.map { match -> match.locationTrackId } }.distinct()
-        val fittedSwitchTracks =
-            fittedSwitchLocationTrackIds.map { locationTrackId ->
-                requireNotNull(locationTrackService.getWithGeometry(layoutContext, locationTrackId)) {
-                    "Location track $locationTrackId for fitted switch not found"
-                }
+        val fittedSwitchTracks = fittedSwitchLocationTrackIds.map { locationTrackId ->
+            requireNotNull(locationTrackService.getWithGeometry(layoutContext, locationTrackId)) {
+                "Location track $locationTrackId for fitted switch not found"
             }
+        }
         val switchContainingTracks = switchService.getLocationTracksLinkedToSwitch(layoutContext, switchId)
         val linkedTracks =
             directlyApplyFittedSwitchChangesToTracks(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDesignInheritanceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDesignInheritanceIT.kt
@@ -99,16 +99,13 @@ constructor(
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("2.2.2.2.2"))
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(
-                publicationRequestIds(referenceLines = listOf(referenceLine)),
-                PublicationMessage.of("ref line to design"),
-            ),
+            publicationRequest(referenceLines = listOf(referenceLine), message = "ref line to design"),
         )
 
         mainDraftContext.save(mainDraftContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(2)))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(kmPosts = listOf(kmPost)), PublicationMessage.of("km post")),
+            publicationRequest(kmPosts = listOf(kmPost), message = "km post"),
         )
 
         val designPublications = publicationLogService.fetchPublications(design)
@@ -146,16 +143,13 @@ constructor(
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("2.2.2.2.2"))
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(
-                publicationRequestIds(trackNumbers = listOf(trackNumber)),
-                PublicationMessage.of("track number to design"),
-            ),
+            publicationRequest(trackNumbers = listOf(trackNumber), message = "track number to design"),
         )
 
         mainDraftContext.save(mainDraftContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(2)))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(kmPosts = listOf(kmPost)), PublicationMessage.of("km post")),
+            publicationRequest(kmPosts = listOf(kmPost), message = "km post"),
         )
 
         val designPublications = publicationLogService.fetchPublications(design)
@@ -196,16 +190,13 @@ constructor(
         fakeRatko.acceptsNewLocationTrackGivingItOid("2.2.2.2.2")
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(
-                publicationRequestIds(locationTracks = listOf(locationTrack)),
-                PublicationMessage.of("location track to design"),
-            ),
+            publicationRequest(locationTracks = listOf(locationTrack), message = "location track to design"),
         )
 
         mainDraftContext.save(mainDraftContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(2)))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(kmPosts = listOf(kmPost)), PublicationMessage.of("km post")),
+            publicationRequest(kmPosts = listOf(kmPost), message = "km post"),
         )
 
         val designPublications = publicationLogService.fetchPublications(design)
@@ -245,16 +236,13 @@ constructor(
 
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(
-                publicationRequestIds(locationTracks = listOf(locationTrack)),
-                PublicationMessage.of("location track in design"),
-            ),
+            publicationRequest(locationTracks = listOf(locationTrack), message = "location track in design"),
         )
 
         mainDraftContext.save(mainDraftContext.fetch(kmPost)!!.copy(kmNumber = KmNumber(2)))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(kmPosts = listOf(kmPost)), PublicationMessage.of("km post")),
+            publicationRequest(kmPosts = listOf(kmPost), message = "km post"),
         )
 
         val designPublications = publicationLogService.fetchPublications(design)
@@ -295,10 +283,7 @@ constructor(
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("3.3.3.3.3"))
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(
-                publicationRequestIds(kmPosts = listOf(kmPost)),
-                PublicationMessage.of("edit km post in design"),
-            ),
+            publicationRequest(kmPosts = listOf(kmPost), message = "edit km post in design"),
         )
         assertEquals("2.2.2.2.2", locationTrackDao.fetchExternalId(design, locationTrack)?.oid?.toString())
         assertEquals("3.3.3.3.3", trackNumberDao.fetchExternalId(design, trackNumber)?.oid?.toString())

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDesignInheritanceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDesignInheritanceIT.kt
@@ -4,7 +4,6 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.math.Point
@@ -45,6 +44,7 @@ constructor(
     val locationTrackDao: LocationTrackDao,
     val fakeRatkoService: FakeRatkoService,
 ) : DBTestBase() {
+
     @BeforeEach
     fun cleanup() {
         val sql =
@@ -83,7 +83,7 @@ constructor(
         // case: track number is only in main-official, but reference line is also edited in design, and km post on
         // the track number is changed -> inherited change is recorded on the track number version in main
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        trackNumberDao.insertExternalId(trackNumber, LayoutBranch.main, Oid("1.1.1.1.1"))
+        testDBService.generateOid(trackNumber, LayoutBranch.main)
         val referenceLine =
             mainOfficialContext
                 .save(referenceLine(trackNumber), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
@@ -126,7 +126,7 @@ constructor(
         // case: track number is edited in design, and km post on the track number is changed -> inherited change is
         // recorded on the track number version in the design
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        trackNumberDao.insertExternalId(trackNumber, LayoutBranch.main, Oid("1.1.1.1.1"))
+        testDBService.generateOid(trackNumber, LayoutBranch.main)
         mainOfficialContext
             .save(referenceLine(trackNumber), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
             .id
@@ -170,7 +170,7 @@ constructor(
         // case: location track is create in main and edited in design, then a km post change is edited in main,
         // causing an inherited change
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        trackNumberDao.insertExternalId(trackNumber, LayoutBranch.main, Oid("1.1.1.1.1"))
+        testDBService.generateOid(trackNumber, LayoutBranch.main)
         mainOfficialContext
             .save(referenceLine(trackNumber), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
             .id
@@ -216,7 +216,7 @@ constructor(
         // case: location track is created in design, then a km post change is edited in main, causing an inherited
         // change
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        trackNumberDao.insertExternalId(trackNumber, LayoutBranch.main, Oid("1.1.1.1.1"))
+        testDBService.generateOid(trackNumber, LayoutBranch.main)
         mainOfficialContext
             .save(referenceLine(trackNumber), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
             .id
@@ -260,7 +260,7 @@ constructor(
     @Test
     fun `self-inherited changes both assign oids and record indirect changes for the inheritance targets`() {
         val trackNumber = mainOfficialContext.save(trackNumber()).id
-        trackNumberDao.insertExternalId(trackNumber, LayoutBranch.main, Oid("1.1.1.1.1"))
+        testDBService.generateOid(trackNumber, LayoutBranch.main)
         mainOfficialContext
             .save(referenceLine(trackNumber), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
             .id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDomainTestData.kt
@@ -1,0 +1,32 @@
+package fi.fta.geoviite.infra.publication
+
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.OperationalPoint
+import fi.fta.geoviite.infra.tracklayout.ReferenceLine
+
+fun publicationRequestIds(
+    trackNumbers: List<IntId<LayoutTrackNumber>> = emptyList(),
+    locationTracks: List<IntId<LocationTrack>> = emptyList(),
+    referenceLines: List<IntId<ReferenceLine>> = emptyList(),
+    switches: List<IntId<LayoutSwitch>> = emptyList(),
+    kmPosts: List<IntId<LayoutKmPost>> = emptyList(),
+    operationalPoints: List<IntId<OperationalPoint>> = emptyList(),
+): PublicationRequestIds =
+    PublicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts, operationalPoints)
+
+fun publicationRequest(
+    trackNumbers: List<IntId<LayoutTrackNumber>> = emptyList(),
+    locationTracks: List<IntId<LocationTrack>> = emptyList(),
+    referenceLines: List<IntId<ReferenceLine>> = emptyList(),
+    switches: List<IntId<LayoutSwitch>> = emptyList(),
+    kmPosts: List<IntId<LayoutKmPost>> = emptyList(),
+    operationalPoints: List<IntId<OperationalPoint>> = emptyList(),
+    message: String = "test publication",
+): PublicationRequest = PublicationRequest(
+    PublicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts, operationalPoints),
+    PublicationMessage.of(message),
+)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -10,7 +10,6 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.MainLayoutContext
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
@@ -81,11 +80,6 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.tracklayout.trackNumberSaveRequest
 import fi.fta.geoviite.infra.util.SortOrder
-import java.time.Instant
-import kotlin.math.absoluteValue
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -94,6 +88,11 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import publicationRequest
 import publish
+import java.time.Instant
+import kotlin.math.absoluteValue
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -771,7 +770,7 @@ constructor(
     @Test
     fun `publication log switch changes in main do not include switch link removals in designs`() {
         val switch = switchDao.save(switch(name = "sw", draft = false)).id
-        switchDao.insertExternalId(switch, LayoutBranch.main, Oid("1.1.1.1.2"))
+        testDBService.generateOid(switch, LayoutBranch.main)
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val locationTrackId =
             locationTrackService
@@ -829,9 +828,9 @@ constructor(
         val switchAddedAndRemoved = switchDao.save(switch(name = "sw-added-and-later-removed", draft = false)).id
         val switchFurtherAddedInMain = switchDao.save(switch(name = "sw-later-added-in-main", draft = false)).id
         val switchFurtherAddedInDesign = switchDao.save(switch(name = "sw-later-added-in-design", draft = false)).id
-        switchDao.insertExternalId(switchAddedAndRemoved, LayoutBranch.main, Oid("1.1.1.1.2"))
-        switchDao.insertExternalId(switchFurtherAddedInMain, LayoutBranch.main, Oid("1.1.1.1.5"))
-        switchDao.insertExternalId(switchFurtherAddedInDesign, LayoutBranch.main, Oid("1.1.1.1.6"))
+        testDBService.generateOid(switchAddedAndRemoved, LayoutBranch.main)
+        testDBService.generateOid(switchFurtherAddedInMain, LayoutBranch.main)
+        testDBService.generateOid(switchFurtherAddedInDesign, LayoutBranch.main)
 
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val locationTrackId =
@@ -893,14 +892,14 @@ constructor(
         val originalSwitchReplacedWithNewSameName =
             switchDao.save(switch(name = "sw-replaced-with-new-same-name", draft = false))
 
-        switchDao.insertExternalId(switchUnlinkedFromTopology.id, LayoutBranch.main, Oid("1.1.1.1.1"))
-        switchDao.insertExternalId(switchUnlinkedFromAlignment.id, LayoutBranch.main, Oid("1.1.1.1.2"))
-        switchDao.insertExternalId(switchAddedToTopologyStart.id, LayoutBranch.main, Oid("1.1.1.1.3"))
-        switchDao.insertExternalId(switchAddedToTopologyEnd.id, LayoutBranch.main, Oid("1.1.1.1.4"))
-        switchDao.insertExternalId(switchAddedToAlignment.id, LayoutBranch.main, Oid("1.1.1.1.5"))
-        switchDao.insertExternalId(switchDeleted.id, LayoutBranch.main, Oid("1.1.1.1.6"))
-        switchDao.insertExternalId(switchMerelyRenamed.id, LayoutBranch.main, Oid("1.1.1.1.7"))
-        switchDao.insertExternalId(originalSwitchReplacedWithNewSameName.id, LayoutBranch.main, Oid("1.1.1.1.8"))
+        testDBService.generateOid(switchUnlinkedFromTopology.id, LayoutBranch.main)
+        testDBService.generateOid(switchUnlinkedFromAlignment.id, LayoutBranch.main)
+        testDBService.generateOid(switchAddedToTopologyStart.id, LayoutBranch.main)
+        testDBService.generateOid(switchAddedToTopologyEnd.id, LayoutBranch.main)
+        testDBService.generateOid(switchAddedToAlignment.id, LayoutBranch.main)
+        testDBService.generateOid(switchDeleted.id, LayoutBranch.main)
+        testDBService.generateOid(switchMerelyRenamed.id, LayoutBranch.main)
+        val originalSwitchOid = testDBService.generateOid(originalSwitchReplacedWithNewSameName.id, LayoutBranch.main)
 
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
 
@@ -933,7 +932,7 @@ constructor(
         )
         val newSwitchReplacingOldWithSameName =
             switchService.saveDraft(LayoutBranch.main, switch(name = "sw-replaced-with-new-same-name", draft = true))
-        switchDao.insertExternalId(newSwitchReplacingOldWithSameName.id, LayoutBranch.main, Oid("1.1.1.1.9"))
+        val newSwitchOid = testDBService.generateOid(newSwitchReplacingOldWithSameName.id, LayoutBranch.main)
 
         locationTrackService.saveDraft(
             LayoutBranch.main,
@@ -970,9 +969,9 @@ constructor(
         assertEquals("linked-switches", diff.propKey.key.toString())
         assertEquals(
             """
-            Vaihteiden sw-deleted, sw-replaced-with-new-same-name (1.1.1.1.8), sw-unlinked-from-alignment,
+            Vaihteiden sw-deleted, sw-replaced-with-new-same-name ($originalSwitchOid), sw-unlinked-from-alignment,
             sw-unlinked-from-topology linkitys purettu. Vaihteet sw-added-to-alignment, sw-added-to-topo-end,
-            sw-added-to-topo-start, sw-replaced-with-new-same-name (1.1.1.1.9) linkitetty.
+            sw-added-to-topo-start, sw-replaced-with-new-same-name ($newSwitchOid) linkitetty.
             """
                 .trimIndent()
                 .replace("\n", " "),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
@@ -49,9 +49,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.queryOne
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -59,6 +56,9 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -118,8 +118,7 @@ constructor(
     @Test
     fun `external ids are fetched for calculated changes affecting assets not published in design`() {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
-        val mainTrackNumberOid = "1.2.3.4.5"
-        trackNumberDao.insertExternalId(trackNumber, LayoutBranch.main, Oid(mainTrackNumberOid))
+        testDBService.generateOid(trackNumber, LayoutBranch.main)
 
         mainOfficialContext.save(
             referenceLine(trackNumber),
@@ -138,10 +137,8 @@ constructor(
             mainOfficialContext.save(
                 switch(joints = listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(10.0, 0.0), null)))
             )
-        val mainSwitchAtStartOid = "2.2.3.4.5"
-        val mainSwitchAtEndOid = "2.2.3.4.6"
-        switchDao.insertExternalId(switchAtStart.id, LayoutBranch.main, Oid(mainSwitchAtStartOid))
-        switchDao.insertExternalId(switchAtEnd.id, LayoutBranch.main, Oid(mainSwitchAtEndOid))
+        testDBService.generateOid(switchAtStart.id, LayoutBranch.main)
+        testDBService.generateOid(switchAtEnd.id, LayoutBranch.main)
 
         val locationTrack1 =
             mainOfficialContext.save(
@@ -159,10 +156,8 @@ constructor(
                 locationTrack(trackNumber),
                 trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
             )
-        val mainLocationTrack1Oid = "3.2.3.4.5"
-        val mainLocationTrack2Oid = "3.2.3.4.6"
-        locationTrackDao.insertExternalId(locationTrack1.id, LayoutBranch.main, Oid(mainLocationTrack1Oid))
-        locationTrackDao.insertExternalId(locationTrack2.id, LayoutBranch.main, Oid(mainLocationTrack2Oid))
+        testDBService.generateOid(locationTrack1.id, LayoutBranch.main)
+        testDBService.generateOid(locationTrack2.id, LayoutBranch.main)
 
         val someDesign = testDBService.createDesignBranch()
         val designDraftContext = testDBService.testContext(someDesign, PublicationState.DRAFT)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
@@ -178,7 +178,7 @@ constructor(
         fakeRatko.acceptsNewSwitchGivingItOid(designSwitchOid)
         publicationService.publishManualPublication(
             someDesign,
-            PublicationRequest(publicationRequestIds(kmPosts = listOf(kmPost)), PublicationMessage.of("aoeu")),
+            publicationRequest(kmPosts = listOf(kmPost), message = "aoeu"),
         )
 
         // GVT-2798 will implement properly querying Ratko for the inherited ext IDs; for now, we
@@ -286,10 +286,7 @@ constructor(
         assertThrows<PublicationFailureException> {
             publicationService.publishManualPublication(
                 LayoutBranch.main,
-                PublicationRequest(
-                    publicationRequestIds(switches = listOf(switch), locationTracks = listOf(locationTrack)),
-                    PublicationMessage.of(""),
-                ),
+                publicationRequest(switches = listOf(switch), locationTracks = listOf(locationTrack)),
             )
         }
         // ... and the OID we tried to use didn't get recorded as being a proper OID
@@ -299,10 +296,7 @@ constructor(
         // ... then publication does succeed
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(
-                publicationRequestIds(switches = listOf(switch), locationTracks = listOf(locationTrack)),
-                PublicationMessage.of(""),
-            ),
+            publicationRequest(switches = listOf(switch), locationTracks = listOf(locationTrack)),
         )
         assertEquals(Oid("1.2.3.4.5"), switchDao.fetchExternalId(LayoutBranch.main, switch)?.oid)
     }
@@ -355,15 +349,12 @@ constructor(
         designDraftContext.save(mainOfficialContext.fetch(kmPost)!!)
 
         val requestPublishAll =
-            PublicationRequest(
-                publicationRequestIds(
-                    trackNumbers = listOf(trackNumber),
-                    referenceLines = listOf(referenceLine),
-                    locationTracks = listOf(locationTrack),
-                    switches = listOf(switch),
-                    kmPosts = listOf(kmPost),
-                ),
-                PublicationMessage.of(""),
+            publicationRequest(
+                trackNumbers = listOf(trackNumber),
+                referenceLines = listOf(referenceLine),
+                locationTracks = listOf(locationTrack),
+                switches = listOf(switch),
+                kmPosts = listOf(kmPost),
             )
 
         fakeRatko.acceptsNewRouteNumbersGivingThemOids(listOf("1.1.1.1.1"))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -11,7 +11,6 @@ import fi.fta.geoviite.infra.common.LayoutBranchType
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.MainBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
 import fi.fta.geoviite.infra.common.SwitchName
@@ -51,7 +50,6 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackNameStructure
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNamingScheme
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.MainOfficialContextData
-import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
 import fi.fta.geoviite.infra.tracklayout.OperationalPointName
 import fi.fta.geoviite.infra.tracklayout.OperationalPointRinfType
@@ -85,8 +83,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.LayoutAssetTable
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
-import java.math.BigDecimal
-import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -102,6 +98,8 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import publicationRequest
 import publish
+import java.math.BigDecimal
+import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -232,15 +230,14 @@ constructor(
         val switch = mainDraftContext.save(switch())
         val trackNumberIds =
             listOf(mainOfficialContext.createLayoutTrackNumber().id, mainOfficialContext.createLayoutTrackNumber().id)
-        val locationTracks =
-            trackNumberIds.map { trackNumberId ->
-                val edge =
-                    edge(
-                        startInnerSwitch = switchLinkYV(switch.id, 1),
-                        segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
-                    )
-                mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
-            }
+        val locationTracks = trackNumberIds.map { trackNumberId ->
+            val edge =
+                edge(
+                    startInnerSwitch = switchLinkYV(switch.id, 1),
+                    segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+                )
+            mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
+        }
 
         val publicationResult =
             publish(publicationService, locationTracks = locationTracks.map { it.id }, switches = listOf(switch.id))
@@ -1700,7 +1697,7 @@ constructor(
                 )
                 .id
         val locationTrack = mainOfficialContext.save(locationTrack(trackNumber), trackGeometryOfSegments(segment)).id
-        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
+        testDBService.generateOid(locationTrack, designBranch)
 
         mainDraftContext.save(
             mainOfficialContext.fetch(referenceLine)!!.copy(startAddress = TrackMeter("0123+0123.000")),
@@ -1727,8 +1724,8 @@ constructor(
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), referenceLineGeometry(segment))
             .id
         val locationTrack = mainOfficialContext.save(locationTrack(trackNumber), trackGeometryOfSegments(segment))
-        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
-        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        testDBService.generateOid(locationTrack.id, designBranch)
+        testDBService.generateOid(locationTrack.id, MainBranch.instance)
         designDraftContext.copyFrom(locationTrack)
 
         publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
@@ -1755,8 +1752,8 @@ constructor(
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), referenceLineGeometry(segment))
             .id
         val locationTrack = mainOfficialContext.save(locationTrack(trackNumber), trackGeometryOfSegments(segment))
-        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
-        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        testDBService.generateOid(locationTrack.id, designBranch)
+        testDBService.generateOid(locationTrack.id, MainBranch.instance)
         designDraftContext.copyFrom(locationTrack)
 
         publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
@@ -1778,8 +1775,8 @@ constructor(
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), referenceLineGeometry(segment))
             .id
         val locationTrack = mainOfficialContext.save(locationTrack(trackNumber), trackGeometryOfSegments(segment))
-        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
-        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        testDBService.generateOid(locationTrack.id, designBranch)
+        testDBService.generateOid(locationTrack.id, MainBranch.instance)
         designDraftContext.copyFrom(locationTrack)
 
         publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
@@ -1807,8 +1804,8 @@ constructor(
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), referenceLineGeometry(segment))
             .id
         val locationTrack = designDraftContext.save(locationTrack(trackNumber), trackGeometryOfSegments(segment))
-        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
-        locationTrackDao.insertExternalId(locationTrack.id, MainBranch.instance, Oid("1.2.3.4.6"))
+        testDBService.generateOid(locationTrack.id, designBranch)
+        testDBService.generateOid(locationTrack.id, MainBranch.instance)
 
         publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
         locationTrackService.mergeToMainBranch(designBranch, locationTrack.id)
@@ -1829,7 +1826,7 @@ constructor(
             .save(referenceLine(trackNumber, startAddress = TrackMeter("0100+0100")), referenceLineGeometry(segment))
             .id
         val locationTrack = designDraftContext.save(locationTrack(trackNumber), trackGeometryOfSegments(segment))
-        locationTrackDao.insertExternalId(locationTrack.id, designBranch, Oid("1.2.3.4.5"))
+        testDBService.generateOid(locationTrack.id, designBranch)
 
         publishManualPublication(designBranch, locationTracks = listOf(locationTrack.id))
         locationTrackService.mergeToMainBranch(designBranch, locationTrack.id)
@@ -1892,9 +1889,9 @@ constructor(
                     )
                 ),
             )
-        trackNumberDao.insertExternalId(tn.id, LayoutBranch.main, Oid("1.2.3.4.5"))
-        switchDao.insertExternalId(sw.id, LayoutBranch.main, Oid("1.2.3.4.6"))
-        locationTrackDao.insertExternalId(lt.id, LayoutBranch.main, Oid("1.2.3.4.6"))
+        testDBService.generateOid(tn.id, LayoutBranch.main)
+        testDBService.generateOid(sw.id, LayoutBranch.main)
+        testDBService.generateOid(lt.id, LayoutBranch.main)
 
         val initialPublishResult =
             publishManualPublication(
@@ -1919,9 +1916,9 @@ constructor(
         assertPublicationResults(initialPublishResult, mainUpdatedResult)
 
         val designBranch = testDBService.createDesignBranch()
-        trackNumberDao.insertExternalId(tn.id, designBranch, Oid("1.2.3.4.7"))
-        switchDao.insertExternalId(sw.id, designBranch, Oid("1.2.3.4.8"))
-        locationTrackDao.insertExternalId(lt.id, designBranch, Oid("1.2.3.4.9"))
+        testDBService.generateOid(tn.id, designBranch)
+        testDBService.generateOid(sw.id, designBranch)
+        testDBService.generateOid(lt.id, designBranch)
         val designCreatedResult =
             touchAsDraftAndPublish(
                 designBranch,
@@ -2038,7 +2035,10 @@ constructor(
         val ordinaryPoint = mainDraftContext.save(operationalPoint(ratoType = OperationalPointRatoType.LP)).id
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            publicationRequest(operationalPoints = listOf(olpPoint, overriddenIdPoint, ordinaryPoint), message = "publish all"),
+            publicationRequest(
+                operationalPoints = listOf(olpPoint, overriddenIdPoint, ordinaryPoint),
+                message = "publish all",
+            ),
         )
         assertEquals(null, operationalPointDao.getRinfIdGenerated(olpPoint))
         assertEquals(null, operationalPointDao.getRinfIdGenerated(overriddenIdPoint))
@@ -2048,7 +2048,10 @@ constructor(
         mainDraftContext.save(mainOfficialContext.fetch(overriddenIdPoint)!!.copy(rinfIdOverride = null))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            publicationRequest(operationalPoints = listOf(olpPoint, overriddenIdPoint), message = "change points to want rinf_id_generated"),
+            publicationRequest(
+                operationalPoints = listOf(olpPoint, overriddenIdPoint),
+                message = "change points to want rinf_id_generated",
+            ),
         )
         assertTrue(operationalPointDao.getRinfIdGenerated(olpPoint) != null)
         assertTrue(operationalPointDao.getRinfIdGenerated(overriddenIdPoint) != null)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -1967,7 +1967,7 @@ constructor(
         val id = mainDraftContext.save(op).id
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(operationalPoints = listOf(id)), PublicationMessage.of("foo")),
+            publicationRequest(operationalPoints = listOf(id), message = "foo"),
         )
         val publishedVersion = mainOfficialContext.fetchVersion(id)!!
         assertEquals(id, publishedVersion.id)
@@ -1981,7 +1981,7 @@ constructor(
         mainDraftContext.save(official.copy(name = OperationalPointName("Lordistan")))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(operationalPoints = listOf(id)), PublicationMessage.of("bar")),
+            publicationRequest(operationalPoints = listOf(id), message = "bar"),
         )
         val editedOfficial = mainOfficialContext.fetch(id)!!
         assertEquals("Lordistan", editedOfficial.name.toString())
@@ -2013,7 +2013,7 @@ constructor(
         assertEquals("Aaponen", candidates.operationalPoints[0].name.toString())
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(operationalPoints = listOf(pointId)), PublicationMessage.of("aa")),
+            publicationRequest(operationalPoints = listOf(pointId), message = "aa"),
         )
         assertEquals("Aaponen", operationalPointService.get(mainOfficialContext.context, pointId)!!.name.toString())
         ratkoTestService.updateRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", "Beepponen"))
@@ -2023,7 +2023,7 @@ constructor(
         assertEquals("Beepponen", editCandidates.operationalPoints[0].name.toString())
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(publicationRequestIds(operationalPoints = listOf(pointId)), PublicationMessage.of("bee")),
+            publicationRequest(operationalPoints = listOf(pointId), message = "bee"),
         )
         assertEquals("Beepponen", operationalPointService.get(mainOfficialContext.context, pointId)!!.name.toString())
     }
@@ -2038,10 +2038,7 @@ constructor(
         val ordinaryPoint = mainDraftContext.save(operationalPoint(ratoType = OperationalPointRatoType.LP)).id
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(
-                publicationRequestIds(operationalPoints = listOf(olpPoint, overriddenIdPoint, ordinaryPoint)),
-                PublicationMessage.of("publish all"),
-            ),
+            publicationRequest(operationalPoints = listOf(olpPoint, overriddenIdPoint, ordinaryPoint), message = "publish all"),
         )
         assertEquals(null, operationalPointDao.getRinfIdGenerated(olpPoint))
         assertEquals(null, operationalPointDao.getRinfIdGenerated(overriddenIdPoint))
@@ -2051,10 +2048,7 @@ constructor(
         mainDraftContext.save(mainOfficialContext.fetch(overriddenIdPoint)!!.copy(rinfIdOverride = null))
         publicationService.publishManualPublication(
             LayoutBranch.main,
-            PublicationRequest(
-                publicationRequestIds(operationalPoints = listOf(olpPoint, overriddenIdPoint)),
-                PublicationMessage.of("change points to want rinf_id_generated"),
-            ),
+            publicationRequest(operationalPoints = listOf(olpPoint, overriddenIdPoint), message = "change points to want rinf_id_generated"),
         )
         assertTrue(operationalPointDao.getRinfIdGenerated(olpPoint) != null)
         assertTrue(operationalPointDao.getRinfIdGenerated(overriddenIdPoint) != null)
@@ -2269,16 +2263,6 @@ constructor(
         assertEquals(2, officialVersion2.version)
     }
 }
-
-fun publicationRequestIds(
-    trackNumbers: List<IntId<LayoutTrackNumber>> = listOf(),
-    locationTracks: List<IntId<LocationTrack>> = listOf(),
-    referenceLines: List<IntId<ReferenceLine>> = listOf(),
-    switches: List<IntId<LayoutSwitch>> = listOf(),
-    kmPosts: List<IntId<LayoutKmPost>> = listOf(),
-    operationalPoints: List<IntId<OperationalPoint>> = listOf(),
-): PublicationRequestIds =
-    PublicationRequestIds(trackNumbers, locationTracks, referenceLines, switches, kmPosts, operationalPoints)
 
 fun <T : LayoutAsset<T>, S : LayoutAssetDao<T, *>> publishAndCheck(
     rowVersion: LayoutRowVersion<T>,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -398,7 +398,7 @@ constructor(
     fun publishingLocationTrackChangesWorks() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
+                .createTrackNumberAndReferenceLine(
                     referenceLineGeometry = referenceLineGeometry(segment(Point(0.0, 0.0), Point(4.0, 4.0)))
                 )
                 .id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
@@ -37,16 +37,15 @@ import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
-import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @Service
@@ -132,7 +131,7 @@ constructor(
                 locationTrack(trackNumberId, topologicalConnectivity = TopologicalConnectivityType.START),
                 trackGeometry(startEdge, endEdge),
             )
-        locationTrackDao.insertExternalId(sourceTrack.id, LayoutBranch.main, someOid())
+        mainOfficialContext.generateOid(sourceTrack.id)
 
         val draftSource =
             locationTrackDao.fetch(sourceTrack).copy(state = sourceLocationTrackState).let { d ->
@@ -235,8 +234,9 @@ data class SplitSetup(
     val targetTracks: List<Pair<LayoutRowVersion<LocationTrack>, IntRange>>,
 ) {
 
-    val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> =
-        targetTracks.map { (track, range) -> track.id to range }
+    val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> = targetTracks.map { (track, range) ->
+        track.id to range
+    }
 
     val trackResponses = (listOf(sourceTrack) + targetTracks.map { it.first })
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
@@ -73,8 +72,6 @@ import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import kotlin.collections.plus
-import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -88,6 +85,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import publicationRequest
 import publish
+import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1841,8 +1839,8 @@ constructor(
     @Test
     fun `switch draft OIDs are checked for uniqueness vs existing OIDs`() {
         testDBService.deleteFromTables("layout", "switch_external_id")
-        switchDao.insertExternalId(mainOfficialContext.save(switch()).id, LayoutBranch.main, Oid("1.2.3.4.5"))
-        val draftSwitch = mainDraftContext.save(switch(draftOid = Oid("1.2.3.4.5"))).id
+        val existingOid = testDBService.generateOid(mainOfficialContext.save(switch()).id, LayoutBranch.main)
+        val draftSwitch = mainDraftContext.save(switch(draftOid = existingOid)).id
         assertContains(
             publicationValidationService
                 .validateSwitches(LayoutBranch.main, PublicationState.DRAFT, listOf(draftSwitch))[0]

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -121,10 +121,6 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.tracklayout.verticalEdge
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.queryOne
-import java.time.Instant
-import java.time.LocalDate
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -134,6 +130,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1310,14 +1310,8 @@ constructor(
         val pointsFromDatabase = ratkoOperationalPointDao.listLatestVersions()
         assertEquals(3, pointsFromDatabase.size)
         val sortedPoints = pointsFromDatabase.sortedBy { it.point.name.toString() }
-        assertEquals(
-            listOf("Kannustamo", "Liukuainen", "Turpasauna"),
-            sortedPoints.map { it.point.name.toString() },
-        )
-        assertEquals(
-            listOf(true, false, false),
-            sortedPoints.map { it.deleted },
-        )
+        assertEquals(listOf("Kannustamo", "Liukuainen", "Turpasauna"), sortedPoints.map { it.point.name.toString() })
+        assertEquals(listOf(true, false, false), sortedPoints.map { it.deleted })
         assertEquals(
             5,
             jdbc.queryOne("""select count(*) as c from integrations.ratko_operational_point_version""") { rs, _ ->
@@ -1339,22 +1333,28 @@ constructor(
 
         ratkoOperationalPointDao.updateOperationalPoints(listOf(alpha, beta, gamma))
 
-        ratkoOperationalPointDao.listLatestVersions().sortedBy { it.point.name.toString() }.also { versions ->
-            assertEquals(3, versions.size)
-            assertEquals(listOf("Alpha", "Beta", "Gamma"), versions.map { it.point.name.toString() })
-            assertEquals(listOf(1, 1, 1), versions.map { it.version })
-            assertEquals(listOf(false, false, false), versions.map { it.deleted })
-        }
+        ratkoOperationalPointDao
+            .listLatestVersions()
+            .sortedBy { it.point.name.toString() }
+            .also { versions ->
+                assertEquals(3, versions.size)
+                assertEquals(listOf("Alpha", "Beta", "Gamma"), versions.map { it.point.name.toString() })
+                assertEquals(listOf(1, 1, 1), versions.map { it.version })
+                assertEquals(listOf(false, false, false), versions.map { it.deleted })
+            }
 
         ratkoOperationalPointDao.updateOperationalPoints(listOf(alpha, gamma))
 
-        ratkoOperationalPointDao.listLatestVersions().sortedBy { it.point.name.toString() }.also { versions ->
-            assertEquals(3, versions.size)
-            assertEquals(listOf("Alpha", "Beta", "Gamma"), versions.map { it.point.name.toString() })
-            assertEquals(listOf(false, true, false), versions.map { it.deleted })
-            val betaVersion = versions.first { it.point.name.toString() == "Beta" }
-            assertEquals(2, betaVersion.version)
-        }
+        ratkoOperationalPointDao
+            .listLatestVersions()
+            .sortedBy { it.point.name.toString() }
+            .also { versions ->
+                assertEquals(3, versions.size)
+                assertEquals(listOf("Alpha", "Beta", "Gamma"), versions.map { it.point.name.toString() })
+                assertEquals(listOf(false, true, false), versions.map { it.deleted })
+                val betaVersion = versions.first { it.point.name.toString() == "Beta" }
+                assertEquals(2, betaVersion.version)
+            }
     }
 
     @Test
@@ -1370,7 +1370,8 @@ constructor(
         fakeRatko.hasOperationalPoints(listOf(station))
         ratkoService.updateOperationalPointsFromRatko()
 
-        operationalPointDao.list(mainDraftContext.context, true)
+        operationalPointDao
+            .list(mainDraftContext.context, true)
             .filter { it.origin == OperationalPointOrigin.RATKO }
             .also { points ->
                 assertEquals(1, points.size)
@@ -1382,7 +1383,8 @@ constructor(
         fakeRatko.hasOperationalPoints(emptyList())
         ratkoService.updateOperationalPointsFromRatko()
 
-        operationalPointDao.list(mainDraftContext.context, true)
+        operationalPointDao
+            .list(mainDraftContext.context, true)
             .filter { it.origin == OperationalPointOrigin.RATKO }
             .also { points ->
                 assertEquals(1, points.size)
@@ -1395,7 +1397,8 @@ constructor(
         fakeRatko.hasOperationalPoints(listOf(recreatedStation))
         ratkoService.updateOperationalPointsFromRatko()
 
-        operationalPointDao.list(mainDraftContext.context, true)
+        operationalPointDao
+            .list(mainDraftContext.context, true)
             .filter { it.origin == OperationalPointOrigin.RATKO }
             .also { points ->
                 assertEquals(1, points.size)
@@ -1780,10 +1783,7 @@ constructor(
     fun `design publication push fetches plan ID for design`() {
         val design = testDBService.createDesignBranch()
         fakeRatko.acceptsNewDesignGivingItId(123)
-        publicationService.publishManualPublication(
-            design,
-            publicationRequest(message = "aoeu"),
-        )
+        publicationService.publishManualPublication(design, publicationRequest(message = "aoeu"))
         ratkoService.pushChangesToRatko(design)
         assertEquals(123, layoutDesignDao.fetchRatkoId(design.designId)?.intValue)
     }
@@ -1792,10 +1792,7 @@ constructor(
     fun `design updates get sent with design publication push`() {
         val design = testDBService.createDesignBranch()
         fakeRatko.acceptsNewDesignGivingItId(123)
-        publicationService.publishManualPublication(
-            design,
-            publicationRequest(message = "aoeu"),
-        )
+        publicationService.publishManualPublication(design, publicationRequest(message = "aoeu"))
         layoutDesignDao.update(
             design.designId,
             LayoutDesignSaveRequest(
@@ -1804,10 +1801,7 @@ constructor(
                 designState = DesignState.ACTIVE,
             ),
         )
-        publicationService.publishManualPublication(
-            design,
-            publicationRequest(message = "aoeu"),
-        )
+        publicationService.publishManualPublication(design, publicationRequest(message = "aoeu"))
         ratkoService.pushChangesToRatko(design)
         layoutDesignDao.update(
             design.designId,
@@ -1817,10 +1811,7 @@ constructor(
                 designState = DesignState.COMPLETED,
             ),
         )
-        publicationService.publishManualPublication(
-            design,
-            publicationRequest(message = "aoeu"),
-        )
+        publicationService.publishManualPublication(design, publicationRequest(message = "aoeu"))
         ratkoService.pushChangesToRatko(design)
         assertEquals(
             listOf(
@@ -1841,14 +1832,8 @@ constructor(
         val design = testDBService.createDesignBranch()
         fakeRatko.acceptsNewDesignGivingItId(123)
         publishAndPush()
-        publicationService.publishManualPublication(
-            design,
-            publicationRequest(message = "aoeu"),
-        )
-        publicationService.publishManualPublication(
-            design,
-            publicationRequest(message = "uuba aaba"),
-        )
+        publicationService.publishManualPublication(design, publicationRequest(message = "aoeu"))
+        publicationService.publishManualPublication(design, publicationRequest(message = "uuba aaba"))
         ratkoService.pushChangesToRatko(design)
         assertEquals(listOf<RatkoPlan>(), fakeRatko.getUpdatesToDesign(123))
     }
@@ -2178,10 +2163,7 @@ constructor(
                 )
                 .id
 
-        val someDuplicateTrackOid1 =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, someDuplicateTrackId1, oid)
-            }
+        val someDuplicateTrackOid1 = testDBService.generateOid(someDuplicateTrackId1, LayoutBranch.main)
 
         val someDuplicateTrackId2 =
             mainOfficialContext
@@ -2191,10 +2173,7 @@ constructor(
                 )
                 .id
 
-        val someDuplicateTrackOid2 =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, someDuplicateTrackId2, oid)
-            }
+        val someDuplicateTrackOid2 = testDBService.generateOid(someDuplicateTrackId2, LayoutBranch.main)
 
         val targetTracks =
             testCreateSplitRequestTargets(
@@ -2250,10 +2229,7 @@ constructor(
                 )
                 .id
 
-        val someDuplicateTrackOid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, someDuplicateTrackId, oid)
-            }
+        val someDuplicateTrackOid = testDBService.generateOid(someDuplicateTrackId, LayoutBranch.main)
 
         val targetTracks =
             testCreateSplitRequestTargets(
@@ -2319,10 +2295,7 @@ constructor(
                 )
                 .id
 
-        val someDuplicateTrackOid =
-            someOid<LocationTrack>().also { oid ->
-                locationTrackService.insertExternalId(LayoutBranch.main, someDuplicateTrackId, oid)
-            }
+        val someDuplicateTrackOid = testDBService.generateOid(someDuplicateTrackId, LayoutBranch.main)
 
         val targetTracks =
             testCreateSplitRequestTargets(
@@ -2602,10 +2575,7 @@ constructor(
 
         return RatkoSplitTestData(
             trackNumberId = trackNumberId,
-            trackNumberOid =
-                someOid<LayoutTrackNumber>().also { oid ->
-                    trackNumberService.insertExternalId(branch, trackNumberId, oid)
-                },
+            trackNumberOid = testDBService.generateOid(trackNumberId, branch),
             splitSourceTrackId = splitSourceTrackId,
             splitSourceTrackOid =
                 splitSourceTrackOid?.also { oid ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -32,6 +32,7 @@ import fi.fta.geoviite.infra.publication.PublicationRequestIds
 import fi.fta.geoviite.infra.publication.PublicationResult
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.PublicationTestSupportService
+import fi.fta.geoviite.infra.publication.publicationRequest
 import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetLocation
@@ -1781,7 +1782,7 @@ constructor(
         fakeRatko.acceptsNewDesignGivingItId(123)
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(publicationRequestIds(), message = PublicationMessage.of("aoeu")),
+            publicationRequest(message = "aoeu"),
         )
         ratkoService.pushChangesToRatko(design)
         assertEquals(123, layoutDesignDao.fetchRatkoId(design.designId)?.intValue)
@@ -1793,7 +1794,7 @@ constructor(
         fakeRatko.acceptsNewDesignGivingItId(123)
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(publicationRequestIds(), message = PublicationMessage.of("aoeu")),
+            publicationRequest(message = "aoeu"),
         )
         layoutDesignDao.update(
             design.designId,
@@ -1805,7 +1806,7 @@ constructor(
         )
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(publicationRequestIds(), message = PublicationMessage.of("aoeu")),
+            publicationRequest(message = "aoeu"),
         )
         ratkoService.pushChangesToRatko(design)
         layoutDesignDao.update(
@@ -1818,7 +1819,7 @@ constructor(
         )
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(publicationRequestIds(), message = PublicationMessage.of("aoeu")),
+            publicationRequest(message = "aoeu"),
         )
         ratkoService.pushChangesToRatko(design)
         assertEquals(
@@ -1842,11 +1843,11 @@ constructor(
         publishAndPush()
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(publicationRequestIds(), message = PublicationMessage.of("aoeu")),
+            publicationRequest(message = "aoeu"),
         )
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(publicationRequestIds(), message = PublicationMessage.of("uuba aaba")),
+            publicationRequest(message = "uuba aaba"),
         )
         ratkoService.pushChangesToRatko(design)
         assertEquals(listOf<RatkoPlan>(), fakeRatko.getUpdatesToDesign(123))
@@ -1883,10 +1884,7 @@ constructor(
         fakeRatko.acceptsNewSwitchGivingItOid("3.3.3.3.3")
         publicationService.publishManualPublication(
             design,
-            PublicationRequest(
-                publicationRequestIds(locationTracks = listOf(locationTrack), switches = listOf(switch)),
-                message = PublicationMessage.of("aoeu"),
-            ),
+            publicationRequest(locationTracks = listOf(locationTrack), switches = listOf(switch), message = "aoeu"),
         )
 
         fakeRatko.acceptsNewDesignGivingItId(123)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -2568,7 +2568,7 @@ constructor(
 
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(straightGeometry.segments), trackNumber)
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(straightGeometry.segments), trackNumber)
                 .id
 
         val splitSourceTrackId = layoutContext.save(locationTrack(trackNumberId), straightGeometry).id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignServiceIT.kt
@@ -5,7 +5,6 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranchType
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.PublicationCause
@@ -223,8 +222,8 @@ constructor(
         // at the time of writing this test, we don't actually have support for updating designs
         // on inheriting calculated changes from main; but once we do, they will be identified by
         // those objects having an extId in the design
-        locationTrackDao.insertExternalId(locationTrack, designBranch, Oid("1.2.3.4.5"))
-        switchDao.insertExternalId(switch, designBranch, Oid("2.3.4.5.6"))
+        testDBService.generateOid(locationTrack, designBranch)
+        testDBService.generateOid(switch, designBranch)
 
         val latestPublicationBeforeDelete = publicationDao.fetchLatestPublications(LayoutBranchType.DESIGN, 1)
         deleteDesign(designId)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -7,7 +7,6 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LocationAccuracy
 import fi.fta.geoviite.infra.common.MainLayoutContext
-import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.error.NoSuchEntityException
 import fi.fta.geoviite.infra.geometry.MetaDataName
@@ -315,7 +314,7 @@ constructor(
                         segments = listOf(someSegment()),
                     )
                 ),
-                someOid(),
+                withOid = true,
             )
         val (_, withEndLink) =
             insertDraft(
@@ -338,7 +337,7 @@ constructor(
                         segments = listOf(someSegment()),
                     )
                 ),
-                someOid(),
+                withOid = true,
             )
         assertEquals(
             listOf<LocationTrackIdentifiers>(),
@@ -358,7 +357,6 @@ constructor(
         val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val switchId = mainOfficialContext.save(switch()).id
 
-        val locationTrack1Oid = someOid<LocationTrack>()
         val locationTrack1 =
             mainOfficialContext.save(
                 locationTrack(trackNumberId = trackNumberId, name = "LT 1"),
@@ -370,7 +368,7 @@ constructor(
                     )
                 ),
             )
-        locationTrackService.insertExternalId(LayoutBranch.main, locationTrack1.id, locationTrack1Oid)
+        val locationTrack1Oid = testDBService.generateOid(locationTrack1.id, LayoutBranch.main)
 
         val locationTrack2 =
             mainOfficialContext.save(
@@ -384,7 +382,6 @@ constructor(
                 ),
             )
 
-        val locationTrack3Oid = someOid<LocationTrack>()
         val locationTrack3 =
             mainOfficialContext.save(
                 locationTrack(trackNumberId = trackNumberId, name = "LT 3"),
@@ -396,7 +393,7 @@ constructor(
                     )
                 ),
             )
-        locationTrackService.insertExternalId(LayoutBranch.main, locationTrack3.id, locationTrack3Oid)
+        val locationTrack3Oid = testDBService.generateOid(locationTrack3.id, LayoutBranch.main)
 
         // add confuser draft; should have no effect
         mainDraftContext.save(mainOfficialContext.fetch(locationTrack1.id)!!)
@@ -520,8 +517,7 @@ constructor(
     fun `idMatches finds switches even if ids or oids need trimming`() {
         val switch1 = mainOfficialContext.save(switch()).let { mainOfficialContext.fetch(it.id) }!!
         val switch2 = mainOfficialContext.save(switch()).let { mainOfficialContext.fetch(it.id) }!!
-        val switch2oid = externalIdForSwitch()
-        switchService.insertExternalIdForSwitch(LayoutBranch.main, switch2.id as IntId, switch2oid)
+        val switch2oid = testDBService.generateOid(switch2.id as IntId, LayoutBranch.main)
 
         val intIdTerm = FreeText(" ${switch1.id} ")
         val intIdMatchFunction = switchService.idMatches(MainLayoutContext.official, intIdTerm, null)
@@ -815,12 +811,10 @@ constructor(
     private fun insertDraft(
         locationTrack: LocationTrack,
         geometry: LocationTrackGeometry,
-        oid: Oid<LocationTrack>? = null,
+        withOid: Boolean = false,
     ): Pair<LocationTrack, LocationTrackIdentifiers> {
         val version = locationTrackService.saveDraft(LayoutBranch.main, locationTrack, geometry)
-        if (oid != null) {
-            locationTrackService.insertExternalId(LayoutBranch.main, version.id, oid)
-        }
+        val oid = if (withOid) testDBService.generateOid(version.id, LayoutBranch.main) else null
         val track = locationTrackService.getOrThrow(MainLayoutContext.draft, version.id)
         val identifiers = LocationTrackIdentifiers(version, oid)
         return track to identifiers

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchServiceIT.kt
@@ -255,8 +255,9 @@ constructor(
         val switches = pageSwitches(getSwitches(), 0, null, Point(422222.2, 7222222.2)).items
 
         val indexOfRandomSwitch = switches.indexOfFirst { s -> s.id == idOfRandomSwitch }
-        val indexOfSwitchLocatedAtComparisonPoint =
-            switches.indexOfFirst { s -> s.id == idOfSwitchLocatedAtComparisonPoint }
+        val indexOfSwitchLocatedAtComparisonPoint = switches.indexOfFirst { s ->
+            s.id == idOfSwitchLocatedAtComparisonPoint
+        }
 
         assertTrue(indexOfRandomSwitch >= 0)
         assertTrue(indexOfSwitchLocatedAtComparisonPoint >= 0)
@@ -515,11 +516,11 @@ constructor(
 
     @Test
     fun `idMatches finds switches even if ids or oids need trimming`() {
-        val switch1 = mainOfficialContext.save(switch()).let { mainOfficialContext.fetch(it.id) }!!
-        val switch2 = mainOfficialContext.save(switch()).let { mainOfficialContext.fetch(it.id) }!!
-        val switch2oid = testDBService.generateOid(switch2.id as IntId, LayoutBranch.main)
+        val (switch1Id, switch1) = mainOfficialContext.save(switch()).id.let { it to mainOfficialContext.fetch(it)!! }
+        val (switch2Id, switch2) = mainOfficialContext.save(switch()).id.let { it to mainOfficialContext.fetch(it)!! }
+        val switch2oid = testDBService.generateOid(switch2Id, LayoutBranch.main)
 
-        val intIdTerm = FreeText(" ${switch1.id} ")
+        val intIdTerm = FreeText(" $switch1Id ")
         val intIdMatchFunction = switchService.idMatches(MainLayoutContext.official, intIdTerm, null)
 
         val oidTerm = FreeText(" $switch2oid ")
@@ -711,12 +712,8 @@ constructor(
     @Test
     fun `deleteSwitchLinks removes switch references from location tracks when set to true`() {
         val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val switch =
-            switchService.getOrThrow(
-                MainLayoutContext.draft,
-                switchService.saveDraft(LayoutBranch.main, switch(draft = true)).id,
-            )
-        val switchId = switch.id as IntId
+        val switchId = switchService.saveDraft(LayoutBranch.main, switch(draft = true)).id
+        val switch = switchService.getOrThrow(MainLayoutContext.draft, switchId)
 
         val (track, _) =
             insertDraft(
@@ -761,12 +758,8 @@ constructor(
     @Test
     fun `deleteSwitchLinks keeps switch references when set to false`() {
         val tnId = mainDraftContext.createLayoutTrackNumber().id
-        val switch =
-            switchService.getOrThrow(
-                MainLayoutContext.draft,
-                switchService.saveDraft(LayoutBranch.main, switch(draft = true)).id,
-            )
-        val switchId = switch.id as IntId
+        val switchId = switchService.saveDraft(LayoutBranch.main, switch(draft = true)).id
+        val switch = switchService.getOrThrow(MainLayoutContext.draft, switchId)
 
         val (track, _) =
             insertDraft(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -63,7 +63,7 @@ constructor(
 
         assertNull(trackNumberDao.fetchExternalId(LayoutBranch.main, trackNumber.id as IntId))
 
-        val newExternalId = externalIdForTrackNumber()
+        val newExternalId = someOid<LayoutTrackNumber>()
         trackNumberService.insertExternalId(LayoutBranch.main, trackNumber.id, newExternalId)
 
         assertEquals(newExternalId, trackNumberDao.fetchExternalId(LayoutBranch.main, trackNumber.id)?.oid)
@@ -96,7 +96,7 @@ constructor(
     fun `should return correct lengths for km posts`() {
         val trackNumber =
             trackNumberDao.fetch(trackNumberDao.save(trackNumber(testDBService.getUnusedTrackNumber(), draft = false)))
-        val trackOid = externalIdForTrackNumber()
+        val trackOid = someOid<LayoutTrackNumber>()
         trackNumberService.insertExternalId(LayoutBranch.main, trackNumber.id as IntId, trackOid)
 
         referenceLineAndGeometry(
@@ -548,7 +548,7 @@ constructor(
     fun `idMatches finds track numbers even if ids or oids need trimming`() {
         val tn1 = mainOfficialContext.save(trackNumber(TrackNumber("001"))).let { mainOfficialContext.fetch(it.id) }!!
         val tn2 = mainOfficialContext.save(trackNumber(TrackNumber("002"))).let { mainOfficialContext.fetch(it.id) }!!
-        val track2oid = externalIdForTrackNumber()
+        val track2oid = someOid<LayoutTrackNumber>()
         trackNumberService.insertExternalId(LayoutBranch.main, tn2.id as IntId, track2oid)
 
         val intIdTerm = FreeText(" ${tn1.id} ")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -17,8 +17,6 @@ import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import fi.fta.geoviite.infra.util.FreeText
-import java.math.BigDecimal
-import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -30,6 +28,8 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.math.BigDecimal
+import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -387,7 +387,7 @@ constructor(
         val referenceLineSegment = segment(Point(0.0, 0.0), Point(2000.0, 0.0))
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
+                .createTrackNumberAndReferenceLine(
                     referenceLineGeometry = referenceLineGeometry(referenceLineSegment),
                     startAddress = TrackMeter(KmNumber(0), BigDecimal(0.0)),
                 )
@@ -402,7 +402,7 @@ constructor(
     fun `ReferenceLine polygon is resolved correctly without cropping`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
+                .createTrackNumberAndReferenceLine(
                     referenceLineGeometry(segment(Point(32.0, 0.0), Point(50.0, 0.0))),
                     startAddress = TrackMeter(KmNumber(0), BigDecimal(32.0)),
                 )
@@ -445,9 +445,7 @@ constructor(
     fun `ReferenceLine polygon is resolved correctly with cropping`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(4000.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(4000.0, 0.0))))
                 .id
 
         mainOfficialContext.saveAndFetch(
@@ -498,7 +496,7 @@ constructor(
     fun `overlapping plan search cropping works correctly in different edge cases`() {
         val id =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
+                .createTrackNumberAndReferenceLine(
                     referenceLineGeometry(segment(Point(1500.0, 0.0), Point(3500.0, 0.0))),
                     startAddress = TrackMeter(KmNumber(1), BigDecimal(500.0)),
                 )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -24,7 +24,6 @@ import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.util.FreeText
-import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -37,6 +36,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -193,7 +193,7 @@ constructor(
 
         assertNull(locationTrackDao.fetchExternalId(LayoutBranch.main, id))
 
-        locationTrackService.insertExternalId(LayoutBranch.main, id, externalIdForLocationTrack())
+        locationTrackService.insertExternalId(LayoutBranch.main, id, someOid())
 
         assertNotNull(locationTrackDao.fetchExternalId(LayoutBranch.main, id))
     }
@@ -686,27 +686,25 @@ constructor(
         val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(someReferenceLineGeometry()).id
 
         val (originalLocationTrack, _) = insertAndFetchDraft(locationTrack(trackNumberId, draft = true), geometry)
-        publish(originalLocationTrack.id as IntId)
-        val originalLocationTrackId = originalLocationTrack.id
+        val originalTrackId = originalLocationTrack.id as IntId
+        publish(originalTrackId)
 
         val (duplicateInOfficial, _) =
-            insertAndFetchDraft(
-                locationTrack(trackNumberId, duplicateOf = originalLocationTrackId, draft = true),
-                geometry,
-            )
-        publish(duplicateInOfficial.id as IntId<LocationTrack>)
+            insertAndFetchDraft(locationTrack(trackNumberId, duplicateOf = originalTrackId, draft = true), geometry)
+        val duplicateTrackId = duplicateInOfficial.id as IntId
+        publish(duplicateTrackId)
 
         val newTrackName = trackNameStructure(duplicateInOfficial.name.toString() + " NEW NAME FOR DRAFT")
         val duplicateInDraftVersion =
             locationTrackService.update(
                 LayoutBranch.main,
-                duplicateInOfficial.id,
+                duplicateTrackId,
                 saveRequest(trackNumberId, 1)
                     .copy(
                         namingScheme = newTrackName.scheme,
                         nameFreeText = newTrackName.freeText,
                         nameSpecifier = newTrackName.specifier,
-                        duplicateOf = originalLocationTrackId,
+                        duplicateOf = originalTrackId,
                     ),
             )
         val duplicateInDraft = locationTrackService.get(MainLayoutContext.draft, duplicateInDraftVersion.id)!!
@@ -714,7 +712,7 @@ constructor(
         assertEquals(
             duplicateInOfficial.name,
             locationTrackService
-                .getInfoboxExtras(MainLayoutContext.official, originalLocationTrackId)
+                .getInfoboxExtras(MainLayoutContext.official, originalTrackId)
                 ?.duplicates
                 ?.firstOrNull()
                 ?.name,
@@ -722,7 +720,7 @@ constructor(
         assertEquals(
             duplicateInDraft.name,
             locationTrackService
-                .getInfoboxExtras(MainLayoutContext.draft, originalLocationTrackId)
+                .getInfoboxExtras(MainLayoutContext.draft, originalTrackId)
                 ?.duplicates
                 ?.firstOrNull()
                 ?.name,
@@ -1183,7 +1181,7 @@ constructor(
     fun `idMatches finds tracks even if ids or oids need trimming`() {
         val track1 = createPublishedLocationTrack(1)
         val track2 = createPublishedLocationTrack(2)
-        val track2oid = externalIdForLocationTrack()
+        val track2oid = someOid<LocationTrack>()
         locationTrackService.insertExternalId(LayoutBranch.main, track2.track.id as IntId, track2oid)
 
         val intIdTerm = FreeText(" ${track1.track.id} ")

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -683,7 +683,7 @@ constructor(
     @Test
     fun fetchDuplicatesIsVersioned() {
         val geometry = someTrackGeometry()
-        val trackNumberId = mainOfficialContext.createLayoutTrackNumberAndReferenceLine(someReferenceLineGeometry()).id
+        val trackNumberId = mainOfficialContext.createTrackNumberAndReferenceLine(someReferenceLineGeometry()).id
 
         val (originalLocationTrack, _) = insertAndFetchDraft(locationTrack(trackNumberId, draft = true), geometry)
         val originalTrackId = originalLocationTrack.id as IntId
@@ -838,9 +838,7 @@ constructor(
     fun `LocationTrack polygon is simplified to reduce point count`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(2000.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(2000.0, 0.0))))
                 .id
         val trackSegment = segment(Point(0.0, 0.0), Point(1000.0, 0.0))
         assertTrue(trackSegment.segmentPoints.size > 900)
@@ -854,9 +852,7 @@ constructor(
     fun `LocationTrack polygon is resolved correctly without cropping`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
                 .id
         val (track, _) =
             mainOfficialContext.save(
@@ -900,9 +896,7 @@ constructor(
     fun `LocationTrack polygon is resolved correctly with cropping`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(4000.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(4000.0, 0.0))))
                 .id
         val (track, _) =
             mainOfficialContext.save(
@@ -958,7 +952,7 @@ constructor(
     fun `overlapping plan search cropping works correctly in different edge cases`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
+                .createTrackNumberAndReferenceLine(
                     referenceLineGeometry(segment(Point(2000.0, 0.0), Point(5000.0, 0.0)))
                 )
                 .id
@@ -1198,9 +1192,7 @@ constructor(
     fun `getInfoboxExtras includes operational point addresses`() {
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
-                )
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(segment(Point(0.0, 0.0), Point(100.0, 0.0))))
                 .id
 
         val op1Id =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/StationLinkServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/StationLinkServiceIT.kt
@@ -32,7 +32,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
         stationLinkService.getStationLinks(mainOfficialContext.context).also { links -> assertTrue(links.isEmpty()) }
 
         val tnVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
+            mainOfficialContext.createTrackNumberAndReferenceLine(
                 referenceLineGeometryOfPoints(Point(0.0, 0.0), Point(100.0, 0.0))
             )
         val op1 = mainOfficialContext.save(operationalPoint("OP1", location = Point(20.0, 0.0)))
@@ -133,7 +133,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
         stationLinkService.getStationLinks(mainOfficialContext.context).also { links -> assertTrue(links.isEmpty()) }
 
         val tnVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
+            mainOfficialContext.createTrackNumberAndReferenceLine(
                 referenceLineGeometryOfPoints(Point(0.0, 0.0), Point(100.0, 0.0))
             )
         val op1 = mainOfficialContext.save(operationalPoint("OP1", location = Point(10.0, 0.0)))
@@ -198,7 +198,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
     @Test
     fun `getStationLinks returns correct links when the track doesn't cover the whole way`() {
         val tnVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
+            mainOfficialContext.createTrackNumberAndReferenceLine(
                 referenceLineGeometryOfPoints(Point(0.0, 0.0), Point(200.0, 0.0))
             )
         val op1Version = mainOfficialContext.save(operationalPoint("OP1", location = Point(20.0, 0.0)))
@@ -290,7 +290,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
     @Test
     fun `getStationLinks does not produce links for OLP-type operational points`() {
         val tnVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
+            mainOfficialContext.createTrackNumberAndReferenceLine(
                 referenceLineGeometryOfPoints(Point(0.0, 0.0), Point(100.0, 0.0))
             )
         val op1 = mainOfficialContext.save(operationalPoint("OP1", location = Point(20.0, 0.0)))
@@ -329,7 +329,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
     @Test
     fun `getStationLinks returns correct links when filtering by operational point id`() {
         val tnVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
+            mainOfficialContext.createTrackNumberAndReferenceLine(
                 referenceLineGeometryOfPoints(Point(0.0, 0.0), Point(200.0, 0.0))
             )
         val op1 = mainOfficialContext.save(operationalPoint("OP1", location = Point(10.0, 0.0)))
@@ -433,7 +433,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
     @Test
     fun `getStationLinks handles tracks referencing deleted operational points`() {
         val tnVersion =
-            mainOfficialContext.createLayoutTrackNumberAndReferenceLine(
+            mainOfficialContext.createTrackNumberAndReferenceLine(
                 referenceLineGeometryOfPoints(Point(0.0, 0.0), Point(100.0, 0.0))
             )
         val op1 = mainOfficialContext.save(operationalPoint("OP1", location = Point(20.0, 0.0)))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -1090,33 +1090,6 @@ fun offsetSegment(segment: LayoutSegment, amount: Point): LayoutSegment {
     return segment.copy(geometry = segment.geometry.withPoints(newPoints))
 }
 
-fun externalIdForLocationTrack(): Oid<LocationTrack> {
-    val first = nextInt(100, 999)
-    val second = nextInt(100, 999)
-    val third = nextInt(100, 999)
-    val fourth = nextInt(100, 999)
-
-    return Oid("$first.$second.$third.$fourth")
-}
-
-fun externalIdForTrackNumber(): Oid<LayoutTrackNumber> {
-    val first = nextInt(100, 999)
-    val second = nextInt(100, 999)
-    val third = nextInt(100, 999)
-    val fourth = nextInt(100, 999)
-
-    return Oid("$first.$second.$third.$fourth")
-}
-
-fun externalIdForSwitch(): Oid<LayoutSwitch> {
-    val first = nextInt(100, 999)
-    val second = nextInt(100, 999)
-    val third = nextInt(100, 999)
-    val fourth = nextInt(100, 999)
-
-    return Oid("$first.$second.$third.$fourth")
-}
-
 fun switchLinkingAtStart(
     locationTrackId: DomainId<LocationTrack>,
     geometry: LocationTrackGeometry,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/BasicMapTestUI.kt
@@ -11,12 +11,10 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineGeometry
-import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
@@ -54,7 +52,6 @@ constructor(
     private val kmPostDao: LayoutKmPostDao,
     private val referenceLineDao: ReferenceLineDao,
     private val alignmentDao: LayoutAlignmentDao,
-    private val locationTrackDao: LocationTrackDao,
 ) : SeleniumTest() {
     lateinit var WEST_LT: Pair<LocationTrack, LocationTrackGeometry>
     lateinit var GEOMETRY_PLAN: GeometryPlan
@@ -80,7 +77,7 @@ constructor(
         val eastLocationTrack = eastLocationTrack(trackNumberEastId.id)
 
         val westLtId = mainOfficialContext.saveLocationTrack(WEST_LT).id
-        locationTrackDao.insertExternalId(westLtId, LayoutBranch.main, someOid())
+        testDBService.generateOid(westLtId, LayoutBranch.main)
         mainOfficialContext.saveLocationTrack(eastLocationTrack)
         insertReferenceLine(WEST_REFERENCE_LINE)
         insertReferenceLine(eastReferenceLine)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
@@ -23,15 +23,15 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EAppBar
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenExists
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -84,7 +84,7 @@ constructor(
                 .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments), trackNumber)
                 .id
         val sourceTrackId = mainOfficialContext.save(locationTrack(trackNumberId), geometry).id
-        locationTrackService.insertExternalId(LayoutBranch.main, sourceTrackId, someOid())
+        testDBService.generateOid(sourceTrackId, LayoutBranch.main)
 
         val sourceTrackName = locationTrackService.get(MainLayoutContext.official, sourceTrackId)!!.name.toString()
         mainOfficialContext.save(locationTrack(trackNumberId), trackGeometry(turningEdges1))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
@@ -23,15 +23,15 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EAppBar
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenExists
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -81,7 +81,7 @@ constructor(
             trackGeometry(combineEdges(listOf(preEdge) + straightEdges1 + edge1To2 + straightEdges2 + postEdge))
         val trackNumberId =
             mainOfficialContext
-                .createLayoutTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments), trackNumber)
+                .createTrackNumberAndReferenceLine(referenceLineGeometry(geometry.segments), trackNumber)
                 .id
         val sourceTrackId = mainOfficialContext.save(locationTrack(trackNumberId), geometry).id
         testDBService.generateOid(sourceTrackId, LayoutBranch.main)


### PR DESCRIPTION
Ensinnäkin, pahoittelut mega-pullarista mutta kyseessä on tosiaan data-init patternien refaktorointi IT-testeissä joten vaikutukset ovat vähän väkisin moneen tiedostoon. Toisaalta muutokset ovat luonteeltaan hyvin samankaltaisia.

### Miksi katsoin tämän hyödylliseksi

Eli pohjaongelmana on että meillä on eri vaiheissa kehitystä rakenneltu vähän erillisiä helppereitä ratkaisemaan samaa ongelmaa: miten alustaa raide/ratanumero/pituusmittauslinja testiä varten. Tähän hommaan on nyt aika kasa helppereitä mutta myös kasa erillisiä testdataserviceitä ja funkkareita. 

Se "perusversio" on että:
- Itse datarakenteita voi tehdä puhtailla funkkareilla jotka asuu ...DomainTestData.kt filuissa ja niillä on laaja paletti default-arvoja, joiden avulla voi asettaa ne arvot jotka omaa testiä kiinnostaa ja muihin kenttiin tulee automaattisesti "jotain" (josta testi tietenkään ei saa riippua muutoin kuin että sieltä tulee jotain ehjää).
- Tallennusta varten on kasa helppereitä kaikissa IT/UI testeissä (kantaluokan kautta) automaattisesti saatavilla olevissa testDbService:llä ja testikonteksteilla. Näillä voi hyvin lyhyellä syntaksilla tallentaa / hakea olioita ja mukana on myös sekalainen joukko "create"-henkisiä helppereitä jotka tekee useamman olion ja tallentaa ne ja palauttaa vain id:n jne.

Tuon lisäksi on olemassa erinäisiä test data serviceitä jotka on syntyneet eri vaiheissa kehitystä. Tyypillisesti näissä tehdään joku kasa olioita jotka muodostaa jonkun kivan kokonaisuuden, mutta mukana on myös paljon sellaisia joille noissa perusversio-helppereissä ei vain joskus aikanaan ollut kyllin helppoa tapaa mutta nykyään on. Noissa lisäserviceissä on aina lisähintana se että tulee ylimääräinen hyppy siihen ketjuun testiä lukiessa ja monesti ne rakentaa kasan oletuksia sinne GreatValidDataCollection-olioon joista testi oikeasti riippuu mutta se ei testissä itsessään näy. Eli ne ovat fragiileja ja tuskaisia ylläpidon kannalta, mutta joissain caseissa tuollainen nippu on ihan järkevä konsepti, esim vaihde + siihen liittyvät raiteet + niille ratanumerot/referencelinet niin että ne vaihteen pisteet voidaan geokoodata.

### Mitä tässä on tehty

Itse testien logiikkaan pyrin koskemaan mahdollisimman vähän. Tämän pitäisi olla vain data-init juttua. Pari poikkeusta löytyy ja niistä mainitsen erikseen.

Tässä on purettu kasa noita testdataservice helppereitä pois ja siltä osin kun ne on tuntuneet hyödyllisiltä, laajennettu TestDBServicen ja test-kontekstien tarjontaa tarpeen täyttämiseksi. Pääosin koodin määrä testeissä silti pieneneni tai pysyi suht vastaavana, mutta joissain tapauksissa hiukan myös kasvoi. Kaikissa paikoissa kuitenkin on nyt nähdäkseni melko eksplisiittisesti testissä nähtävissä että mistä datasta se testi riippuu ja toisaalta on vähemmän boilerplate koodia ylläpidettäväksi. Bonuksena kun eri paikoissa alustellaan samanlaiset jutut samoilla helppereillä niin se ohjaa myös AI:ta helpommin oikeaan suuntaan.

Läheskään kaikkia tämänhenkisiä en vielä saanut korjattua, mutta eiköhän tämä ole jo kyllin iso setti. Katson saisiko tuolta jäljellejäävistä jotain hyviä kokonaisuuksia vielä kasaan.