### PR TITLE
GVT-3537 & GVT-3612: Parannuksia reitityskarttatyökaluun sekä sen ja linkitystilojen yhteistoimintaan

### DIFF
--- a/ui/src/map/map-view.tsx
+++ b/ui/src/map/map-view.tsx
@@ -548,21 +548,25 @@ const MapView: React.FC<MapViewProps> = ({
                             (loading) => onLayerLoading(layerName, loading),
                         );
                     case 'route-highlight-layer':
-                        return createRouteHighlightLayer(
-                            mapTiles,
-                            existingOlLayer as GeoviiteMapLayer<LineString | OlPoint>,
-                            layoutContext,
-                            changeTimes,
-                            routeResult,
-                            (loading) => onLayerLoading(layerName, loading),
-                        );
+                        return !!linkingState || !!splittingState
+                            ? undefined
+                            : createRouteHighlightLayer(
+                                  mapTiles,
+                                  existingOlLayer as GeoviiteMapLayer<LineString | OlPoint>,
+                                  layoutContext,
+                                  changeTimes,
+                                  routeResult,
+                                  (loading) => onLayerLoading(layerName, loading),
+                              );
                     case 'route-marker-layer':
-                        return createRouteMarkerLayer(
-                            existingOlLayer as GeoviiteMapLayer<LineString | OlPoint>,
-                            hoveredRouteLocation,
-                            routeLocations,
-                            (loading) => onLayerLoading(layerName, loading),
-                        );
+                        return !!linkingState || !!splittingState
+                            ? undefined
+                            : createRouteMarkerLayer(
+                                  existingOlLayer as GeoviiteMapLayer<LineString | OlPoint>,
+                                  hoveredRouteLocation,
+                                  routeLocations,
+                                  (loading) => onLayerLoading(layerName, loading),
+                              );
                     case 'km-post-layer':
                         return createKmPostLayer(
                             mapTiles,
@@ -875,14 +879,17 @@ const MapView: React.FC<MapViewProps> = ({
             if (areaTool) {
                 setActiveToolId(areaTool?.id);
             }
-        } else if (activeTool?.id === 'operational-point-area') {
-            // When leaving operational point area mode, revert to default tool
+        } else if (
+            activeTool?.id === 'operational-point-area' ||
+            (activeTool?.id === 'route-finding' && (!!linkingState || !!splittingState))
+        ) {
+            // Revert to select-or-highlight when leaving operational point area mode or when entering a linking or splitting state
             const selectTool = mapTools?.find((tool) => tool.id === 'select-or-highlight');
             if (selectTool) {
                 setActiveToolId(selectTool?.id);
             }
         }
-    }, [linkingState, mapTools, activeTool]);
+    }, [linkingState, splittingState, mapTools, activeTool]);
 
     const mapClassNames = createClassName(styles.map);
 

--- a/ui/src/map/tools/route-finding-tool.tsx
+++ b/ui/src/map/tools/route-finding-tool.tsx
@@ -111,6 +111,8 @@ export function createRouteFindingTool(
                 deactivate: () => {
                     map.un('click', clickEventsKey.listener);
                     map.un('pointermove', pointerMoveEventsKey.listener);
+
+                    onHoveredLocationChange(undefined);
                 },
             };
         },

--- a/ui/src/track-layout/track-layout-view.tsx
+++ b/ui/src/track-layout/track-layout-view.tsx
@@ -49,6 +49,7 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
         showVerticalGeometryDiagram && styles['track-layout--show-diagram'],
     );
 
+    const splittingState = useTrackLayoutAppSelector((s) => s.splittingState);
     const linkingState = useTrackLayoutAppSelector((s) => s.linkingState);
     const isPlacingOperationalPointArea =
         linkingState?.type === LinkingType.PlacingOperationalPointArea;
@@ -92,20 +93,24 @@ export const TrackLayoutView: React.FC<TrackLayoutViewProps> = ({
     );
 
     const mapTools = React.useMemo(() => {
-        const selectableTools = [selectOrHighlightComboTool, measurementTool, routeFindingTool].map(
-            (tool) => ({
-                ...tool,
-                disabled: isPlacingOperationalPointArea || isPlacingOperationalPointLocation,
-                hidden: false,
-            }),
-        );
+        const selectableTools = [selectOrHighlightComboTool, measurementTool].map((tool) => ({
+            ...tool,
+            disabled: isPlacingOperationalPointArea || isPlacingOperationalPointLocation,
+            hidden: false,
+        }));
+        const routeTool = {
+            ...routeFindingTool,
+            disabled: !!linkingState || !!splittingState,
+            hidden: false,
+        };
+
         const operationalPointTool = {
             ...operationalPointAreaTool,
             disabled: !isPlacingOperationalPointArea,
             hidden: !isPlacingOperationalPointArea,
         };
-        return [...selectableTools, operationalPointTool];
-    }, [isPlacingOperationalPointArea, isPlacingOperationalPointLocation, routeFindingTool]);
+        return [...selectableTools, routeTool, operationalPointTool];
+    }, [isPlacingOperationalPointArea, linkingState, splittingState, routeFindingTool]);
 
     return (
         <div className={className} qa-id="track-layout-content">


### PR DESCRIPTION
Aiemmin reititystyökalu pysyi päällä linkitystilaan siirryttäessä. Tämä ei kuitenkaan ole haluttua eikä linkityksissä reiteillä tee mitään, joten deaktivoidaan reititystyökalu ja piilotetaan reitit kun joku linkitys- tai splittaustila aktivoidaan. Karttatasot tuodaan takaisin näkyviin linkityksen tai splittauksen loputtua (GVT-3537)

Lisäksi aiemmin reititystyökalu jätti näkyviin hoverin tekemän vaaleanvihreän indikaattoripallukan kun työkalusta vaihdettiin pois. Nyt se clearataan aina kun työkalu deaktivoidaan (GVT-3612)