### PR TITLE
GVT-3506 Part 2: Toiminnallisten pisteiden Ratko-muutosten tarkastelu fieldistä erilliseksi bäkkärihauksi

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPoint.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPoint.kt
@@ -22,7 +22,6 @@ data class OperationalPoint(
     val state: OperationalPointState,
     val origin: OperationalPointOrigin,
     val ratkoVersion: Int?,
-    val hasExternalChanges: Boolean,
     /** Read-only in the OperationalPoint object, comes from the ID table. */
     val rinfIdGenerated: RinfId?,
     val rinfIdOverride: RinfId?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
@@ -35,6 +35,16 @@ class OperationalPointController(
     private val publicationValidationService: PublicationValidationService,
 ) {
     @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
+    @GetMapping("/operational-points/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/externally-changed")
+    fun getExternallyChangedOperationalPointIds(
+        @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
+        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
+    ): List<IntId<OperationalPoint>> {
+        val context = LayoutContext.of(layoutBranch, publicationState)
+        return operationalPointService.getExternallyChangedOperationalPointIds(context)
+    }
+
+    @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
     @GetMapping("/operational-points/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/{id}")
     fun getSingleOperationalPoint(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.aspects.GeoviiteController
 import fi.fta.geoviite.infra.authorization.AUTH_EDIT_LAYOUT
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE
 import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT
+import fi.fta.geoviite.infra.authorization.AUTH_VIEW_LAYOUT_DRAFT
 import fi.fta.geoviite.infra.authorization.LAYOUT_BRANCH
 import fi.fta.geoviite.infra.authorization.PUBLICATION_STATE
 import fi.fta.geoviite.infra.common.DesignBranch
@@ -34,13 +35,12 @@ class OperationalPointController(
     private val stationLinkService: StationLinkService,
     private val publicationValidationService: PublicationValidationService,
 ) {
-    @PreAuthorize(AUTH_VIEW_DRAFT_OR_OFFICIAL_BY_PUBLICATION_STATE)
-    @GetMapping("/operational-points/{$LAYOUT_BRANCH}/{$PUBLICATION_STATE}/externally-changed")
+    @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
+    @GetMapping("/operational-points/{$LAYOUT_BRANCH}/draft/externally-changed")
     fun getExternallyChangedOperationalPointIds(
         @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
-        @PathVariable(PUBLICATION_STATE) publicationState: PublicationState,
     ): List<IntId<OperationalPoint>> {
-        val context = LayoutContext.of(layoutBranch, publicationState)
+        val context = LayoutContext.of(layoutBranch, PublicationState.DRAFT)
         return operationalPointService.getExternallyChangedOperationalPointIds(context)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointDao.kt
@@ -107,12 +107,7 @@ class OperationalPointDao(
               op.ratko_operational_point_version,
               op.origin,
               op.rinf_id_generated,
-              op.rinf_id_override,
-              (op.ratko_operational_point_version is distinct from
-                  (select ratko_operational_point_version
-                   from layout.operational_point_in_layout_context('OFFICIAL', null)
-                   where id = op.id)
-              ) as external_change
+              op.rinf_id_override
             from layout.operational_point_version_view op
               inner join lateral
                 (
@@ -384,7 +379,6 @@ class OperationalPointDao(
             polygon = rs.getPolygonPointListOrNull("polygon")?.let(::Polygon),
             origin = rs.getEnum("origin"),
             ratkoVersion = rs.getIntOrNull("ratko_operational_point_version"),
-            hasExternalChanges = rs.getBoolean("external_change"),
             contextData =
                 rs.getLayoutContextData(
                     "id",
@@ -400,6 +394,32 @@ class OperationalPointDao(
 
     fun getChangeTime(): Instant {
         return fetchLatestChangeTime(DbTable.LAYOUT_OPERATIONAL_POINT)
+    }
+
+    fun fetchExternallyChangedOperationalPointIds(layoutContext: LayoutContext): List<IntId<OperationalPoint>> {
+        val sql =
+            """
+            select op.id
+            from layout.operational_point_in_layout_context(
+                :publication_state::layout.publication_state,
+                :design_id
+            ) op
+            inner join layout.operational_point_version_view opv
+                on opv.id = op.id
+                and opv.version = op.version
+                and opv.layout_context_id = op.layout_context_id
+            where opv.ratko_operational_point_version is distinct from
+                (select ratko_operational_point_version
+                 from layout.operational_point_in_layout_context('OFFICIAL', null)
+                 where id = op.id)
+            """
+                .trimIndent()
+        val params =
+            mapOf(
+                "publication_state" to layoutContext.state.name,
+                "design_id" to layoutContext.branch.designId?.intValue,
+            )
+        return jdbcTemplate.query(sql, params) { rs, _ -> rs.getIntId<OperationalPoint>("id") }
     }
 
     fun findNameDuplicates(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointService.kt
@@ -43,6 +43,9 @@ class OperationalPointService(
             )
         )
 
+    fun getExternallyChangedOperationalPointIds(layoutContext: LayoutContext): List<IntId<OperationalPoint>> =
+        dao.fetchExternallyChangedOperationalPointIds(layoutContext)
+
     @Transactional
     fun insert(branch: LayoutBranch, request: InternalOperationalPointSaveRequest): LayoutRowVersion<OperationalPoint> =
         saveDraft(
@@ -58,7 +61,6 @@ class OperationalPointService(
                 location = null,
                 origin = OperationalPointOrigin.GEOVIITE,
                 ratkoVersion = null,
-                hasExternalChanges = false,
                 contextData = LayoutContextData.newDraft(branch, dao.createId()),
                 rinfIdOverride = request.rinfIdOverride,
                 rinfIdGenerated = null,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -594,22 +594,22 @@ constructor(
     }
 
     @Test
-    fun `GEOVIITE-origin OP has hasExternalChanges = false through its lifecycle`() {
+    fun `GEOVIITE-origin OP is never listed as externally changed`() {
         // Draft-only
         val version = operationalPointService.insert(LayoutBranch.main, internalPointSaveRequest("geoviite-op"))
-        assertEquals(false, operationalPointService.get(mainDraftContext.context, version.id)!!.hasExternalChanges)
+        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
 
         // After publishing
         operationalPointService.publish(LayoutBranch.main, version)
-        assertEquals(false, operationalPointService.get(mainOfficialContext.context, version.id)!!.hasExternalChanges)
+        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(version.id))
 
         // After user edit
         operationalPointService.update(LayoutBranch.main, version.id, internalPointUpdateRequest("updated"))
-        assertEquals(false, operationalPointService.get(mainDraftContext.context, version.id)!!.hasExternalChanges)
+        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
     }
 
     @Test
-    fun `hasExternalChanges reflects Ratko sync state through the OP lifecycle`() {
+    fun `externally changed OP IDs reflect Ratko sync state through the OP lifecycle`() {
         val externalPointId =
             ratkoTestService.setupRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", name = "external"))[0]
 
@@ -621,7 +621,7 @@ constructor(
                 ratkoVersion = 1,
             )
         )
-        assertEquals(true, operationalPointService.get(mainDraftContext.context, externalPointId)!!.hasExternalChanges)
+        assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
 
         // After publishing: official version compares against itself, no external change
         testDBService.save(
@@ -631,7 +631,7 @@ constructor(
                 ratkoVersion = 1,
             )
         )
-        assertEquals(false, operationalPointService.get(mainOfficialContext.context, externalPointId)!!.hasExternalChanges)
+        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
 
         // Manual user edit (no Ratko sync): still no external change
         operationalPointService.update(
@@ -639,10 +639,10 @@ constructor(
             externalPointId,
             externalPointSaveRequest(rinfType = OperationalPointRinfType.FREIGHT_TERMINAL),
         )
-        assertEquals(false, operationalPointService.get(mainDraftContext.context, externalPointId)!!.hasExternalChanges)
+        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
 
         // New Ratko sync bumps version: external change detected
         ratkoTestService.updateRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", name = "changed external"))
-        assertEquals(true, operationalPointService.get(mainDraftContext.context, externalPointId)!!.hasExternalChanges)
+        assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -9,6 +9,8 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.RatkoTestService
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -597,15 +599,15 @@ constructor(
     fun `GEOVIITE-origin OP is never listed as externally changed`() {
         // Draft-only
         val version = operationalPointService.insert(LayoutBranch.main, internalPointSaveRequest("geoviite-op"))
-        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
+        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
 
         // After publishing
         operationalPointService.publish(LayoutBranch.main, version)
-        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(version.id))
+        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(version.id))
 
         // After user edit
         operationalPointService.update(LayoutBranch.main, version.id, internalPointUpdateRequest("updated"))
-        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
+        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
     }
 
     @Test
@@ -621,7 +623,7 @@ constructor(
                 ratkoVersion = 1,
             )
         )
-        assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
+        assertContains(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context), externalPointId)
 
         // After publishing: official version compares against itself, no external change
         testDBService.save(
@@ -631,7 +633,7 @@ constructor(
                 ratkoVersion = 1,
             )
         )
-        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
+        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
 
         // Manual user edit (no Ratko sync): still no external change
         operationalPointService.update(
@@ -639,19 +641,19 @@ constructor(
             externalPointId,
             externalPointSaveRequest(rinfType = OperationalPointRinfType.FREIGHT_TERMINAL),
         )
-        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
+        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
 
         // New Ratko sync bumps version: external change detected
         ratkoTestService.updateRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", name = "changed external"))
-        assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
+        assertContains(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context), externalPointId)
 
         // After second publication: versions equalize, no external change
         val draftVersion = operationalPointService.getOrThrow(mainDraftContext.context, externalPointId).getVersionOrThrow()
         operationalPointService.publish(LayoutBranch.main, draftVersion)
-        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
+        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
 
         // Ratko deletion (point removed from Ratko): external change detected again
         ratkoTestService.updateRatkoOperationalPoints()
-        assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
+        assertContains(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context), externalPointId)
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -10,9 +10,9 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.RatkoTestService
 import kotlin.test.assertContains
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
@@ -599,15 +599,27 @@ constructor(
     fun `GEOVIITE-origin OP is never listed as externally changed`() {
         // Draft-only
         val version = operationalPointService.insert(LayoutBranch.main, internalPointSaveRequest("geoviite-op"))
-        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
+        assertFalse(
+            operationalPointService
+                .getExternallyChangedOperationalPointIds(mainDraftContext.context)
+                .contains(version.id)
+        )
 
         // After publishing
         operationalPointService.publish(LayoutBranch.main, version)
-        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(version.id))
+        assertFalse(
+            operationalPointService
+                .getExternallyChangedOperationalPointIds(mainOfficialContext.context)
+                .contains(version.id)
+        )
 
         // After user edit
         operationalPointService.update(LayoutBranch.main, version.id, internalPointUpdateRequest("updated"))
-        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(version.id))
+        assertFalse(
+            operationalPointService
+                .getExternallyChangedOperationalPointIds(mainDraftContext.context)
+                .contains(version.id)
+        )
     }
 
     @Test
@@ -623,7 +635,10 @@ constructor(
                 ratkoVersion = 1,
             )
         )
-        assertContains(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context), externalPointId)
+        assertContains(
+            operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context),
+            externalPointId,
+        )
 
         // After publishing: official version compares against itself, no external change
         testDBService.save(
@@ -633,7 +648,11 @@ constructor(
                 ratkoVersion = 1,
             )
         )
-        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
+        assertFalse(
+            operationalPointService
+                .getExternallyChangedOperationalPointIds(mainOfficialContext.context)
+                .contains(externalPointId)
+        )
 
         // Manual user edit (no Ratko sync): still no external change
         operationalPointService.update(
@@ -641,19 +660,34 @@ constructor(
             externalPointId,
             externalPointSaveRequest(rinfType = OperationalPointRinfType.FREIGHT_TERMINAL),
         )
-        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
+        assertFalse(
+            operationalPointService
+                .getExternallyChangedOperationalPointIds(mainDraftContext.context)
+                .contains(externalPointId)
+        )
 
         // New Ratko sync bumps version: external change detected
         ratkoTestService.updateRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", name = "changed external"))
-        assertContains(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context), externalPointId)
+        assertContains(
+            operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context),
+            externalPointId,
+        )
 
         // After second publication: versions equalize, no external change
-        val draftVersion = operationalPointService.getOrThrow(mainDraftContext.context, externalPointId).getVersionOrThrow()
+        val draftVersion =
+            operationalPointService.getOrThrow(mainDraftContext.context, externalPointId).getVersionOrThrow()
         operationalPointService.publish(LayoutBranch.main, draftVersion)
-        assertFalse(operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
+        assertFalse(
+            operationalPointService
+                .getExternallyChangedOperationalPointIds(mainOfficialContext.context)
+                .contains(externalPointId)
+        )
 
         // Ratko deletion (point removed from Ratko): external change detected again
         ratkoTestService.updateRatkoOperationalPoints()
-        assertContains(operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context), externalPointId)
+        assertContains(
+            operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context),
+            externalPointId,
+        )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -644,5 +644,14 @@ constructor(
         // New Ratko sync bumps version: external change detected
         ratkoTestService.updateRatkoOperationalPoints(ratkoOperationalPoint("1.2.3.4.5", name = "changed external"))
         assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
+
+        // After second publication: versions equalize, no external change
+        val draftVersion = operationalPointService.getOrThrow(mainDraftContext.context, externalPointId).getVersionOrThrow()
+        operationalPointService.publish(LayoutBranch.main, draftVersion)
+        assertEquals(false, operationalPointService.getExternallyChangedOperationalPointIds(mainOfficialContext.context).contains(externalPointId))
+
+        // Ratko deletion (point removed from Ratko): external change detected again
+        ratkoTestService.updateRatkoOperationalPoints()
+        assertEquals(true, operationalPointService.getExternallyChangedOperationalPointIds(mainDraftContext.context).contains(externalPointId))
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -1242,7 +1242,6 @@ fun operationalPoint(
         polygon = polygon,
         origin = origin,
         ratkoVersion = ratkoVersion,
-        hasExternalChanges = false,
         contextData = contextData,
         rinfIdGenerated = rinfIdGenerated?.let(::RinfId),
         rinfIdOverride = rinfIdOverride?.let(::RinfId),

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -30,8 +30,8 @@ import {
     refreshOperationalPointSelection,
     refreshSwitchSelection,
     refreshTrackNumberSelection,
-    useExternallyChangedOperationalPointIds,
 } from 'track-layout/track-layout-react-utils';
+import { getExternallyChangedOperationalPointIds } from 'track-layout/layout-operational-point-api';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
 import { PrivilegeRequired } from 'user/privilege-required';
@@ -50,7 +50,7 @@ import {
 } from 'map/map-utils';
 import { DesignSelectionContainer } from 'tool-bar/workspace-selection';
 import { CloseableModal } from 'vayla-design-lib/closeable-modal/closeable-modal';
-import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
+import { LoaderStatus, useLoader, useLoaderWithStatus } from 'utils/react-utils';
 import {
     getLayoutDesign,
     LayoutDesignSaveRequest,
@@ -118,11 +118,17 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         () => designId && getLayoutDesign(getChangeTimes().layoutDesign, designId),
         [getChangeTimes().layoutDesign, designId],
     );
-    const hasRatkoChanges =
-        useExternallyChangedOperationalPointIds(
-            layoutContext.branch,
-            getChangeTimes().operationalPoints,
-        ).length > 0;
+    const externallyChangedOps = useLoader(
+        () =>
+            layoutContext.publicationState === 'DRAFT'
+                ? getExternallyChangedOperationalPointIds(
+                      layoutContext.branch,
+                      getChangeTimes().operationalPoints,
+                  )
+                : Promise.resolve([]),
+        [layoutContext.publicationState, layoutContext.branch, getChangeTimes().operationalPoints],
+    );
+    const hasRatkoChanges = (externallyChangedOps?.length ?? 0) > 0;
     const currentDesignExists =
         designLoadStatus === LoaderStatus.Ready && currentDesign !== undefined;
 

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -30,7 +30,7 @@ import {
     refreshOperationalPointSelection,
     refreshSwitchSelection,
     refreshTrackNumberSelection,
-    useOperationalPoints,
+    useExternallyChangedOperationalPointIds,
 } from 'track-layout/track-layout-react-utils';
 import { SplittingState } from 'tool-panel/location-track/split-store';
 import { LinkingState, LinkingType } from 'linking/linking-model';
@@ -118,10 +118,10 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         () => designId && getLayoutDesign(getChangeTimes().layoutDesign, designId),
         [getChangeTimes().layoutDesign, designId],
     );
-    const hasRatkoChanges = useOperationalPoints(
+    const hasRatkoChanges = useExternallyChangedOperationalPointIds(
         layoutContext,
         getChangeTimes().operationalPoints,
-    ).some((point) => point.hasExternalChanges);
+    ).length > 0;
     const currentDesignExists =
         designLoadStatus === LoaderStatus.Ready && currentDesign !== undefined;
 

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -118,10 +118,11 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         () => designId && getLayoutDesign(getChangeTimes().layoutDesign, designId),
         [getChangeTimes().layoutDesign, designId],
     );
-    const hasRatkoChanges = useExternallyChangedOperationalPointIds(
-        layoutContext,
-        getChangeTimes().operationalPoints,
-    ).length > 0;
+    const hasRatkoChanges =
+        useExternallyChangedOperationalPointIds(
+            layoutContext.branch,
+            getChangeTimes().operationalPoints,
+        ).length > 0;
     const currentDesignExists =
         designLoadStatus === LoaderStatus.Ready && currentDesign !== undefined;
 

--- a/ui/src/tool-bar/tool-bar.tsx
+++ b/ui/src/tool-bar/tool-bar.tsx
@@ -118,17 +118,16 @@ export const ToolBar: React.FC<ToolbarParams> = ({
         () => designId && getLayoutDesign(getChangeTimes().layoutDesign, designId),
         [getChangeTimes().layoutDesign, designId],
     );
-    const externallyChangedOps = useLoader(
+    const hasRatkoChanges = useLoader(
         () =>
             layoutContext.publicationState === 'DRAFT'
                 ? getExternallyChangedOperationalPointIds(
                       layoutContext.branch,
                       getChangeTimes().operationalPoints,
-                  )
-                : Promise.resolve([]),
+                  ).then((externallyChangedOps) => externallyChangedOps.length > 0)
+                : Promise.resolve(false),
         [layoutContext.publicationState, layoutContext.branch, getChangeTimes().operationalPoints],
     );
-    const hasRatkoChanges = (externallyChangedOps?.length ?? 0) > 0;
     const currentDesignExists =
         designLoadStatus === LoaderStatus.Ready && currentDesign !== undefined;
 

--- a/ui/src/track-layout/layout-operational-point-api.ts
+++ b/ui/src/track-layout/layout-operational-point-api.ts
@@ -34,6 +34,7 @@ type OperationalPointSaveRequest =
     | ExternalOperationalPointSaveRequest;
 
 const allOperationalPointsCache = asyncCache<string, OperationalPoint[]>();
+const externallyChangedOpsCache = asyncCache<string, OperationalPointId[]>();
 const operationalPointOidsCache = asyncCache<
     OperationalPointId,
     { [key in LayoutBranch]?: Oid } | undefined
@@ -210,7 +211,13 @@ export async function getOperationalPointValidation(
 
 export const getExternallyChangedOperationalPointIds = (
     layoutContext: LayoutContext,
+    changeTime: TimeStamp = getChangeTimes().operationalPoints,
 ): Promise<OperationalPointId[]> =>
-    getNonNull<OperationalPointId[]>(
-        `${layoutUri('operational-points', layoutContext)}/externally-changed`,
+    externallyChangedOpsCache.get(
+        changeTime,
+        `${layoutContext.branch}_${layoutContext.publicationState}`,
+        () =>
+            getNonNull<OperationalPointId[]>(
+                `${layoutUri('operational-points', layoutContext)}/externally-changed`,
+            ),
     );

--- a/ui/src/track-layout/layout-operational-point-api.ts
+++ b/ui/src/track-layout/layout-operational-point-api.ts
@@ -210,14 +210,14 @@ export async function getOperationalPointValidation(
 }
 
 export const getExternallyChangedOperationalPointIds = (
-    layoutContext: LayoutContext,
+    layoutBranch: LayoutBranch,
     changeTime: TimeStamp = getChangeTimes().operationalPoints,
 ): Promise<OperationalPointId[]> =>
     externallyChangedOpsCache.get(
         changeTime,
-        `${layoutContext.branch}_${layoutContext.publicationState}`,
+        layoutBranch,
         () =>
             getNonNull<OperationalPointId[]>(
-                `${layoutUri('operational-points', layoutContext)}/externally-changed`,
+                `${layoutUriByBranch('operational-points', layoutBranch)}/draft/externally-changed`,
             ),
     );

--- a/ui/src/track-layout/layout-operational-point-api.ts
+++ b/ui/src/track-layout/layout-operational-point-api.ts
@@ -207,3 +207,10 @@ export async function getOperationalPointValidation(
         `${layoutUri('operational-points', layoutContext, id)}/validation`,
     );
 }
+
+export const getExternallyChangedOperationalPointIds = (
+    layoutContext: LayoutContext,
+): Promise<OperationalPointId[]> =>
+    getNonNull<OperationalPointId[]>(
+        `${layoutUri('operational-points', layoutContext)}/externally-changed`,
+    );

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -482,7 +482,6 @@ export type OperationalPointOrigin = 'GEOVIITE' | 'RATKO';
 export type OperationalPoint = {
     id: OperationalPointId;
     origin: OperationalPointOrigin;
-    hasExternalChanges: boolean;
     name: string;
     abbreviation?: string;
     uicCode: UICCode;

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -306,13 +306,13 @@ export function useOperationalPoints(
 }
 
 export function useExternallyChangedOperationalPointIds(
-    layoutContext: LayoutContext,
+    layoutBranch: LayoutBranch,
     changeTime?: TimeStamp,
 ): OperationalPointId[] {
     return (
         useLoader(
-            () => getExternallyChangedOperationalPointIds(layoutContext.branch, changeTime),
-            [(layoutContext.branch, layoutContext.publicationState, changeTime)],
+            () => getExternallyChangedOperationalPointIds(layoutBranch, changeTime),
+            [layoutBranch, changeTime],
         ) || EMPTY_ARRAY
     );
 }

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -68,6 +68,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { getLayoutDesignByBranch, LayoutDesign } from 'track-layout/layout-design-api';
 import {
     getAllOperationalPoints,
+    getExternallyChangedOperationalPointIds,
     getOperationalPoint,
 } from 'track-layout/layout-operational-point-api';
 
@@ -299,6 +300,18 @@ export function useOperationalPoints(
     return (
         useLoader(
             () => getAllOperationalPoints(layoutContext, changeTime),
+            [layoutContext.branch, layoutContext.publicationState, changeTime],
+        ) || EMPTY_ARRAY
+    );
+}
+
+export function useExternallyChangedOperationalPointIds(
+    layoutContext: LayoutContext,
+    changeTime?: TimeStamp,
+): OperationalPointId[] {
+    return (
+        useLoader(
+            () => getExternallyChangedOperationalPointIds(layoutContext),
             [layoutContext.branch, layoutContext.publicationState, changeTime],
         ) || EMPTY_ARRAY
     );

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -68,7 +68,6 @@ import { ChangeTimes } from 'common/common-slice';
 import { getLayoutDesignByBranch, LayoutDesign } from 'track-layout/layout-design-api';
 import {
     getAllOperationalPoints,
-    getExternallyChangedOperationalPointIds,
     getOperationalPoint,
 } from 'track-layout/layout-operational-point-api';
 
@@ -301,18 +300,6 @@ export function useOperationalPoints(
         useLoader(
             () => getAllOperationalPoints(layoutContext, changeTime),
             [layoutContext.branch, layoutContext.publicationState, changeTime],
-        ) || EMPTY_ARRAY
-    );
-}
-
-export function useExternallyChangedOperationalPointIds(
-    layoutBranch: LayoutBranch,
-    changeTime?: TimeStamp,
-): OperationalPointId[] {
-    return (
-        useLoader(
-            () => getExternallyChangedOperationalPointIds(layoutBranch, changeTime),
-            [layoutBranch, changeTime],
         ) || EMPTY_ARRAY
     );
 }

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -311,8 +311,8 @@ export function useExternallyChangedOperationalPointIds(
 ): OperationalPointId[] {
     return (
         useLoader(
-            () => getExternallyChangedOperationalPointIds(layoutContext, changeTime),
-            [layoutContext.branch, layoutContext.publicationState, changeTime],
+            () => getExternallyChangedOperationalPointIds(layoutContext.branch, changeTime),
+            [(layoutContext.branch, layoutContext.publicationState, changeTime)],
         ) || EMPTY_ARRAY
     );
 }

--- a/ui/src/track-layout/track-layout-react-utils.tsx
+++ b/ui/src/track-layout/track-layout-react-utils.tsx
@@ -311,7 +311,7 @@ export function useExternallyChangedOperationalPointIds(
 ): OperationalPointId[] {
     return (
         useLoader(
-            () => getExternallyChangedOperationalPointIds(layoutContext),
+            () => getExternallyChangedOperationalPointIds(layoutContext, changeTime),
             [layoutContext.branch, layoutContext.publicationState, changeTime],
         ) || EMPTY_ARRAY
     );


### PR DESCRIPTION
Tämä muutostarve kirposi siis tämän pullarikommentin myötä: https://github.com/finnishtransportagency/geoviite/pull/2312/changes#r3159447590

Päädyin tekemään tämän niin, että tein endpointin joka listaa kaikki Ratkossa muuttuneet toiminnalliset pisteet.