### PR TITLE
GVT-3587: Puuttuvat linkkien disabloinnit raiteen/ratanumeron linkitystiloissa

### DIFF
--- a/ui/src/geoviite-design-lib/alignment/location-track-badge.tsx
+++ b/ui/src/geoviite-design-lib/alignment/location-track-badge.tsx
@@ -23,14 +23,15 @@ export const LocationTrackBadge: React.FC<LocationTrackBadgeProps> = ({
     onClick,
     status = LocationTrackBadgeStatus.DEFAULT,
 }: LocationTrackBadgeProps) => {
+    const disabled = status === LocationTrackBadgeStatus.DISABLED;
     const classes = createClassName(
         styles['alignment-badge'],
         status,
-        onClick && styles['alignment-badge--clickable'],
+        !disabled && onClick && styles['alignment-badge--clickable'],
     );
 
     return (
-        <div className={classes} onClick={onClick}>
+        <div className={classes} onClick={!disabled ? onClick : undefined}>
             <span>{locationTrack.name}</span>
         </div>
     );

--- a/ui/src/geoviite-design-lib/alignment/track-number-badge.tsx
+++ b/ui/src/geoviite-design-lib/alignment/track-number-badge.tsx
@@ -14,7 +14,7 @@ type TrackNumberBadgeLinkProps = {
     layoutContext: LayoutContext;
     changeTime: TimeStamp;
     onClick?: (trackNumberId: LayoutTrackNumberId) => void;
-    disabled?: boolean;
+    status?: TrackNumberBadgeStatus;
 };
 
 type TrackNumberBadgeProps = {
@@ -36,9 +36,9 @@ export const TrackNumberBadgeLink: React.FC<TrackNumberBadgeLinkProps> = ({
     layoutContext,
     changeTime,
     onClick,
-    disabled,
+    status,
 }: TrackNumberBadgeLinkProps) => {
-    const [trackNumber, status] = useTrackNumberWithStatus(
+    const [trackNumber, trackNumberFetchStatus] = useTrackNumberWithStatus(
         trackNumberId,
         layoutContext,
         changeTime,
@@ -57,12 +57,8 @@ export const TrackNumberBadgeLink: React.FC<TrackNumberBadgeLinkProps> = ({
         }
     }, [onClick, trackNumberId]);
 
-    return status === LoaderStatus.Ready && trackNumber ? (
-        <TrackNumberBadge
-            trackNumber={trackNumber}
-            onClick={disabled ? undefined : clickAction}
-            status={disabled ? TrackNumberBadgeStatus.DISABLED : undefined}
-        />
+    return trackNumberFetchStatus === LoaderStatus.Ready && trackNumber ? (
+        <TrackNumberBadge trackNumber={trackNumber} onClick={clickAction} status={status} />
     ) : (
         <Spinner />
     );
@@ -73,15 +69,17 @@ export const TrackNumberBadge: React.FC<TrackNumberBadgeProps> = ({
     onClick,
     status = TrackNumberBadgeStatus.DEFAULT,
 }: TrackNumberBadgeProps) => {
+    const disabled = status === TrackNumberBadgeStatus.DISABLED;
+
     const classes = createClassName(
         styles['alignment-badge'],
         styles['alignment-badge--reference'],
         status,
-        onClick && styles['alignment-badge--clickable'],
+        !disabled && onClick && styles['alignment-badge--clickable'],
     );
 
     return (
-        <div className={classes} onClick={onClick}>
+        <div className={classes} onClick={!disabled ? onClick : undefined}>
             <span>{trackNumber.number}</span>
         </div>
     );

--- a/ui/src/geoviite-design-lib/alignment/track-number-badge.tsx
+++ b/ui/src/geoviite-design-lib/alignment/track-number-badge.tsx
@@ -14,6 +14,7 @@ type TrackNumberBadgeLinkProps = {
     layoutContext: LayoutContext;
     changeTime: TimeStamp;
     onClick?: (trackNumberId: LayoutTrackNumberId) => void;
+    disabled?: boolean;
 };
 
 type TrackNumberBadgeProps = {
@@ -35,6 +36,7 @@ export const TrackNumberBadgeLink: React.FC<TrackNumberBadgeLinkProps> = ({
     layoutContext,
     changeTime,
     onClick,
+    disabled,
 }: TrackNumberBadgeLinkProps) => {
     const [trackNumber, status] = useTrackNumberWithStatus(
         trackNumberId,
@@ -56,7 +58,11 @@ export const TrackNumberBadgeLink: React.FC<TrackNumberBadgeLinkProps> = ({
     }, [onClick, trackNumberId]);
 
     return status === LoaderStatus.Ready && trackNumber ? (
-        <TrackNumberBadge trackNumber={trackNumber} onClick={clickAction} />
+        <TrackNumberBadge
+            trackNumber={trackNumber}
+            onClick={disabled ? undefined : clickAction}
+            status={disabled ? TrackNumberBadgeStatus.DISABLED : undefined}
+        />
     ) : (
         <Spinner />
     );

--- a/ui/src/geoviite-design-lib/operational-point/operational-point-badge.scss
+++ b/ui/src/geoviite-design-lib/operational-point/operational-point-badge.scss
@@ -25,7 +25,6 @@
 
     &--disabled {
         opacity: 0.5;
-        cursor: not-allowed;
     }
 
     &--clickable {

--- a/ui/src/geoviite-design-lib/operational-point/operational-point-badge.tsx
+++ b/ui/src/geoviite-design-lib/operational-point/operational-point-badge.tsx
@@ -66,14 +66,19 @@ export const OperationalPointBadge: React.FC<OperationalPointBadgeProps> = ({
     onClick,
     status = OperationalPointBadgeStatus.DEFAULT,
 }: OperationalPointBadgeProps) => {
+    const disabled = status === OperationalPointBadgeStatus.DISABLED;
+
     const classes = createClassName(
         styles['operational-point-badge'],
         status,
-        onClick && styles['operational-point-badge--clickable'],
+        !disabled && onClick && styles['operational-point-badge--clickable'],
     );
 
     return (
-        <span className={classes} onClick={onClick} qa-id={'operational-point-badge'}>
+        <span
+            className={classes}
+            onClick={!disabled ? onClick : undefined}
+            qa-id={'operational-point-badge'}>
             {operationalPoint.name}
         </span>
     );

--- a/ui/src/geoviite-design-lib/operational-point/operational-point-badge.tsx
+++ b/ui/src/geoviite-design-lib/operational-point/operational-point-badge.tsx
@@ -13,6 +13,7 @@ type OperationalPointBadgeLinkProps = {
     layoutContext: LayoutContext;
     changeTime: TimeStamp;
     onClick?: (operationalPointId: OperationalPointId) => void;
+    disabled?: boolean;
 };
 
 type OperationalPointBadgeProps = {
@@ -32,6 +33,7 @@ export const OperationalPointBadgeLink: React.FC<OperationalPointBadgeLinkProps>
     layoutContext,
     changeTime,
     onClick,
+    disabled,
 }: OperationalPointBadgeLinkProps) => {
     const op = useOperationalPoint(operationalPointId, layoutContext, changeTime);
 
@@ -48,7 +50,15 @@ export const OperationalPointBadgeLink: React.FC<OperationalPointBadgeLinkProps>
         }
     }, [onClick, operationalPointId]);
 
-    return op ? <OperationalPointBadge operationalPoint={op} onClick={clickAction} /> : <Spinner />;
+    return op ? (
+        <OperationalPointBadge
+            operationalPoint={op}
+            onClick={disabled ? undefined : clickAction}
+            status={disabled ? OperationalPointBadgeStatus.DISABLED : undefined}
+        />
+    ) : (
+        <Spinner />
+    );
 };
 
 export const OperationalPointBadge: React.FC<OperationalPointBadgeProps> = ({

--- a/ui/src/geoviite-design-lib/switch/switch-badge.tsx
+++ b/ui/src/geoviite-design-lib/switch/switch-badge.tsx
@@ -25,14 +25,16 @@ export const SwitchBadge: React.FC<SwitchBadgeProps> = ({
     switchIsValid = true,
     status = SwitchBadgeStatus.DEFAULT,
 }: SwitchBadgeProps) => {
+    const disabled = status === SwitchBadgeStatus.DISABLED;
+
     const classes = createClassName(
         styles['switch-badge'],
         status,
         !switchIsValid && styles['switch-badge--invalid'],
-        onClick && styles['switch-badge--clickable'],
+        !disabled && onClick && styles['switch-badge--clickable'],
     );
     return (
-        <span className={classes} onClick={onClick}>
+        <span className={classes} onClick={!disabled ? onClick : undefined}>
             <Icons.Switch size={IconSize.SMALL} color={IconColor.INHERIT} />
             <span>{switchItem.name}</span>
         </span>

--- a/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
+++ b/ui/src/geoviite-design-lib/track-number/track-number-link.tsx
@@ -12,6 +12,7 @@ import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 
 export type TrackNumberLinkContainerProps = {
     trackNumberId?: LayoutTrackNumberId;
+    disabled?: boolean;
 };
 
 export type TrackNumberLinkProps = {
@@ -19,6 +20,7 @@ export type TrackNumberLinkProps = {
     layoutContext: LayoutContext;
     changeTime: TimeStamp;
     onClick?: (trackNumberId: LayoutTrackNumberId) => void;
+    disabled?: boolean;
 };
 
 function createSelectAction() {
@@ -34,6 +36,7 @@ function createSelectAction() {
 
 export const TrackNumberLinkContainer: React.FC<TrackNumberLinkContainerProps> = ({
     trackNumberId,
+    disabled,
 }) => {
     const layoutContext = useTrackLayoutAppSelector((state) => state.layoutContext);
     const changeTime = useCommonDataAppSelector((state) => state.changeTimes.layoutTrackNumber);
@@ -43,6 +46,7 @@ export const TrackNumberLinkContainer: React.FC<TrackNumberLinkContainerProps> =
             trackNumberId={trackNumberId}
             layoutContext={layoutContext}
             changeTime={changeTime}
+            disabled={disabled}
         />
     );
 };
@@ -52,6 +56,7 @@ export const TrackNumberLink: React.FC<TrackNumberLinkProps> = ({
     layoutContext,
     changeTime,
     onClick,
+    disabled,
 }: TrackNumberLinkProps) => {
     const { t } = useTranslation();
     const [trackNumber, status] = useTrackNumberWithStatus(
@@ -64,7 +69,7 @@ export const TrackNumberLink: React.FC<TrackNumberLinkProps> = ({
 
     return status === LoaderStatus.Ready && trackNumber ? (
         <React.Fragment>
-            <AnchorLink onClick={() => clickAction(trackNumber.id)}>
+            <AnchorLink disabled={disabled} onClick={() => clickAction(trackNumber.id)}>
                 {trackNumber.number}
             </AnchorLink>
             {trackNumber.state === 'DELETED' ? (

--- a/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
+++ b/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
@@ -16,6 +16,7 @@ type LocationTracksPanelProps = {
     onToggleLocationTrackSelection: (locationTrack: LocationTrackId) => void;
     selectedLocationTracks?: LocationTrackId[];
     canSelectLocationTrack: boolean;
+    disabled?: boolean;
     max?: number;
     showMoreMax?: number;
 };
@@ -25,6 +26,7 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
     onToggleLocationTrackSelection,
     selectedLocationTracks,
     canSelectLocationTrack,
+    disabled,
     max = 16,
     showMoreMax = 48,
 }: LocationTracksPanelProps) => {
@@ -91,7 +93,7 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
                             }>
                             <LocationTrackBadge
                                 locationTrack={track}
-                                status={isSelected ? LocationTrackBadgeStatus.SELECTED : undefined}
+                                status={disabled ? LocationTrackBadgeStatus.DISABLED : isSelected ? LocationTrackBadgeStatus.SELECTED : undefined}
                             />
                             <span>
                                 <LocationTrackTypeLabel type={track.type} />

--- a/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
+++ b/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
@@ -99,7 +99,9 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
                             key={track.id}
                             className={itemClassName}
                             onClick={() =>
-                                canSelectLocationTrack && onToggleLocationTrackSelection(track.id)
+                                canSelectLocationTrack &&
+                                !disabled &&
+                                onToggleLocationTrackSelection(track.id)
                             }>
                             <LocationTrackBadge locationTrack={track} status={status()} />
                             <span>

--- a/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
+++ b/ui/src/selection-panel/location-track-panel/location-tracks-panel.tsx
@@ -84,6 +84,16 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
                         canSelectLocationTrack &&
                             'location-tracks-panel__location-track--can-select',
                     );
+                    const status = () => {
+                        if (disabled) {
+                            return LocationTrackBadgeStatus.DISABLED;
+                        } else if (isSelected) {
+                            return LocationTrackBadgeStatus.SELECTED;
+                        } else {
+                            return undefined;
+                        }
+                    };
+
                     return (
                         <li
                             key={track.id}
@@ -91,10 +101,7 @@ export const LocationTracksPanel: React.FC<LocationTracksPanelProps> = ({
                             onClick={() =>
                                 canSelectLocationTrack && onToggleLocationTrackSelection(track.id)
                             }>
-                            <LocationTrackBadge
-                                locationTrack={track}
-                                status={disabled ? LocationTrackBadgeStatus.DISABLED : isSelected ? LocationTrackBadgeStatus.SELECTED : undefined}
-                            />
+                            <LocationTrackBadge locationTrack={track} status={status()} />
                             <span>
                                 <LocationTrackTypeLabel type={track.type} />
                             </span>

--- a/ui/src/selection-panel/selection-panel-container.tsx
+++ b/ui/src/selection-panel/selection-panel-container.tsx
@@ -119,6 +119,7 @@ export const SelectionPanelContainer: React.FC<SelectionPanelContainerProps> = (
             mapLayoutMenu={state.map.layerMenu.layout}
             onMapLayerMenuItemChange={delegates.onLayerMenuItemChange}
             splittingState={state.splittingState}
+            linkingState={state.linkingState}
             grouping={state.geometryPlanViewSettings.grouping}
             visibleSources={state.geometryPlanViewSettings.visibleSources}
             togglePlanDownloadPopupOpen={togglePlanDownload}

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -49,6 +49,7 @@ import { ChangeTimes } from 'common/common-slice';
 import { Eye } from 'geoviite-design-lib/eye/eye';
 import { TrackNumberColorKey } from 'selection-panel/track-number-panel/color-selector/color-selector-utils';
 import { SplittingState } from 'tool-panel/location-track/split-store';
+import { LinkingState } from 'linking/linking-model';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT, VIEW_GEOMETRY } from 'user/user-model';
 import { objectEntries } from 'utils/array-utils';
@@ -88,6 +89,7 @@ type SelectionPanelProps = {
     onMapLayerMenuItemChange: (change: MapLayerMenuChange) => void;
     mapLayoutMenu: MapLayerMenuItem[];
     splittingState: SplittingState | undefined;
+    linkingState: LinkingState | undefined;
     grouping: GeometryPlanGrouping;
     visibleSources: PlanSource[];
     planDownloadPopupOpen: boolean;
@@ -122,12 +124,14 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
     onMapLayerMenuItemChange,
     mapLayoutMenu,
     splittingState,
+    linkingState,
     grouping,
     visibleSources,
     planDownloadPopupOpen,
     togglePlanDownloadPopupOpen,
 }: SelectionPanelProps) => {
     const { t } = useTranslation();
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
     const [visibleTrackNumbers, setVisibleTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
     const [fixNamesDialogOpen, setFixNamesDialogOpen] = React.useState(false);
     const [fixNamesPreviews, setFixNamesPreviews] = React.useState<SwitchNameFixPreview[]>([]);
@@ -275,7 +279,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
             <section>
                 <h3 className={styles['selection-panel__title']}>
                     {`${t('selection-panel.track-numbers-title')} (${visibleTrackNumbers.length})`}
-                    {!splittingState && (
+                    {!isLinkingOrSplitting && (
                         <Eye
                             onVisibilityToggle={() => {
                                 if (diagramLayerMenuItem) {
@@ -296,7 +300,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedTrackNumberIds}
                         onSelectTrackNumber={onTrackNumberSelection}
                         onSelectColor={onTrackNumberColorSelection}
-                        disabled={!!splittingState}
+                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('trackNumbers')}
                     />
                 </div>
             </section>
@@ -318,7 +322,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                     selectedTrackNumberIds={selectedTrackNumberIds}
                     togglePlanOpen={togglePlanOpen}
                     onSelect={onSelect}
-                    disabled={!!splittingState}
+                    disabled={isLinkingOrSplitting}
                     grouping={grouping}
                     visibleSources={visibleSources}
                     planDownloadPopupOpen={planDownloadPopupOpen}
@@ -342,7 +346,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                                 isToggle: true,
                             })
                         }
-                        disabled={!!splittingState}
+                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('kmPosts')}
                     />
                 </div>
             </section>
@@ -359,7 +363,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedItems.trackNumbers}
                         canSelectReferenceLine={selectableItemTypes.includes('trackNumbers')}
                         onToggleReferenceLineSelection={onToggleReferenceLineSelection}
-                        disabled={!!splittingState}
+                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('trackNumbers')}
                     />
                 </div>
             </section>
@@ -374,6 +378,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedLocationTracks={selectedItems.locationTracks}
                         canSelectLocationTrack={selectableItemTypes.includes('locationTracks')}
                         onToggleLocationTrackSelection={onToggleLocationTrackSelection}
+                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('locationTracks')}
                     />
                 </div>
             </section>
@@ -410,6 +415,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         switchCount={switchCount}
                         selectedSwitches={selectedItems.switches}
                         onToggleSwitchSelection={onToggleSwitchSelection}
+                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('switches')}
                     />
                     <FixSwitchNamesDialog
                         isOpen={fixNamesDialogOpen}
@@ -430,7 +436,7 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         onToggleOperationalPointSelection={(op) =>
                             onToggleOperationalPointSelection(op.id)
                         }
-                        disabled={!!splittingState}
+                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('operationalPoints')}
                     />
                 </div>
             </section>

--- a/ui/src/selection-panel/switch-panel/switch-panel.tsx
+++ b/ui/src/selection-panel/switch-panel/switch-panel.tsx
@@ -53,7 +53,11 @@ const SwitchPanel: React.FC<SwitchPanelProps> = ({
                         <li key={switchItem.id}>
                             <SwitchBadge
                                 switchItem={switchItem}
-                                onClick={() => onToggleSwitchSelection(switchItem.id)}
+                                onClick={
+                                    disabled
+                                        ? undefined
+                                        : () => onToggleSwitchSelection(switchItem.id)
+                                }
                                 status={status()}
                             />
                         </li>

--- a/ui/src/selection-panel/switch-panel/switch-panel.tsx
+++ b/ui/src/selection-panel/switch-panel/switch-panel.tsx
@@ -38,12 +38,23 @@ const SwitchPanel: React.FC<SwitchPanelProps> = ({
             <ol className={styles['switch-panel__switches']}>
                 {sortedSwitches.map((switchItem) => {
                     const isSelected = selectedSwitches?.some((p) => p === switchItem.id);
+
+                    const status = () => {
+                        if (disabled) {
+                            return SwitchBadgeStatus.DISABLED;
+                        } else if (isSelected) {
+                            return SwitchBadgeStatus.SELECTED;
+                        } else {
+                            return undefined;
+                        }
+                    };
+
                     return (
                         <li key={switchItem.id}>
                             <SwitchBadge
                                 switchItem={switchItem}
                                 onClick={() => onToggleSwitchSelection(switchItem.id)}
-                                status={disabled ? SwitchBadgeStatus.DISABLED : isSelected ? SwitchBadgeStatus.SELECTED : undefined}
+                                status={status()}
                             />
                         </li>
                     );

--- a/ui/src/selection-panel/switch-panel/switch-panel.tsx
+++ b/ui/src/selection-panel/switch-panel/switch-panel.tsx
@@ -10,6 +10,7 @@ type SwitchPanelProps = {
     switches: LayoutSwitch[];
     onToggleSwitchSelection: (layoutSwitchId: LayoutSwitchId) => void;
     selectedSwitches?: LayoutSwitchId[];
+    disabled?: boolean;
 };
 
 const SwitchPanel: React.FC<SwitchPanelProps> = ({
@@ -17,6 +18,7 @@ const SwitchPanel: React.FC<SwitchPanelProps> = ({
     switchCount,
     onToggleSwitchSelection,
     selectedSwitches,
+    disabled,
 }: SwitchPanelProps) => {
     const { t } = useTranslation();
 
@@ -41,7 +43,7 @@ const SwitchPanel: React.FC<SwitchPanelProps> = ({
                             <SwitchBadge
                                 switchItem={switchItem}
                                 onClick={() => onToggleSwitchSelection(switchItem.id)}
-                                status={isSelected ? SwitchBadgeStatus.SELECTED : undefined}
+                                status={disabled ? SwitchBadgeStatus.DISABLED : isSelected ? SwitchBadgeStatus.SELECTED : undefined}
                             />
                         </li>
                     );

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -121,11 +121,12 @@ const TrackMeterRange: React.FC<TrackMeterRangeProps> = ({ start, end }) => {
 const PlanVisibilityToggle: React.FC<{
     section: AlignmentPlanSection;
     isVisible: boolean;
+    disabled?: boolean;
     togglePlanVisibility: (
         planId: GeometryPlanId,
         alignmentId: GeometryAlignmentId | undefined,
     ) => void;
-}> = ({ section, isVisible, togglePlanVisibility }) => {
+}> = ({ section, isVisible, disabled, togglePlanVisibility }) => {
     const planId = section.planId;
 
     return (
@@ -134,6 +135,7 @@ const PlanVisibilityToggle: React.FC<{
             {planId && section.isLinked && (
                 <Eye
                     visibility={isVisible}
+                    disabled={disabled}
                     onVisibilityToggle={() => {
                         togglePlanVisibility(planId, section.alignmentId);
                     }}
@@ -218,6 +220,7 @@ const AlignmentPlanSectionInfoboxContentM: React.FC<AlignmentPlanSectionInfoboxC
                                 <PlanVisibilityToggle
                                     section={section}
                                     togglePlanVisibility={togglePlanVisibility}
+                                    disabled={isLinkingOrSplitting}
                                     isVisible={visiblePlans.some(
                                         (plan) => plan.id === section.planId,
                                     )}

--- a/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
+++ b/ui/src/tool-panel/alignment-plan-section-infobox-content.tsx
@@ -49,6 +49,7 @@ type GeometryPlanLabelProps = {
     planName: string | undefined;
     alignmentName: string | undefined;
     onGeometryClick: () => void;
+    disabled?: boolean;
 };
 
 const GeometryPlanLabel: React.FC<GeometryPlanLabelProps> = ({
@@ -56,6 +57,7 @@ const GeometryPlanLabel: React.FC<GeometryPlanLabelProps> = ({
     planName,
     alignmentName,
     onGeometryClick,
+    disabled,
 }) => {
     const { t } = useTranslation();
 
@@ -66,6 +68,7 @@ const GeometryPlanLabel: React.FC<GeometryPlanLabelProps> = ({
                     <AnchorLink
                         title={`${planName}, ${alignmentName}`}
                         className={styles['alignment-plan-section-infobox__plan-link-content']}
+                        disabled={disabled}
                         onClick={onGeometryClick}>
                         {planName}
                     </AnchorLink>
@@ -146,6 +149,9 @@ const AlignmentPlanSectionInfoboxContentM: React.FC<AlignmentPlanSectionInfoboxC
 }) => {
     const delegates = React.useMemo(() => createDelegates(TrackLayoutActions), []);
     const visiblePlans = useTrackLayoutAppSelector((state) => state.selection.visiblePlans);
+    const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
 
     function togglePlanVisibility(
         planId: GeometryPlanId,
@@ -198,6 +204,7 @@ const AlignmentPlanSectionInfoboxContentM: React.FC<AlignmentPlanSectionInfoboxC
                                     planName={section.planName}
                                     alignmentName={section.alignmentName}
                                     onGeometryClick={() => selectGeometry(section.planId)}
+                                    disabled={isLinkingOrSplitting}
                                 />
                             </div>
                         }

--- a/ui/src/tool-panel/geometry-plan/geometry-plan-infobox.tsx
+++ b/ui/src/tool-panel/geometry-plan/geometry-plan-infobox.tsx
@@ -25,6 +25,7 @@ import { LayoutTrackNumberId } from 'track-layout/track-layout-model';
 import { TrackNumberLinkContainer } from 'geoviite-design-lib/track-number/track-number-link';
 import { InfraModelDownloadButton } from 'geoviite-design-lib/infra-model-download/infra-model-download-button';
 import { GeometryPlanApplicability } from 'tool-panel/geometry-plan/geometry-plan-applicability';
+import { useTrackLayoutAppSelector } from 'store/hooks';
 
 type GeometryPlanInfoboxProps = {
     planHeader: GeometryPlanHeader;
@@ -78,6 +79,9 @@ const GeometryPlanInfobox: React.FC<GeometryPlanInfoboxProps> = ({
 }: GeometryPlanInfoboxProps) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
+    const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
     const trackNumberId = usePlanTrackNumberId(changeTimes, planHeader.trackNumber);
     const coordinateSystemModel = useLoader(
         () =>
@@ -139,7 +143,10 @@ const GeometryPlanInfobox: React.FC<GeometryPlanInfoboxProps> = ({
                     label={t('tool-panel.geometry-plan.track-number')}
                     value={
                         trackNumberId ? (
-                            <TrackNumberLinkContainer trackNumberId={trackNumberId} />
+                            <TrackNumberLinkContainer
+                                trackNumberId={trackNumberId}
+                                disabled={isLinkingOrSplitting}
+                            />
                         ) : (
                             planHeader.trackNumber
                         )

--- a/ui/src/tool-panel/km-post/km-post-infobox-container.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox-container.tsx
@@ -37,6 +37,9 @@ export const KmPostInfoboxContainer: React.FC<KmPostInfoboxContainerProps> = ({
             onDataChange={onDataChange}
             onSelect={delegates.onSelect}
             onUnselect={delegates.onUnselect}
+            isLinkingOrSplitting={
+                !!trackLayoutState.linkingState || !!trackLayoutState.splittingState
+            }
             onShowOnMap={() =>
                 kmPost.layoutLocation &&
                 delegates.showArea(calculateBoundingBoxToShowAroundLocation(kmPost.layoutLocation))

--- a/ui/src/tool-panel/km-post/km-post-infobox.tsx
+++ b/ui/src/tool-panel/km-post/km-post-infobox.tsx
@@ -51,6 +51,7 @@ type KmPostInfoboxProps = {
     visibilities: KmPostInfoboxVisibilities;
     onVisibilityChange: (visibilities: KmPostInfoboxVisibilities) => void;
     changeTimes: ChangeTimes;
+    isLinkingOrSplitting?: boolean;
 };
 
 const CoordinateSystemField: React.FC<{
@@ -96,6 +97,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
     visibilities,
     onVisibilityChange,
     changeTimes,
+    isLinkingOrSplitting,
 }: KmPostInfoboxProps) => {
     const { t } = useTranslation();
     const navigate = useAppNavigate();
@@ -192,6 +194,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                         value={
                             <TrackNumberLinkContainer
                                 trackNumberId={updatedKmPost?.trackNumberId}
+                                disabled={isLinkingOrSplitting}
                             />
                         }
                     />
@@ -284,6 +287,7 @@ const KmPostInfobox: React.FC<KmPostInfoboxProps> = ({
                                     )}{' '}
                                     <AnchorLink
                                         className={styles['km-post-infobox__plan-link']}
+                                        disabled={isLinkingOrSplitting}
                                         onClick={() => {
                                             if (infoboxExtras?.sourceGeometryPlanId) {
                                                 delegates.onSelect({

--- a/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-basic-info-infobox.tsx
@@ -40,6 +40,7 @@ type LocationTrackBasicInfoInfoboxContainerProps = {
     openEditLocationTrackDialog: () => void;
     editingDisabled: boolean;
     editingDisabledReason: string | undefined;
+    isLinkingOrSplitting?: boolean;
 };
 
 export const LocationTrackBasicInfoInfoboxContainer: React.FC<
@@ -73,6 +74,7 @@ const LocationTrackBasicInfoInfoboxM: React.FC<LocationTrackBasicInfoInfoboxProp
     openEditLocationTrackDialog,
     editingDisabled,
     editingDisabledReason,
+    isLinkingOrSplitting,
     onSelect,
     showArea,
 }) => {
@@ -91,6 +93,7 @@ const LocationTrackBasicInfoInfoboxM: React.FC<LocationTrackBasicInfoInfoboxProp
             return (
                 <span>
                     <AnchorLink
+                        disabled={isLinkingOrSplitting}
                         onClick={() => {
                             onSelect({
                                 switches: [switchId],
@@ -149,7 +152,12 @@ const LocationTrackBasicInfoInfoboxM: React.FC<LocationTrackBasicInfoInfoboxProp
                 <InfoboxField
                     qaId="location-track-track-number"
                     label={t('tool-panel.location-track.track-number')}
-                    value={<TrackNumberLinkContainer trackNumberId={trackNumber?.id} />}
+                    value={
+                        <TrackNumberLinkContainer
+                            trackNumberId={trackNumber?.id}
+                            disabled={isLinkingOrSplitting}
+                        />
+                    }
                 />
                 <InfoboxField
                     qaId="location-track-name"
@@ -188,6 +196,7 @@ const LocationTrackBasicInfoInfoboxM: React.FC<LocationTrackBasicInfoInfoboxProp
                                 layoutContext={layoutContext}
                                 changeTime={changeTimes.layoutLocationTrack}
                                 currentTrackNumberId={trackNumber?.id}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                         }
                     />

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -23,6 +23,7 @@ export type LocationTrackInfoboxDuplicateOfProps = {
     existingDuplicate: LocationTrackDuplicate | undefined;
     duplicatesOfLocationTrack: LocationTrackDuplicate[] | undefined;
     currentTrackNumberId: LayoutTrackNumberId | undefined;
+    isLinkingOrSplitting?: boolean;
 };
 
 const getTrackNumberName = (
@@ -36,6 +37,7 @@ const LocationTrackInfoboxDuplicateOfM: React.FC<LocationTrackInfoboxDuplicateOf
     duplicatesOfLocationTrack,
     currentTrackNumberId,
     layoutContext,
+    isLinkingOrSplitting,
 }: LocationTrackInfoboxDuplicateOfProps) => {
     const { t } = useTranslation();
     const trackNumbers = useTrackNumbers(layoutContext);
@@ -78,6 +80,7 @@ const LocationTrackInfoboxDuplicateOfM: React.FC<LocationTrackInfoboxDuplicateOf
             <LocationTrackLink
                 locationTrackId={existingDuplicate.id}
                 locationTrackName={existingDuplicate.name}
+                disabled={isLinkingOrSplitting}
             />
             &nbsp;
             {showWarningIcon && <LocationTrackDuplicateInfoIcon level={'ERROR'} />}
@@ -92,6 +95,7 @@ const LocationTrackInfoboxDuplicateOfM: React.FC<LocationTrackInfoboxDuplicateOf
                     explicitDuplicateLocationTrackNames={explicitDuplicateLocationTrackNames}
                     trackNumbers={trackNumbers}
                     currentTrackNumberId={currentTrackNumberId}
+                    isLinkingOrSplitting={isLinkingOrSplitting}
                 />
             ))}
         </ul>

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-of.tsx
@@ -83,7 +83,9 @@ const LocationTrackInfoboxDuplicateOfM: React.FC<LocationTrackInfoboxDuplicateOf
                 disabled={isLinkingOrSplitting}
             />
             &nbsp;
-            {showWarningIcon && <LocationTrackDuplicateInfoIcon level={'ERROR'} />}
+            {showWarningIcon && (
+                <LocationTrackDuplicateInfoIcon level={'ERROR'} disabled={!!isLinkingOrSplitting} />
+            )}
         </span>
     ) : duplicatesOfLocationTrack ? (
         <ul className={styles['location-track-infobox-duplicate-of__ul']}>

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
@@ -22,6 +22,7 @@ type LocationTrackInfoboxDuplicateTrackEntryProps = {
     currentTrackNumberId: LayoutTrackNumberId | undefined;
     trackNumbers: LayoutTrackNumber[] | undefined;
     explicitDuplicateLocationTrackNames: LayoutLocationTrack[];
+    isLinkingOrSplitting?: boolean;
 };
 
 type NoticeLevel = 'ERROR' | 'WARNING' | 'INFO';
@@ -199,6 +200,7 @@ export const LocationTrackInfoboxDuplicateTrackEntry: React.FC<
     currentTrackNumberId,
     trackNumbers,
     explicitDuplicateLocationTrackNames,
+    isLinkingOrSplitting,
 }: LocationTrackInfoboxDuplicateTrackEntryProps) => {
     const { t } = useTranslation();
 
@@ -269,6 +271,7 @@ export const LocationTrackInfoboxDuplicateTrackEntry: React.FC<
                 <LocationTrackLink
                     locationTrackId={duplicate.id}
                     locationTrackName={duplicate.name}
+                    disabled={isLinkingOrSplitting}
                 />
                 {notices.length > 0 && <LocationTrackDuplicateInfoIcon level={iconType} />}
             </span>

--- a/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox-duplicate-track-entry.tsx
@@ -34,7 +34,10 @@ type LocationTrackDuplicateNotice = {
 
 export const LocationTrackDuplicateInfoIcon: React.FC<{
     level: NoticeLevel;
-}> = ({ level }) => {
+    disabled: boolean;
+}> = ({ level, disabled }) => {
+    const color = disabled ? IconColor.DISABLED : IconColor.INHERIT;
+
     return (
         <span
             className={createClassName(
@@ -43,9 +46,9 @@ export const LocationTrackDuplicateInfoIcon: React.FC<{
                 level === 'ERROR' && styles['location-track-infobox-duplicate-of__icon--error'],
             )}>
             {level === 'ERROR' || level === 'WARNING' ? (
-                <Icons.StatusError color={IconColor.INHERIT} size={IconSize.SMALL} />
+                <Icons.StatusError color={color} size={IconSize.SMALL} />
             ) : (
-                <Icons.Info color={IconColor.INHERIT} size={IconSize.SMALL} />
+                <Icons.Info color={color} size={IconSize.SMALL} />
             )}
         </span>
     );
@@ -273,7 +276,12 @@ export const LocationTrackInfoboxDuplicateTrackEntry: React.FC<
                     locationTrackName={duplicate.name}
                     disabled={isLinkingOrSplitting}
                 />
-                {notices.length > 0 && <LocationTrackDuplicateInfoIcon level={iconType} />}
+                {notices.length > 0 && (
+                    <LocationTrackDuplicateInfoIcon
+                        level={iconType}
+                        disabled={!!isLinkingOrSplitting}
+                    />
+                )}
             </span>
         </li>
     );

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -133,6 +133,7 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 visibilities={visibilities}
                 visibilityChange={visibilityChange}
                 openEditLocationTrackDialog={openEditLocationTrackDialog}
+                isLinkingOrSplitting={!!linkingState || !!splittingState}
             />
             {splittingState && (
                 <LocationTrackSplittingInfoboxContainer

--- a/ui/src/tool-panel/location-track/location-track-link.tsx
+++ b/ui/src/tool-panel/location-track/location-track-link.tsx
@@ -7,6 +7,7 @@ import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
 export type LocationTrackLinkProps = {
     locationTrackId: LocationTrackId;
     locationTrackName: string;
+    disabled?: boolean;
 };
 
 export const LocationTrackLink: React.FC<LocationTrackLinkProps> = (
@@ -16,6 +17,7 @@ export const LocationTrackLink: React.FC<LocationTrackLinkProps> = (
 
     return (
         <AnchorLink
+            disabled={props.disabled}
             onClick={() => {
                 delegates.onSelect({
                     locationTracks: [props.locationTrackId],

--- a/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-links-infobox.tsx
@@ -16,6 +16,7 @@ import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getManyOperationalPoints } from 'track-layout/layout-operational-point-api';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import { LocationTrackOperationalPointRow } from './location-track-operational-point-row';
+import { useTrackLayoutAppSelector } from 'store/hooks';
 
 const maxOperationalPointsToDisplay = 10;
 
@@ -39,6 +40,9 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
     onSelect,
 }) => {
     const { t } = useTranslation();
+    const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
 
     const [infoboxExtras, infoboxExtrasLoadStatus] = useLocationTrackInfoboxExtras(
         locationTrack.id,
@@ -100,6 +104,7 @@ export const LocationTrackOperationalPointLinksInfobox: React.FC<
                                         layoutContext={layoutContext}
                                         locationTrack={locationTrack}
                                         onSelect={onSelect}
+                                        isLinkingOrSplitting={isLinkingOrSplitting}
                                     />
                                 ))}
                             </div>

--- a/ui/src/tool-panel/location-track/location-track-operational-point-row.tsx
+++ b/ui/src/tool-panel/location-track/location-track-operational-point-row.tsx
@@ -5,7 +5,10 @@ import { LayoutContext, TrackMeter } from 'common/common-model';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import styles from './location-track-operational-point-links-infobox.scss';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
-import { OperationalPointBadge } from 'geoviite-design-lib/operational-point/operational-point-badge';
+import {
+    OperationalPointBadge,
+    OperationalPointBadgeStatus,
+} from 'geoviite-design-lib/operational-point/operational-point-badge';
 import { OnSelectOptions } from 'selection/selection-model';
 import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
 import { createClassName } from 'vayla-design-lib/utils';
@@ -17,11 +20,17 @@ type LocationTrackOperationalPointRowProps = {
     layoutContext: LayoutContext;
     locationTrack: LayoutLocationTrack;
     onSelect: (items: OnSelectOptions) => void;
+    isLinkingOrSplitting: boolean;
 };
 
-export const LocationTrackOperationalPointRow: React.FC<
-    LocationTrackOperationalPointRowProps
-> = ({ operationalPoint, address, layoutContext, locationTrack, onSelect }) => {
+export const LocationTrackOperationalPointRow: React.FC<LocationTrackOperationalPointRowProps> = ({
+    operationalPoint,
+    address,
+    layoutContext,
+    locationTrack,
+    onSelect,
+    isLinkingOrSplitting,
+}) => {
     const { t } = useTranslation();
     const [showDetachDialog, setShowDetachDialog] = React.useState(false);
     const remarkClassNames = createClassName(
@@ -34,10 +43,14 @@ export const LocationTrackOperationalPointRow: React.FC<
             <div>
                 <OperationalPointBadge
                     operationalPoint={operationalPoint}
+                    status={isLinkingOrSplitting ? OperationalPointBadgeStatus.DISABLED : undefined}
                     onClick={() =>
                         onSelect({
                             operationalPoints: [operationalPoint.id],
-                            selectedTab: { id: operationalPoint.id, type: 'OPERATIONAL_POINT' },
+                            selectedTab: {
+                                id: operationalPoint.id,
+                                type: 'OPERATIONAL_POINT',
+                            },
                         })
                     }
                 />
@@ -60,6 +73,7 @@ export const LocationTrackOperationalPointRow: React.FC<
             <div>
                 {layoutContext.publicationState === 'DRAFT' && (
                     <Button
+                        disabled={isLinkingOrSplitting}
                         size={ButtonSize.SMALL}
                         variant={ButtonVariant.GHOST}
                         onClick={() => setShowDetachDialog(true)}>

--- a/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
@@ -17,6 +17,7 @@ import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
 import { getSwitches } from 'track-layout/layout-switch-api';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import { LocationTrackSwitchRow } from './location-track-switch-row';
+import { useTrackLayoutAppSelector } from 'store/hooks';
 
 const maxSwitchesToDisplay = 10;
 
@@ -64,6 +65,8 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
         useLocationTrackInfoboxExtras(locationTrack.id, layoutContext, changeTimes)[0]?.switches ??
         [];
     const switchIds = switches.map((s) => s.switchId);
+    const linkingState = useTrackLayoutAppSelector((s) => s.linkingState);
+    const splittingState = useTrackLayoutAppSelector((s) => s.splittingState);
 
     const [switchItems, switchItemLoadStatus] = useLoaderWithStatus(
         () =>
@@ -130,6 +133,7 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
                                         validationIssues={validationIssues}
                                         locationTrack={locationTrack}
                                         onSelect={onSelect}
+                                        isLinkingOrSplitting={!!linkingState || !!splittingState}
                                     />
                                 ))}
                             </div>

--- a/ui/src/tool-panel/location-track/location-track-switch-row.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-row.tsx
@@ -6,7 +6,7 @@ import { Point } from 'model/geometry';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
 import styles from './location-track-switch-links-infobox.scss';
 import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track-meter';
-import { SwitchBadge } from 'geoviite-design-lib/switch/switch-badge';
+import { SwitchBadge, SwitchBadgeStatus } from 'geoviite-design-lib/switch/switch-badge';
 import { OnSelectOptions } from 'selection/selection-model';
 import { LayoutValidationIssue } from 'publication/publication-model';
 import infoboxStyles from 'tool-panel/infobox/infobox.module.scss';
@@ -50,6 +50,7 @@ export const LocationTrackSwitchRow: React.FC<LocationTrackSwitchRowProps> = ({
                 <SwitchBadge
                     switchItem={switchItem}
                     switchIsValid={validationIssues.length === 0}
+                    status={isLinkingOrSplitting ? SwitchBadgeStatus.DISABLED : undefined}
                     onClick={() =>
                         onSelect({
                             switches: [switchItem.id],

--- a/ui/src/tool-panel/location-track/location-track-switch-row.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-row.tsx
@@ -21,6 +21,7 @@ type LocationTrackSwitchRowProps = {
     displayAddress?: TrackMeter;
     locationTrack: LayoutLocationTrack;
     onSelect: (items: OnSelectOptions) => void;
+    isLinkingOrSplitting: boolean;
 };
 
 export const LocationTrackSwitchRow: React.FC<LocationTrackSwitchRowProps> = ({
@@ -31,6 +32,7 @@ export const LocationTrackSwitchRow: React.FC<LocationTrackSwitchRowProps> = ({
     displayAddress,
     locationTrack,
     onSelect,
+    isLinkingOrSplitting,
 }) => {
     const { t } = useTranslation();
     const [showDetachDialog, setShowDetachDialog] = React.useState(false);
@@ -74,6 +76,7 @@ export const LocationTrackSwitchRow: React.FC<LocationTrackSwitchRowProps> = ({
             <div>
                 {layoutContext.publicationState === 'DRAFT' && (
                     <Button
+                        disabled={isLinkingOrSplitting}
                         size={ButtonSize.SMALL}
                         variant={ButtonVariant.GHOST}
                         onClick={() => setShowDetachDialog(true)}>

--- a/ui/src/tool-panel/operational-point/operational-point-station-links-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-station-links-infobox.tsx
@@ -10,6 +10,7 @@ import { getOperationalPointStationLinks } from 'track-layout/layout-operational
 import { StationLinkView } from 'tool-panel/operational-point/station-link-view';
 import styles from './operational-point-infobox.scss';
 import { getMaxTimestamp } from 'utils/date-utils';
+import { useTrackLayoutAppSelector } from 'store/hooks';
 import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,
@@ -35,6 +36,9 @@ export const OperationalPointStationLinksInfobox: React.FC<
     onSelectLocationTrack,
 }) => {
     const { t } = useTranslation();
+    const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
 
     const changeTime = getMaxTimestamp(
         changeTimes.layoutLocationTrack,
@@ -74,6 +78,7 @@ export const OperationalPointStationLinksInfobox: React.FC<
                                             layoutContext={layoutContext}
                                             changeTimes={changeTimes}
                                             onSelectLocationTrack={onSelectLocationTrack}
+                                            isLinkingOrSplitting={isLinkingOrSplitting}
                                         />
                                     </li>
                                 ))}

--- a/ui/src/tool-panel/operational-point/operational-point-switches-direction-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-switches-direction-infobox.tsx
@@ -174,7 +174,11 @@ const OperationalPointSwitchRow: React.FC<OperationalPointSwitchRowProps> = ({
             <div className={styles['operational-point-linking-infobox__switch-cell']}>
                 <SwitchBadge
                     switchItem={switchItem}
-                    status={isLinkingOrSplitting ? SwitchBadgeStatus.DISABLED : undefined}
+                    status={
+                        isLinkingOrSplitting && !isEditing
+                            ? SwitchBadgeStatus.DISABLED
+                            : undefined
+                    }
                     onClick={() => onSelectSwitch(switchItem.id)}
                 />
                 {switchLocation ? (

--- a/ui/src/tool-panel/operational-point/operational-point-switches-direction-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-switches-direction-infobox.tsx
@@ -24,7 +24,7 @@ import {
     MAP_POINT_DEFAULT_BBOX_OFFSET,
 } from 'map/map-utils';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
-import { SwitchBadge } from 'geoviite-design-lib/switch/switch-badge';
+import { SwitchBadge, SwitchBadgeStatus } from 'geoviite-design-lib/switch/switch-badge';
 import { useOperationalPoint } from 'track-layout/track-layout-react-utils';
 import { getChangeTimes } from 'common/change-time-api';
 
@@ -40,6 +40,7 @@ type OperationalPointSwitchesDirectionInfoboxProps = {
     massLinkingAction: () => void;
     showArea: (area: BoundingBox) => void;
     onSelectSwitch: (switchId: LayoutSwitchId) => void;
+    isLinkingOrSplitting: boolean;
 };
 
 export const OperationalPointSwitchesDirectionInfobox: React.FC<
@@ -56,6 +57,7 @@ export const OperationalPointSwitchesDirectionInfobox: React.FC<
     massLinkingAction,
     showArea,
     onSelectSwitch,
+    isLinkingOrSplitting,
 }) => {
     const { t } = useTranslation();
 
@@ -110,6 +112,7 @@ export const OperationalPointSwitchesDirectionInfobox: React.FC<
                                 linkingAction={linkingAction}
                                 showArea={showArea}
                                 onSelectSwitch={onSelectSwitch}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                         ))
                     )}
@@ -139,6 +142,7 @@ type OperationalPointSwitchRowProps = {
     linkingAction: (id: LayoutSwitchId) => void;
     showArea: (area: BoundingBox) => void;
     onSelectSwitch: (switchId: LayoutSwitchId) => void;
+    isLinkingOrSplitting: boolean;
 };
 
 const OperationalPointSwitchRow: React.FC<OperationalPointSwitchRowProps> = ({
@@ -150,6 +154,7 @@ const OperationalPointSwitchRow: React.FC<OperationalPointSwitchRowProps> = ({
     linkingAction,
     showArea,
     onSelectSwitch,
+    isLinkingOrSplitting,
 }) => {
     const switchLocation = getSwitchLocation(switchItem);
 
@@ -169,6 +174,7 @@ const OperationalPointSwitchRow: React.FC<OperationalPointSwitchRowProps> = ({
             <div className={styles['operational-point-linking-infobox__switch-cell']}>
                 <SwitchBadge
                     switchItem={switchItem}
+                    status={isLinkingOrSplitting ? SwitchBadgeStatus.DISABLED : undefined}
                     onClick={() => onSelectSwitch(switchItem.id)}
                 />
                 {switchLocation ? (

--- a/ui/src/tool-panel/operational-point/operational-point-switches-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-switches-infobox.tsx
@@ -89,6 +89,8 @@ export const OperationalPointSwitchesInfobox: React.FC<OperationalPointSwitchesI
     const { t } = useTranslation();
     const delegates = useMemo(() => createDelegates(trackLayoutActionCreators), []);
     const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
     const operationalPointSwitchLinkingState =
         linkingState?.type === LinkingType.LinkingOperationalPointSwitches
             ? linkingState
@@ -257,6 +259,7 @@ export const OperationalPointSwitchesInfobox: React.FC<OperationalPointSwitchesI
                                 massLinkingAction={addAllSwitches}
                                 showArea={delegates.showArea}
                                 onSelectSwitch={onSelectSwitch}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                             <OperationalPointSwitchesDirectionInfobox
                                 layoutContext={layoutContext}
@@ -274,6 +277,7 @@ export const OperationalPointSwitchesInfobox: React.FC<OperationalPointSwitchesI
                                 massLinkingAction={removeAllSwitches}
                                 showArea={delegates.showArea}
                                 onSelectSwitch={onSelectSwitch}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                             <div
                                 className={

--- a/ui/src/tool-panel/operational-point/operational-point-tracks-direction-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-tracks-direction-infobox.tsx
@@ -7,7 +7,10 @@ import { compareIgnoreCase } from 'utils/string-utils';
 import { createClassName } from 'vayla-design-lib/utils';
 import InfoboxText from 'tool-panel/infobox/infobox-text';
 import { Button, ButtonSize, ButtonVariant } from 'vayla-design-lib/button/button';
-import { LocationTrackBadge } from 'geoviite-design-lib/alignment/location-track-badge';
+import {
+    LocationTrackBadge,
+    LocationTrackBadgeStatus,
+} from 'geoviite-design-lib/alignment/location-track-badge';
 import { IconColor, Icons } from 'vayla-design-lib/icon/Icon';
 
 type OperationalPointTracksDirectionInfoboxProps = {
@@ -18,6 +21,7 @@ type OperationalPointTracksDirectionInfoboxProps = {
     linkingAction: (id: LocationTrackId) => void;
     massLinkingAction: () => void;
     onSelectLocationTrack: (locationTrackId: LocationTrackId) => void;
+    isLinkingOrSplitting: boolean;
 };
 
 export const OperationalPointTracksDirectionInfobox: React.FC<
@@ -30,6 +34,7 @@ export const OperationalPointTracksDirectionInfobox: React.FC<
     linkingAction,
     massLinkingAction,
     onSelectLocationTrack,
+    isLinkingOrSplitting,
 }) => {
     const { t } = useTranslation();
 
@@ -82,6 +87,7 @@ export const OperationalPointTracksDirectionInfobox: React.FC<
                                 isEditing={isEditing}
                                 linkingAction={linkingAction}
                                 onSelectLocationTrack={onSelectLocationTrack}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                         ))
                     )}
@@ -109,6 +115,7 @@ type OperationalPointTrackRowProps = {
     isEditing: boolean;
     linkingAction: (id: LocationTrackId) => void;
     onSelectLocationTrack: (locationTrackId: LocationTrackId) => void;
+    isLinkingOrSplitting: boolean;
 };
 
 const OperationalPointTrackRow: React.FC<OperationalPointTrackRowProps> = ({
@@ -118,11 +125,13 @@ const OperationalPointTrackRow: React.FC<OperationalPointTrackRowProps> = ({
     isEditing,
     linkingAction,
     onSelectLocationTrack,
+    isLinkingOrSplitting,
 }) => {
     return (
         <>
             <LocationTrackBadge
                 locationTrack={trackItem}
+                status={isLinkingOrSplitting ? LocationTrackBadgeStatus.DISABLED : undefined}
                 onClick={() => onSelectLocationTrack(trackItem.id)}
             />
             <Hide when={!isEditing}>

--- a/ui/src/tool-panel/operational-point/operational-point-tracks-direction-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-tracks-direction-infobox.tsx
@@ -131,7 +131,11 @@ const OperationalPointTrackRow: React.FC<OperationalPointTrackRowProps> = ({
         <>
             <LocationTrackBadge
                 locationTrack={trackItem}
-                status={isLinkingOrSplitting ? LocationTrackBadgeStatus.DISABLED : undefined}
+                status={
+                    isLinkingOrSplitting && !isEditing
+                        ? LocationTrackBadgeStatus.DISABLED
+                        : undefined
+                }
                 onClick={() => onSelectLocationTrack(trackItem.id)}
             />
             <Hide when={!isEditing}>

--- a/ui/src/tool-panel/operational-point/operational-point-tracks-direction-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-tracks-direction-infobox.tsx
@@ -127,16 +127,14 @@ const OperationalPointTrackRow: React.FC<OperationalPointTrackRowProps> = ({
     onSelectLocationTrack,
     isLinkingOrSplitting,
 }) => {
+    const isDisabled = isLinkingOrSplitting && !isEditing;
+
     return (
         <>
             <LocationTrackBadge
                 locationTrack={trackItem}
-                status={
-                    isLinkingOrSplitting && !isEditing
-                        ? LocationTrackBadgeStatus.DISABLED
-                        : undefined
-                }
-                onClick={() => onSelectLocationTrack(trackItem.id)}
+                status={isDisabled ? LocationTrackBadgeStatus.DISABLED : undefined}
+                onClick={isDisabled ? undefined : () => onSelectLocationTrack(trackItem.id)}
             />
             <Hide when={!isEditing}>
                 <Button

--- a/ui/src/tool-panel/operational-point/operational-point-tracks-infobox.tsx
+++ b/ui/src/tool-panel/operational-point/operational-point-tracks-infobox.tsx
@@ -75,6 +75,8 @@ export const OperationalPointTracksInfobox: React.FC<OperationalPointTracksInfob
     const { t } = useTranslation();
     const delegates = React.useMemo(() => createDelegates(trackLayoutActionCreators), []);
     const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
     const operationalPointTrackLinkingState =
         linkingState?.type === LinkingType.LinkingOperationalPointTracks ? linkingState : undefined;
     const isEditing = !!operationalPointTrackLinkingState;
@@ -216,6 +218,7 @@ export const OperationalPointTracksInfobox: React.FC<OperationalPointTracksInfob
                                     delegates.setOperationalPointLinkedTracks([])
                                 }
                                 onSelectLocationTrack={onSelectLocationTrack}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                             <OperationalPointTracksDirectionInfobox
                                 tracksInOperationalPointPolygon={tracksInOperationalPointPolygon}
@@ -229,6 +232,7 @@ export const OperationalPointTracksInfobox: React.FC<OperationalPointTracksInfob
                                     )
                                 }
                                 onSelectLocationTrack={onSelectLocationTrack}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                             <div
                                 className={

--- a/ui/src/tool-panel/operational-point/station-link-view.tsx
+++ b/ui/src/tool-panel/operational-point/station-link-view.tsx
@@ -80,7 +80,11 @@ export const StationLinkView: React.FC<StationLinkViewProps> = ({
                             status={
                                 isLinkingOrSplitting ? LocationTrackBadgeStatus.DISABLED : undefined
                             }
-                            onClick={() => onSelectLocationTrack(track.id)}
+                            onClick={
+                                isLinkingOrSplitting
+                                    ? undefined
+                                    : () => onSelectLocationTrack(track.id)
+                            }
                         />
                     ))}
                 </div>

--- a/ui/src/tool-panel/operational-point/station-link-view.tsx
+++ b/ui/src/tool-panel/operational-point/station-link-view.tsx
@@ -10,7 +10,10 @@ import {
 import { OperationalPointBadgeLink } from 'geoviite-design-lib/operational-point/operational-point-badge';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import styles from './operational-point-infobox.scss';
-import { TrackNumberBadgeLink } from 'geoviite-design-lib/alignment/track-number-badge';
+import {
+    TrackNumberBadgeLink,
+    TrackNumberBadgeStatus,
+} from 'geoviite-design-lib/alignment/track-number-badge';
 
 export type StationLinkViewProps = {
     stationLink: StationLink;
@@ -62,7 +65,7 @@ export const StationLinkView: React.FC<StationLinkViewProps> = ({
                     trackNumberId={stationLink.trackNumberId}
                     layoutContext={layoutContext}
                     changeTime={changeTimes.layoutTrackNumber}
-                    disabled={isLinkingOrSplitting}
+                    status={isLinkingOrSplitting ? TrackNumberBadgeStatus.DISABLED : undefined}
                 />
                 <span className={styles['operational-point-infobox__station-link-length']}>
                     {Math.round(stationLink.length)} m
@@ -75,9 +78,7 @@ export const StationLinkView: React.FC<StationLinkViewProps> = ({
                             key={track.id}
                             locationTrack={track}
                             status={
-                                isLinkingOrSplitting
-                                    ? LocationTrackBadgeStatus.DISABLED
-                                    : undefined
+                                isLinkingOrSplitting ? LocationTrackBadgeStatus.DISABLED : undefined
                             }
                             onClick={() => onSelectLocationTrack(track.id)}
                         />

--- a/ui/src/tool-panel/operational-point/station-link-view.tsx
+++ b/ui/src/tool-panel/operational-point/station-link-view.tsx
@@ -3,7 +3,10 @@ import { LocationTrackId, OperationalPointId, StationLink } from 'track-layout/t
 import { LayoutContext } from 'common/common-model';
 import { ChangeTimes } from 'common/common-slice';
 import { useLocationTracks } from 'track-layout/track-layout-react-utils';
-import { LocationTrackBadge } from 'geoviite-design-lib/alignment/location-track-badge';
+import {
+    LocationTrackBadge,
+    LocationTrackBadgeStatus,
+} from 'geoviite-design-lib/alignment/location-track-badge';
 import { OperationalPointBadgeLink } from 'geoviite-design-lib/operational-point/operational-point-badge';
 import { IconColor, Icons, IconSize } from 'vayla-design-lib/icon/Icon';
 import styles from './operational-point-infobox.scss';
@@ -15,6 +18,7 @@ export type StationLinkViewProps = {
     layoutContext: LayoutContext;
     changeTimes: ChangeTimes;
     onSelectLocationTrack: (locationTrackId: LocationTrackId) => void;
+    isLinkingOrSplitting: boolean;
 };
 
 export const StationLinkView: React.FC<StationLinkViewProps> = ({
@@ -23,6 +27,7 @@ export const StationLinkView: React.FC<StationLinkViewProps> = ({
     layoutContext,
     changeTimes,
     onSelectLocationTrack,
+    isLinkingOrSplitting,
 }) => {
     const locationTracks = useLocationTracks(
         stationLink.locationTrackIds,
@@ -43,18 +48,21 @@ export const StationLinkView: React.FC<StationLinkViewProps> = ({
                         operationalPointId={firstOp}
                         layoutContext={layoutContext}
                         changeTime={changeTimes.operationalPoints}
+                        disabled={isLinkingOrSplitting}
                     />
                     <Icons.Next size={IconSize.SMALL} color={IconColor.INHERIT} />
                     <OperationalPointBadgeLink
                         operationalPointId={secondOp}
                         layoutContext={layoutContext}
                         changeTime={changeTimes.operationalPoints}
+                        disabled={isLinkingOrSplitting}
                     />
                 </span>
                 <TrackNumberBadgeLink
                     trackNumberId={stationLink.trackNumberId}
                     layoutContext={layoutContext}
                     changeTime={changeTimes.layoutTrackNumber}
+                    disabled={isLinkingOrSplitting}
                 />
                 <span className={styles['operational-point-infobox__station-link-length']}>
                     {Math.round(stationLink.length)} m
@@ -66,6 +74,11 @@ export const StationLinkView: React.FC<StationLinkViewProps> = ({
                         <LocationTrackBadge
                             key={track.id}
                             locationTrack={track}
+                            status={
+                                isLinkingOrSplitting
+                                    ? LocationTrackBadgeStatus.DISABLED
+                                    : undefined
+                            }
                             onClick={() => onSelectLocationTrack(track.id)}
                         />
                     ))}

--- a/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox-track-meters.tsx
@@ -13,11 +13,13 @@ import NavigableTrackMeter from 'geoviite-design-lib/track-meter/navigable-track
 type JointTrackMeterProps = {
     jointTrackMeter: SwitchJointTrackMeter;
     addressPlaceHolder: string;
+    isLinkingOrSplitting?: boolean;
 };
 
 const JointTrackMeter: React.FC<JointTrackMeterProps> = ({
     jointTrackMeter,
     addressPlaceHolder,
+    isLinkingOrSplitting,
 }) => {
     const { t } = useTranslation();
     return (
@@ -36,6 +38,7 @@ const JointTrackMeter: React.FC<JointTrackMeterProps> = ({
             <LocationTrackLink
                 locationTrackId={jointTrackMeter.locationTrackId}
                 locationTrackName={jointTrackMeter.locationTrackName}
+                disabled={isLinkingOrSplitting}
             />
         </span>
     );
@@ -45,12 +48,14 @@ export type SwitchInfoboxTrackMetersProps = {
     switchId: LayoutSwitchId;
     jointTrackMeters: SwitchJointTrackMeter[];
     presentationJoint?: JointNumber;
+    isLinkingOrSplitting?: boolean;
 };
 
 export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> = ({
     switchId,
     jointTrackMeters,
     presentationJoint,
+    isLinkingOrSplitting,
 }: SwitchInfoboxTrackMetersProps) => {
     const { t } = useTranslation();
 
@@ -82,6 +87,7 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                             <JointTrackMeter
                                 jointTrackMeter={pja}
                                 addressPlaceHolder={addressMissingText}
+                                isLinkingOrSplitting={isLinkingOrSplitting}
                             />
                         </li>
                     ))}
@@ -107,6 +113,7 @@ export const SwitchInfoboxTrackMeters: React.FC<SwitchInfoboxTrackMetersProps> =
                                         <JointTrackMeter
                                             jointTrackMeter={a}
                                             addressPlaceHolder={addressMissingText}
+                                            isLinkingOrSplitting={isLinkingOrSplitting}
                                         />
                                     </li>
                                 ))}

--- a/ui/src/tool-panel/switch/switch-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-infobox.tsx
@@ -54,6 +54,7 @@ import { SwitchOid } from 'track-layout/oid';
 import { SwitchChangeInfoInfobox } from 'tool-panel/switch/switch-change-info-infobox';
 import { getOperationalPoint } from 'track-layout/layout-operational-point-api';
 import { AnchorLink } from 'geoviite-design-lib/link/anchor-link';
+import { useTrackLayoutAppSelector } from 'store/hooks';
 
 type SwitchInfoboxProps = {
     switchId: LayoutSwitchId;
@@ -136,12 +137,14 @@ export const getSwitchJointTrackMeters = async (
 const OperationalPointLink: React.FC<{
     operationalPoint: OperationalPoint;
     onSelect: (options: OnSelectOptions) => void;
-}> = ({ operationalPoint, onSelect }) => {
+    disabled?: boolean;
+}> = ({ operationalPoint, onSelect, disabled }) => {
     const { t } = useTranslation();
 
     return (
         <span>
             <AnchorLink
+                disabled={disabled}
                 onClick={() => {
                     onSelect({
                         operationalPoints: [operationalPoint.id],
@@ -171,6 +174,9 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
     onSelectLocationTrackBadge,
 }: SwitchInfoboxProps) => {
     const { t } = useTranslation();
+    const linkingState = useTrackLayoutAppSelector((state) => state.linkingState);
+    const splittingState = useTrackLayoutAppSelector((state) => state.splittingState);
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
     const switchOwners = useLoader(() => getSwitchOwners(), []);
     const switchStructures = useLoader(() => getSwitchStructures(), []);
     const layoutSwitch = useLoader(
@@ -317,6 +323,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                                         switchId={switchId}
                                         jointTrackMeters={switchJointTrackMeters}
                                         presentationJoint={structure?.presentationJointNumber}
+                                        isLinkingOrSplitting={isLinkingOrSplitting}
                                     />
                                 )) || <Spinner />
                             }
@@ -330,6 +337,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                                     <OperationalPointLink
                                         operationalPoint={operationalPoint}
                                         onSelect={onSelect}
+                                        disabled={isLinkingOrSplitting}
                                     />
                                 ) : (
                                     t('tool-panel.switch.layout.not-linked')
@@ -399,6 +407,7 @@ const SwitchInfobox: React.FC<SwitchInfoboxProps> = ({
                             jointConnections={switchJointConnections}
                             layoutContext={layoutContext}
                             onSelectLocationTrackBadge={onSelectLocationTrackBadge}
+                            isLinkingOrSplitting={isLinkingOrSplitting}
                         />
                     )}
                     <PrivilegeRequired privilege={EDIT_LAYOUT}>

--- a/ui/src/tool-panel/switch/switch-joint-infobox.tsx
+++ b/ui/src/tool-panel/switch/switch-joint-infobox.tsx
@@ -15,7 +15,10 @@ import {
 import { useLoader } from 'utils/react-utils';
 import { filterNotEmpty } from 'utils/array-utils';
 import { switchJointNumberToString } from 'utils/enum-localization-utils';
-import { LocationTrackBadge } from 'geoviite-design-lib/alignment/location-track-badge';
+import {
+    LocationTrackBadge,
+    LocationTrackBadgeStatus,
+} from 'geoviite-design-lib/alignment/location-track-badge';
 import styles from './switch-infobox.scss';
 import { TopologicalJointConnection } from 'linking/linking-model';
 import { getLocationTracks } from 'track-layout/layout-location-track-api';
@@ -29,6 +32,7 @@ type SwitchJointInfobox = {
     switchesToDetach?: LayoutSwitchId[];
     layoutContext: LayoutContext;
     onSelectLocationTrackBadge?: (locationTrackId: LocationTrackId) => void;
+    isLinkingOrSplitting?: boolean;
 };
 
 const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
@@ -38,6 +42,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
     switchesToDetach,
     layoutContext,
     onSelectLocationTrackBadge,
+    isLinkingOrSplitting,
 }) => {
     const { t } = useTranslation();
     const locationTracksEndingAtJoint = combineLocationTrackIds(
@@ -92,6 +97,7 @@ const SwitchJointInfobox: React.FC<SwitchJointInfobox> = ({
                 <LocationTrackBadge
                     key={t.id}
                     locationTrack={t}
+                    status={isLinkingOrSplitting ? LocationTrackBadgeStatus.DISABLED : undefined}
                     onClick={locationTrackBadgeOnClickHandler(t.id)}
                 />
             ));

--- a/ui/src/tool-panel/track-number/track-number-infobox-linking-container.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox-linking-container.tsx
@@ -38,6 +38,7 @@ const TrackNumberInfoboxLinkingContainer: React.FC<TrackNumberInfoboxLinkingCont
             trackNumber={trackNumber}
             referenceLine={referenceLine}
             linkingState={trackLayoutState.linkingState}
+            splittingState={trackLayoutState.splittingState}
             onStartReferenceLineGeometryChange={(interval) => {
                 delegates.addForcedVisibleLayer(['alignment-linking-layer']);
                 delegates.startAlignmentGeometryChange(interval);

--- a/ui/src/tool-panel/track-number/track-number-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-infobox.tsx
@@ -21,6 +21,7 @@ import {
     useReferenceLineStartAndEnd,
 } from 'track-layout/track-layout-react-utils';
 import { LinkingAlignment, LinkingState, LinkingType, LinkInterval } from 'linking/linking-model';
+import { SplittingState } from 'tool-panel/location-track/split-store';
 import { BoundingBox } from 'model/geometry';
 import { updateReferenceLineGeometry } from 'linking/linking-api';
 import InfoboxButtons from 'tool-panel/infobox/infobox-buttons';
@@ -49,6 +50,7 @@ type TrackNumberInfoboxProps = {
     referenceLine: LayoutReferenceLine | undefined;
     layoutContext: LayoutContext;
     linkingState?: LinkingState;
+    splittingState?: SplittingState;
     showArea: (area: BoundingBox) => void;
     onSelect: OnSelectFunction;
     onUnselect: (items: OptionalUnselectableItemCollections) => void;
@@ -86,6 +88,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     referenceLine,
     layoutContext,
     linkingState,
+    splittingState,
     showArea,
     onSelect,
     onUnselect,
@@ -99,6 +102,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
     shownLocationTrackIds,
 }: TrackNumberInfoboxProps) => {
     const { t } = useTranslation();
+    const isLinkingOrSplitting = !!linkingState || !!splittingState;
     const trackNumberChangeTime = getMaxTimestamp(
         changeTimes.layoutTrackNumber,
         changeTimes.layoutReferenceLine,
@@ -357,6 +361,7 @@ const TrackNumberInfobox: React.FC<TrackNumberInfoboxProps> = ({
                 contentVisible={visibilities.locationTracks}
                 onContentVisibilityChange={() => visibilityChange('locationTracks')}
                 changeTime={changeTimes.layoutLocationTrack}
+                isLinkingOrSplitting={isLinkingOrSplitting}
             />
             {referenceLine && (
                 <PrivilegeRequired privilege={VIEW_GEOMETRY}>

--- a/ui/src/tool-panel/track-number/track-number-location-track-infobox.tsx
+++ b/ui/src/tool-panel/track-number/track-number-location-track-infobox.tsx
@@ -26,6 +26,7 @@ type TrackNumberLocationTrackInfoboxProps = {
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
     changeTime: TimeStamp;
+    isLinkingOrSplitting?: boolean;
 };
 
 const TrackNumberLocationTrackInfoboxM: React.FC<TrackNumberLocationTrackInfoboxProps> = ({
@@ -35,6 +36,7 @@ const TrackNumberLocationTrackInfoboxM: React.FC<TrackNumberLocationTrackInfobox
     contentVisible,
     onContentVisibilityChange,
     changeTime,
+    isLinkingOrSplitting,
 }) => {
     const { t } = useTranslation();
     const [filterByVisibleArea, setFilterByVisibleArea] = React.useState(true);
@@ -87,6 +89,7 @@ const TrackNumberLocationTrackInfoboxM: React.FC<TrackNumberLocationTrackInfobox
                                         <LocationTrackLink
                                             locationTrackId={lt.id}
                                             locationTrackName={lt.name}
+                                            disabled={isLinkingOrSplitting}
                                         />
                                     </span>
                                     <span

--- a/ui/src/vayla-design-lib/link/link.scss
+++ b/ui/src/vayla-design-lib/link/link.scss
@@ -3,4 +3,9 @@
 .link {
     cursor: pointer;
     color: colors.$color-blue-dark;
+
+    &--disabled {
+        cursor: default;
+        color: colors.$color-black-lighter;
+    }
 }

--- a/ui/src/vayla-design-lib/link/link.tsx
+++ b/ui/src/vayla-design-lib/link/link.tsx
@@ -2,12 +2,16 @@ import * as React from 'react';
 import styles from './link.scss';
 import { createClassName } from 'vayla-design-lib/utils';
 
-export const Link: React.FC<React.HTMLProps<HTMLAnchorElement>> = (
-    props: React.HTMLProps<HTMLAnchorElement>,
-) => {
-    const className = createClassName(styles.link, props.className);
+type LinkProps = React.HTMLProps<HTMLAnchorElement> & { disabled?: boolean };
+
+export const Link: React.FC<LinkProps> = ({ disabled, onClick, ...props }: LinkProps) => {
+    const className = createClassName(
+        styles.link,
+        disabled && styles['link--disabled'],
+        props.className,
+    );
     return (
-        <a {...props} className={className}>
+        <a {...props} className={className} onClick={disabled ? undefined : onClick}>
             {props.children}
         </a>
     );

--- a/ui/src/vayla-design-lib/link/link.tsx
+++ b/ui/src/vayla-design-lib/link/link.tsx
@@ -4,14 +4,20 @@ import { createClassName } from 'vayla-design-lib/utils';
 
 type LinkProps = React.HTMLProps<HTMLAnchorElement> & { disabled?: boolean };
 
-export const Link: React.FC<LinkProps> = ({ disabled, onClick, ...props }: LinkProps) => {
+export const Link: React.FC<LinkProps> = ({ disabled, onClick, href, ...props }: LinkProps) => {
     const className = createClassName(
         styles.link,
         disabled && styles['link--disabled'],
         props.className,
     );
+    const overriddenHref = disabled ? undefined : href;
+
     return (
-        <a {...props} className={className} onClick={disabled ? undefined : onClick}>
+        <a
+            {...props}
+            href={overriddenHref}
+            className={className}
+            onClick={disabled ? undefined : onClick}>
             {props.children}
         </a>
     );


### PR DESCRIPTION
Iso pullari, mutta sisältää kasan parannuksia vasemman ja oikean paneelien linkkien, badgejen ja nappien disablointeihin linkitys- ja splittaustilojen ollessa päällä. Samalla päivitetty joitain badgeja ja linkkejä, että disabloinnit saadaan visualisoitua paremmin.