### PR TITLE
GVT-3577 & GVT-3578: Karttatyökalufiksejä & refaktorointia

### DIFF
--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -111,8 +111,12 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     }${fileName}`;
     const showMap = props.validationResponse?.planLayout !== undefined;
 
-    const mapTools = [selectOrHighlightComboTool, measurementTool].map(
-        alwaysSelectableMapToolMenuItem,
+    const mapTools = React.useMemo(
+        () =>
+            [selectOrHighlightComboTool, measurementTool].map(
+                alwaysSelectableMapToolMenuItem,
+            ),
+        [],
     );
 
     return (

--- a/ui/src/infra-model/view/infra-model-view.tsx
+++ b/ui/src/infra-model/view/infra-model-view.tsx
@@ -25,6 +25,7 @@ import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_GEOMETRY_FILE } from 'user/user-model';
 import { selectOrHighlightComboTool } from 'map/tools/select-or-highlight-combo-tool';
 import { measurementTool } from 'map/tools/measurement-tool';
+import { alwaysSelectableMapToolMenuItem } from 'map/tools/tool-model';
 
 export type InfraModelBaseProps = InfraModelState & {
     onExtraParametersChange: <TKey extends keyof ExtraInfraModelParameters>(
@@ -110,6 +111,10 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
     }${fileName}`;
     const showMap = props.validationResponse?.planLayout !== undefined;
 
+    const mapTools = [selectOrHighlightComboTool, measurementTool].map(
+        alwaysSelectableMapToolMenuItem,
+    );
+
     return (
         <div className={styles['infra-model-upload']}>
             <InfraModelToolbar
@@ -180,7 +185,7 @@ export const InfraModelView: React.FC<InfraModelViewProps> = (props: InfraModelV
                     <MapContext.Provider value="infra-model">
                         <MapViewContainer
                             manuallySetPlan={planLayout ?? undefined}
-                            mapTools={[selectOrHighlightComboTool, measurementTool]}
+                            mapTools={mapTools}
                             customActiveMapToolId={selectOrHighlightComboTool?.id}
                         />
                     </MapContext.Provider>

--- a/ui/src/map/map-view-container.tsx
+++ b/ui/src/map/map-view-container.tsx
@@ -13,7 +13,7 @@ import { HighlightedAlignment } from 'tool-panel/alignment-plan-section-infobox-
 import { GeometryPlanLayout } from 'track-layout/track-layout-model';
 import { LayoutContext, officialMainLayoutContext } from 'common/common-model';
 import { PublicationCandidate } from 'publication/publication-model';
-import { MapToolId, MapToolWithButton } from 'map/tools/tool-model';
+import { MapToolMenuItem, MapToolId } from 'map/tools/tool-model';
 import { DesignPublicationMode } from 'preview/preview-tool-bar';
 import { RouteResult } from 'track-layout/layout-routing-api';
 import { RouteLocation } from 'track-layout/track-layout-slice';
@@ -93,7 +93,7 @@ type MapViewContainerProps = {
     publicationCandidates?: PublicationCandidate[];
     customActiveMapToolId?: MapToolId;
     designPublicationMode?: DesignPublicationMode;
-    mapTools: MapToolWithButton[];
+    mapTools: MapToolMenuItem[];
     hoveredRouteLocation?: RouteLocation;
 };
 export const MapViewContainer: React.FC<MapViewContainerProps> = ({

--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -25,10 +25,10 @@ import {
 import { createSwitchLinkingLayer } from './layers/switch/switch-linking-layer';
 import styles from './map.module.scss';
 import {
+    MapToolMenuItem,
     MapToolActivateOptions,
     MapToolHandle,
     MapToolId,
-    MapToolWithButton,
 } from './tools/tool-model';
 import { calculateMapTiles } from 'map/map-utils';
 import { defaults as defaultControls, ScaleLine } from 'ol/control';
@@ -155,7 +155,7 @@ export type MapViewProps = {
     publicationCandidates?: PublicationCandidate[];
     customActiveMapToolId?: MapToolId;
     designPublicationMode?: DesignPublicationMode;
-    mapTools?: MapToolWithButton[];
+    mapTools?: MapToolMenuItem[];
     layoutContextMode?: LayoutContextMode;
     selectedDesignId?: LayoutDesignId;
     routeLocations?: RouteLocations;
@@ -290,7 +290,6 @@ const MapView: React.FC<MapViewProps> = ({
         customActiveMapToolId || (mapTools && first(mapTools)?.id),
     );
     const activeTool = mapTools?.find((tool) => tool.id === activeToolId);
-    //    const routeToolData = React.useState<RouteToolData>()
     const [hoveredLocation, setHoveredLocation] = React.useState<Point>();
     const inPreviewView = !!designPublicationMode;
     const isSelectingDesign = layoutContextMode === 'DESIGN' && !selectedDesignId;

--- a/ui/src/map/tools/area-select-tool.tsx
+++ b/ui/src/map/tools/area-select-tool.tsx
@@ -136,7 +136,7 @@ export function createAreaSelectTool(
                 },
             };
         },
-        component: ({ isActive, setActiveTool, disabled }) => {
+        component: ({ isActive, setActiveTool, disabled, hidden }) => {
             return (
                 <MapToolButton
                     id={id}
@@ -144,6 +144,7 @@ export function createAreaSelectTool(
                     isActive={isActive}
                     icon={Icons.SelectArea}
                     disabled={disabled}
+                    hidden={hidden}
                 />
             );
         },

--- a/ui/src/map/tools/map-tool-button.tsx
+++ b/ui/src/map/tools/map-tool-button.tsx
@@ -10,8 +10,8 @@ type MapToolButtonProps = {
     isActive: boolean;
     setActive: (id: MapToolId) => void;
     icon: IconComponent;
-    disabled?: boolean;
-    hidden?: boolean;
+    disabled: boolean;
+    hidden: boolean;
 };
 
 const MapToolButtonM = ({

--- a/ui/src/map/tools/measurement-tool.tsx
+++ b/ui/src/map/tools/measurement-tool.tsx
@@ -172,7 +172,7 @@ export const measurementTool: MapToolWithButton = {
         };
     },
 
-    component: ({ isActive, setActiveTool, disabled }) => {
+    component: ({ isActive, setActiveTool, hidden, disabled }) => {
         return (
             <MapToolButton
                 id={id}
@@ -180,6 +180,7 @@ export const measurementTool: MapToolWithButton = {
                 setActive={setActiveTool}
                 icon={Icons.Measure}
                 disabled={disabled}
+                hidden={hidden}
             />
         );
     },

--- a/ui/src/map/tools/route-finding-tool.tsx
+++ b/ui/src/map/tools/route-finding-tool.tsx
@@ -115,13 +115,15 @@ export function createRouteFindingTool(
             };
         },
 
-        component: ({ isActive, setActiveTool }) => {
+        component: ({ isActive, setActiveTool, disabled, hidden }) => {
             return (
                 <MapToolButton
                     id={id}
                     isActive={isActive}
                     setActive={setActiveTool}
                     icon={Icons.VectorRight}
+                    disabled={disabled}
+                    hidden={hidden}
                 />
             );
         },

--- a/ui/src/map/tools/select-or-highlight-combo-tool.tsx
+++ b/ui/src/map/tools/select-or-highlight-combo-tool.tsx
@@ -24,7 +24,7 @@ export const selectOrHighlightComboTool: MapToolWithButton = {
         };
     },
 
-    component: ({ isActive, setActiveTool, disabled }) => {
+    component: ({ isActive, setActiveTool, disabled, hidden }) => {
         return (
             <MapToolButton
                 id={id}
@@ -32,6 +32,7 @@ export const selectOrHighlightComboTool: MapToolWithButton = {
                 setActive={setActiveTool}
                 icon={Icons.Select}
                 disabled={disabled}
+                hidden={hidden}
             />
         );
     },

--- a/ui/src/map/tools/tool-model.ts
+++ b/ui/src/map/tools/tool-model.ts
@@ -42,8 +42,8 @@ export type MapToolHandle = {
 export type MapToolProps = {
     isActive: boolean;
     setActiveTool: (id: MapToolId) => void;
-    disabled?: boolean;
-    hidden?: boolean;
+    disabled: boolean;
+    hidden: boolean;
 };
 
 export type MapTool = {
@@ -55,6 +55,16 @@ export type MapTool = {
 
 export type MapToolWithButton = MapTool & {
     component: React.ComponentType<MapToolProps>;
-    disabled?: boolean;
-    hidden?: boolean;
 };
+
+export type MapToolMenuItem = MapToolWithButton & {
+    component: React.ComponentType<MapToolProps>;
+    disabled: boolean;
+    hidden: boolean;
+};
+
+export const alwaysSelectableMapToolMenuItem = (tool: MapToolWithButton): MapToolMenuItem => ({
+    ...tool,
+    disabled: false,
+    hidden: false,
+});

--- a/ui/src/preview/preview-view.tsx
+++ b/ui/src/preview/preview-view.tsx
@@ -76,6 +76,7 @@ import { measurementTool } from 'map/tools/measurement-tool';
 import { previewViewAreaSelectTool } from 'map/tools/preview-view-area-select-tool';
 import { prevIfObjectsEqual } from 'utils/object-utils';
 import { cancelOperationalPoint } from 'track-layout/layout-operational-point-api';
+import { alwaysSelectableMapToolMenuItem } from 'map/tools/tool-model';
 
 export type PreviewProps = {
     layoutContext: LayoutContext;
@@ -497,7 +498,10 @@ export const PreviewView: React.FC<PreviewProps> = (props: PreviewProps) => {
     );
 
     const mapTools = React.useMemo(
-        () => [selectOrHighlightComboTool, measurementTool, publishCandidateSelectTool],
+        () =>
+            [selectOrHighlightComboTool, measurementTool, publishCandidateSelectTool].map(
+                alwaysSelectableMapToolMenuItem,
+            ),
         [publishCandidateSelectTool],
     );
 

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -105,7 +105,7 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
             hidden: !isPlacingOperationalPointArea,
         };
         return [...selectableTools, operationalPointTool];
-    }, [isPlacingOperationalPointArea, isPlacingOperationalPointLocation, routeLocations]);
+    }, [isPlacingOperationalPointArea, isPlacingOperationalPointLocation, routeFindingTool]);
 
     return (
         <div className={className} qa-id="track-layout-content">

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -10,7 +10,10 @@ import { VerticalGeometryDiagramContainer } from 'vertical-geometry/vertical-geo
 import { ToolBarContainer } from 'tool-bar/tool-bar-container';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { VIEW_GEOMETRY } from 'user/user-model';
-import { ProgressIndicatorType, ProgressIndicatorWrapper, } from 'vayla-design-lib/progress/progress-indicator-wrapper';
+import {
+    ProgressIndicatorType,
+    ProgressIndicatorWrapper,
+} from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { selectOrHighlightComboTool } from 'map/tools/select-or-highlight-combo-tool';
 import { measurementTool } from 'map/tools/measurement-tool';
 import { createRouteFindingTool } from 'map/tools/route-finding-tool';
@@ -49,6 +52,8 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
     const linkingState = useTrackLayoutAppSelector((s) => s.linkingState);
     const isPlacingOperationalPointArea =
         linkingState?.type === LinkingType.PlacingOperationalPointArea;
+    const isPlacingOperationalPointLocation =
+        linkingState?.type === LinkingType.PlacingOperationalPoint;
 
     const [hoveredOverPlanSection, setHoveredOverPlanSection] =
         React.useState<HighlightedAlignment>();
@@ -90,7 +95,8 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
         const selectableTools = [selectOrHighlightComboTool, measurementTool, routeFindingTool].map(
             (tool) => ({
                 ...tool,
-                disabled: isPlacingOperationalPointArea,
+                disabled: isPlacingOperationalPointArea || isPlacingOperationalPointLocation,
+                hidden: false,
             }),
         );
         const operationalPointTool = {
@@ -99,7 +105,7 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
             hidden: !isPlacingOperationalPointArea,
         };
         return [...selectableTools, operationalPointTool];
-    }, [isPlacingOperationalPointArea, routeLocations]);
+    }, [isPlacingOperationalPointArea, isPlacingOperationalPointLocation, routeLocations]);
 
     return (
         <div className={className} qa-id="track-layout-content">


### PR DESCRIPTION
Käytännön bugit olivat siis:

1. Reititystyökalu ei disabloitunut karttatyökaluvalikossa toiminnallisen pisteen aluetta asettaessa (GVT-3577)
2. Mikään muukaan karttatyökalu ei disabloitunut karttatyökaluvalikossa toiminnallisen pisteen pistemäistä sijaintia asettaessa (GVT-3578)

Bugeista toka korjautui melkein one-linerilla, mutta ensimmäinen johti kaninkoloon siitä että miten meidän karttatyökalujen disablet ylipäätään toimii, sillä koodi oli alunperinkin päällisin puolin oikein. Tästä kuitenkin lisää koodikommenteissa