### PR TITLE
General: Fix plan section memoization in track number infobox

### DIFF
--- a/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-geometry-infobox.tsx
@@ -59,16 +59,19 @@ export const TrackNumberGeometryInfobox: React.FC<TrackNumberGeometryInfoboxProp
             changeTime,
         ],
     );
-    const onHighlightSection: OnHighlightSection = (section) =>
-        onHighlightItem(
-            section === undefined
-                ? undefined
-                : {
-                      ...section,
-                      id: trackNumberId,
-                      type: 'REFERENCE_LINE',
-                  },
-        );
+    const onHighlightSection: OnHighlightSection = React.useCallback(
+        (section) =>
+            onHighlightItem(
+                section === undefined
+                    ? undefined
+                    : {
+                          ...section,
+                          id: trackNumberId,
+                          type: 'REFERENCE_LINE',
+                      },
+            ),
+        [onHighlightItem, trackNumberId],
+    );
     return (
         <Infobox
             title={t('tool-panel.alignment-plan-sections.reference-line-geometries')}


### PR DESCRIPTION
Firefoxissa jopa ihan näkyvä vaikutus, jos valitsee ratanumeron 006 ja zoomailee kartalla "Pituusmittauslinjan geometriat"-näkymä päällä.