### PR TITLE
GVT-3594 Ratko error handling refactor

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
@@ -1,7 +1,7 @@
 package fi.fta.geoviite.infra.integration
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
@@ -53,20 +53,24 @@ data class RatkoErrorData(
     override val technicalMessage: String,
 ) : RatkoPushError
 
-sealed interface RatkoAssetId<T : LayoutAsset<T>> {
+sealed interface RatkoAssetRef<T : LayoutAsset<T>> {
     val id: IntId<T>
+    val oid: Oid<T>?
     val type: RatkoAssetType
 }
 
-data class RatkoSwitchId(override val id: IntId<LayoutSwitch>) : RatkoAssetId<LayoutSwitch> {
+data class RatkoSwitchRef(override val id: IntId<LayoutSwitch>, override val oid: Oid<LayoutSwitch>?) :
+    RatkoAssetRef<LayoutSwitch> {
     override val type: RatkoAssetType = RatkoAssetType.SWITCH
 }
 
-data class RatkoLocationTrackId(override val id: IntId<LocationTrack>) : RatkoAssetId<LocationTrack> {
+data class RatkoLocationTrackRef(override val id: IntId<LocationTrack>, override val oid: Oid<LocationTrack>?) :
+    RatkoAssetRef<LocationTrack> {
     override val type: RatkoAssetType = RatkoAssetType.LOCATION_TRACK
 }
 
-data class RatkoTrackNumberId(override val id: IntId<LayoutTrackNumber>) : RatkoAssetId<LayoutTrackNumber> {
+data class RatkoTrackNumberRef(override val id: IntId<LayoutTrackNumber>, override val oid: Oid<LayoutTrackNumber>?) :
+    RatkoAssetRef<LayoutTrackNumber> {
     override val type: RatkoAssetType = RatkoAssetType.TRACK_NUMBER
 }
 
@@ -75,14 +79,8 @@ data class RatkoPushGeneralError(private val data: RatkoErrorData) : RatkoPushEr
 data class RatkoPushAssetError<T : LayoutAsset<T>>(
     val operation: RatkoOperation,
     private val data: RatkoErrorData,
-    @JsonIgnore val ratkoAssetId: RatkoAssetId<T>,
-) : RatkoPushError by data {
-    val assetId: IntId<T>
-        get() = ratkoAssetId.id
-
-    val assetType: RatkoAssetType
-        get() = ratkoAssetId.type
-}
+    val assetRef: RatkoAssetRef<T>,
+) : RatkoPushError by data
 
 data class RatkoPushErrorResponse(val error: RatkoPushError, val publicationId: IntId<Publication>)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/IntegrationModels.kt
@@ -1,7 +1,12 @@
 package fi.fta.geoviite.infra.integration
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import java.time.Instant
 
 enum class RatkoPushErrorType {
@@ -32,23 +37,54 @@ data class RatkoPush(
     val status: RatkoPushStatus,
 )
 
-data class RatkoPushError<T>(
-    val id: IntId<RatkoPushError<*>>,
-    val ratkoPushId: IntId<RatkoPush>,
-    val errorType: RatkoPushErrorType,
-    val operation: RatkoOperation,
-    val assetId: IntId<T>,
-    val assetType: RatkoAssetType,
-)
+sealed interface RatkoPushError {
+    val id: IntId<RatkoPushError>
+    val ratkoPushId: IntId<RatkoPush>
+    val errorType: RatkoPushErrorType
+    val ratkoStatusCode: String?
+    val technicalMessage: String
+}
 
-data class RatkoPushErrorWithAsset(
-    val id: IntId<RatkoPushError<*>>,
-    val ratkoPushId: IntId<RatkoPush>,
-    val errorType: RatkoPushErrorType,
+data class RatkoErrorData(
+    override val id: IntId<RatkoPushError>,
+    override val ratkoPushId: IntId<RatkoPush>,
+    override val errorType: RatkoPushErrorType,
+    override val ratkoStatusCode: String?,
+    override val technicalMessage: String,
+) : RatkoPushError
+
+sealed interface RatkoAssetId<T : LayoutAsset<T>> {
+    val id: IntId<T>
+    val type: RatkoAssetType
+}
+
+data class RatkoSwitchId(override val id: IntId<LayoutSwitch>) : RatkoAssetId<LayoutSwitch> {
+    override val type: RatkoAssetType = RatkoAssetType.SWITCH
+}
+
+data class RatkoLocationTrackId(override val id: IntId<LocationTrack>) : RatkoAssetId<LocationTrack> {
+    override val type: RatkoAssetType = RatkoAssetType.LOCATION_TRACK
+}
+
+data class RatkoTrackNumberId(override val id: IntId<LayoutTrackNumber>) : RatkoAssetId<LayoutTrackNumber> {
+    override val type: RatkoAssetType = RatkoAssetType.TRACK_NUMBER
+}
+
+data class RatkoPushGeneralError(private val data: RatkoErrorData) : RatkoPushError by data
+
+data class RatkoPushAssetError<T : LayoutAsset<T>>(
     val operation: RatkoOperation,
-    val assetType: RatkoAssetType,
-    val asset: LayoutAsset<*>,
-)
+    private val data: RatkoErrorData,
+    @JsonIgnore val ratkoAssetId: RatkoAssetId<T>,
+) : RatkoPushError by data {
+    val assetId: IntId<T>
+        get() = ratkoAssetId.id
+
+    val assetType: RatkoAssetType
+        get() = ratkoAssetId.type
+}
+
+data class RatkoPushErrorResponse(val error: RatkoPushError, val publicationId: IntId<Publication>)
 
 enum class RatkoPushStatus {
     IN_PROGRESS,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -304,9 +304,7 @@ constructor(
     }
 
     private fun ensureDraftIdExists(draftOid: Oid<LayoutSwitch>) {
-        requireNotNull(ratkoClient?.getSwitchAsset(RatkoOid(draftOid.toString()))) {
-            "OID $draftOid does not exist in Ratko"
-        }
+        requireNotNull(ratkoClient?.getSwitchAsset(RatkoOid(draftOid))) { "OID $draftOid does not exist in Ratko" }
     }
 
     fun getCalculatedChanges(versions: ValidationVersions): CalculatedChanges =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -45,12 +45,12 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
-import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.Instant
 
 @GeoviiteService
 class PublicationService
@@ -279,31 +279,28 @@ constructor(
         )
     }
 
-    private fun insertExternalIdForLocationTrack(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>) {
+    private fun insertExternalIdForLocationTrack(branch: LayoutBranch, id: IntId<LocationTrack>) {
         val locationTrackOid =
             ratkoClient?.let { s -> requireNotNull(s.getNewLocationTrackOid()) { "No OID received from RATKO" } }
-                ?: ratkoFakeOidGenerator?.generateFakeRatkoOID(
-                    LOCATION_TRACK_FAKE_OID_CONTEXT,
-                    locationTrackId.intValue,
-                )
-        locationTrackOid?.let { oid -> locationTrackService.insertExternalId(branch, locationTrackId, Oid(oid.id)) }
+                ?: ratkoFakeOidGenerator?.generateFakeRatkoOID(LOCATION_TRACK_FAKE_OID_CONTEXT, id.intValue)
+        locationTrackOid?.let { oid -> locationTrackService.insertExternalId(branch, id, Oid(oid.id)) }
     }
 
-    private fun insertExternalIdForTrackNumber(branch: LayoutBranch, trackNumberId: IntId<LayoutTrackNumber>) {
+    private fun insertExternalIdForTrackNumber(branch: LayoutBranch, id: IntId<LayoutTrackNumber>) {
         val routeNumberOid =
             ratkoClient?.let { s -> requireNotNull(s.getNewRouteNumberOid()) { "No OID received from RATKO" } }
-                ?: ratkoFakeOidGenerator?.generateFakeRatkoOID(TRACK_NUMBER_FAKE_OID_CONTEXT, trackNumberId.intValue)
-        routeNumberOid?.let { oid -> trackNumberService.insertExternalId(branch, trackNumberId, Oid(oid.id)) }
+                ?: ratkoFakeOidGenerator?.generateFakeRatkoOID(TRACK_NUMBER_FAKE_OID_CONTEXT, id.intValue)
+        routeNumberOid?.let { oid -> trackNumberService.insertExternalId(branch, id, Oid(oid.id)) }
     }
 
-    private fun insertExternalIdForSwitch(branch: LayoutBranch, switchId: IntId<LayoutSwitch>) {
+    private fun insertExternalIdForSwitch(branch: LayoutBranch, id: IntId<LayoutSwitch>) {
         val switchOid =
-            switchDao.get(branch.draft, switchId)?.draftOid?.also(::ensureDraftIdExists)?.toString()
+            switchDao.get(branch.draft, id)?.draftOid?.also { ensureDraftIdExists(it) }?.toString()
                 ?: ratkoClient?.let { s -> requireNotNull(s.getNewSwitchOid().id) { "No OID received from RATKO" } }
                 ?: ratkoFakeOidGenerator
-                    ?.generateFakeRatkoOID<LayoutSwitch>(SWITCH_FAKE_OID_CONTEXT, switchId.intValue)
+                    ?.generateFakeRatkoOID<LayoutSwitch>(SWITCH_FAKE_OID_CONTEXT, id.intValue)
                     ?.toString()
-        switchOid?.let { oid -> switchService.insertExternalIdForSwitch(branch, switchId, Oid(oid)) }
+        switchOid?.let { oid -> switchService.insertExternalIdForSwitch(branch, id, Oid(oid)) }
     }
 
     private fun ensureDraftIdExists(draftOid: Oid<LayoutSwitch>) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
@@ -4,8 +4,6 @@ import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.FullRatkoExternalId
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.integration.RatkoOperation
-import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.integration.SwitchJointChange
 import fi.fta.geoviite.infra.publication.PublishedSwitch
 import fi.fta.geoviite.infra.ratko.model.PushableLayoutBranch
@@ -62,38 +60,31 @@ constructor(
             }
             .sortedBy { (switch, _) -> sortByDeletedStateFirst(switch.stateCategory) }
             .forEach { (layoutSwitch, changedJoints) ->
-                try {
-                    val externalId =
-                        getFullExtIdAndManagePlanItem(
-                            layoutBranch,
-                            layoutSwitch.id as IntId,
-                            layoutSwitch.designAssetState,
-                            ratkoClient,
-                            switchDao::fetchExternalId,
-                            switchDao::savePlanItemId,
-                        )
-                    requireNotNull(externalId) { "OID required for switch, sw=${layoutSwitch.id}" }
-                    ratkoClient.getSwitchAsset(RatkoOid<RatkoSwitchAsset>(externalId.oid))?.also { existingRatkoSwitch
-                        ->
-                        updateSwitch(
-                            layoutBranch = layoutBranch.branch,
-                            layoutSwitch = layoutSwitch,
-                            layoutSwitchExternalId = externalId,
-                            existingRatkoSwitch = existingRatkoSwitch,
-                            jointChanges = changedJoints,
-                            moment = publicationTime,
-                        )
-                    }
-                        ?: if (
-                            layoutSwitch.stateCategory == LayoutStateCategory.EXISTING &&
-                                layoutSwitch.designAssetState != DesignAssetState.CANCELLED
-                        ) {
-                            createSwitch(layoutSwitch, externalId, changedJoints)
-                        } else {
-                            null
-                        }
-                } catch (ex: RatkoPushException) {
-                    throw RatkoSwitchPushException(ex, layoutSwitch)
+                val externalId =
+                    getFullExtIdAndManagePlanItem(
+                        layoutBranch,
+                        layoutSwitch.id as IntId,
+                        layoutSwitch.designAssetState,
+                        ratkoClient,
+                        switchDao::fetchExternalId,
+                        switchDao::savePlanItemId,
+                    )
+                requireNotNull(externalId) { "OID required for switch, sw=${layoutSwitch.id}" }
+                val existingRatkoSwitch = ratkoClient.getSwitchAsset(RatkoOid(externalId.oid))
+                if (existingRatkoSwitch != null) {
+                    updateSwitch(
+                        layoutBranch = layoutBranch.branch,
+                        layoutSwitch = layoutSwitch,
+                        layoutSwitchExternalId = externalId,
+                        existingRatkoSwitch = existingRatkoSwitch,
+                        jointChanges = changedJoints,
+                        moment = publicationTime,
+                    )
+                } else if (
+                    layoutSwitch.stateCategory == LayoutStateCategory.EXISTING &&
+                        layoutSwitch.designAssetState != DesignAssetState.CANCELLED
+                ) {
+                    createSwitch(layoutSwitch, externalId, changedJoints)
                 }
             }
     }
@@ -106,62 +97,43 @@ constructor(
         jointChanges: List<SwitchJointChange>,
         moment: Instant,
     ) {
-        try {
-            require(layoutSwitch.id is IntId) { "Cannot push draft switches to Ratko, $layoutSwitch" }
-            val switchOid = RatkoOid<RatkoSwitchAsset>(layoutSwitchExternalId.oid)
+        require(layoutSwitch.id is IntId) { "Cannot push draft switches to Ratko, $layoutSwitch" }
+        val switchOid = RatkoOid<LayoutSwitch>(layoutSwitchExternalId.oid)
 
-            val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
-            val switchOwner = switchLibraryService.getSwitchOwner(layoutSwitch.ownerId)
+        val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
+        val switchOwner = switchLibraryService.getSwitchOwner(layoutSwitch.ownerId)
 
-            val updatedRatkoSwitch =
-                convertToRatkoSwitch(
-                    layoutSwitch = layoutSwitch,
-                    layoutSwitchExternalId = layoutSwitchExternalId,
-                    switchStructure = switchStructure,
-                    switchOwner = switchOwner,
-                    existingRatkoSwitch = existingRatkoSwitch,
-                )
-
-            val existingLocations = existingRatkoSwitch.locations ?: emptyList()
-
-            val includeBaseLocations =
-                layoutSwitch.joints.any { lj -> jointChanges.none { jc -> jc.number == lj.number && !jc.isRemoved } }
-
-            val baseRatkoLocations =
-                if (includeBaseLocations && existingLocations.isNotEmpty())
-                    getBaseRatkoSwitchLocations(
-                        layoutBranch = layoutBranch,
-                        switchId = layoutSwitch.id as IntId,
-                        existingRatkoLocations = existingLocations,
-                        jointChanges = jointChanges,
-                        switchStructure = switchStructure,
-                        moment = moment,
-                    )
-                else emptyList()
-
-            updateSwitchProperties(
-                switchOid = switchOid,
-                currentRatkoSwitch = existingRatkoSwitch,
-                updatedRatkoSwitch = updatedRatkoSwitch,
-            )
-
-            updateSwitchLocations(
-                switchOid = switchOid,
-                baseRatkoLocations = baseRatkoLocations,
-                jointChanges = jointChanges,
+        val updatedRatkoSwitch =
+            convertToRatkoSwitch(
+                layoutSwitch = layoutSwitch,
+                layoutSwitchExternalId = layoutSwitchExternalId,
                 switchStructure = switchStructure,
+                switchOwner = switchOwner,
+                existingRatkoSwitch = existingRatkoSwitch,
             )
 
-            updateSwitchGeoms(
-                switchOid = switchOid,
-                switchBaseType = switchStructure.baseType,
-                joints = layoutSwitch.joints,
-            )
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.UPDATE, ex)
-        }
+        val existingLocations = existingRatkoSwitch.locations ?: emptyList()
+
+        val includeBaseLocations =
+            layoutSwitch.joints.any { lj -> jointChanges.none { jc -> jc.number == lj.number && !jc.isRemoved } }
+
+        val baseRatkoLocations =
+            if (includeBaseLocations && existingLocations.isNotEmpty())
+                getBaseRatkoSwitchLocations(
+                    layoutBranch = layoutBranch,
+                    switchId = layoutSwitch.id as IntId,
+                    existingRatkoLocations = existingLocations,
+                    jointChanges = jointChanges,
+                    switchStructure = switchStructure,
+                    moment = moment,
+                )
+            else emptyList()
+
+        updateSwitchProperties(switchOid, existingRatkoSwitch, updatedRatkoSwitch)
+
+        updateSwitchLocations(switchOid, baseRatkoLocations, jointChanges, switchStructure)
+
+        updateSwitchGeoms(switchOid, switchStructure.baseType, layoutSwitch.joints)
     }
 
     private fun getBaseRatkoSwitchLocations(
@@ -211,16 +183,16 @@ constructor(
     }
 
     private fun updateSwitchGeoms(
-        switchOid: RatkoOid<RatkoSwitchAsset>,
+        switchOid: RatkoOid<LayoutSwitch>,
         switchBaseType: SwitchBaseType,
         joints: Collection<LayoutSwitchJoint>,
     ) {
         val switchGeometries = convertToRatkoAssetGeometries(joints, switchBaseType)
-        ratkoClient.replaceAssetGeoms(switchOid, switchGeometries)
+        ratkoClient.replaceSwitchGeoms(switchOid, switchGeometries)
     }
 
     private fun updateSwitchLocations(
-        switchOid: RatkoOid<RatkoSwitchAsset>,
+        switchOid: RatkoOid<LayoutSwitch>,
         baseRatkoLocations: List<RatkoAssetLocation>,
         jointChanges: List<SwitchJointChange>,
         switchStructure: SwitchStructure,
@@ -235,7 +207,7 @@ constructor(
                     ratkoAssetLocation.copy(priority = index + 1)
                 }
 
-            ratkoClient.replaceAssetLocations(switchOid, ratkoSwitchLocations)
+            ratkoClient.replaceSwitchLocations(switchOid, ratkoSwitchLocations)
         }
     }
 
@@ -245,15 +217,15 @@ constructor(
     }
 
     private fun updateSwitchProperties(
-        switchOid: RatkoOid<RatkoSwitchAsset>,
+        switchOid: RatkoOid<LayoutSwitch>,
         currentRatkoSwitch: RatkoSwitchAsset,
         updatedRatkoSwitch: RatkoSwitchAsset,
     ) {
-        ratkoClient.updateAssetProperties(switchOid, updatedRatkoSwitch.properties)
+        ratkoClient.updateSwitchProperties(switchOid, updatedRatkoSwitch.properties)
 
         // Switch state is only touched by Geoviite when the category is different
         if (updatedRatkoSwitch.state != currentRatkoSwitch.state) {
-            ratkoClient.updateAssetState(switchOid, updatedRatkoSwitch.state)
+            ratkoClient.updateSwitchState(switchOid, updatedRatkoSwitch.state)
         }
     }
 
@@ -262,40 +234,30 @@ constructor(
         layoutSwitchExternalId: FullRatkoExternalId<LayoutSwitch>?,
         jointChanges: List<SwitchJointChange>,
     ) {
-        try {
-            val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
-            val switchOwner = switchLibraryService.getSwitchOwner(layoutSwitch.ownerId)
+        val switchStructure = switchLibraryService.getSwitchStructure(layoutSwitch.switchStructureId)
+        val switchOwner = switchLibraryService.getSwitchOwner(layoutSwitch.ownerId)
 
-            val ratkoSwitch =
-                convertToRatkoSwitch(
-                    layoutSwitch = layoutSwitch,
-                    layoutSwitchExternalId = layoutSwitchExternalId,
-                    switchStructure = switchStructure,
-                    switchOwner = switchOwner,
-                )
-
-            val switchOid = ratkoClient.newAsset<RatkoSwitchAsset>(ratkoSwitch)
-            checkNotNull(switchOid) { "Did not receive oid from Ratko for switch $ratkoSwitch" }
-            assert(!isFakeOID(switchOid)) { "Cannot push fake OID $switchOid into Ratko" }
-
-            val switchLocations = generateSwitchLocations(jointChanges, switchStructure)
-            ratkoClient.replaceAssetLocations(switchOid, switchLocations)
-
-            updateSwitchGeoms(
-                switchOid = switchOid,
-                switchBaseType = switchStructure.baseType,
-                joints = layoutSwitch.joints,
+        val ratkoSwitch =
+            convertToRatkoSwitch(
+                layoutSwitch = layoutSwitch,
+                layoutSwitchExternalId = layoutSwitchExternalId,
+                switchStructure = switchStructure,
+                switchOwner = switchOwner,
             )
 
-            // Update asset locations again to make Ratko to locate the switch correctly on map.
-            // Ratko will eventually fix this problem on their side, but until then, use this
-            // workaround.
-            ratkoClient.replaceAssetLocations(switchOid, switchLocations)
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.CREATE, ex)
-        }
+        val switchOid = ratkoClient.newSwitch(ratkoSwitch)
+        checkNotNull(switchOid) { "Did not receive oid from Ratko for switch $ratkoSwitch" }
+        assert(!isFakeOID(switchOid)) { "Cannot push fake OID $switchOid into Ratko" }
+
+        val switchLocations = generateSwitchLocations(jointChanges, switchStructure)
+        ratkoClient.replaceSwitchLocations(switchOid, switchLocations)
+
+        updateSwitchGeoms(switchOid, switchStructure.baseType, layoutSwitch.joints)
+
+        // Update asset locations again to make Ratko to locate the switch correctly on map.
+        // Ratko will eventually fix this problem on their side, but until then, use this
+        // workaround.
+        ratkoClient.replaceSwitchLocations(switchOid, switchLocations)
     }
 
     private fun generateSwitchLocations(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -14,6 +14,7 @@ import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.MainBranchRatkoExternalId
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.common.TrackMeter
+import fi.fta.geoviite.infra.integration.RatkoAssetType
 import fi.fta.geoviite.infra.integration.RatkoOperation
 import fi.fta.geoviite.infra.integration.RatkoOperation.CREATE
 import fi.fta.geoviite.infra.integration.RatkoOperation.DELETE
@@ -26,14 +27,14 @@ import fi.fta.geoviite.infra.integration.RatkoPushErrorType.PROPERTIES
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType.STATE
 import fi.fta.geoviite.infra.logging.integrationCall
 import fi.fta.geoviite.infra.ratko.model.GEOVIITE_NAME
-import fi.fta.geoviite.infra.ratko.model.RatkoAsset
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetGeometry
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetLocation
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetProperty
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetState
-import fi.fta.geoviite.infra.ratko.model.RatkoAssetType
 import fi.fta.geoviite.infra.ratko.model.RatkoBulkTransferResponse
+import fi.fta.geoviite.infra.ratko.model.RatkoErrorResponse
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrack
+import fi.fta.geoviite.infra.ratko.model.RatkoMetadataAsset
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.ratko.model.RatkoOperationalPointAssetsResponse
 import fi.fta.geoviite.infra.ratko.model.RatkoOperationalPointParse
@@ -47,11 +48,14 @@ import fi.fta.geoviite.infra.ratko.model.RatkoPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoPointStates
 import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
 import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAsset
+import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAssetType
 import fi.fta.geoviite.infra.ratko.model.RatkoTrackMeter
 import fi.fta.geoviite.infra.ratko.model.parseAsset
 import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.split.Split
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -107,6 +111,35 @@ fun <T> isFakeOID(oid: RatkoOid<T>): Boolean = isFakeOID(oid.toString())
 
 fun <T> isFakeOID(oid: Oid<T>): Boolean = isFakeOID(oid.toString())
 
+sealed class RatkoPushTarget<T> {
+    abstract val oid: Oid<T>
+    abstract val assetType: RatkoAssetType
+}
+
+data class RatkoPushTargetLocationTrack(override val oid: Oid<LocationTrack>) : RatkoPushTarget<LocationTrack>() {
+    constructor(oid: RatkoOid<LocationTrack>) : this(Oid(oid.id))
+
+    constructor(track: RatkoLocationTrack) : this(requireNotNull(track.id))
+
+    override val assetType: RatkoAssetType = RatkoAssetType.LOCATION_TRACK
+}
+
+data class RatkoPushTargetTrackNumber(override val oid: Oid<LayoutTrackNumber>) : RatkoPushTarget<LayoutTrackNumber>() {
+    constructor(oid: RatkoOid<LayoutTrackNumber>) : this(Oid(oid.id))
+
+    constructor(routeNumber: RatkoRouteNumber) : this(requireNotNull(routeNumber.id))
+
+    override val assetType: RatkoAssetType = RatkoAssetType.TRACK_NUMBER
+}
+
+data class RatkoPushTargetSwitch(override val oid: Oid<LayoutSwitch>) : RatkoPushTarget<LayoutSwitch>() {
+    constructor(oid: RatkoOid<LayoutSwitch>) : this(Oid(oid.id))
+
+    constructor(switch: RatkoSwitchAsset) : this(requireNotNull(switch.id))
+
+    override val assetType: RatkoAssetType = RatkoAssetType.SWITCH
+}
+
 @Component
 @ConditionalOnBean(RatkoFakeOidGeneratorConfiguration::class)
 class RatkoFakeOidGenerator {
@@ -143,11 +176,11 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             .block(defaultBlockTimeout) ?: RatkoStatus(RatkoConnectionStatus.OFFLINE, null)
     }
 
-    fun getLocationTrack(locationTrackOid: RatkoOid<RatkoLocationTrack>): RatkoLocationTrack? {
+    fun getLocationTrack(locationTrackOid: RatkoOid<LocationTrack>): RatkoLocationTrack? {
         logger.integrationCall("getLocationTrack", "locationTrackOid" to locationTrackOid)
 
-        return getWithJsonResponseBody(combinePaths(LOCATION_TRACK_LOCATIONS_PATH, locationTrackOid), LOCATION)?.let {
-            response ->
+        val url = combinePaths(LOCATION_TRACK_LOCATIONS_PATH, locationTrackOid)
+        return getWithJsonResponseBody(url, LOCATION, RatkoPushTargetLocationTrack(locationTrackOid))?.let { response ->
             ratkoJsonMapper.readTree(response).firstOrNull()?.let { locationTrackJsonNode ->
                 replaceKmM(locationTrackJsonNode.get("nodecollection"))
                 parseJsonNode<RatkoLocationTrack>(locationTrackJsonNode, "getLocationTrack")
@@ -158,22 +191,32 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun updateLocationTrackProperties(locationTrack: RatkoLocationTrack, oid: Oid<LocationTrack>) {
         logger.integrationCall("updateLocationTrackProperties", "locationTrack" to locationTrack)
 
-        patchWithoutResponseBody("$LOCATION_TRACK_PATCH_PATH/${oid}", locationTrack)
+        patchGeometryWithoutResponseBody(
+            "$LOCATION_TRACK_PATCH_PATH/${oid}",
+            locationTrack,
+            RatkoPushTargetLocationTrack(oid),
+        )
     }
 
-    fun deleteLocationTrackPoints(locationTrackOid: RatkoOid<RatkoLocationTrack>, km: KmNumber?) {
+    fun deleteLocationTrackPoints(locationTrackOid: RatkoOid<LocationTrack>, km: KmNumber?) {
         logger.integrationCall("deleteLocationTrackPoints", "locationTrackOid" to locationTrackOid, "km" to km)
 
-        deletePoints(combinePaths(LOCATION_TRACK_POINTS_PATH_V1_0, locationTrackOid, km))
+        deletePoints(
+            combinePaths(LOCATION_TRACK_POINTS_PATH_V1_0, locationTrackOid, km),
+            RatkoPushTargetLocationTrack(locationTrackOid),
+        )
     }
 
-    fun deleteRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, km: KmNumber?) {
+    fun deleteRouteNumberPoints(routeNumberOid: RatkoOid<LayoutTrackNumber>, km: KmNumber?) {
         logger.integrationCall("deleteRouteNumberPoints", "routeNumberOid" to routeNumberOid, "km" to km)
 
-        deletePoints(combinePaths(ROUTE_NUMBER_POINTS_PATH, routeNumberOid, km))
+        deletePoints(
+            combinePaths(ROUTE_NUMBER_POINTS_PATH, routeNumberOid, km),
+            RatkoPushTargetTrackNumber(routeNumberOid),
+        )
     }
 
-    fun updateRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, points: List<RatkoPoint>) {
+    fun updateRouteNumberPoints(routeNumberOid: RatkoOid<LayoutTrackNumber>, points: List<RatkoPoint>) {
         logger.integrationCall(
             "updateRouteNumberPoints",
             "routeNumberOid" to routeNumberOid,
@@ -188,11 +231,12 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                 "points" to "${chunk.first().kmM}..${chunk.last().kmM}",
             )
 
-            patchWithoutResponseBody(combinePaths(ROUTE_NUMBER_POINTS_PATH, routeNumberOid), chunk)
+            val pushTarget = RatkoPushTargetTrackNumber(routeNumberOid)
+            patchGeometryWithoutResponseBody(combinePaths(ROUTE_NUMBER_POINTS_PATH, routeNumberOid), chunk, pushTarget)
         }
     }
 
-    fun createRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, points: List<RatkoPoint>) {
+    fun createRouteNumberPoints(routeNumberOid: RatkoOid<LayoutTrackNumber>, points: List<RatkoPoint>) {
         logger.integrationCall(
             "createRouteNumberPoints",
             "routeNumberOid" to routeNumberOid,
@@ -208,14 +252,15 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             )
 
             val url = combinePaths(ROUTE_NUMBER_POINTS_PATH, routeNumberOid)
+            val pushTarget = RatkoPushTargetTrackNumber(routeNumberOid)
             postSpec(url, chunk)
-                .defaultErrorHandler(GEOMETRY, CREATE, url, chunk)
+                .defaultErrorHandler(GEOMETRY, CREATE, pushTarget, url, chunk)
                 .toBodilessEntity()
                 .block(defaultBlockTimeout)
         }
     }
 
-    fun updateLocationTrackPoints(locationTrackOid: RatkoOid<RatkoLocationTrack>, points: List<RatkoPoint>) {
+    fun updateLocationTrackPoints(locationTrackOid: RatkoOid<LocationTrack>, points: List<RatkoPoint>) {
         logger.integrationCall(
             "updateLocationTrackPoints",
             "locationTrackOid" to locationTrackOid,
@@ -224,10 +269,11 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         )
 
         val url = "$LOCATION_TRACK_POINTS_PATH_V1_1/$locationTrackOid?updateKmMvalues=true"
-        patchWithoutResponseBody(url, points)
+        val pushTarget = RatkoPushTargetLocationTrack(locationTrackOid)
+        patchGeometryWithoutResponseBody(url, points, pushTarget)
     }
 
-    fun createLocationTrackPoints(locationTrackOid: RatkoOid<RatkoLocationTrack>, points: List<RatkoPoint>) {
+    fun createLocationTrackPoints(locationTrackOid: RatkoOid<LocationTrack>, points: List<RatkoPoint>) {
         logger.integrationCall(
             "createLocationTrackPoints",
             "locationTrackOid" to locationTrackOid,
@@ -243,8 +289,9 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             )
 
             val url = combinePaths(LOCATION_TRACK_POINTS_PATH_V1_0, locationTrackOid)
+            val pushTarget = RatkoPushTargetLocationTrack(locationTrackOid)
             postSpec(url, chunk)
-                .defaultErrorHandler(GEOMETRY, CREATE, url, chunk)
+                .defaultErrorHandler(GEOMETRY, CREATE, pushTarget, url, chunk)
                 .toBodilessEntity()
                 .block(defaultBlockTimeout)
         }
@@ -272,6 +319,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             )
 
         val url = "$LOCATION_TRACK_PATCH_PATH/${targetTrackExternalId.oid}"
+        val pushTarget = RatkoPushTargetLocationTrack(targetTrackExternalId.oid)
 
         client
             .patch()
@@ -285,12 +333,12 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue(mapOf<String, Any>())
             .retrieve()
-            .defaultErrorHandler(GEOMETRY, UPDATE, "$url?$params")
+            .defaultErrorHandler(GEOMETRY, UPDATE, pushTarget, "$url?$params")
             .toBodilessEntity()
             .block(defaultBlockTimeout)
     }
 
-    fun forceRatkoToRedrawLocationTrack(locationTrackOids: Set<RatkoOid<RatkoLocationTrack>>) {
+    fun forceRatkoToRedrawLocationTrack(locationTrackOids: Set<RatkoOid<LocationTrack>>) {
         logger.integrationCall("updateLocationTrackGeometryMValues", "locationTrackOids" to locationTrackOids)
 
         patchSpec(combinePaths(LOCATION_TRACK_PATH, "geom"), locationTrackOids.map { it.id })
@@ -300,49 +348,54 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
     fun newLocationTrack(
         locationTrack: RatkoLocationTrack,
-        locationTrackOidOfGeometry: RatkoOid<RatkoLocationTrack>? = null,
-    ): RatkoOid<RatkoLocationTrack>? {
+        locationTrackOidOfGeometry: RatkoOid<LocationTrack>? = null,
+    ): RatkoOid<LocationTrack>? {
         logger.integrationCall("newLocationTrack", "locationTrack" to locationTrack)
         assert(locationTrack.id != null && !isFakeOID(locationTrack.id)) {
             "Cannot push fake OID ${locationTrack.id} into Ratko"
         }
 
+        val pushTarget = RatkoPushTargetLocationTrack(locationTrack)
         return locationTrackOidOfGeometry?.let { referencedGeometryOid ->
-            postWithResponseBody(
-                "$LOCATION_TRACK_PATH?locationtrackOidOfGeometry=${referencedGeometryOid.id}",
-                locationTrack,
-            )
-        } ?: postWithResponseBody(LOCATION_TRACK_PATH, locationTrack)
+            val url = "$LOCATION_TRACK_PATH?locationtrackOidOfGeometry=${referencedGeometryOid.id}"
+            postWithResponseBody(url, locationTrack, PROPERTIES, CREATE, pushTarget)
+        } ?: postWithResponseBody(LOCATION_TRACK_PATH, locationTrack, PROPERTIES, CREATE, pushTarget)
     }
 
-    fun <T : RatkoAsset> newAsset(asset: RatkoAsset): RatkoOid<T>? {
-        logger.integrationCall("newAsset", "asset" to asset)
-
-        return postWithJsonResponseBody(ASSET_PATH, asset.withoutGeometries())
+    fun newSwitch(switch: RatkoSwitchAsset): RatkoOid<LayoutSwitch>? {
+        logger.integrationCall("newSwitch", "switch" to switch)
+        val pushTarget = RatkoPushTargetSwitch(switch)
+        return postWithJsonResponseBody(ASSET_PATH, switch.withoutGeometries(), PROPERTIES, CREATE, pushTarget)
             ?.let { response -> ratkoJsonMapper.readTree(response).firstOrNull()?.get("id")?.textValue() }
             ?.let(::RatkoOid)
     }
 
-    fun <T : RatkoAsset> replaceAssetLocations(assetOid: RatkoOid<T>, locations: List<RatkoAssetLocation>) {
-        logger.integrationCall("replaceAssetLocations", "assetOid" to assetOid, "locations" to locations)
-
-        putWithoutResponseBody(
-            combinePaths(ASSET_PATH, assetOid, "locations"),
-            locations.map { it.withoutGeometries() },
-            LOCATION,
-        )
+    fun newMetadataAsset(asset: RatkoMetadataAsset): RatkoOid<RatkoMetadataAsset>? {
+        logger.integrationCall("newMetadataAsset", "asset" to asset)
+        return postWithJsonResponseBody(ASSET_PATH, asset.withoutGeometries(), PROPERTIES, CREATE, null)
+            ?.let { response -> ratkoJsonMapper.readTree(response).firstOrNull()?.get("id")?.textValue() }
+            ?.let(::RatkoOid)
     }
 
-    fun <T : RatkoAsset> replaceAssetGeoms(assetOid: RatkoOid<T>, geoms: Collection<RatkoAssetGeometry>) {
-        logger.integrationCall("replaceAssetGeoms", "assetOid" to assetOid, "geoms" to geoms)
-
-        putWithoutResponseBody(combinePaths(ASSET_PATH, assetOid, "geoms"), geoms, GEOMETRY)
+    fun replaceSwitchLocations(assetOid: RatkoOid<LayoutSwitch>, locations: List<RatkoAssetLocation>) {
+        logger.integrationCall("replaceSwitchLocations", "assetOid" to assetOid, "locations" to locations)
+        val url = combinePaths(ASSET_PATH, assetOid, "locations")
+        val pushTarget = RatkoPushTargetSwitch(assetOid)
+        putWithoutResponseBody(url, locations.map { it.withoutGeometries() }, LOCATION, pushTarget)
     }
 
-    fun <T : RatkoAsset> getSwitchAsset(assetOid: RatkoOid<T>): RatkoSwitchAsset? {
+    fun replaceSwitchGeoms(assetOid: RatkoOid<LayoutSwitch>, geoms: Collection<RatkoAssetGeometry>) {
+        logger.integrationCall("replaceSwitchGeoms", "assetOid" to assetOid, "geoms" to geoms)
+        val url = combinePaths(ASSET_PATH, assetOid, "geoms")
+        val pushTarget = RatkoPushTargetSwitch(assetOid)
+        putWithoutResponseBody(url, geoms, GEOMETRY, pushTarget)
+    }
+
+    fun getSwitchAsset(assetOid: RatkoOid<LayoutSwitch>): RatkoSwitchAsset? {
         logger.integrationCall("getSwitchAsset", "assetOid" to assetOid)
 
-        return getWithJsonResponseBody(combinePaths(ASSET_PATH, assetOid))
+        val pushTarget = RatkoPushTargetSwitch(assetOid)
+        return getWithJsonResponseBody(combinePaths(ASSET_PATH, assetOid), PROPERTIES, pushTarget)
             ?.let { response -> ratkoJsonMapper.readTree(response) }
             ?.let { switchJsonNode ->
                 switchJsonNode.get("assetGeoms")?.forEach { asset ->
@@ -353,14 +406,16 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             }
     }
 
-    fun <T : RatkoAsset> updateAssetState(assetOid: RatkoOid<T>, state: RatkoAssetState) {
-        logger.integrationCall("updateAssetState", "assetOid" to assetOid, "state" to state)
+    fun updateSwitchState(switchOid: RatkoOid<LayoutSwitch>, state: RatkoAssetState) {
+        logger.integrationCall("updateSwitchState", "switchOid" to switchOid, "state" to state)
 
+        val pushTarget = RatkoPushTargetSwitch(switchOid)
         val responseJson =
-            getSpec(combinePaths(ASSET_PATH, assetOid))
+            getSpec(combinePaths(ASSET_PATH, switchOid))
                 .bodyToMono<String>()
                 .onErrorResume(WebClientResponseException::class.java) {
-                    Mono.error(RatkoPushException(PROPERTIES, FETCH_EXISTING, it))
+                    val response = parseErrorResponse(it.responseBodyAsString)
+                    Mono.error(RatkoAssetPushException(PROPERTIES, FETCH_EXISTING, pushTarget, response, it))
                 }
                 .block(defaultBlockTimeout)
 
@@ -410,23 +465,22 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
         switchJsonObject.remove("childAssets")
 
-        putWithoutResponseBody(combinePaths(ASSET_PATH, assetOid), switchJsonObject.toString(), STATE)
+        putWithoutResponseBody(combinePaths(ASSET_PATH, switchOid), switchJsonObject.toString(), STATE, pushTarget)
     }
 
-    fun <T : RatkoAsset> updateAssetProperties(assetOid: RatkoOid<T>, properties: Collection<RatkoAssetProperty>) {
-        logger.integrationCall("updateAssetProperties", "assetOid" to assetOid, "properties" to properties)
+    fun updateSwitchProperties(switchOid: RatkoOid<LayoutSwitch>, properties: Collection<RatkoAssetProperty>) {
+        logger.integrationCall("updateAssetProperties", "switchOid" to switchOid, "properties" to properties)
 
-        putWithoutResponseBody(combinePaths(ASSET_PATH, assetOid, "properties"), properties)
+        val url = combinePaths(ASSET_PATH, switchOid, "properties")
+        putWithoutResponseBody(url, properties, PROPERTIES, RatkoPushTargetSwitch(switchOid))
     }
 
     fun createPlanItem(ratkoPlanId: RatkoPlanId, realOid: Oid<*>?): RatkoPlanItemId {
         logger.integrationCall("createPlanItem")
 
-        val rv =
-            postWithResponseBody<RatkoPlanItem>(
-                "/api/plan/v1.0/plans/${ratkoPlanId.intValue}/plan_items",
-                RatkoPlanItem(id = null, state = RatkoPlanState.OPEN, planId = ratkoPlanId, realOid = realOid),
-            )
+        val url = "/api/plan/v1.0/plans/${ratkoPlanId.intValue}/plan_items"
+        val content = RatkoPlanItem(id = null, state = RatkoPlanState.OPEN, planId = ratkoPlanId, realOid = realOid)
+        val rv = postWithResponseBody<RatkoPlanItem>(url, content, PROPERTIES, CREATE, null)
         return requireNotNull(rv?.id) {
             "Expected plan item ID from Ratko when creating plan item in Ratko plan " +
                 "${ratkoPlanId.intValue} with real OID $realOid"
@@ -436,50 +490,59 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun updatePlanItem(item: RatkoPlanItem) {
         logger.integrationCall("updatePlanItem")
         val id = requireNotNull(item.id).intValue
-        putWithoutResponseBody("/api/plan/v1.0/plan_items/$id", item)
+        putWithoutResponseBody("/api/plan/v1.0/plan_items/$id", item, PROPERTIES, null)
     }
 
-    fun getNewLocationTrackOid(): RatkoOid<RatkoLocationTrack> {
+    fun getNewLocationTrackOid(): RatkoOid<LocationTrack> {
         logger.integrationCall("getNewLocationTrackOid")
-
-        return requireNotNull(postWithResponseBody(LOCATION_TRACK_PATH, "{}"))
+        return requireNotNull(postWithResponseBody(LOCATION_TRACK_PATH, "{}", PROPERTIES, CREATE, null))
     }
 
-    fun getNewRouteNumberOid(): RatkoOid<RatkoRouteNumber> {
+    fun getNewRouteNumberOid(): RatkoOid<LayoutTrackNumber> {
         logger.integrationCall("getNewRouteNumberOid")
-
-        return requireNotNull(postWithResponseBody(ROUTE_NUMBER_PATH, "{}"))
+        return requireNotNull(postWithResponseBody(ROUTE_NUMBER_PATH, "{}", PROPERTIES, CREATE, null))
     }
 
-    fun getNewSwitchOid(): RatkoOid<RatkoSwitchAsset> {
+    fun getNewSwitchOid(): RatkoOid<LayoutSwitch> {
         logger.integrationCall("getNewSwitchOid")
-
         val body = "{\"type\":\"turnout\"}"
-
-        return requireNotNull(postWithResponseBody<List<RatkoOid<RatkoSwitchAsset>>>(ASSET_PATH, body)?.firstOrNull())
+        return requireNotNull(
+            postWithResponseBody<List<RatkoOid<LayoutSwitch>>>(ASSET_PATH, body, PROPERTIES, CREATE, null)
+                ?.firstOrNull()
+        )
     }
 
-    fun getRouteNumber(routeNumberOid: RatkoOid<RatkoRouteNumber>): RatkoRouteNumber? {
+    fun getRouteNumber(routeNumberOid: RatkoOid<LayoutTrackNumber>): RatkoRouteNumber? {
         logger.integrationCall("getRouteNumber", "routeNumberOid" to routeNumberOid)
 
-        return getWithJsonResponseBody(combinePaths(ROUTE_NUMBER_LOCATIONS_PATH, routeNumberOid))?.let { response ->
-            ratkoJsonMapper.readTree(response).let { routeNumberJsonNode ->
-                replaceKmM(routeNumberJsonNode.get("nodecollection"))
-                parseJsonNode<RatkoRouteNumber>(routeNumberJsonNode, "getRouteNumber")
+        return getWithJsonResponseBody(
+                combinePaths(ROUTE_NUMBER_LOCATIONS_PATH, routeNumberOid),
+                PROPERTIES,
+                RatkoPushTargetTrackNumber(routeNumberOid),
+            )
+            ?.let { response ->
+                ratkoJsonMapper.readTree(response).let { routeNumberJsonNode ->
+                    replaceKmM(routeNumberJsonNode.get("nodecollection"))
+                    parseJsonNode<RatkoRouteNumber>(routeNumberJsonNode, "getRouteNumber")
+                }
             }
-        }
     }
 
-    fun newRouteNumber(routeNumber: RatkoRouteNumber): RatkoOid<RatkoRouteNumber>? {
+    fun newRouteNumber(routeNumber: RatkoRouteNumber): RatkoOid<LayoutTrackNumber>? {
         logger.integrationCall("newRouteNumber", "routeNumber" to routeNumber)
         assert(routeNumber.id != null && !isFakeOID(routeNumber.id)) {
             "Cannot push fake OID ${routeNumber.id} into Ratko"
         }
-
-        return postWithResponseBody(ROUTE_NUMBER_PATH, routeNumber)
+        return postWithResponseBody(
+            ROUTE_NUMBER_PATH,
+            routeNumber,
+            PROPERTIES,
+            CREATE,
+            RatkoPushTargetTrackNumber(routeNumber),
+        )
     }
 
-    fun forceRatkoToRedrawRouteNumber(routeNumberOids: Set<RatkoOid<RatkoRouteNumber>>) {
+    fun forceRatkoToRedrawRouteNumber(routeNumberOids: Set<RatkoOid<LayoutTrackNumber>>) {
         logger.integrationCall("updateRouteNumberGeometryMValues", "routeNumberOids" to routeNumberOids)
 
         patchSpec(combinePaths(ROUTE_NUMBER_PATH, "geom"), routeNumberOids.map { it.id })
@@ -490,7 +553,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     fun updateRouteNumber(routeNumber: RatkoRouteNumber) {
         logger.integrationCall("updateRouteNumber", "routeNumber" to routeNumber)
 
-        putWithoutResponseBody(ROUTE_NUMBER_PATH, routeNumber)
+        putWithoutResponseBody(ROUTE_NUMBER_PATH, routeNumber, PROPERTIES, RatkoPushTargetTrackNumber(routeNumber))
     }
 
     fun fetchOperationalPoints(): List<RatkoOperationalPointParse> {
@@ -504,12 +567,15 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                     postWithResponseBody<RatkoOperationalPointAssetsResponse>(
                             "$ASSET_PATH/search?fields=summary",
                             mapOf(
-                                "assetType" to RatkoAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
+                                "assetType" to RatkoSwitchAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
                                 "pageNumber" to pageNumber++,
                                 "size" to 100,
                                 "sortOrder" to "ASC",
                                 "secondarySortOrder" to "ASC",
                             ),
+                            PROPERTIES,
+                            CREATE,
+                            null,
                         )
                         ?.assets
                 ) {
@@ -528,6 +594,9 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             postWithResponseBody<RatkoBulkTransferResponse>(
                     url = "$BULK_TRANSFER_PATH/start",
                     content = mapOf("this-is-something-that-should-be-defined" to "in-the-future"),
+                    PROPERTIES,
+                    CREATE,
+                    null,
                 )
                 ?.id
         checkNotNull(bulkTransferId) { "Received bulk transfer id was null" }
@@ -556,14 +625,14 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
 
     fun createPlan(plan: RatkoPlan): RatkoPlanId? {
         logger.integrationCall("createPlan", "plan" to plan)
-        val rv = postWithResponseBody<RatkoPlanResponse>(url = PLAN_PATH, plan)
+        val rv = postWithResponseBody<RatkoPlanResponse>(url = PLAN_PATH, plan, PROPERTIES, CREATE, null)
         return rv?.id
     }
 
     fun updatePlan(plan: RatkoPlan) {
         logger.integrationCall("updatePlan", "plan" to plan)
         val ratkoId = requireNotNull(plan.id).intValue
-        return putWithoutResponseBody(url = "$PLAN_PATH/$ratkoId", plan)
+        return putWithoutResponseBody(url = "$PLAN_PATH/$ratkoId", plan, PROPERTIES, null)
     }
 
     private fun replaceKmM(nodeCollection: JsonNode?) {
@@ -605,41 +674,62 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
         }
     }
 
-    private fun postWithJsonResponseBody(url: String, content: Any): String? =
+    private fun postWithJsonResponseBody(
+        url: String,
+        content: Any,
+        errorType: RatkoPushErrorType,
+        operation: RatkoOperation,
+        target: RatkoPushTarget<*>?,
+    ): String? =
         postSpec(url, content)
-            .defaultErrorHandler(PROPERTIES, CREATE, url, content)
+            .defaultErrorHandler(errorType, operation, target, url, content)
             .bodyToMono<String>()
             .block(defaultBlockTimeout)
 
-    private inline fun <reified TOut : Any> postWithResponseBody(url: String, content: Any): TOut? =
-        postWithJsonResponseBody(url, content)?.let { parseJsonValue<TOut>(it, url) }
+    private inline fun <reified TOut : Any> postWithResponseBody(
+        url: String,
+        content: Any,
+        errorType: RatkoPushErrorType,
+        operation: RatkoOperation,
+        target: RatkoPushTarget<*>?,
+    ): TOut? =
+        postWithJsonResponseBody(url, content, errorType, operation, target)?.let { parseJsonValue<TOut>(it, url) }
 
-    private fun getWithJsonResponseBody(url: String, errorType: RatkoPushErrorType = PROPERTIES): String? =
+    private fun getWithJsonResponseBody(
+        url: String,
+        errorType: RatkoPushErrorType,
+        target: RatkoPushTarget<*>?,
+    ): String? =
         getSpec(url)
-            .defaultErrorHandler(errorType, FETCH_EXISTING, url)
+            .defaultErrorHandler(errorType, FETCH_EXISTING, target, url)
             .bodyToMono<String>()
             .onErrorResume(WebClientResponseException::class.java) { ex ->
                 if (ex.statusCode == NOT_FOUND) Mono.empty() else Mono.error(ex)
             }
             .block(defaultBlockTimeout)
 
-    private fun putWithoutResponseBody(url: String, content: Any, errorType: RatkoPushErrorType = PROPERTIES) {
+    private fun putWithoutResponseBody(
+        url: String,
+        content: Any,
+        errorType: RatkoPushErrorType,
+        target: RatkoPushTarget<*>?,
+    ) {
         putSpec(url, content)
-            .defaultErrorHandler(errorType, UPDATE, url, content)
+            .defaultErrorHandler(errorType, UPDATE, target, url, content)
             .toBodilessEntity()
             .block(defaultBlockTimeout)
     }
 
-    private fun patchWithoutResponseBody(url: String, content: Any) {
+    private fun patchGeometryWithoutResponseBody(url: String, content: Any, target: RatkoPushTarget<*>) {
         patchSpec(url, content)
-            .defaultErrorHandler(GEOMETRY, UPDATE, url, content)
+            .defaultErrorHandler(GEOMETRY, UPDATE, target, url, content)
             .toBodilessEntity()
             .block(defaultBlockTimeout)
     }
 
-    private fun deletePoints(url: String) {
+    private fun deletePoints(url: String, target: RatkoPushTarget<*>) {
         deleteSpec(url)
-            .defaultErrorHandler(GEOMETRY, DELETE, url)
+            .defaultErrorHandler(GEOMETRY, DELETE, target, url)
             .toBodilessEntity()
             .onErrorResume(WebClientResponseException::class.java) { ex ->
                 if (ex.statusCode == NOT_FOUND) Mono.empty() else Mono.error(ex)
@@ -663,6 +753,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
     private fun WebClient.ResponseSpec.defaultErrorHandler(
         errorType: RatkoPushErrorType,
         operation: RatkoOperation,
+        target: RatkoPushTarget<*>?,
         requestUrl: String,
         requestBody: Any? = null,
     ) =
@@ -673,15 +764,24 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
             },
             { response ->
                 response.bodyToMono<String>().switchIfEmpty(Mono.just("")).flatMap { responseBody ->
+                    val errorResponse = parseErrorResponse(responseBody)
                     val request = getBodyJsonForLog(requestBody).take(MAX_JSON_LOG_LENGTH)
                     val truncatedResponse = responseBody.take(MAX_JSON_LOG_LENGTH)
                     logger.error(
                         "Error during Ratko push: status=${response.statusCode()} responseBody=$truncatedResponse requestUrl=\"$requestUrl\" requestBody=$request"
                     )
-                    Mono.error(RatkoPushException(errorType, operation))
+                    Mono.error(
+                        target?.let { RatkoAssetPushException(errorType, operation, target, errorResponse) }
+                            ?: RatkoException(errorType, operation, errorResponse)
+                    )
                 }
             },
         )
+
+    private fun parseErrorResponse(responseBody: String): RatkoErrorResponse? =
+        responseBody.takeIf(String::isNotEmpty)?.let {
+            runCatching { ratkoJsonMapper.readValue<RatkoErrorResponse>(responseBody) }.getOrNull()
+        }
 
     private fun getBodyJsonForLog(body: Any?): String =
         runCatching { body?.let { it as? String ?: ratkoJsonMapper.writeValueAsString(it) } ?: "null" }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -27,6 +27,7 @@ import fi.fta.geoviite.infra.integration.RatkoPushErrorType.PROPERTIES
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType.STATE
 import fi.fta.geoviite.infra.logging.integrationCall
 import fi.fta.geoviite.infra.ratko.model.GEOVIITE_NAME
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetApiType
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetGeometry
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetLocation
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetProperty
@@ -48,7 +49,6 @@ import fi.fta.geoviite.infra.ratko.model.RatkoPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoPointStates
 import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
 import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAsset
-import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAssetType
 import fi.fta.geoviite.infra.ratko.model.RatkoTrackMeter
 import fi.fta.geoviite.infra.ratko.model.parseAsset
 import fi.fta.geoviite.infra.split.BulkTransfer
@@ -567,7 +567,7 @@ class RatkoClient @Autowired constructor(val client: RatkoWebClient) {
                     postWithResponseBody<RatkoOperationalPointAssetsResponse>(
                             "$ASSET_PATH/search?fields=summary",
                             mapOf(
-                                "assetType" to RatkoSwitchAssetType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
+                                "assetType" to RatkoAssetApiType.RAILWAY_TRAFFIC_OPERATIONAL_POINT.value,
                                 "pageNumber" to pageNumber++,
                                 "size" to 100,
                                 "sortOrder" to "ASC",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -117,7 +117,7 @@ sealed class RatkoPushTarget<T> {
 }
 
 data class RatkoPushTargetLocationTrack(override val oid: Oid<LocationTrack>) : RatkoPushTarget<LocationTrack>() {
-    constructor(oid: RatkoOid<LocationTrack>) : this(Oid(oid.id))
+    constructor(oid: RatkoOid<LocationTrack>) : this(oid.toOid())
 
     constructor(track: RatkoLocationTrack) : this(requireNotNull(track.id))
 
@@ -125,7 +125,7 @@ data class RatkoPushTargetLocationTrack(override val oid: Oid<LocationTrack>) : 
 }
 
 data class RatkoPushTargetTrackNumber(override val oid: Oid<LayoutTrackNumber>) : RatkoPushTarget<LayoutTrackNumber>() {
-    constructor(oid: RatkoOid<LayoutTrackNumber>) : this(Oid(oid.id))
+    constructor(oid: RatkoOid<LayoutTrackNumber>) : this(oid.toOid())
 
     constructor(routeNumber: RatkoRouteNumber) : this(requireNotNull(routeNumber.id))
 
@@ -133,7 +133,7 @@ data class RatkoPushTargetTrackNumber(override val oid: Oid<LayoutTrackNumber>) 
 }
 
 data class RatkoPushTargetSwitch(override val oid: Oid<LayoutSwitch>) : RatkoPushTarget<LayoutSwitch>() {
-    constructor(oid: RatkoOid<LayoutSwitch>) : this(Oid(oid.id))
+    constructor(oid: RatkoOid<LayoutSwitch>) : this(oid.toOid())
 
     constructor(switch: RatkoSwitchAsset) : this(requireNotNull(switch.id))
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoController.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.error.Integration
 import fi.fta.geoviite.infra.error.IntegrationNotConfiguredException
 import fi.fta.geoviite.infra.integration.LocationTrackChange
+import fi.fta.geoviite.infra.integration.RatkoPushErrorResponse
 import fi.fta.geoviite.infra.util.toResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -46,7 +47,7 @@ class RatkoController(private val ratkoServiceParam: RatkoService?, private val 
 
     @PreAuthorize(AUTH_VIEW_PUBLICATION)
     @GetMapping("/errors/current")
-    fun getLatestPublicationError(): ResponseEntity<RatkoPushErrorAndDetails> =
+    fun getLatestPublicationError(): ResponseEntity<RatkoPushErrorResponse> =
         toResponse(ratkoLocalService.fetchCurrentRatkoPushError())
 
     @PreAuthorize(AUTH_BASIC)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -17,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.transaction.annotation.Transactional
 
-// data class RatkoPushErrorAndDetails(val error: RatkoPushError, val publication: PublicationDetails?)
-
 @GeoviiteService
 class RatkoLocalService
 @Autowired

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -3,25 +3,11 @@ package fi.fta.geoviite.infra.ratko
 import fi.fta.geoviite.infra.aspects.GeoviiteService
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.configuration.CACHE_RATKO_HEALTH_STATUS
-import fi.fta.geoviite.infra.integration.RatkoAssetType.LOCATION_TRACK
-import fi.fta.geoviite.infra.integration.RatkoAssetType.SWITCH
-import fi.fta.geoviite.infra.integration.RatkoAssetType.TRACK_NUMBER
-import fi.fta.geoviite.infra.integration.RatkoPushError
-import fi.fta.geoviite.infra.integration.RatkoPushErrorWithAsset
-import fi.fta.geoviite.infra.publication.PublicationDetails
-import fi.fta.geoviite.infra.publication.PublicationLogService
+import fi.fta.geoviite.infra.integration.RatkoPushErrorResponse
 import fi.fta.geoviite.infra.ratko.RatkoClient.RatkoStatus
 import fi.fta.geoviite.infra.ratko.model.RatkoOperationalPoint
-import fi.fta.geoviite.infra.tracklayout.LayoutAsset
-import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
-import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
-import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
 import fi.fta.geoviite.infra.tracklayout.OperationalPointOrigin
@@ -31,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.transaction.annotation.Transactional
 
-data class RatkoPushErrorAndDetails(val error: RatkoPushErrorWithAsset, val publication: PublicationDetails?)
+// data class RatkoPushErrorAndDetails(val error: RatkoPushError, val publication: PublicationDetails?)
 
 @GeoviiteService
 class RatkoLocalService
@@ -39,12 +25,12 @@ class RatkoLocalService
 constructor(
     private val ratkoClient: RatkoClient?,
     private val ratkoPushDao: RatkoPushDao,
-    private val trackNumberService: LayoutTrackNumberService,
-    private val locationTrackService: LocationTrackService,
-    private val switchService: LayoutSwitchService,
+    //    private val trackNumberService: LayoutTrackNumberService,
+    //    private val locationTrackService: LocationTrackService,
+    //    private val switchService: LayoutSwitchService,
     private val ratkoOperationalPointDao: RatkoOperationalPointDao,
     private val operationalPointDao: OperationalPointDao,
-    private val publicationLogService: PublicationLogService,
+    //    private val publicationLogService: PublicationLogService,
 ) {
 
     @Cacheable(CACHE_RATKO_HEALTH_STATUS, sync = true)
@@ -68,20 +54,19 @@ constructor(
     }
 
     @Transactional(readOnly = true)
-    fun fetchCurrentRatkoPushError(): RatkoPushErrorAndDetails? =
+    fun fetchCurrentRatkoPushError(): RatkoPushErrorResponse? =
         ratkoPushDao.getCurrentRatkoPushError()?.let { (ratkoError, publicationId) ->
-            val asset = getErrorAssetOrThrow(ratkoError)
-
-            val errorWithAsset =
-                RatkoPushErrorWithAsset(
-                    ratkoError.id,
-                    ratkoError.ratkoPushId,
-                    ratkoError.errorType,
-                    ratkoError.operation,
-                    ratkoError.assetType,
-                    asset,
-                )
-            RatkoPushErrorAndDetails(errorWithAsset, publicationLogService.getPublicationDetails(publicationId))
+            RatkoPushErrorResponse(ratkoError, publicationId)
+            //            val enrichedError: RatkoPushErrorResponse =
+            //                when (ratkoError) {
+            //                    is RatkoPushAssetError<*> ->
+            //                        RatkoPushErrorWithAsset(ratkoError, getAssetOrThrow(ratkoError.ratkoAssetId))
+            //                    is RatkoPushGeneralError -> ratkoError
+            //                    else -> error("")
+            //                }
+            //
+            //            RatkoPushErrorAndDetails(enrichedError,
+            // publicationLogService.getPublicationDetails(publicationId))
         }
 
     private fun updateAndFetchRatkoOperationalPointOids(
@@ -177,18 +162,12 @@ constructor(
         }
     }
 
-    private fun getErrorAssetOrThrow(ratkoError: RatkoPushError<*>): LayoutAsset<*> {
-        val asset =
-            when (ratkoError.assetType) {
-                TRACK_NUMBER ->
-                    trackNumberService.get(MainLayoutContext.official, ratkoError.assetId as IntId<LayoutTrackNumber>)
-
-                LOCATION_TRACK ->
-                    locationTrackService.get(MainLayoutContext.official, ratkoError.assetId as IntId<LocationTrack>)
-
-                SWITCH -> switchService.get(MainLayoutContext.official, ratkoError.assetId as IntId<LayoutSwitch>)
-            }
-        checkNotNull(asset) { "No asset found for id! ${ratkoError.assetType} ${ratkoError.assetId}" }
-        return asset
-    }
+    //    @Suppress("UNCHECKED_CAST")
+    //    private fun <T : LayoutAsset<T>> getAssetOrThrow(assetId: RatkoAssetId<T>): LayoutAsset<T> =
+    //        when (assetId) {
+    //            is RatkoSwitchId -> switchService.getOrThrow(MainLayoutContext.official, assetId.id)
+    //            is RatkoTrackNumberId -> trackNumberService.getOrThrow(MainLayoutContext.official, assetId.id)
+    //            is RatkoLocationTrackId -> locationTrackService.getOrThrow(MainLayoutContext.official, assetId.id)
+    //        }
+    //            as LayoutAsset<T>
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalService.kt
@@ -25,12 +25,8 @@ class RatkoLocalService
 constructor(
     private val ratkoClient: RatkoClient?,
     private val ratkoPushDao: RatkoPushDao,
-    //    private val trackNumberService: LayoutTrackNumberService,
-    //    private val locationTrackService: LocationTrackService,
-    //    private val switchService: LayoutSwitchService,
     private val ratkoOperationalPointDao: RatkoOperationalPointDao,
     private val operationalPointDao: OperationalPointDao,
-    //    private val publicationLogService: PublicationLogService,
 ) {
 
     @Cacheable(CACHE_RATKO_HEALTH_STATUS, sync = true)
@@ -57,16 +53,6 @@ constructor(
     fun fetchCurrentRatkoPushError(): RatkoPushErrorResponse? =
         ratkoPushDao.getCurrentRatkoPushError()?.let { (ratkoError, publicationId) ->
             RatkoPushErrorResponse(ratkoError, publicationId)
-            //            val enrichedError: RatkoPushErrorResponse =
-            //                when (ratkoError) {
-            //                    is RatkoPushAssetError<*> ->
-            //                        RatkoPushErrorWithAsset(ratkoError, getAssetOrThrow(ratkoError.ratkoAssetId))
-            //                    is RatkoPushGeneralError -> ratkoError
-            //                    else -> error("")
-            //                }
-            //
-            //            RatkoPushErrorAndDetails(enrichedError,
-            // publicationLogService.getPublicationDetails(publicationId))
         }
 
     private fun updateAndFetchRatkoOperationalPointOids(
@@ -161,13 +147,4 @@ constructor(
             }
         }
     }
-
-    //    @Suppress("UNCHECKED_CAST")
-    //    private fun <T : LayoutAsset<T>> getAssetOrThrow(assetId: RatkoAssetId<T>): LayoutAsset<T> =
-    //        when (assetId) {
-    //            is RatkoSwitchId -> switchService.getOrThrow(MainLayoutContext.official, assetId.id)
-    //            is RatkoTrackNumberId -> trackNumberService.getOrThrow(MainLayoutContext.official, assetId.id)
-    //            is RatkoLocationTrackId -> locationTrackService.getOrThrow(MainLayoutContext.official, assetId.id)
-    //        }
-    //            as LayoutAsset<T>
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -16,15 +16,12 @@ import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.AlignmentAddresses
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
-import fi.fta.geoviite.infra.integration.RatkoOperation
-import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.publication.PublicationDao
 import fi.fta.geoviite.infra.publication.PublishedLocationTrack
 import fi.fta.geoviite.infra.publication.PublishedSwitchJoint
 import fi.fta.geoviite.infra.ratko.model.PushableLayoutBranch
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrack
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrackState
-import fi.fta.geoviite.infra.ratko.model.RatkoMetadataAsset
 import fi.fta.geoviite.infra.ratko.model.RatkoNodes
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.ratko.model.RatkoSplit
@@ -48,11 +45,11 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
-import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import java.time.Instant
 
 data class LocationTrackKilometers(
     val id: IntId<LocationTrack>,
@@ -257,8 +254,9 @@ constructor(
         publicationTime: Instant,
         geocodingContext: GeocodingContext<ReferenceLineM>,
     ): Set<KmNumber> {
-        val switchesToUpdate =
-            relinkedSwitches.filter { relinkedSwitch -> relinkedSwitch in splitTargetTrack.track.switchIds }
+        val switchesToUpdate = relinkedSwitches.filter { relinkedSwitch ->
+            relinkedSwitch in splitTargetTrack.track.switchIds
+        }
 
         val trackKmsToUpdate =
             switchesToUpdate
@@ -313,41 +311,36 @@ constructor(
                         locationTrackDao::savePlanItemId,
                     )
                 requireNotNull(externalId) { "OID required for location track, lt=${locationTrack.id}" }
-                try {
-                    ratkoClient.getLocationTrack(RatkoOid(externalId.oid))?.let { existingLocationTrack ->
-                        if (
-                            locationTrack.state == LocationTrackState.DELETED ||
-                                locationTrack.designAssetState == DesignAssetState.CANCELLED
-                        ) {
-                            deleteLocationTrack(
-                                branch = branch.branch,
-                                locationTrack = locationTrack,
-                                locationTrackExternalId = externalId,
-                                existingRatkoLocationTrack = existingLocationTrack,
-                                moment = publicationTime,
-                            )
-                        } else {
-                            updateLocationTrack(
-                                branch = branch.branch,
-                                locationTrack = locationTrack,
-                                locationTrackExternalId = externalId,
-                                existingRatkoLocationTrack = existingLocationTrack,
-                                changedKmNumbers = changedKmNumbers,
-                                moment = publicationTime,
-                            )
-                        }
+                ratkoClient.getLocationTrack(RatkoOid(externalId.oid))?.let { existingLocationTrack ->
+                    if (
+                        locationTrack.state == LocationTrackState.DELETED ||
+                            locationTrack.designAssetState == DesignAssetState.CANCELLED
+                    ) {
+                        deleteLocationTrack(
+                            branch = branch.branch,
+                            locationTrack = locationTrack,
+                            locationTrackExternalId = externalId,
+                            existingRatkoLocationTrack = existingLocationTrack,
+                        )
+                    } else {
+                        updateLocationTrack(
+                            branch = branch.branch,
+                            locationTrack = locationTrack,
+                            locationTrackExternalId = externalId,
+                            existingRatkoLocationTrack = existingLocationTrack,
+                            changedKmNumbers = changedKmNumbers,
+                            moment = publicationTime,
+                        )
                     }
-                        ?: if (
-                            locationTrack.state != LocationTrackState.DELETED &&
-                                locationTrack.designAssetState != DesignAssetState.CANCELLED
-                        ) {
-                            createLocationTrack(branch.branch, locationTrack, externalId, publicationTime)
-                        } else {
-                            null
-                        }
-                } catch (ex: RatkoPushException) {
-                    throw RatkoLocationTrackPushException(ex, locationTrack)
                 }
+                    ?: if (
+                        locationTrack.state != LocationTrackState.DELETED &&
+                            locationTrack.designAssetState != DesignAssetState.CANCELLED
+                    ) {
+                        createLocationTrack(branch.branch, locationTrack, externalId, publicationTime)
+                    } else {
+                        null
+                    }
                 externalId.oid
             }
     }
@@ -365,7 +358,7 @@ constructor(
     private fun getExternalId(branch: LayoutBranch, locationTrackId: IntId<LocationTrack>): Oid<LocationTrack>? =
         locationTrackDao.fetchExternalId(branch, locationTrackId)?.oid
 
-    fun forceRedraw(locationTrackOids: Set<RatkoOid<RatkoLocationTrack>>) {
+    fun forceRedraw(locationTrackOids: Set<RatkoOid<LocationTrack>>) {
         if (locationTrackOids.isNotEmpty()) {
             ratkoClient.forceRatkoToRedrawLocationTrack(locationTrackOids)
         }
@@ -378,64 +371,57 @@ constructor(
         moment: Instant,
         locationTrackOidOfGeometry: MainBranchRatkoExternalId<LocationTrack>? = null,
     ) {
-        try {
-            val (addresses, jointPoints) = getLocationTrackPoints(branch, locationTrack, moment)
+        val (addresses, jointPoints) = getLocationTrackPoints(branch, locationTrack, moment)
 
-            val ratkoNodes = convertToRatkoNodeCollection(addresses)
-            val trackNumberOid = getDesignOrInheritedTrackNumberOid(branch, locationTrack.trackNumberId)
+        val ratkoNodes = convertToRatkoNodeCollection(addresses)
+        val trackNumberOid = getDesignOrInheritedTrackNumberOid(branch, locationTrack.trackNumberId)
 
-            val duplicateOfOidLocationTrack =
-                locationTrack.duplicateOf?.let { duplicateId -> getExternalId(branch, duplicateId) }
-            val owner = locationTrackService.getLocationTrackOwner(locationTrack.ownerId)
+        val duplicateOfOidLocationTrack =
+            locationTrack.duplicateOf?.let { duplicateId -> getExternalId(branch, duplicateId) }
+        val owner = locationTrackService.getLocationTrackOwner(locationTrack.ownerId)
 
-            val ratkoLocationTrack =
-                convertToRatkoLocationTrack(
-                    locationTrack = locationTrack,
-                    locationTrackExternalId = locationTrackExternalId,
-                    trackNumberOid = trackNumberOid,
-                    nodeCollection = ratkoNodes,
-                    duplicateOfOid = duplicateOfOidLocationTrack,
-                    owner = owner,
-                )
-            checkNotNull(
-                ratkoClient.newLocationTrack(ratkoLocationTrack, locationTrackOidOfGeometry?.oid?.let(::RatkoOid))
-            ) {
-                "Did not receive oid from Ratko for location track $ratkoLocationTrack"
-            }
+        val ratkoLocationTrack =
+            convertToRatkoLocationTrack(
+                locationTrack = locationTrack,
+                locationTrackExternalId = locationTrackExternalId,
+                trackNumberOid = trackNumberOid,
+                nodeCollection = ratkoNodes,
+                duplicateOfOid = duplicateOfOidLocationTrack,
+                owner = owner,
+            )
+        checkNotNull(
+            ratkoClient.newLocationTrack(ratkoLocationTrack, locationTrackOidOfGeometry?.oid?.let(::RatkoOid))
+        ) {
+            "Did not receive oid from Ratko for location track $ratkoLocationTrack"
+        }
 
-            val switchPoints =
-                jointPoints.filterNot { jp ->
-                    jp.address == addresses.startPoint.address || jp.address == addresses.endPoint.address
-                }
+        val switchPoints = jointPoints.filterNot { jp ->
+            jp.address == addresses.startPoint.address || jp.address == addresses.endPoint.address
+        }
 
-            val midPoints = (addresses.midPoints + switchPoints).sortedBy { p -> p.address }
+        val midPoints = (addresses.midPoints + switchPoints).sortedBy { p -> p.address }
 
-            locationTrackOidOfGeometry?.let { referencedGeometryOid ->
-                logger.info(
-                    "Referenced geometry from track=$referencedGeometryOid was already set for ${locationTrackExternalId.oid}"
-                )
-            } ?: createLocationTrackPoints(RatkoOid(locationTrackExternalId.oid.toString()), midPoints)
+        locationTrackOidOfGeometry?.let { referencedGeometryOid ->
+            logger.info(
+                "Referenced geometry from track=$referencedGeometryOid was already set for ${locationTrackExternalId.oid}"
+            )
+        } ?: createLocationTrackPoints(RatkoOid(locationTrackExternalId.oid.toString()), midPoints)
 
-            if (branch is MainBranch) {
-                val allPoints = listOf(addresses.startPoint) + midPoints + listOf(addresses.endPoint)
-                createLocationTrackMetadata(
-                    branch,
-                    locationTrack,
-                    locationTrackExternalId,
-                    allPoints,
-                    trackNumberOid,
-                    moment,
-                )
-            }
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.CREATE, ex)
+        if (branch is MainBranch) {
+            val allPoints = listOf(addresses.startPoint) + midPoints + listOf(addresses.endPoint)
+            createLocationTrackMetadata(
+                branch,
+                locationTrack,
+                locationTrackExternalId,
+                allPoints,
+                trackNumberOid,
+                moment,
+            )
         }
     }
 
     private fun createLocationTrackPoints(
-        locationTrackOid: RatkoOid<RatkoLocationTrack>,
+        locationTrackOid: RatkoOid<LocationTrack>,
         addressPoints: Collection<AddressPoint<LocationTrackM>>,
     ) =
         toRatkoPointsGroupedByKm(addressPoints).forEach { points ->
@@ -480,44 +466,38 @@ constructor(
                         if (changedKmNumbers == null) listOf(origMetaDataRange)
                         else geocodingContext.cutRangeByKms(origMetaDataRange, changedKmNumbers)
 
-                    val splitMetaDataAssets =
-                        splitAddressRanges.mapNotNull { addressRange ->
-                            val startPoint =
-                                findAddressPoint(
-                                    points = alignmentPoints,
-                                    seek = addressRange.start,
-                                    rounding = AddressRounding.UP,
-                                )
+                    val splitMetaDataAssets = splitAddressRanges.mapNotNull { addressRange ->
+                        val startPoint =
+                            findAddressPoint(
+                                points = alignmentPoints,
+                                seek = addressRange.start,
+                                rounding = AddressRounding.UP,
+                            )
 
-                            val endPoint =
-                                findAddressPoint(
-                                    points = alignmentPoints,
-                                    seek = addressRange.endInclusive,
-                                    rounding = AddressRounding.DOWN,
-                                )
+                        val endPoint =
+                            findAddressPoint(
+                                points = alignmentPoints,
+                                seek = addressRange.endInclusive,
+                                rounding = AddressRounding.DOWN,
+                            )
 
-                            val splitMetaData =
-                                metadata.copy(
-                                    startPoint = startPoint.point.toPoint(),
-                                    endPoint = endPoint.point.toPoint(),
-                                )
+                        val splitMetaData =
+                            metadata.copy(startPoint = startPoint.point.toPoint(), endPoint = endPoint.point.toPoint())
 
-                            // Ignore metadata where the address range is under 1m, since there are
-                            // no address points for it
-                            if (startPoint.address + 1 <= endPoint.address)
-                                convertToRatkoMetadataAsset(
-                                    trackNumberOid = trackNumberOid,
-                                    locationTrackExternalId = locationTrackExternalId,
-                                    segmentMetadata = splitMetaData,
-                                    startTrackMeter = startPoint.address,
-                                    endTrackMeter = endPoint.address,
-                                )
-                            else null
-                        }
-
-                    splitMetaDataAssets.forEach { metadataAsset ->
-                        ratkoClient.newAsset<RatkoMetadataAsset>(metadataAsset)
+                        // Ignore metadata where the address range is under 1m, since there are
+                        // no address points for it
+                        if (startPoint.address + 1 <= endPoint.address)
+                            convertToRatkoMetadataAsset(
+                                trackNumberOid = trackNumberOid,
+                                locationTrackExternalId = locationTrackExternalId,
+                                segmentMetadata = splitMetaData,
+                                startTrackMeter = startPoint.address,
+                                endTrackMeter = endPoint.address,
+                            )
+                        else null
                     }
+
+                    splitMetaDataAssets.forEach { metadataAsset -> ratkoClient.newMetadataAsset(metadataAsset) }
                 }
             }
     }
@@ -542,25 +522,18 @@ constructor(
         locationTrack: LocationTrack,
         locationTrackExternalId: FullRatkoExternalId<LocationTrack>,
         existingRatkoLocationTrack: RatkoLocationTrack,
-        moment: Instant,
     ) {
-        try {
-            val deletedEndsPoints =
-                existingRatkoLocationTrack.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)
+        val deletedEndsPoints =
+            existingRatkoLocationTrack.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)
 
-            updateLocationTrackProperties(
-                branch = branch,
-                locationTrack = locationTrack,
-                locationTrackExternalId = locationTrackExternalId,
-                changedNodeCollection = deletedEndsPoints,
-            )
+        updateLocationTrackProperties(
+            branch = branch,
+            locationTrack = locationTrack,
+            locationTrackExternalId = locationTrackExternalId,
+            changedNodeCollection = deletedEndsPoints,
+        )
 
-            ratkoClient.deleteLocationTrackPoints(RatkoOid(locationTrackExternalId.oid), null)
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.DELETE, ex)
-        }
+        ratkoClient.deleteLocationTrackPoints(RatkoOid(locationTrackExternalId.oid), null)
     }
 
     private fun updateLocationTrack(
@@ -574,103 +547,93 @@ constructor(
         locationTrackOidOfGeometry: MainBranchRatkoExternalId<LocationTrack>? = null,
         splitStartAndEnd: Pair<TrackMeter, TrackMeter>? = null,
     ): Set<KmNumber> {
-        try {
-            val locationTrackRatkoOid = RatkoOid<RatkoLocationTrack>(locationTrackExternalId.oid)
-            val trackNumberOid = getDesignOrInheritedTrackNumberOid(branch, locationTrack.trackNumberId)
+        val locationTrackRatkoOid = RatkoOid(locationTrackExternalId.oid)
+        val trackNumberOid = getDesignOrInheritedTrackNumberOid(branch, locationTrack.trackNumberId)
 
-            val (addresses, jointPoints) = getLocationTrackPoints(branch, locationTrack, moment)
-            val existingStartNode = existingRatkoLocationTrack.nodecollection?.getStartNode()
-            val existingEndNode = existingRatkoLocationTrack.nodecollection?.getEndNode()
+        val (addresses, jointPoints) = getLocationTrackPoints(branch, locationTrack, moment)
+        val existingStartNode = existingRatkoLocationTrack.nodecollection?.getStartNode()
+        val existingEndNode = existingRatkoLocationTrack.nodecollection?.getEndNode()
 
-            val updatedEndPointNodeCollection =
-                getEndPointNodeCollection(
-                    alignmentAddresses = addresses,
-                    changedKmNumbers = changedKmNumbers,
-                    existingStartNode = existingStartNode,
-                    existingEndNode = existingEndNode,
+        val updatedEndPointNodeCollection =
+            getEndPointNodeCollection(
+                alignmentAddresses = addresses,
+                changedKmNumbers = changedKmNumbers,
+                existingStartNode = existingStartNode,
+                existingEndNode = existingEndNode,
+            )
+
+        val switchPoints = jointPoints.filterNot { jp ->
+            jp.address == addresses.startPoint.address || jp.address == addresses.endPoint.address
+        }
+
+        val changedMidPoints =
+            (addresses.midPoints + switchPoints)
+                .filter { p -> changedKmNumbers.contains(p.address.kmNumber) }
+                .sortedBy { p -> p.address }
+
+        // Update location track end points before deleting anything, otherwise old end points
+        // will stay in use
+        updateLocationTrackProperties(
+            branch = branch,
+            locationTrack = locationTrack,
+            locationTrackExternalId = locationTrackExternalId,
+            changedNodeCollection = updatedEndPointNodeCollection,
+            locationTrackStateOverride = locationTrackStateOverride,
+        )
+
+        val allKms = addresses.allPoints.asSequence().map { point -> point.address.kmNumber }.toSet()
+        val updatedKmNumbers =
+            if (locationTrackOidOfGeometry != null) {
+                val (startAddress, endAddress) = splitStartAndEnd.let(::requireNotNull)
+                ratkoClient.patchLocationTrackPoints(
+                    sourceTrackExternalId = locationTrackOidOfGeometry,
+                    targetTrackExternalId = MainBranchRatkoExternalId(locationTrackExternalId.oid),
+                    startAddress = startAddress,
+                    endAddress = endAddress,
                 )
+                val copiedKmNumbers =
+                    allKms
+                        .filter { kmNumber -> kmNumber >= startAddress.kmNumber && kmNumber <= endAddress.kmNumber }
+                        .toSet()
+                copiedKmNumbers
+            } else {
+                val minTrackKm = allKms.min()
+                val maxTrackKm = allKms.max()
 
-            val switchPoints =
-                jointPoints.filterNot { jp ->
-                    jp.address == addresses.startPoint.address || jp.address == addresses.endPoint.address
-                }
+                // This happens for example when a km-post has been removed in the "middle" of a
+                // track.
+                val removedKmsWithinTrackBoundaries =
+                    changedKmNumbers
+                        .filterNot { changedKm -> changedKm in allKms }
+                        .filter { kmNumber -> kmNumber > minTrackKm && kmNumber < maxTrackKm }
+                        .toSet()
 
-            val changedMidPoints =
-                (addresses.midPoints + switchPoints)
-                    .filter { p -> changedKmNumbers.contains(p.address.kmNumber) }
-                    .sortedBy { p -> p.address }
+                deleteLocationTrackPoints(removedKmsWithinTrackBoundaries, locationTrackRatkoOid)
+                updateLocationTrackGeometry(locationTrackOid = locationTrackRatkoOid, newPoints = changedMidPoints)
+                changedKmNumbers
+            }
 
-            // Update location track end points before deleting anything, otherwise old end points
-            // will stay in use
-            updateLocationTrackProperties(
+        if (branch is MainBranch) {
+            createLocationTrackMetadata(
                 branch = branch,
                 locationTrack = locationTrack,
                 locationTrackExternalId = locationTrackExternalId,
-                changedNodeCollection = updatedEndPointNodeCollection,
-                locationTrackStateOverride = locationTrackStateOverride,
+                alignmentPoints = listOf(addresses.startPoint) + changedMidPoints + listOf(addresses.endPoint),
+                trackNumberOid = trackNumberOid,
+                moment = moment,
+                changedKmNumbers = changedKmNumbers,
             )
-
-            val allKms = addresses.allPoints.asSequence().map { point -> point.address.kmNumber }.toSet()
-            val updatedKmNumbers =
-                if (locationTrackOidOfGeometry != null) {
-                    val (startAddress, endAddress) = splitStartAndEnd.let(::requireNotNull)
-                    ratkoClient.patchLocationTrackPoints(
-                        sourceTrackExternalId = locationTrackOidOfGeometry,
-                        targetTrackExternalId = MainBranchRatkoExternalId(locationTrackExternalId.oid),
-                        startAddress = startAddress,
-                        endAddress = endAddress,
-                    )
-                    val copiedKmNumbers =
-                        allKms
-                            .filter { kmNumber -> kmNumber >= startAddress.kmNumber && kmNumber <= endAddress.kmNumber }
-                            .toSet()
-                    copiedKmNumbers
-                } else {
-                    val minTrackKm = allKms.min()
-                    val maxTrackKm = allKms.max()
-
-                    // This happens for example when a km-post has been removed in the "middle" of a
-                    // track.
-                    val removedKmsWithinTrackBoundaries =
-                        changedKmNumbers
-                            .filterNot { changedKm -> changedKm in allKms }
-                            .filter { kmNumber -> kmNumber > minTrackKm && kmNumber < maxTrackKm }
-                            .toSet()
-
-                    deleteLocationTrackPoints(removedKmsWithinTrackBoundaries, locationTrackRatkoOid)
-                    updateLocationTrackGeometry(locationTrackOid = locationTrackRatkoOid, newPoints = changedMidPoints)
-                    changedKmNumbers
-                }
-
-            if (branch is MainBranch) {
-                createLocationTrackMetadata(
-                    branch = branch,
-                    locationTrack = locationTrack,
-                    locationTrackExternalId = locationTrackExternalId,
-                    alignmentPoints = listOf(addresses.startPoint) + changedMidPoints + listOf(addresses.endPoint),
-                    trackNumberOid = trackNumberOid,
-                    moment = moment,
-                    changedKmNumbers = changedKmNumbers,
-                )
-            }
-
-            return updatedKmNumbers
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.UPDATE, ex)
         }
+
+        return updatedKmNumbers
     }
 
-    private fun deleteLocationTrackPoints(
-        changedKmNumbers: Set<KmNumber>,
-        locationTrackOid: RatkoOid<RatkoLocationTrack>,
-    ) {
+    private fun deleteLocationTrackPoints(changedKmNumbers: Set<KmNumber>, locationTrackOid: RatkoOid<LocationTrack>) {
         changedKmNumbers.forEach { kmNumber -> ratkoClient.deleteLocationTrackPoints(locationTrackOid, kmNumber) }
     }
 
     private fun updateLocationTrackGeometry(
-        locationTrackOid: RatkoOid<RatkoLocationTrack>,
+        locationTrackOid: RatkoOid<LocationTrack>,
         newPoints: Collection<AddressPoint<LocationTrackM>>,
     ) =
         toRatkoPointsGroupedByKm(newPoints).forEach { points ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoOperationalPointDao.kt
@@ -16,18 +16,14 @@ import fi.fta.geoviite.infra.util.getOid
 import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.time.Instant
 
-data class RatkoOperationalPointVersion(
-    val point: RatkoOperationalPoint,
-    val version: Int,
-    val deleted: Boolean,
-)
+data class RatkoOperationalPointVersion(val point: RatkoOperationalPoint, val version: Int, val deleted: Boolean)
 
 fun toRatkoOperationalPoint(rs: ResultSet): RatkoOperationalPoint {
     return RatkoOperationalPoint(
@@ -172,7 +168,7 @@ class RatkoOperationalPointDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) :
               where external_id = :oid and version = :version 
             """
                 .trimIndent()
-        return jdbcTemplate.queryOne(sql, mapOf("oid" to oid.toString(), "version" to version)) { rs, _ ->
+        return jdbcTemplate.queryOne(sql, mapOf("oid" to oid, "version" to version)) { rs, _ ->
             toRatkoOperationalPoint(rs)
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -73,15 +73,18 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                     else status
                 end
             where end_time is null
-            returning id
+            returning id, status
             """
                 .trimIndent()
 
         jdbcTemplate.setUser()
-        val updatedPushes = jdbcTemplate.query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") }
-        updatedPushes.forEach { pushId ->
-            insertRatkoPushError(pushId, RatkoPushErrorType.INTERNAL, "Stuck operation cleared as FAILED")
-        }
+        val updatedPushes =
+            jdbcTemplate.query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") to rs.getEnum<RatkoPushStatus>("status") }
+        updatedPushes
+            .filter { (_, status) -> status == RatkoPushStatus.FAILED }
+            .forEach { (pushId, _) ->
+                insertRatkoPushError(pushId, RatkoPushErrorType.INTERNAL, "Stuck operation cleared as FAILED")
+            }
         logger.daoAccess(AccessType.UPDATE, RatkoPush::class, updatedPushes)
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -2,9 +2,10 @@ package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.integration.RatkoAssetId
+import fi.fta.geoviite.infra.common.Oid
+import fi.fta.geoviite.infra.integration.RatkoAssetRef
 import fi.fta.geoviite.infra.integration.RatkoErrorData
-import fi.fta.geoviite.infra.integration.RatkoLocationTrackId
+import fi.fta.geoviite.infra.integration.RatkoLocationTrackRef
 import fi.fta.geoviite.infra.integration.RatkoOperation
 import fi.fta.geoviite.infra.integration.RatkoPush
 import fi.fta.geoviite.infra.integration.RatkoPushAssetError
@@ -12,8 +13,8 @@ import fi.fta.geoviite.infra.integration.RatkoPushError
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.integration.RatkoPushGeneralError
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
-import fi.fta.geoviite.infra.integration.RatkoSwitchId
-import fi.fta.geoviite.infra.integration.RatkoTrackNumberId
+import fi.fta.geoviite.infra.integration.RatkoSwitchRef
+import fi.fta.geoviite.infra.integration.RatkoTrackNumberRef
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.Publication
@@ -27,6 +28,7 @@ import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.getInstantOrNull
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getIntIdOrNull
+import fi.fta.geoviite.infra.util.getOidOrNull
 import fi.fta.geoviite.infra.util.produceIf
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.queryOptional
@@ -300,8 +302,11 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
               ratko_push_error.error_type,
               ratko_push_error.operation,
               ratko_push_error.track_number_id,
+              ratko_push_error.track_number_oid,
               ratko_push_error.location_track_id,
+              ratko_push_error.location_track_oid,
               ratko_push_error.switch_id,
+              ratko_push_error.switch_oid,
               ratko_push_error.ratko_push_id,
               ratko_push_error.ratko_response_code,
               ratko_push_error.technical_message
@@ -330,10 +335,13 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                         val pushOperation =
                             rs.getEnumOrNull<RatkoOperation>("operation")?.let { operation ->
                                 operation to
-                                    toAssetId(
+                                    toAssetRef(
                                         rs.getIntIdOrNull("track_number_id"),
+                                        rs.getOidOrNull("track_number_oid"),
                                         rs.getIntIdOrNull("location_track_id"),
+                                        rs.getOidOrNull("location_track_oid"),
                                         rs.getIntIdOrNull("switch_id"),
+                                        rs.getOidOrNull("switch_oid"),
                                     )
                             }
 
@@ -349,15 +357,18 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             .also { logger.daoAccess(AccessType.FETCH, RatkoPushError::class) }
     }
 
-    private fun toAssetId(
+    private fun toAssetRef(
         trackNumberId: IntId<LayoutTrackNumber>?,
+        trackNumberOid: Oid<LayoutTrackNumber>?,
         locationTrackId: IntId<LocationTrack>?,
+        locationTrackOid: Oid<LocationTrack>?,
         switchId: IntId<LayoutSwitch>?,
-    ): RatkoAssetId<*> =
+        switchOid: Oid<LayoutSwitch>?,
+    ): RatkoAssetRef<*> =
         when {
-            trackNumberId != null -> RatkoTrackNumberId(trackNumberId)
-            locationTrackId != null -> RatkoLocationTrackId(locationTrackId)
-            switchId != null -> RatkoSwitchId(switchId)
+            trackNumberId != null -> RatkoTrackNumberRef(trackNumberId, trackNumberOid)
+            locationTrackId != null -> RatkoLocationTrackRef(locationTrackId, locationTrackOid)
+            switchId != null -> RatkoSwitchRef(switchId, switchOid)
             else -> error("Ratko push error without asset!")
         }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -302,7 +302,9 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
               ratko_push_error.track_number_id,
               ratko_push_error.location_track_id,
               ratko_push_error.switch_id,
-              ratko_push_error.ratko_push_id
+              ratko_push_error.ratko_push_id,
+              ratko_push_error.ratko_response_code,
+              ratko_push_error.technical_message
             from integrations.ratko_push
               inner join integrations.ratko_push_content on ratko_push_content.ratko_push_id = ratko_push.id
               left join integrations.ratko_push_error on ratko_push_error.ratko_push_id = ratko_push.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -199,9 +199,9 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 "ratko_push_id" to ratkoPushId.intValue,
                 "error_type" to ratkoPushErrorType.name,
                 "operation" to operation?.name,
-                "track_number_oid" to (target as? RatkoPushTargetTrackNumber)?.oid.toString(),
-                "location_track_oid" to (target as? RatkoPushTargetLocationTrack)?.oid.toString(),
-                "switch_oid" to (target as? RatkoPushTargetSwitch)?.oid.toString(),
+                "track_number_oid" to (target as? RatkoPushTargetTrackNumber)?.oid,
+                "location_track_oid" to (target as? RatkoPushTargetLocationTrack)?.oid,
+                "switch_oid" to (target as? RatkoPushTargetSwitch)?.oid,
                 "ratko_response_code" to ratkoStatus,
                 "technical_message" to technicalMessage,
             )
@@ -334,8 +334,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                             )
                         val pushOperation =
                             rs.getEnumOrNull<RatkoOperation>("operation")?.let { operation ->
-                                operation to
-                                    toAssetRef(
+                                toAssetRef(
                                         rs.getIntIdOrNull("track_number_id"),
                                         rs.getOidOrNull("track_number_oid"),
                                         rs.getIntIdOrNull("location_track_id"),
@@ -343,6 +342,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                                         rs.getIntIdOrNull("switch_id"),
                                         rs.getOidOrNull("switch_oid"),
                                     )
+                                    ?.let { operation to it }
                             }
 
                         val pushError =
@@ -364,11 +364,11 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
         locationTrackOid: Oid<LocationTrack>?,
         switchId: IntId<LayoutSwitch>?,
         switchOid: Oid<LayoutSwitch>?,
-    ): RatkoAssetRef<*> =
+    ): RatkoAssetRef<*>? =
         when {
             trackNumberId != null -> RatkoTrackNumberRef(trackNumberId, trackNumberOid)
             locationTrackId != null -> RatkoLocationTrackRef(locationTrackId, locationTrackOid)
             switchId != null -> RatkoSwitchRef(switchId, switchOid)
-            else -> error("Ratko push error without asset!")
+            else -> null
         }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -2,12 +2,18 @@ package fi.fta.geoviite.infra.ratko
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
-import fi.fta.geoviite.infra.integration.RatkoAssetType
+import fi.fta.geoviite.infra.integration.RatkoAssetId
+import fi.fta.geoviite.infra.integration.RatkoErrorData
+import fi.fta.geoviite.infra.integration.RatkoLocationTrackId
 import fi.fta.geoviite.infra.integration.RatkoOperation
 import fi.fta.geoviite.infra.integration.RatkoPush
+import fi.fta.geoviite.infra.integration.RatkoPushAssetError
 import fi.fta.geoviite.infra.integration.RatkoPushError
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType
+import fi.fta.geoviite.infra.integration.RatkoPushGeneralError
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
+import fi.fta.geoviite.infra.integration.RatkoSwitchId
+import fi.fta.geoviite.infra.integration.RatkoTrackNumberId
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.Publication
@@ -16,18 +22,19 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.getEnum
+import fi.fta.geoviite.infra.util.getEnumOrNull
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.getInstantOrNull
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getIntIdOrNull
+import fi.fta.geoviite.infra.util.produceIf
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
-import java.time.Instant
-import kotlin.collections.emptyMap
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -69,9 +76,11 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 .trimIndent()
 
         jdbcTemplate.setUser()
-        jdbcTemplate
-            .query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") }
-            .also { updatedPushes -> logger.daoAccess(AccessType.UPDATE, RatkoPush::class, updatedPushes) }
+        val updatedPushes = jdbcTemplate.query(sql) { rs, _ -> rs.getIntId<RatkoPush>("id") }
+        updatedPushes.forEach { pushId ->
+            insertRatkoPushError(pushId, RatkoPushErrorType.INTERNAL, "Stuck operation cleared as FAILED")
+        }
+        logger.daoAccess(AccessType.UPDATE, RatkoPush::class, updatedPushes)
     }
 
     @Transactional
@@ -143,31 +152,42 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
     }
 
     @Transactional
-    fun <T> insertRatkoPushError(
+    fun insertRatkoPushError(
         ratkoPushId: IntId<RatkoPush>,
         ratkoPushErrorType: RatkoPushErrorType,
-        operation: RatkoOperation,
-        assetType: RatkoAssetType,
-        assetId: IntId<T>,
-    ): IntId<RatkoPushError<T>> {
+        technicalMessage: String,
+        ratkoStatus: String? = null,
+        operation: RatkoOperation? = null,
+        target: RatkoPushTarget<*>? = null,
+    ): IntId<RatkoPushError> {
         // language=SQL
         val sql =
             """
             insert into integrations.ratko_push_error(
               ratko_push_id,
+              track_number_oid,
               track_number_id,
+              location_track_oid,
               location_track_id,
+              switch_oid,
               switch_id,
               error_type,
-              operation
+              operation,
+              ratko_response_code,
+              technical_message
             )
             values(
               :ratko_push_id, 
-              :track_number_id, 
-              :location_track_id, 
-              :switch_id,
+              :track_number_oid, 
+              (select id from layout.track_number_external_id where external_id = :track_number_oid), 
+              :location_track_oid, 
+              (select id from layout.location_track_external_id where external_id = :location_track_oid), 
+              :switch_oid,
+              (select id from layout.switch_external_id where external_id = :switch_oid), 
               :error_type::integrations.ratko_push_error_type, 
-              :operation::integrations.ratko_push_error_operation
+              :operation::integrations.ratko_push_error_operation,
+              :ratko_response_code,
+              :technical_message
             )
             returning id
             """
@@ -176,14 +196,16 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             mapOf(
                 "ratko_push_id" to ratkoPushId.intValue,
                 "error_type" to ratkoPushErrorType.name,
-                "operation" to operation.name,
-                "track_number_id" to if (assetType == RatkoAssetType.TRACK_NUMBER) assetId.intValue else null,
-                "location_track_id" to if (assetType == RatkoAssetType.LOCATION_TRACK) assetId.intValue else null,
-                "switch_id" to if (assetType == RatkoAssetType.SWITCH) assetId.intValue else null,
+                "operation" to operation?.name,
+                "track_number_oid" to (target as? RatkoPushTargetTrackNumber)?.oid.toString(),
+                "location_track_oid" to (target as? RatkoPushTargetLocationTrack)?.oid.toString(),
+                "switch_oid" to (target as? RatkoPushTargetSwitch)?.oid.toString(),
+                "ratko_response_code" to ratkoStatus,
+                "technical_message" to technicalMessage,
             )
 
         return jdbcTemplate
-            .queryOne<IntId<RatkoPushError<T>>>(sql, params, ratkoPushId.toString()) { rs, _ -> rs.getIntId("id") }
+            .queryOne<IntId<RatkoPushError>>(sql, params, ratkoPushId.toString()) { rs, _ -> rs.getIntId("id") }
             .also { errorId -> logger.daoAccess(AccessType.INSERT, RatkoPushError::class, errorId) }
     }
 
@@ -268,7 +290,7 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
             .onEach { (_, pushes) -> logger.daoAccess(AccessType.FETCH, RatkoPush::class, pushes.map { it.id }) }
     }
 
-    fun getCurrentRatkoPushError(): Pair<RatkoPushError<*>, IntId<Publication>>? {
+    fun getCurrentRatkoPushError(): Pair<RatkoPushError, IntId<Publication>>? {
         val sql =
             """
             select 
@@ -291,35 +313,49 @@ class RatkoPushDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdb
                 .trimIndent()
 
         return jdbcTemplate
-            .queryOptional(sql, emptyMap<String, Object>()) { rs, _ ->
+            .queryOptional(sql, emptyMap<String, Any>()) { rs, _ ->
                 val status = rs.getEnum<RatkoPushStatus>("status")
-                if (status != RatkoPushStatus.SUCCESSFUL) {
-                    val errorId = rs.getIntId<RatkoPushError<*>>("id")
-                    val trackNumberId = rs.getIntIdOrNull<LayoutTrackNumber>("track_number_id")
-                    val locationTrackId = rs.getIntIdOrNull<LocationTrack>("location_track_id")
-                    val switchId = rs.getIntIdOrNull<LayoutSwitch>("switch_id")
-                    val pushError =
-                        RatkoPushError(
-                            id = errorId,
-                            ratkoPushId = rs.getIntId("ratko_push_id"),
-                            errorType = rs.getEnum("error_type"),
-                            operation = rs.getEnum("operation"),
-                            assetId =
-                                trackNumberId
-                                    ?: locationTrackId
-                                    ?: switchId
-                                    ?: error("Encountered Ratko push error without asset! id: $errorId"),
-                            assetType =
-                                trackNumberId?.let { RatkoAssetType.TRACK_NUMBER }
-                                    ?: locationTrackId?.let { RatkoAssetType.LOCATION_TRACK }
-                                    ?: switchId.let { RatkoAssetType.SWITCH },
-                        )
+                produceIf(status != RatkoPushStatus.SUCCESSFUL) { rs.getIntIdOrNull<RatkoPushError>("id") }
+                    ?.let { errorId ->
+                        val errorData =
+                            RatkoErrorData(
+                                id = errorId,
+                                ratkoPushId = rs.getIntId("ratko_push_id"),
+                                errorType = rs.getEnum("error_type"),
+                                ratkoStatusCode = rs.getString("ratko_response_code"),
+                                technicalMessage = rs.getString("technical_message"),
+                            )
+                        val pushOperation =
+                            rs.getEnumOrNull<RatkoOperation>("operation")?.let { operation ->
+                                operation to
+                                    toAssetId(
+                                        rs.getIntIdOrNull("track_number_id"),
+                                        rs.getIntIdOrNull("location_track_id"),
+                                        rs.getIntIdOrNull("switch_id"),
+                                    )
+                            }
 
-                    pushError to rs.getIntId<Publication>("publication_id")
-                } else {
-                    null
-                }
+                        val pushError =
+                            when (pushOperation) {
+                                null -> RatkoPushGeneralError(errorData)
+                                else -> RatkoPushAssetError(pushOperation.first, errorData, pushOperation.second)
+                            }
+
+                        pushError to rs.getIntId<Publication>("publication_id")
+                    }
             }
             .also { logger.daoAccess(AccessType.FETCH, RatkoPushError::class) }
     }
+
+    private fun toAssetId(
+        trackNumberId: IntId<LayoutTrackNumber>?,
+        locationTrackId: IntId<LocationTrack>?,
+        switchId: IntId<LayoutSwitch>?,
+    ): RatkoAssetId<*> =
+        when {
+            trackNumberId != null -> RatkoTrackNumberId(trackNumberId)
+            locationTrackId != null -> RatkoLocationTrackId(locationTrackId)
+            switchId != null -> RatkoSwitchId(switchId)
+            else -> error("Ratko push error without asset!")
+        }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
@@ -8,8 +8,6 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.GeocodingService
-import fi.fta.geoviite.infra.integration.RatkoOperation
-import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.publication.PublishedTrackNumber
 import fi.fta.geoviite.infra.ratko.model.PushableLayoutBranch
 import fi.fta.geoviite.infra.ratko.model.RatkoNodes
@@ -59,40 +57,36 @@ constructor(
                         trackNumberDao::savePlanItemId,
                     )
                 requireNotNull(externalId) { "OID required for track number, tn=${trackNumber.id}" }
-                try {
-                    ratkoClient.getRouteNumber(RatkoOid(externalId.oid))?.let { existingRouteNumber ->
-                        if (
-                            trackNumber.state == LayoutState.DELETED ||
-                                trackNumber.designAssetState == DesignAssetState.CANCELLED
-                        ) {
-                            deleteRouteNumber(trackNumber, externalId, existingRouteNumber)
-                        } else {
-                            updateRouteNumber(
-                                branch = branch.branch,
-                                existingRatkoRouteNumber = existingRouteNumber,
-                                trackNumber = trackNumber,
-                                trackNumberExternalId = externalId,
-                                moment = publicationTime,
-                                changedKmNumbers = changedKmNumbers,
-                            )
-                        }
+                ratkoClient.getRouteNumber(RatkoOid(externalId.oid))?.let { existingRouteNumber ->
+                    if (
+                        trackNumber.state == LayoutState.DELETED ||
+                            trackNumber.designAssetState == DesignAssetState.CANCELLED
+                    ) {
+                        deleteRouteNumber(trackNumber, externalId, existingRouteNumber)
+                    } else {
+                        updateRouteNumber(
+                            branch = branch.branch,
+                            existingRatkoRouteNumber = existingRouteNumber,
+                            trackNumber = trackNumber,
+                            trackNumberExternalId = externalId,
+                            moment = publicationTime,
+                            changedKmNumbers = changedKmNumbers,
+                        )
                     }
-                        ?: if (
-                            trackNumber.state != LayoutState.DELETED &&
-                                trackNumber.designAssetState != DesignAssetState.CANCELLED
-                        ) {
-                            createRouteNumber(branch.branch, trackNumber, externalId, publicationTime)
-                        } else {
-                            null
-                        }
-                } catch (ex: RatkoPushException) {
-                    throw RatkoTrackNumberPushException(ex, trackNumber)
                 }
+                    ?: if (
+                        trackNumber.state != LayoutState.DELETED &&
+                            trackNumber.designAssetState != DesignAssetState.CANCELLED
+                    ) {
+                        createRouteNumber(branch.branch, trackNumber, externalId, publicationTime)
+                    } else {
+                        null
+                    }
                 externalId.oid
             }
     }
 
-    fun forceRedraw(routeNumberOids: Set<RatkoOid<RatkoRouteNumber>>) {
+    fun forceRedraw(routeNumberOids: Set<RatkoOid<LayoutTrackNumber>>) {
         if (routeNumberOids.isNotEmpty()) {
             ratkoClient.forceRatkoToRedrawRouteNumber(routeNumberOids)
         }
@@ -103,19 +97,12 @@ constructor(
         trackNumberExternalId: FullRatkoExternalId<LayoutTrackNumber>,
         existingRatkoRouteNumber: RatkoRouteNumber,
     ) {
-        try {
-            val deletedEndsPoints =
-                existingRatkoRouteNumber.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)
+        val deletedEndsPoints = existingRatkoRouteNumber.nodecollection?.let(::toNodeCollectionMarkingEndpointsNotInUse)
 
-            updateRouteNumberProperties(trackNumber, trackNumberExternalId, deletedEndsPoints)
+        updateRouteNumberProperties(trackNumber, trackNumberExternalId, deletedEndsPoints)
 
-            val routeNumberOid = RatkoOid<RatkoRouteNumber>(trackNumberExternalId.oid)
-            ratkoClient.deleteRouteNumberPoints(routeNumberOid, null)
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.DELETE, ex)
-        }
+        val routeNumberOid = RatkoOid<LayoutTrackNumber>(trackNumberExternalId.oid)
+        ratkoClient.deleteRouteNumberPoints(routeNumberOid, null)
     }
 
     private fun updateRouteNumber(
@@ -126,52 +113,46 @@ constructor(
         moment: Instant,
         changedKmNumbers: Set<KmNumber>,
     ) {
-        try {
-            require(trackNumber.id is IntId) { "Only layout route numbers can be updated, id=${trackNumber.id}" }
+        require(trackNumber.id is IntId) { "Only layout route numbers can be updated, id=${trackNumber.id}" }
 
-            val addresses =
-                geocodingService
-                    .getGeocodingContextAtMoment(branch, trackNumber.id as IntId, moment)
-                    ?.referenceLineAddresses
-                    ?.addresses
-            checkNotNull(addresses) { "Cannot calculate addresses for track number, id=${trackNumber.id}" }
+        val addresses =
+            geocodingService
+                .getGeocodingContextAtMoment(branch, trackNumber.id as IntId, moment)
+                ?.referenceLineAddresses
+                ?.addresses
+        checkNotNull(addresses) { "Cannot calculate addresses for track number, id=${trackNumber.id}" }
 
-            val existingStartNode = existingRatkoRouteNumber.nodecollection?.getStartNode()
-            val existingEndNode = existingRatkoRouteNumber.nodecollection?.getEndNode()
+        val existingStartNode = existingRatkoRouteNumber.nodecollection?.getStartNode()
+        val existingEndNode = existingRatkoRouteNumber.nodecollection?.getEndNode()
 
-            val routeNumberOid = RatkoOid<RatkoRouteNumber>(trackNumberExternalId.oid)
-            val endPointNodeCollection =
-                getEndPointNodeCollection(
-                    alignmentAddresses = addresses,
-                    changedKmNumbers = changedKmNumbers,
-                    existingStartNode = existingStartNode,
-                    existingEndNode = existingEndNode,
-                )
-
-            // Update route number end points before deleting anything, otherwise old end points
-            // will stay in use
-            updateRouteNumberProperties(trackNumber, trackNumberExternalId, endPointNodeCollection)
-
-            deleteRouteNumberPoints(routeNumberOid, changedKmNumbers)
-
-            updateRouteNumberGeometry(
-                routeNumberOid = routeNumberOid,
-                newPoints = addresses.midPoints.filter { p -> changedKmNumbers.contains(p.address.kmNumber) },
+        val routeNumberOid = RatkoOid(trackNumberExternalId.oid)
+        val endPointNodeCollection =
+            getEndPointNodeCollection(
+                alignmentAddresses = addresses,
+                changedKmNumbers = changedKmNumbers,
+                existingStartNode = existingStartNode,
+                existingEndNode = existingEndNode,
             )
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.UPDATE, ex)
-        }
+
+        // Update route number end points before deleting anything, otherwise old end points
+        // will stay in use
+        updateRouteNumberProperties(trackNumber, trackNumberExternalId, endPointNodeCollection)
+
+        deleteRouteNumberPoints(routeNumberOid, changedKmNumbers)
+
+        updateRouteNumberGeometry(
+            routeNumberOid = routeNumberOid,
+            newPoints = addresses.midPoints.filter { p -> changedKmNumbers.contains(p.address.kmNumber) },
+        )
     }
 
-    private fun deleteRouteNumberPoints(routeNumberOid: RatkoOid<RatkoRouteNumber>, changedKmNumbers: Set<KmNumber>) =
+    private fun deleteRouteNumberPoints(routeNumberOid: RatkoOid<LayoutTrackNumber>, changedKmNumbers: Set<KmNumber>) =
         changedKmNumbers.forEach { kmNumber ->
             ratkoClient.deleteRouteNumberPoints(routeNumberOid, kmNumber)
         }
 
     private fun updateRouteNumberGeometry(
-        routeNumberOid: RatkoOid<RatkoRouteNumber>,
+        routeNumberOid: RatkoOid<LayoutTrackNumber>,
         newPoints: Collection<AddressPoint<ReferenceLineM>>,
     ) =
         toRatkoPointsGroupedByKm(newPoints).forEach { points ->
@@ -184,32 +165,26 @@ constructor(
         trackNumberOid: FullRatkoExternalId<LayoutTrackNumber>,
         moment: Instant,
     ) {
-        try {
-            require(trackNumber.id is IntId) { "Only layout route numbers can be updated, id=${trackNumber.id}" }
+        require(trackNumber.id is IntId) { "Only layout route numbers can be updated, id=${trackNumber.id}" }
 
-            val addresses =
-                geocodingService
-                    .getGeocodingContextAtMoment(branch, trackNumber.id as IntId, moment)
-                    ?.referenceLineAddresses
-                    ?.addresses
-            checkNotNull(addresses) { "Cannot calculate addresses for track number, id=${trackNumber.id}" }
+        val addresses =
+            geocodingService
+                .getGeocodingContextAtMoment(branch, trackNumber.id as IntId, moment)
+                ?.referenceLineAddresses
+                ?.addresses
+        checkNotNull(addresses) { "Cannot calculate addresses for track number, id=${trackNumber.id}" }
 
-            val ratkoNodes = convertToRatkoNodeCollection(addresses)
-            val ratkoRouteNumber = convertToRatkoRouteNumber(trackNumber, trackNumberOid, ratkoNodes)
-            val routeNumberOid = ratkoClient.newRouteNumber(ratkoRouteNumber)
-            checkNotNull(routeNumberOid) { "Did not receive oid from Ratko for track number $ratkoRouteNumber" }
-            if (trackNumber.state != LayoutState.DELETED) {
-                createRouteNumberPoints(routeNumberOid, addresses.midPoints)
-            }
-        } catch (ex: RatkoPushException) {
-            throw ex
-        } catch (ex: Exception) {
-            throw RatkoPushException(RatkoPushErrorType.INTERNAL, RatkoOperation.CREATE, ex)
+        val ratkoNodes = convertToRatkoNodeCollection(addresses)
+        val ratkoRouteNumber = convertToRatkoRouteNumber(trackNumber, trackNumberOid, ratkoNodes)
+        val routeNumberOid = ratkoClient.newRouteNumber(ratkoRouteNumber)
+        checkNotNull(routeNumberOid) { "Did not receive oid from Ratko for track number $ratkoRouteNumber" }
+        if (trackNumber.state != LayoutState.DELETED) {
+            createRouteNumberPoints(routeNumberOid, addresses.midPoints)
         }
     }
 
     private fun createRouteNumberPoints(
-        routeNumberOid: RatkoOid<RatkoRouteNumber>,
+        routeNumberOid: RatkoOid<LayoutTrackNumber>,
         newPoints: Collection<AddressPoint<ReferenceLineM>>,
     ) =
         toRatkoPointsGroupedByKm(newPoints).forEach { points ->

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -14,7 +14,6 @@ import fi.fta.geoviite.infra.integration.CalculatedChangesService
 import fi.fta.geoviite.infra.integration.DatabaseLock
 import fi.fta.geoviite.infra.integration.LocationTrackChange
 import fi.fta.geoviite.infra.integration.LockDao
-import fi.fta.geoviite.infra.integration.RatkoAssetType
 import fi.fta.geoviite.infra.integration.RatkoOperation
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
@@ -29,10 +28,10 @@ import fi.fta.geoviite.infra.publication.PublishedSwitch
 import fi.fta.geoviite.infra.ratko.model.PushableDesignBranch
 import fi.fta.geoviite.infra.ratko.model.PushableLayoutBranch
 import fi.fta.geoviite.infra.ratko.model.PushableMainBranch
+import fi.fta.geoviite.infra.ratko.model.RatkoErrorResponse
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrack
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.ratko.model.RatkoPlanId
-import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
 import fi.fta.geoviite.infra.ratko.model.RatkoSplit
 import fi.fta.geoviite.infra.ratko.model.existingRatkoPlan
 import fi.fta.geoviite.infra.ratko.model.newRatkoPlan
@@ -41,30 +40,31 @@ import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.tracklayout.LayoutDesign
 import fi.fta.geoviite.infra.tracklayout.LayoutDesignDao
-import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
-import java.time.Duration
-import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.Duration
+import java.time.Instant
 
-open class RatkoPushException(val type: RatkoPushErrorType, val operation: RatkoOperation, cause: Exception? = null) :
-    RuntimeException(cause)
+class RatkoException(
+    val type: RatkoPushErrorType,
+    val operation: RatkoOperation,
+    val response: RatkoErrorResponse?,
+    cause: Exception? = null,
+) : RuntimeException(cause)
 
-class RatkoSwitchPushException(exception: RatkoPushException, val switch: LayoutSwitch) :
-    RatkoPushException(exception.type, exception.operation, exception)
-
-class RatkoLocationTrackPushException(exception: RatkoPushException, val locationTrack: LocationTrack) :
-    RatkoPushException(exception.type, exception.operation, exception)
-
-class RatkoTrackNumberPushException(exception: RatkoPushException, val trackNumber: LayoutTrackNumber) :
-    RatkoPushException(exception.type, exception.operation, exception)
+class RatkoAssetPushException(
+    val type: RatkoPushErrorType,
+    val operation: RatkoOperation,
+    val target: RatkoPushTarget<*>,
+    val response: RatkoErrorResponse?,
+    cause: Exception? = null,
+) : RuntimeException(cause)
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)
@@ -242,32 +242,31 @@ constructor(
                     }
                     .map { switchChange -> toFakePublishedSwitch(branch, switchChange, latestPublicationMoment) }
 
-            val publishedLocationTrackChanges =
-                locationTrackChanges.map { locationTrackChange ->
-                    val locationTrack =
-                        locationTrackService.getOfficialAtMoment(
-                            branch = branch,
-                            id = locationTrackChange.locationTrackId,
-                            moment = latestPublicationMoment,
-                        )
-                    checkNotNull(locationTrack) {
-                        "No location track exists with id ${locationTrackChange.locationTrackId} and timestamp $latestPublicationMoment"
-                    }
-
-                    // Fake PublishedLocationTrack, Ratko integration is built around published
-                    // items
-                    PublishedLocationTrack(
-                        version =
-                            checkNotNull(locationTrack.version) {
-                                "Location track missing version, id=${locationTrackChange.locationTrackId}"
-                            },
-                        baseVersion = null,
-                        name = locationTrack.name,
-                        trackNumberId = locationTrack.trackNumberId,
-                        operation = Operation.MODIFY,
-                        changedKmNumbers = locationTrackChange.changedKmNumbers,
+            val publishedLocationTrackChanges = locationTrackChanges.map { locationTrackChange ->
+                val locationTrack =
+                    locationTrackService.getOfficialAtMoment(
+                        branch = branch,
+                        id = locationTrackChange.locationTrackId,
+                        moment = latestPublicationMoment,
                     )
+                checkNotNull(locationTrack) {
+                    "No location track exists with id ${locationTrackChange.locationTrackId} and timestamp $latestPublicationMoment"
                 }
+
+                // Fake PublishedLocationTrack, Ratko integration is built around published
+                // items
+                PublishedLocationTrack(
+                    version =
+                        checkNotNull(locationTrack.version) {
+                            "Location track missing version, id=${locationTrackChange.locationTrackId}"
+                        },
+                    baseVersion = null,
+                    name = locationTrack.name,
+                    trackNumberId = locationTrack.trackNumberId,
+                    operation = Operation.MODIFY,
+                    changedKmNumbers = locationTrackChange.changedKmNumbers,
+                )
+            }
 
             val pushedLocationTrackOids =
                 ratkoLocationTrackService.pushLocationTrackChangesToRatko(
@@ -276,18 +275,15 @@ constructor(
                     latestPublicationMoment,
                 )
 
-            val distinctJoints =
-                switchChanges.map { switchChange ->
-                    switchChange.copy(
-                        changedJoints = switchChange.changedJoints.distinctBy { changedJoint -> changedJoint.number }
-                    )
-                }
+            val distinctJoints = switchChanges.map { switchChange ->
+                switchChange.copy(
+                    changedJoints = switchChange.changedJoints.distinctBy { changedJoint -> changedJoint.number }
+                )
+            }
             ratkoAssetService.pushSwitchChangesToRatko(pushableBranch, distinctJoints, latestPublicationMoment)
 
             try {
-                ratkoLocationTrackService.forceRedraw(
-                    pushedLocationTrackOids.map { RatkoOid<RatkoLocationTrack>(it) }.toSet()
-                )
+                ratkoLocationTrackService.forceRedraw(pushedLocationTrackOids.map(::RatkoOid).toSet())
             } catch (_: Exception) {
                 logger.warn("Failed to push M values for location tracks $pushedLocationTrackOids")
             }
@@ -321,10 +317,9 @@ constructor(
                     lastPublicationTime,
                 )
 
-            val publicationsToSplits =
-                publications.mapNotNull { publication ->
-                    publication.split?.id?.let { splitId -> publication to splitService.getOrThrow(splitId) }
-                }
+            val publicationsToSplits = publications.mapNotNull { publication ->
+                publication.split?.id?.let { splitId -> publication to splitService.getOrThrow(splitId) }
+            }
 
             val locationTrackKilometersPushedInSplits =
                 publicationsToSplits
@@ -356,10 +351,9 @@ constructor(
                     lastPublicationTime,
                 )
 
-            val changedKilometersOverride =
-                locationTrackKilometersPushedInSplits
-                    .map { locationTrackKilometers -> locationTrackKilometers.id to locationTrackKilometers.kilometers }
-                    .toMap()
+            val changedKilometersOverride = locationTrackKilometersPushedInSplits.associate { locationTrackKilometers ->
+                locationTrackKilometers.id to locationTrackKilometers.kilometers
+            }
 
             pushSwitchChanges(
                 layoutBranch = pushableBranch,
@@ -373,20 +367,19 @@ constructor(
             ratkoPushDao.updatePushStatus(ratkoPushId, RatkoPushStatus.IN_PROGRESS_M_VALUES)
 
             try {
-                ratkoRouteNumberService.forceRedraw(
-                    pushedRouteNumberOids.map { RatkoOid<RatkoRouteNumber>(it) }.toSet()
-                )
+                ratkoRouteNumberService.forceRedraw(pushedRouteNumberOids.map { RatkoOid(it) }.toSet())
             } catch (_: Exception) {
                 logger.warn("Failed to push M values for route numbers $pushedRouteNumberOids")
             }
 
-            val locationTrackOidsPushedInSplits =
-                locationTrackKilometersPushedInSplits.map { locationTrackKilometers -> locationTrackKilometers.oid }
+            val locationTrackOidsPushedInSplits = locationTrackKilometersPushedInSplits.map { locationTrackKilometers ->
+                locationTrackKilometers.oid
+            }
             try {
                 ratkoLocationTrackService.forceRedraw(
                     listOf(locationTrackOidsPushedInSplits, pushedLocationTrackOids)
                         .flatten()
-                        .map { RatkoOid<RatkoLocationTrack>(it) }
+                        .map { RatkoOid(it) }
                         .toSet()
                 )
             } catch (_: Exception) {
@@ -400,31 +393,28 @@ constructor(
             ratkoPushDao.updatePushStatus(ratkoPushId, RatkoPushStatus.SUCCESSFUL)
         } catch (ex: Exception) {
             when (ex) {
-                is RatkoTrackNumberPushException ->
+                is RatkoAssetPushException ->
                     ratkoPushDao.insertRatkoPushError(
                         ratkoPushId,
                         ex.type,
+                        ex.response?.sanitizedMessage ?: "Asset push failed",
+                        ex.response?.sanitizedCode,
                         ex.operation,
-                        RatkoAssetType.TRACK_NUMBER,
-                        ex.trackNumber.id as IntId,
+                        ex.target,
                     )
-
-                is RatkoLocationTrackPushException ->
+                is RatkoException ->
                     ratkoPushDao.insertRatkoPushError(
                         ratkoPushId,
                         ex.type,
+                        ex.response?.sanitizedMessage ?: "Asset push failed",
+                        ex.response?.sanitizedCode,
                         ex.operation,
-                        RatkoAssetType.LOCATION_TRACK,
-                        ex.locationTrack.id as IntId,
                     )
-
-                is RatkoSwitchPushException ->
+                else ->
                     ratkoPushDao.insertRatkoPushError(
                         ratkoPushId,
-                        ex.type,
-                        ex.operation,
-                        RatkoAssetType.SWITCH,
-                        ex.switch.id as IntId,
+                        RatkoPushErrorType.INTERNAL,
+                        "Ratko push failed with internal error (${ex::class.simpleName})",
                     )
             }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
@@ -16,7 +16,7 @@ abstract class RatkoAsset(
     open val properties: Collection<RatkoAssetProperty>,
     open val rowMetadata: RatkoMetadata,
     open val locations: List<RatkoAssetLocation>?,
-    val type: RatkoSwitchAssetType,
+    val type: RatkoAssetApiType,
     open val isPlanContext: Boolean,
     open val planItemIds: List<Int>?,
 ) {
@@ -32,7 +32,7 @@ data class RatkoMetadataAsset(
 ) :
     RatkoAsset(
         state = RatkoAssetState.IN_USE,
-        type = RatkoSwitchAssetType.METADATA,
+        type = RatkoAssetApiType.METADATA,
         rowMetadata = rowMetadata,
         properties = properties,
         locations = locations,
@@ -55,7 +55,7 @@ data class RatkoSwitchAsset(
 ) :
     RatkoAsset(
         state = state,
-        type = RatkoSwitchAssetType.TURNOUT,
+        type = RatkoAssetApiType.TURNOUT,
         rowMetadata = rowMetadata,
         properties = properties,
         locations = locations,
@@ -130,7 +130,7 @@ enum class RatkoAssetState(@get:JsonValue val value: String, val category: Layou
     @Suppress("unused") OLD("OLD"),
 }
 
-enum class RatkoSwitchAssetType(@get:JsonValue val value: String) {
+enum class RatkoAssetApiType(@get:JsonValue val value: String) {
     TURNOUT("turnout"),
     METADATA("metadata_location_accuracy"),
     RAILWAY_TRAFFIC_OPERATIONAL_POINT(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoAssetModel.kt
@@ -8,6 +8,7 @@ import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 abstract class RatkoAsset(
@@ -15,7 +16,7 @@ abstract class RatkoAsset(
     open val properties: Collection<RatkoAssetProperty>,
     open val rowMetadata: RatkoMetadata,
     open val locations: List<RatkoAssetLocation>?,
-    val type: RatkoAssetType,
+    val type: RatkoSwitchAssetType,
     open val isPlanContext: Boolean,
     open val planItemIds: List<Int>?,
 ) {
@@ -31,7 +32,7 @@ data class RatkoMetadataAsset(
 ) :
     RatkoAsset(
         state = RatkoAssetState.IN_USE,
-        type = RatkoAssetType.METADATA,
+        type = RatkoSwitchAssetType.METADATA,
         rowMetadata = rowMetadata,
         properties = properties,
         locations = locations,
@@ -54,7 +55,7 @@ data class RatkoSwitchAsset(
 ) :
     RatkoAsset(
         state = state,
-        type = RatkoAssetType.TURNOUT,
+        type = RatkoSwitchAssetType.TURNOUT,
         rowMetadata = rowMetadata,
         properties = properties,
         locations = locations,
@@ -129,7 +130,7 @@ enum class RatkoAssetState(@get:JsonValue val value: String, val category: Layou
     @Suppress("unused") OLD("OLD"),
 }
 
-enum class RatkoAssetType(@get:JsonValue val value: String) {
+enum class RatkoSwitchAssetType(@get:JsonValue val value: String) {
     TURNOUT("turnout"),
     METADATA("metadata_location_accuracy"),
     RAILWAY_TRAFFIC_OPERATIONAL_POINT(
@@ -161,7 +162,7 @@ data class IncomingRatkoNodes(val nodes: Collection<IncomingRatkoNode> = listOf(
 
 data class IncomingRatkoNode(val point: IncomingRatkoPoint, val nodeType: RatkoNodeType)
 
-data class IncomingRatkoPoint(val geometry: IncomingRatkoGeometry, val routenumber: RatkoOid<RatkoRouteNumber>)
+data class IncomingRatkoPoint(val geometry: IncomingRatkoGeometry, val routenumber: RatkoOid<LayoutTrackNumber>)
 
 data class IncomingRatkoGeometry(val type: RatkoGeometryType, val coordinates: List<Double>, val crs: RatkoCrs)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -20,7 +20,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import fi.fta.geoviite.infra.util.formatForLog
+import fi.fta.geoviite.infra.util.limitLength
 import java.math.BigDecimal
 import java.math.RoundingMode
 
@@ -32,10 +32,10 @@ const val MAX_RATKO_ERROR_CODE_LENGTH = 20
 
 data class RatkoErrorResponse(private val code: String, private val message: String) {
     val sanitizedCode: String
-        get() = formatForLog(code, MAX_RATKO_ERROR_CODE_LENGTH)
+        get() = limitLength(code, MAX_RATKO_ERROR_CODE_LENGTH)
 
     val sanitizedMessage: String
-        get() = formatForLog(message, MAX_RATKO_ERROR_LENGTH)
+        get() = limitLength(message, MAX_RATKO_ERROR_LENGTH)
 }
 
 data class RatkoOid<T>(val id: String) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -38,10 +38,17 @@ data class RatkoErrorResponse(private val code: String, private val message: Str
         get() = limitLength(message, MAX_RATKO_ERROR_LENGTH)
 }
 
+/**
+ * Ratko OID wrapper holds an extra layer compared to Geoviite Oid type:
+ * - Geoviite Oid maps in JSON to: "123.456.789"
+ * - Ratko Oid maps in JSON to: { id: "123.456.789" }
+ */
 data class RatkoOid<T>(val id: String) {
     constructor(oid: Oid<T>) : this(oid.toString())
 
     override fun toString() = id
+
+    fun toOid(): Oid<T> = Oid(id)
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL) data class RatkoMetadata(val sourceName: String = GEOVIITE_NAME)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoCommonModel.kt
@@ -18,14 +18,28 @@ import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.util.formatForLog
 import java.math.BigDecimal
 import java.math.RoundingMode
 
 val RATKO_SRID = WGS_84_SRID
 const val GEOVIITE_NAME = "GEOVIITE"
 
+const val MAX_RATKO_ERROR_LENGTH = 500
+const val MAX_RATKO_ERROR_CODE_LENGTH = 20
+
+data class RatkoErrorResponse(private val code: String, private val message: String) {
+    val sanitizedCode: String
+        get() = formatForLog(code, MAX_RATKO_ERROR_CODE_LENGTH)
+
+    val sanitizedMessage: String
+        get() = formatForLog(message, MAX_RATKO_ERROR_LENGTH)
+}
+
 data class RatkoOid<T>(val id: String) {
-    constructor(oid: Oid<*>) : this(oid.toString())
+    constructor(oid: Oid<T>) : this(oid.toString())
 
     override fun toString() = id
 }
@@ -52,8 +66,8 @@ data class RatkoPoint(
     val geometry: RatkoGeometry?,
     val state: RatkoPointState?,
     val rowMetadata: RatkoMetadata? = null,
-    val locationtrack: RatkoOid<RatkoLocationTrack>? = null,
-    val routenumber: RatkoOid<RatkoRouteNumber>? = null,
+    val locationtrack: RatkoOid<LocationTrack>? = null,
+    val routenumber: RatkoOid<LayoutTrackNumber>? = null,
 ) {
     fun withoutGeometry() = this.copy(geometry = null)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/model/RatkoLocationTrackModel.kt
@@ -9,13 +9,14 @@ import fi.fta.geoviite.infra.publication.PublicationDetails
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.split.SplitTarget
 import fi.fta.geoviite.infra.tracklayout.DbLocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class RatkoLocationTrack(
     val id: Oid<LocationTrack>?,
-    val routenumber: RatkoOid<RatkoRouteNumber>?,
+    val routenumber: RatkoOid<LayoutTrackNumber>?,
     val nodecollection: RatkoNodes?,
     val name: String,
     val description: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -35,16 +35,13 @@ import fi.fta.geoviite.infra.util.getOidOrNull
 import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
-import java.sql.ResultSet
-import java.sql.Timestamp
-import java.time.Instant
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.plus
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
 
 const val SWITCH_CACHE_SIZE = 10000L
 
@@ -243,7 +240,7 @@ class LayoutSwitchDao(
                     "switch_structure_id" to item.switchStructureId.intValue,
                     "state_category" to item.stateCategory.name,
                     "trap_point" to item.trapPoint,
-                    "owner_id" to item.ownerId?.intValue,
+                    "owner_id" to item.ownerId.intValue,
                     "operational_point_id" to item.operationalPointId?.intValue,
                     "draft" to item.isDraft,
                     "design_asset_state" to item.designAssetState?.name,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -141,7 +141,7 @@ constructor(
         )
 
     private fun checkRatkoOidPresence(oid: Oid<LayoutSwitch>): Boolean? = ratkoClient?.let { client ->
-        return try {
+        try {
             client.getSwitchAsset(RatkoOid(oid)) != null
         } catch (ex: Exception) {
             logger.warn("checkRatkoOidPresence exception: $ex")

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -142,7 +142,7 @@ constructor(
 
     private fun checkRatkoOidPresence(oid: Oid<LayoutSwitch>): Boolean? = ratkoClient?.let { client ->
         return try {
-            client.getSwitchAsset(RatkoOid(oid.toString())) != null
+            client.getSwitchAsset(RatkoOid(oid)) != null
         } catch (ex: Exception) {
             logger.warn("checkRatkoOidPresence exception: $ex")
             null

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -21,9 +21,9 @@ import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.page
-import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 
 data class LayoutSwitchConnectionUpdates(val clearJoints: Boolean, val clearTracks: Boolean)
 
@@ -99,14 +99,15 @@ constructor(
         branch: LayoutBranch,
         ids: List<IntId<LayoutSwitch>>,
         operationalPointId: IntId<OperationalPoint>,
-    ): List<IntId<LayoutSwitch>> =
-        ids.map { id ->
-            saveDraft(branch, dao.getOrThrow(branch.draft, id).copy(operationalPointId = operationalPointId)).id
-        }
+    ): List<IntId<LayoutSwitch>> = ids.map { id ->
+        saveDraft(branch, dao.getOrThrow(branch.draft, id).copy(operationalPointId = operationalPointId)).id
+    }
 
     @Transactional
     fun unlinkFromOperationalPoint(branch: LayoutBranch, ids: List<IntId<LayoutSwitch>>): List<IntId<LayoutSwitch>> =
-        ids.map { id -> saveDraft(branch, dao.getOrThrow(branch.draft, id).copy(operationalPointId = null)).id }
+        ids.map { id ->
+            saveDraft(branch, dao.getOrThrow(branch.draft, id).copy(operationalPointId = null)).id
+        }
 
     fun findSwitchesRelatedToOperationalPoint(
         context: LayoutContext,
@@ -139,15 +140,13 @@ constructor(
                 },
         )
 
-    private fun checkRatkoOidPresence(oid: Oid<LayoutSwitch>): Boolean? {
-        if (ratkoClient != null)
-            return try {
-                ratkoClient.getSwitchAsset(RatkoOid(oid.toString())) != null
-            } catch (ex: Exception) {
-                logger.warn("checkRatkoOidPresence exception: $ex")
-                null
-            }
-        else return null
+    private fun checkRatkoOidPresence(oid: Oid<LayoutSwitch>): Boolean? = ratkoClient?.let { client ->
+        return try {
+            client.getSwitchAsset(RatkoOid(oid.toString())) != null
+        } catch (ex: Exception) {
+            logger.warn("checkRatkoOidPresence exception: $ex")
+            null
+        }
     }
 
     fun idMatches(
@@ -222,6 +221,7 @@ constructor(
             locationTrackService.updateDependencies(branch, switchId = v.id, noUpdateLocationTracks = setOf())
         }
 
+    @Transactional(readOnly = true)
     fun getSwitchesInArea(
         layoutContext: LayoutContext,
         bbox: BoundingBox,
@@ -241,6 +241,7 @@ constructor(
         return SwitchAreaSummary(switchCount = totalCount, switches = switches)
     }
 
+    @Transactional(readOnly = true)
     fun previewNameFixes(layoutContext: LayoutContext, bbox: BoundingBox): List<SwitchNameFixPreview> {
         val filter = switchFilter(bbox = bbox, includeSwitchesWithNoJoints = false)
         val allSwitches = listWithStructure(layoutContext, includeDeleted = false)
@@ -282,8 +283,9 @@ fun pageSwitches(
     comparisonPoint: Point?,
 ): Page<LayoutSwitch> {
     return if (comparisonPoint != null) {
-        val switchesWithDistance: List<Pair<LayoutSwitch, Double?>> =
-            switches.map { (switch, structure) -> associateByDistance(switch, structure, comparisonPoint) }
+        val switchesWithDistance: List<Pair<LayoutSwitch, Double?>> = switches.map { (switch, structure) ->
+            associateByDistance(switch, structure, comparisonPoint)
+        }
         page(switchesWithDistance, offset ?: 0, limit, ::compareByDistanceNullsFirst).map { (s, _) -> s }
     } else {
         page(switches.map { (s, _) -> s }, offset ?: 0, limit, Comparator.comparing(LayoutSwitch::name))

--- a/infra/src/main/resources/db/migration/prod/V146__expand_ratko_push_error.sql
+++ b/infra/src/main/resources/db/migration/prod/V146__expand_ratko_push_error.sql
@@ -1,0 +1,5 @@
+alter table integrations.ratko_push_error
+  alter column operation drop not null,
+  add column ratko_response_code varchar(20)  null,
+  add column technical_message   varchar(500) not null default '',
+  alter column technical_message drop default;

--- a/infra/src/main/resources/db/migration/prod/V146__expand_ratko_push_error.sql
+++ b/infra/src/main/resources/db/migration/prod/V146__expand_ratko_push_error.sql
@@ -2,4 +2,28 @@ alter table integrations.ratko_push_error
   alter column operation drop not null,
   add column ratko_response_code varchar(20)  null,
   add column technical_message   varchar(500) not null default '',
-  alter column technical_message drop default;
+  alter column technical_message drop default,
+  add column track_number_oid    varchar(50)  null,
+  add column location_track_oid  varchar(50)  null,
+  add column switch_oid          varchar(50)  null;
+
+update integrations.ratko_push_error
+  set track_number_oid = (
+    select external_id from layout.track_number_external_id
+    where id = track_number_id and layout_context_id = 'main_official'
+  )
+  where track_number_id is not null;
+
+update integrations.ratko_push_error
+  set location_track_oid = (
+    select external_id from layout.location_track_external_id
+    where id = location_track_id and layout_context_id = 'main_official'
+  )
+  where location_track_id is not null;
+
+update integrations.ratko_push_error
+  set switch_oid = (
+    select external_id from layout.switch_external_id
+    where id = switch_id and layout_context_id = 'main_official'
+  )
+  where switch_id is not null;

--- a/infra/src/main/resources/db/migration/prod/V146__expand_ratko_push_error.sql
+++ b/infra/src/main/resources/db/migration/prod/V146__expand_ratko_push_error.sql
@@ -1,29 +1,37 @@
 alter table integrations.ratko_push_error
-  alter column operation drop not null,
   add column ratko_response_code varchar(20)  null,
   add column technical_message   varchar(500) not null default '',
-  alter column technical_message drop default,
   add column track_number_oid    varchar(50)  null,
   add column location_track_oid  varchar(50)  null,
   add column switch_oid          varchar(50)  null;
 
+alter table integrations.ratko_push_error
+  alter column operation drop not null,
+  alter column technical_message drop default;
+
 update integrations.ratko_push_error
-  set track_number_oid = (
-    select external_id from layout.track_number_external_id
-    where id = track_number_id and layout_context_id = 'main_official'
+set
+  track_number_oid = (
+    select external_id
+      from layout.track_number_external_id
+      where id = track_number_id and layout_context_id = 'main_official'
   )
   where track_number_id is not null;
 
 update integrations.ratko_push_error
-  set location_track_oid = (
-    select external_id from layout.location_track_external_id
-    where id = location_track_id and layout_context_id = 'main_official'
+set
+  location_track_oid = (
+    select external_id
+      from layout.location_track_external_id
+      where id = location_track_id and layout_context_id = 'main_official'
   )
   where location_track_id is not null;
 
 update integrations.ratko_push_error
-  set switch_oid = (
-    select external_id from layout.switch_external_id
-    where id = switch_id and layout_context_id = 'main_official'
+set
+  switch_oid = (
+    select external_id
+      from layout.switch_external_id
+      where id = switch_id and layout_context_id = 'main_official'
   )
   where switch_id is not null;

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -2110,8 +2110,10 @@
             "switch": "Vaihteen",
             "connection-issue": "Yhteysvirhe Ratko-viennissä",
             "internal-error": "SISÄINEN VIRHE: {{assetType}} ({{name}}) {{operation}} epäonnistui. Ota yhteyttä {{geoviiteSupportEmail}}",
+            "general-internal-error": "SISÄINEN VIRHE: Ota yhteyttä {{geoviiteSupportEmail}}",
             "ratko-error": "{{assetType}} ({{name}}) {{errorType}} {{operation}} epäonnistui",
-            "ratko-fetch-error": "{{assetType}} ({{name}}) {{operation}} epäonnistui"
+            "ratko-fetch-error": "{{assetType}} ({{name}}) {{operation}} epäonnistui",
+            "general-error": "Ratkovienti epäonnistui"
         }
     },
     "split-details-dialog": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -16,6 +16,7 @@ import fi.fta.geoviite.infra.ratko.model.IncomingRatkoGeometry
 import fi.fta.geoviite.infra.ratko.model.IncomingRatkoNode
 import fi.fta.geoviite.infra.ratko.model.IncomingRatkoNodes
 import fi.fta.geoviite.infra.ratko.model.IncomingRatkoPoint
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetApiType
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetGeometry
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetLocation
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetProperty
@@ -33,7 +34,6 @@ import fi.fta.geoviite.infra.ratko.model.RatkoPlan
 import fi.fta.geoviite.infra.ratko.model.RatkoPlanItem
 import fi.fta.geoviite.infra.ratko.model.RatkoPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
-import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAssetType
 import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
@@ -118,7 +118,7 @@ class FakeRatko(port: Int) {
         post("/api/infra/v1.0/points/${oid}").respond(ok())
         patch("/api/infra/v1.1/points/${oid}").respond(ok())
         post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
-        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoAssetApiType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -141,7 +141,7 @@ class FakeRatko(port: Int) {
 
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
         patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
-        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoAssetApiType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -164,7 +164,7 @@ class FakeRatko(port: Int) {
             .respond(ok())
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
         patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
-        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoAssetApiType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -194,7 +194,7 @@ class FakeRatko(port: Int) {
             )
             .respond(ok())
         patch("/api/infra/v1.1/points/${oid}").respond(ok())
-        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoAssetApiType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -228,7 +228,7 @@ class FakeRatko(port: Int) {
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
         patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
         post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
-        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoAssetApiType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -368,7 +368,7 @@ class FakeRatko(port: Int) {
                     .withMethod("POST")
                     .withBody(
                         JsonBody.json(
-                            mapOf("type" to RatkoSwitchAssetType.METADATA.value) +
+                            mapOf("type" to RatkoAssetApiType.METADATA.value) +
                                 (locationTrackOid?.let { oid -> metadataFilterOn("locationtrack", oid) } ?: mapOf()) +
                                 (routeNumberOid?.let { oid -> metadataFilterOn("routenumber", oid) } ?: mapOf())
                         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -606,7 +606,41 @@ class FakeRatko(port: Int) {
             )
     }
 
+    fun rejectsRouteNumberCreationWithError(oid: String, code: String, message: String) {
+        doesNotHaveRouteNumber(oid)
+        post("/api/infra/v1.0/routenumbers", mapOf("id" to oid)).respond(errorJson(code, message))
+    }
+
+    fun rejectsLocationTrackCreationWithError(oid: String, code: String, message: String) {
+        doesNotHaveLocationTrack(oid)
+        post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(errorJson(code, message))
+    }
+
+    fun rejectsSwitchCreationWithError(oid: String, code: String, message: String) {
+        doesNotHaveSwitch(oid)
+        post("/api/assets/v1.2", mapOf("type" to "turnout", "id" to oid)).respond(errorJson(code, message))
+    }
+
+    fun rejectsPlanCreationWithError(code: String, message: String) {
+        post("/api/plan/v1.0/plans").respond(errorJson(code, message))
+    }
+
+    fun respondsWithMalformedBodyForRouteNumberCreation(oid: String) {
+        doesNotHaveRouteNumber(oid)
+        post("/api/infra/v1.0/routenumbers", mapOf("id" to oid))
+            .respond(
+                HttpResponse.response("{not valid json}")
+                    .withStatusCode(200)
+                    .withContentType(MediaType.APPLICATION_JSON)
+            )
+    }
+
     private fun ok() = HttpResponse.response().withStatusCode(200)
+
+    private fun errorJson(code: String, message: String) =
+        HttpResponse.response(jsonMapper.writeValueAsString(mapOf("code" to code, "message" to message)))
+            .withStatusCode(400)
+            .withContentType(MediaType.APPLICATION_JSON)
 
     private fun notFoundJson(body: Any) =
         HttpResponse.response(jsonMapper.writeValueAsString(body))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/FakeRatko.kt
@@ -19,7 +19,6 @@ import fi.fta.geoviite.infra.ratko.model.IncomingRatkoPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetGeometry
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetLocation
 import fi.fta.geoviite.infra.ratko.model.RatkoAssetProperty
-import fi.fta.geoviite.infra.ratko.model.RatkoAssetType
 import fi.fta.geoviite.infra.ratko.model.RatkoCrs
 import fi.fta.geoviite.infra.ratko.model.RatkoGeometryType
 import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrack
@@ -34,6 +33,7 @@ import fi.fta.geoviite.infra.ratko.model.RatkoPlan
 import fi.fta.geoviite.infra.ratko.model.RatkoPlanItem
 import fi.fta.geoviite.infra.ratko.model.RatkoPoint
 import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumber
+import fi.fta.geoviite.infra.ratko.model.RatkoSwitchAssetType
 import fi.fta.geoviite.infra.split.BulkTransfer
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
@@ -118,7 +118,7 @@ class FakeRatko(port: Int) {
         post("/api/infra/v1.0/points/${oid}").respond(ok())
         patch("/api/infra/v1.1/points/${oid}").respond(ok())
         post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
-        post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -141,7 +141,7 @@ class FakeRatko(port: Int) {
 
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
         patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
-        post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -164,7 +164,7 @@ class FakeRatko(port: Int) {
             .respond(ok())
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
         patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
-        post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -194,7 +194,7 @@ class FakeRatko(port: Int) {
             )
             .respond(ok())
         patch("/api/infra/v1.1/points/${oid}").respond(ok())
-        post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -228,7 +228,7 @@ class FakeRatko(port: Int) {
         post("/api/infra/v1.0/points/${oid}", times = Times.exactly(0)).respond(ok())
         patch("/api/infra/v1.1/points/${oid}", times = Times.exactly(0)).respond(ok())
         post("/api/infra/v1.0/locationtracks", mapOf("id" to oid)).respond(okJson(mapOf("id" to oid)))
-        post("/api/assets/v1.2", mapOf("type" to RatkoAssetType.METADATA.value))
+        post("/api/assets/v1.2", mapOf("type" to RatkoSwitchAssetType.METADATA.value))
             .respond(okJson(listOf(mapOf("id" to oid))))
     }
 
@@ -368,7 +368,7 @@ class FakeRatko(port: Int) {
                     .withMethod("POST")
                     .withBody(
                         JsonBody.json(
-                            mapOf("type" to RatkoAssetType.METADATA.value) +
+                            mapOf("type" to RatkoSwitchAssetType.METADATA.value) +
                                 (locationTrackOid?.let { oid -> metadataFilterOn("locationtrack", oid) } ?: mapOf()) +
                                 (routeNumberOid?.let { oid -> metadataFilterOn("routenumber", oid) } ?: mapOf())
                         )
@@ -551,27 +551,59 @@ class FakeRatko(port: Int) {
 
     fun doesNotHaveRouteNumber(oid: String) {
         get("/api/locations/v1.1/routenumber/$oid")
-            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Route number couldn't be found with the external id [$oid]")))
+            .respond(
+                notFoundJson(
+                    mapOf(
+                        "code" to "NOT_FOUND",
+                        "message" to "Route number couldn't be found with the external id [$oid]",
+                    )
+                )
+            )
     }
 
     fun doesNotHaveLocationTrack(oid: String) {
         get("/api/locations/v1.1/locationtracks/$oid")
-            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Location track couldn't be found with the external id [$oid]")))
+            .respond(
+                notFoundJson(
+                    mapOf(
+                        "code" to "NOT_FOUND",
+                        "message" to "Location track couldn't be found with the external id [$oid]",
+                    )
+                )
+            )
     }
 
     fun doesNotHaveSwitch(oid: String) {
         get("/api/assets/v1.2/$oid")
-            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Switch couldn't be found with the external id [$oid]")))
+            .respond(
+                notFoundJson(
+                    mapOf("code" to "NOT_FOUND", "message" to "Switch couldn't be found with the external id [$oid]")
+                )
+            )
     }
 
     fun doesNotHaveLocationTrackPoints(oid: String, km: String) {
         delete("/api/infra/v1.0/points/$oid/$km")
-            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Points couldn't be found for location track [$oid] at km [$km]")))
+            .respond(
+                notFoundJson(
+                    mapOf(
+                        "code" to "NOT_FOUND",
+                        "message" to "Points couldn't be found for location track [$oid] at km [$km]",
+                    )
+                )
+            )
     }
 
     fun doesNotHaveRouteNumberPoints(oid: String, km: String) {
         delete("/api/infra/v1.0/routenumber/points/$oid/$km")
-            .respond(notFoundJson(mapOf("code" to "NOT_FOUND", "message" to "Points couldn't be found for route number [$oid] at km [$km]")))
+            .respond(
+                notFoundJson(
+                    mapOf(
+                        "code" to "NOT_FOUND",
+                        "message" to "Points couldn't be found for route number [$oid] at km [$km]",
+                    )
+                )
+            )
     }
 
     private fun ok() = HttpResponse.response().withStatusCode(200)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoClientIT.kt
@@ -74,7 +74,7 @@ constructor(
         fakeRatko.hasSwitch(ratkoSwitch(oid))
         val layoutSwitch = switch(draft = false)
         val basicUpdateSwitch = createRatkoBasicUpdateSwitch(layoutSwitch, oid)
-        ratkoClient.updateAssetProperties(RatkoOid(oid), basicUpdateSwitch.properties)
+        ratkoClient.updateSwitchProperties(RatkoOid(oid), basicUpdateSwitch.properties)
     }
 
     private fun createRatkoBasicUpdateSwitch(layoutSwitch: LayoutSwitch, oid: String): RatkoSwitchAsset {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
@@ -4,12 +4,13 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
+import fi.fta.geoviite.infra.common.Oid
 import fi.fta.geoviite.infra.integration.CalculatedChanges
 import fi.fta.geoviite.infra.integration.DirectChanges
 import fi.fta.geoviite.infra.integration.IndirectChanges
 import fi.fta.geoviite.infra.integration.LocationTrackChange
-import fi.fta.geoviite.infra.integration.RatkoAssetType
 import fi.fta.geoviite.infra.integration.RatkoOperation
+import fi.fta.geoviite.infra.integration.RatkoPushAssetError
 import fi.fta.geoviite.infra.integration.RatkoPushErrorType
 import fi.fta.geoviite.infra.integration.RatkoPushStatus
 import fi.fta.geoviite.infra.integration.SwitchChange
@@ -32,16 +33,16 @@ import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.publishedVersions
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getInstantOrNull
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -56,6 +57,7 @@ constructor(
     lateinit var trackNumberId: IntId<LayoutTrackNumber>
     lateinit var publicationId: IntId<Publication>
     lateinit var locationTrackId: IntId<LocationTrack>
+    lateinit var locationTrackOid: Oid<LocationTrack>
     lateinit var publicationMoment: Instant
 
     @BeforeEach
@@ -77,6 +79,7 @@ constructor(
         trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
         val locationTrackResponse = insertAndPublishLocationTrack()
         locationTrackId = locationTrackResponse.id
+        locationTrackOid = mainOfficialContext.generateOid(locationTrackId)
         val beforePublish = ratkoPushDao.getLatestPublicationMoment()
         publicationId = createPublication(locationTracks = listOf(Change(null, locationTrackResponse)))
         publicationMoment = publicationDao.getPublication(publicationId).publicationTime
@@ -246,16 +249,16 @@ constructor(
         ratkoPushDao.insertRatkoPushError(
             ratkoPushId,
             RatkoPushErrorType.PROPERTIES,
-            RatkoOperation.UPDATE,
-            RatkoAssetType.LOCATION_TRACK,
-            locationTrackId,
+            "test error message",
+            operation = RatkoOperation.UPDATE,
+            target = RatkoPushTargetLocationTrack(locationTrackOid),
         )
         ratkoPushDao.updatePushStatus(ratkoPushId, status = RatkoPushStatus.FAILED)
         val ratkoPushError = ratkoPushDao.getCurrentRatkoPushError()
 
         assertNotNull(ratkoPushError)
-        assertEquals(locationTrackId, ratkoPushError.first.assetId)
-        assertEquals(RatkoOperation.UPDATE, ratkoPushError.first.operation)
+        assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetId)
+        assertEquals(RatkoOperation.UPDATE, (ratkoPushError.first as RatkoPushAssetError<*>).operation)
         assertEquals(publicationId, ratkoPushError.second)
     }
 
@@ -265,9 +268,9 @@ constructor(
         ratkoPushDao.insertRatkoPushError(
             ratkoPushId,
             RatkoPushErrorType.PROPERTIES,
-            RatkoOperation.UPDATE,
-            RatkoAssetType.LOCATION_TRACK,
-            locationTrackId,
+            "test error message",
+            operation = RatkoOperation.UPDATE,
+            target = RatkoPushTargetLocationTrack(locationTrackOid),
         )
         ratkoPushDao.updatePushStatus(ratkoPushId, status = RatkoPushStatus.FAILED)
         val locationTrackResponse = insertAndPublishLocationTrack()
@@ -277,8 +280,8 @@ constructor(
         val ratkoPushError = ratkoPushDao.getCurrentRatkoPushError()
 
         assertNotNull(ratkoPushError)
-        assertEquals(locationTrackId, ratkoPushError.first.assetId)
-        assertEquals(RatkoOperation.UPDATE, ratkoPushError.first.operation)
+        assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetId)
+        assertEquals(RatkoOperation.UPDATE, (ratkoPushError.first as RatkoPushAssetError<*>).operation)
         assertEquals(publicationId, ratkoPushError.second)
     }
 
@@ -288,9 +291,9 @@ constructor(
         ratkoPushDao.insertRatkoPushError(
             ratkoPushId,
             RatkoPushErrorType.PROPERTIES,
-            RatkoOperation.UPDATE,
-            RatkoAssetType.LOCATION_TRACK,
-            locationTrackId,
+            "test error message",
+            operation = RatkoOperation.UPDATE,
+            target = RatkoPushTargetLocationTrack(locationTrackOid),
         )
         ratkoPushDao.updatePushStatus(ratkoPushId, status = RatkoPushStatus.FAILED)
         val locationTrackResponse = insertAndPublishLocationTrack()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
@@ -257,7 +257,7 @@ constructor(
         val ratkoPushError = ratkoPushDao.getCurrentRatkoPushError()
 
         assertNotNull(ratkoPushError)
-        assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetId)
+        assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetRef.id)
         assertEquals(RatkoOperation.UPDATE, (ratkoPushError.first as RatkoPushAssetError<*>).operation)
         assertEquals(publicationId, ratkoPushError.second)
     }
@@ -280,7 +280,7 @@ constructor(
         val ratkoPushError = ratkoPushDao.getCurrentRatkoPushError()
 
         assertNotNull(ratkoPushError)
-        assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetId)
+        assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetRef.id)
         assertEquals(RatkoOperation.UPDATE, (ratkoPushError.first as RatkoPushAssetError<*>).operation)
         assertEquals(publicationId, ratkoPushError.second)
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
@@ -250,6 +250,7 @@ constructor(
             ratkoPushId,
             RatkoPushErrorType.PROPERTIES,
             "test error message",
+            ratkoStatus = "RATKO_FAIL",
             operation = RatkoOperation.UPDATE,
             target = RatkoPushTargetLocationTrack(locationTrackOid),
         )
@@ -260,6 +261,8 @@ constructor(
         assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetRef.id)
         assertEquals(RatkoOperation.UPDATE, (ratkoPushError.first as RatkoPushAssetError<*>).operation)
         assertEquals(publicationId, ratkoPushError.second)
+        assertEquals("test error message", ratkoPushError.first.technicalMessage)
+        assertEquals("RATKO_FAIL", ratkoPushError.first.ratkoStatusCode)
     }
 
     @Test
@@ -269,6 +272,7 @@ constructor(
             ratkoPushId,
             RatkoPushErrorType.PROPERTIES,
             "test error message",
+            ratkoStatus = "RATKO_FAIL",
             operation = RatkoOperation.UPDATE,
             target = RatkoPushTargetLocationTrack(locationTrackOid),
         )
@@ -283,6 +287,8 @@ constructor(
         assertEquals(locationTrackId, (ratkoPushError.first as RatkoPushAssetError<*>).assetRef.id)
         assertEquals(RatkoOperation.UPDATE, (ratkoPushError.first as RatkoPushAssetError<*>).operation)
         assertEquals(publicationId, ratkoPushError.second)
+        assertEquals("test error message", ratkoPushError.first.technicalMessage)
+        assertEquals("RATKO_FAIL", ratkoPushError.first.ratkoStatusCode)
     }
 
     @Test
@@ -301,9 +307,7 @@ constructor(
 
         val ratkoPushId2 = ratkoPushDao.startPushing(listOf(publicationId2))
         ratkoPushDao.updatePushStatus(ratkoPushId2, status = RatkoPushStatus.SUCCESSFUL)
-        val ratkoPushError = ratkoPushDao.getCurrentRatkoPushError()
-
-        assertNull(ratkoPushError)
+        assertNull(ratkoPushDao.getCurrentRatkoPushError())
     }
 
     fun insertAndPublishLocationTrack(): LayoutRowVersion<LocationTrack> =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -21,6 +21,10 @@ import fi.fta.geoviite.infra.geometry.geometryAlignment
 import fi.fta.geoviite.infra.geometry.lineFromOrigin
 import fi.fta.geoviite.infra.geometry.plan
 import fi.fta.geoviite.infra.inframodel.InfraModelFile
+import fi.fta.geoviite.infra.integration.RatkoAssetType
+import fi.fta.geoviite.infra.integration.RatkoPushAssetError
+import fi.fta.geoviite.infra.integration.RatkoPushErrorType
+import fi.fta.geoviite.infra.integration.RatkoPushGeneralError
 import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
@@ -132,7 +136,9 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
 import java.time.LocalDate
+import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
@@ -165,6 +171,7 @@ constructor(
     val layoutDesignDao: LayoutDesignDao,
     val publicationTestSupportService: PublicationTestSupportService,
     val ratkoTestService: RatkoTestService,
+    val ratkoPushDao: RatkoPushDao,
 ) : DBTestBase() {
 
     @BeforeEach
@@ -2588,6 +2595,111 @@ constructor(
                     .map { edge -> layoutContext.save(locationTrack(trackNumberId), trackGeometry(edge)) }
                     .map { version -> version.id },
         )
+    }
+
+    @Test
+    fun `unexpected exception during push is stored as INTERNAL error`() {
+        val (trackNumberId, trackNumberOid) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineVersion = insertReferenceLineFor(trackNumberId, draft = true)
+
+        fakeRatko.respondsWithMalformedBodyForRouteNumberCreation(trackNumberOid.toString())
+
+        runCatching {
+            publishAndPush(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineVersion.id))
+        }
+
+        val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
+        assertIs<RatkoPushGeneralError>(error)
+        assertEquals(RatkoPushErrorType.INTERNAL, error.errorType)
+        assertNull(error.ratkoStatusCode)
+    }
+
+    @Test
+    fun `RatkoException during push is stored with ratko-provided message and no asset ref`() {
+        val design = testDBService.createDesignBranch()
+        fakeRatko.rejectsPlanCreationWithError("PLAN_ERROR", "Plan creation failed in Ratko")
+        publicationService.publishManualPublication(design, publicationRequest(message = ""))
+        runCatching { ratkoService.pushChangesToRatko(design) }
+
+        val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
+        assertIs<RatkoPushGeneralError>(error)
+        assertEquals("Plan creation failed in Ratko", error.technicalMessage)
+        assertEquals("PLAN_ERROR", error.ratkoStatusCode)
+    }
+
+    @Test
+    fun `RatkoAssetPushException during track number push is stored with correct ref`() {
+        val (trackNumberId, trackNumberOid) =
+            mainDraftContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
+        val referenceLineVersion = insertReferenceLineFor(trackNumberId, draft = true)
+
+        fakeRatko.rejectsRouteNumberCreationWithError(trackNumberOid.toString(), "TN_ERROR", "Track number push failed")
+
+        runCatching {
+            publishAndPush(trackNumbers = listOf(trackNumberId), referenceLines = listOf(referenceLineVersion.id))
+        }
+
+        val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
+        assertIs<RatkoPushAssetError<*>>(error)
+        assertEquals(RatkoAssetType.TRACK_NUMBER, error.assetRef.type)
+        assertEquals(trackNumberId, error.assetRef.id)
+        assertEquals(trackNumberOid, error.assetRef.oid)
+        assertEquals("Track number push failed", error.technicalMessage)
+        assertEquals("TN_ERROR", error.ratkoStatusCode)
+    }
+
+    @Test
+    fun `RatkoAssetPushException during location track push is stored with correct ref`() {
+        val trackNumber = establishedTrackNumber()
+        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        testDBService.generateOid(switch.id, LayoutBranch.main)
+        val throughTrackOid = testDBService.generateOid(throughTrack.id, LayoutBranch.main)
+        val branchingTrackOid = testDBService.generateOid(branchingTrack.id, LayoutBranch.main)
+
+        fakeRatko.rejectsLocationTrackCreationWithError(
+            throughTrackOid.toString(),
+            "LT_ERROR",
+            "Location track push failed",
+        )
+        fakeRatko.doesNotHaveLocationTrack(branchingTrackOid.toString())
+
+        runCatching {
+            publishAndPush(locationTracks = listOf(throughTrack.id, branchingTrack.id), switches = listOf(switch.id))
+        }
+
+        val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
+        assertIs<RatkoPushAssetError<*>>(error)
+        assertEquals(RatkoAssetType.LOCATION_TRACK, error.assetRef.type)
+        assertEquals(throughTrack.id, error.assetRef.id)
+        assertEquals(throughTrackOid, error.assetRef.oid)
+        assertEquals("Location track push failed", error.technicalMessage)
+        assertEquals("LT_ERROR", error.ratkoStatusCode)
+    }
+
+    @Test
+    fun `RatkoAssetPushException during switch push is stored with correct ref`() {
+        val trackNumber = establishedTrackNumber()
+        val (switch, throughTrack, branchingTrack) = setupDraftSwitchAndLocationTracks(trackNumber.id)
+        val switchOid = testDBService.generateOid(switch.id, LayoutBranch.main)
+        val throughTrackOid = testDBService.generateOid(throughTrack.id, LayoutBranch.main)
+        val branchingTrackOid = testDBService.generateOid(branchingTrack.id, LayoutBranch.main)
+
+        fakeRatko.acceptsNewLocationTrackGivingItOid(throughTrackOid.toString())
+        fakeRatko.acceptsNewLocationTrackGivingItOid(branchingTrackOid.toString())
+        fakeRatko.rejectsSwitchCreationWithError(switchOid.toString(), "SW_ERROR", "Switch push failed")
+
+        runCatching {
+            publishAndPush(locationTracks = listOf(throughTrack.id, branchingTrack.id), switches = listOf(switch.id))
+        }
+
+        val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
+        assertIs<RatkoPushAssetError<*>>(error)
+        assertEquals(RatkoAssetType.SWITCH, error.assetRef.type)
+        assertEquals(switch.id, error.assetRef.id)
+        assertEquals(switchOid, error.assetRef.oid)
+        assertEquals("Switch push failed", error.technicalMessage)
+        assertEquals("SW_ERROR", error.ratkoStatusCode)
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/TestRatkoAsset.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/TestRatkoAsset.kt
@@ -1,6 +1,24 @@
 package fi.fta.geoviite.infra.ratko
 
-import fi.fta.geoviite.infra.ratko.model.*
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetGeomAccuracyType
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetGeometryType
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetLocation
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetProperty
+import fi.fta.geoviite.infra.ratko.model.RatkoAssetState
+import fi.fta.geoviite.infra.ratko.model.RatkoCrs
+import fi.fta.geoviite.infra.ratko.model.RatkoGeometryType
+import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrackState
+import fi.fta.geoviite.infra.ratko.model.RatkoLocationTrackType
+import fi.fta.geoviite.infra.ratko.model.RatkoMetadata
+import fi.fta.geoviite.infra.ratko.model.RatkoNodeType
+import fi.fta.geoviite.infra.ratko.model.RatkoNodesType
+import fi.fta.geoviite.infra.ratko.model.RatkoOid
+import fi.fta.geoviite.infra.ratko.model.RatkoPointState
+import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumberState
+import fi.fta.geoviite.infra.ratko.model.RatkoRouteNumberStateType
+import fi.fta.geoviite.infra.ratko.model.RatkoTopologicalConnectivityType
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
 
 /*
 Shadow clones of the parts of Ratko's API that we actually use, in the specific form that Ratko sends them, which can
@@ -20,8 +38,8 @@ data class InterfaceRatkoPoint(
     val geometry: InterfaceRatkoGeometry?,
     val state: RatkoPointState?,
     val rowMetadata: RatkoMetadata? = null,
-    val locationtrack: RatkoOid<RatkoLocationTrack>? = null,
-    val routenumber: RatkoOid<RatkoRouteNumber>? = null,
+    val locationtrack: RatkoOid<LocationTrack>? = null,
+    val routenumber: RatkoOid<LayoutTrackNumber>? = null,
 )
 
 data class InterfaceRatkoNode(val nodeType: RatkoNodeType, val point: InterfaceRatkoPoint)
@@ -42,7 +60,7 @@ data class InterfaceRatkoLocationTrack(
     val id: String,
     val name: String,
     val description: String,
-    val routenumber: RatkoOid<RatkoRouteNumber>?,
+    val routenumber: RatkoOid<LayoutTrackNumber>?,
     val nodecollection: InterfaceRatkoNodes,
     val type: RatkoLocationTrackType,
     val state: RatkoLocationTrackState,
@@ -75,7 +93,7 @@ fun ratkoLocationTrack(
     id: String,
     name: String = "trackname-$id",
     description: String = "description",
-    routenumber: RatkoOid<RatkoRouteNumber> = RatkoOid("1.2.3.4.5"),
+    routenumber: RatkoOid<LayoutTrackNumber> = RatkoOid("1.2.3.4.5"),
     nodecollection: InterfaceRatkoNodes = InterfaceRatkoNodes(listOf(), RatkoNodesType.POINT),
     type: RatkoLocationTrackType = RatkoLocationTrackType.MAIN,
     state: RatkoLocationTrackState = RatkoLocationTrackState.IN_USE,

--- a/ui/src/common/common-model.ts
+++ b/ui/src/common/common-model.ts
@@ -64,6 +64,17 @@ const draftMainContext: LayoutContext = Object.freeze({
     branch: 'MAIN',
 });
 
+export const officialContext = (branch: LayoutBranch): LayoutContext => {
+    if (branch === 'MAIN') {
+        return officialMainContext;
+    } else {
+        return {
+            publicationState: 'DRAFT',
+            branch: branch,
+        };
+    }
+};
+
 export const officialMainLayoutContext = (): LayoutContext => officialMainContext;
 export const draftMainLayoutContext = (): LayoutContext => draftMainContext;
 

--- a/ui/src/publication/card/main-publication-card.tsx
+++ b/ui/src/publication/card/main-publication-card.tsx
@@ -209,7 +209,9 @@ const MainPublicationCard: React.FC<MainPublicationCardProps> = ({
                         {currentRatkoPushError && (
                             <RatkoPushErrorDetails
                                 error={currentRatkoPushError.error}
-                                failedPublication={currentRatkoPushError.publication}
+                                failedPublication={allPublications.find(
+                                    (p) => p.id === currentRatkoPushError.publicationId,
+                                )}
                             />
                         )}
                         <MainPublicationList publications={nonSuccesses} />

--- a/ui/src/publication/card/main-publication-card.tsx
+++ b/ui/src/publication/card/main-publication-card.tsx
@@ -206,11 +206,11 @@ const MainPublicationCard: React.FC<MainPublicationCardProps> = ({
                 )}
                 {nonSuccesses.length > 0 && (
                     <PublicationCardSection title={t('publication-card.waiting')}>
-                        {currentRatkoPushError && (
+                        {latestFailures.length > 0 && (
                             <RatkoPushErrorDetails
-                                error={currentRatkoPushError.error}
+                                error={currentRatkoPushError?.error}
                                 failedPublication={allPublications.find(
-                                    (p) => p.id === currentRatkoPushError.publicationId,
+                                    (p) => p.id === currentRatkoPushError?.publicationId,
                                 )}
                             />
                         )}

--- a/ui/src/ratko/ratko-api.ts
+++ b/ui/src/ratko/ratko-api.ts
@@ -1,8 +1,9 @@
 import { API_URI, getNonNullAdt, getNullable, postNullable } from 'api/api-fetch';
-import { LayoutBranchType, PublicationDetails } from 'publication/publication-model';
+import { LayoutBranchType } from 'publication/publication-model';
 import { RatkoPushError } from 'ratko/ratko-model';
 import { LocationTrackId } from 'track-layout/track-layout-model';
 import { KmNumber } from 'common/common-model';
+import { PublicationId } from 'publication/publication-model';
 
 const RATKO_URI = `${API_URI}/ratko`;
 
@@ -43,7 +44,7 @@ export function pushLocationTracksToRatko(locationTrackChanges: LocationTrackCha
 
 type RatkoPushErrorAndPublication = {
     error: RatkoPushError;
-    publication: PublicationDetails;
+    publicationId: PublicationId;
 };
 
 export const getCurrentPublicationFailure = async () =>

--- a/ui/src/ratko/ratko-model.ts
+++ b/ui/src/ratko/ratko-model.ts
@@ -1,7 +1,7 @@
 import {
-    LayoutLocationTrack,
-    LayoutSwitch,
-    LayoutTrackNumber,
+    LayoutSwitchId,
+    LayoutTrackNumberId,
+    LocationTrackId,
 } from 'track-layout/track-layout-model';
 
 export enum RatkoPushStatus {
@@ -40,29 +40,23 @@ export type RatkoPushErrorId = string;
 
 export type RatkoPushId = string;
 
-export type RatkoPushError = {
+type RatkoPushErrorBase = {
     id: RatkoPushErrorId;
     ratkoPushId: RatkoPushId;
     errorType: RatkoPushErrorType;
-    operation: RatkoPushErrorOperation;
-} & RatkoPushErrorAsset;
+    ratkoStatusCode: string | null;
+    technicalMessage: string;
+};
 
 export type RatkoPushErrorAsset =
-    | RatkoPushErrorTrackNumber
-    | RatkoPushErrorLocationTrack
-    | RatkoPushErrorSwitch;
+    | { assetType: RatkoAssetType.LOCATION_TRACK; assetId: LocationTrackId; operation: RatkoPushErrorOperation }
+    | { assetType: RatkoAssetType.TRACK_NUMBER; assetId: LayoutTrackNumberId; operation: RatkoPushErrorOperation }
+    | { assetType: RatkoAssetType.SWITCH; assetId: LayoutSwitchId; operation: RatkoPushErrorOperation };
 
-type RatkoPushErrorLocationTrack = {
-    assetType: RatkoAssetType.LOCATION_TRACK;
-    asset: LayoutLocationTrack;
-};
+export type RatkoPushAssetError = RatkoPushErrorBase & RatkoPushErrorAsset;
 
-type RatkoPushErrorTrackNumber = {
-    assetType: RatkoAssetType.TRACK_NUMBER;
-    asset: LayoutTrackNumber;
-};
+export type RatkoPushError = RatkoPushErrorBase | RatkoPushAssetError;
 
-type RatkoPushErrorSwitch = {
-    assetType: RatkoAssetType.SWITCH;
-    asset: LayoutSwitch;
-};
+export function isAssetError(error: RatkoPushError): error is RatkoPushAssetError {
+    return 'assetType' in error;
+}

--- a/ui/src/ratko/ratko-model.ts
+++ b/ui/src/ratko/ratko-model.ts
@@ -36,6 +36,26 @@ export enum RatkoAssetType {
     SWITCH = 'SWITCH',
 }
 
+export type RatkoLocationTrackRef = {
+    type: RatkoAssetType.LOCATION_TRACK;
+    id: LocationTrackId;
+    oid?: string;
+};
+
+export type RatkoTrackNumberRef = {
+    type: RatkoAssetType.TRACK_NUMBER;
+    id: LayoutTrackNumberId;
+    oid?: string;
+};
+
+export type RatkoSwitchRef = {
+    type: RatkoAssetType.SWITCH;
+    id: LayoutSwitchId;
+    oid?: string;
+};
+
+export type RatkoAssetRef = RatkoLocationTrackRef | RatkoTrackNumberRef | RatkoSwitchRef;
+
 export type RatkoPushErrorId = string;
 
 export type RatkoPushId = string;
@@ -44,19 +64,17 @@ type RatkoPushErrorBase = {
     id: RatkoPushErrorId;
     ratkoPushId: RatkoPushId;
     errorType: RatkoPushErrorType;
-    ratkoStatusCode: string | null;
+    ratkoStatusCode?: string;
     technicalMessage: string;
 };
 
-export type RatkoPushErrorAsset =
-    | { assetType: RatkoAssetType.LOCATION_TRACK; assetId: LocationTrackId; operation: RatkoPushErrorOperation }
-    | { assetType: RatkoAssetType.TRACK_NUMBER; assetId: LayoutTrackNumberId; operation: RatkoPushErrorOperation }
-    | { assetType: RatkoAssetType.SWITCH; assetId: LayoutSwitchId; operation: RatkoPushErrorOperation };
-
-export type RatkoPushAssetError = RatkoPushErrorBase & RatkoPushErrorAsset;
+export type RatkoPushAssetError = RatkoPushErrorBase & {
+    operation: RatkoPushErrorOperation;
+    assetRef: RatkoAssetRef;
+};
 
 export type RatkoPushError = RatkoPushErrorBase | RatkoPushAssetError;
 
 export function isAssetError(error: RatkoPushError): error is RatkoPushAssetError {
-    return 'assetType' in error;
+    return 'assetRef' in error;
 }

--- a/ui/src/ratko/ratko-push-error.scss
+++ b/ui/src/ratko/ratko-push-error.scss
@@ -11,4 +11,11 @@
         font-weight: 600;
         margin-right: 2px;
     }
+
+    &__technical-message {
+        font-size: 0.85em;
+        opacity: 0.85;
+        margin-top: 4px;
+        word-break: break-word;
+    }
 }

--- a/ui/src/ratko/ratko-push-error.scss
+++ b/ui/src/ratko/ratko-push-error.scss
@@ -13,8 +13,8 @@
     }
 
     &__technical-message {
-        font-size: 0.85em;
-        opacity: 0.85;
+        font-size: 10px;
+        color: vayla-design.$color-red-darker;
         margin-top: 4px;
         word-break: break-word;
     }

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -62,7 +62,7 @@ function useAssetName(assetRef: RatkoAssetRef | undefined): string | undefined {
 
 function formatAssetLabel(name: string | undefined, oid: string | undefined): string | undefined {
     if (name === undefined) return undefined;
-    return oid ? `${name} (${oid})` : name;
+    return oid ? `${name}, OID ${oid}` : name;
 }
 
 export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -2,20 +2,20 @@ import * as React from 'react';
 import { PublicationDetails } from 'publication/publication-model';
 import styles from 'ratko/ratko-push-error.scss';
 import { useTranslation } from 'react-i18next';
-import {
-    isAssetError,
-    RatkoAssetRef,
-    RatkoAssetType,
-    RatkoPushError,
-} from 'ratko/ratko-model';
+import { isAssetError, RatkoAssetRef, RatkoAssetType, RatkoPushError } from 'ratko/ratko-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
-import { useLayoutDesign, useLocationTrack, useSwitch, useTrackNumber } from 'track-layout/track-layout-react-utils';
+import {
+    useLayoutDesign,
+    useLocationTrack,
+    useSwitch,
+    useTrackNumber,
+} from 'track-layout/track-layout-react-utils';
 import { getChangeTimes } from 'common/change-time-api';
 import { useEnvironmentInfo } from 'environment/environment-info';
 import { officialMainLayoutContext } from 'common/common-model';
 
 type RatkoPushErrorDetailsProps = {
-    error: RatkoPushError;
+    error: RatkoPushError | undefined;
     failedPublication: PublicationDetails | undefined;
 };
 
@@ -77,9 +77,13 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
         failedPublication?.layoutBranch.branch ?? 'MAIN',
     )?.name;
 
-    const errorAsset = isAssetError(error) ? error : undefined;
+    const errorAsset = error && isAssetError(error) ? error : undefined;
     const assetName = useAssetName(errorAsset?.assetRef);
     const assetLabel = formatAssetLabel(assetName, errorAsset?.assetRef.oid);
+
+    if (!error) {
+        return <div className={styles['ratko-push-error']}>Ratkovienti epäonnistui</div>;
+    }
 
     const isConnectionIssue = failedPublication?.ratkoPushStatus === 'CONNECTION_ISSUE';
     const isInternalError = error.errorType === 'INTERNAL';
@@ -114,15 +118,32 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
 
     const pushErrorString = (): string => {
         if (isConnectionIssue) return t('publication-card.push-error.connection-issue');
-        else if (isInternalError) return internalErrorString ?? t('publication-card.push-error.general-internal-error');
-        else if (isFetchError) return ratkoFetchErrorString ?? '';
-        else return ratkoErrorString ?? '';
+        if (isInternalError) {
+            return (
+                internalErrorString ??
+                t('publication-card.push-error.general-internal-error', {
+                    geoviiteSupportEmail: environmentInfo?.geoviiteSupportEmailAddress,
+                })
+            );
+        }
+        if (isFetchError)
+            return ratkoFetchErrorString ?? t('publication-card.push-error.general-error');
+        return ratkoErrorString ?? t('publication-card.push-error.general-error');
     };
+
+    const technicalDetails = error.ratkoStatusCode
+        ? `[${error.ratkoStatusCode}] ${error.technicalMessage}`
+        : error.technicalMessage;
 
     return (
         <div className={styles['ratko-push-error']}>
-            {design && <span className={styles['ratko-push-error__design-name']}>{design}: </span>}
-            {pushErrorString()}
+            <div>
+                {design && (
+                    <span className={styles['ratko-push-error__design-name']}>{design}: </span>
+                )}
+                {pushErrorString()}
+            </div>
+            <div className={styles['ratko-push-error__technical-message']}>{technicalDetails}</div>
         </div>
     );
 };

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -4,9 +4,9 @@ import styles from 'ratko/ratko-push-error.scss';
 import { useTranslation } from 'react-i18next';
 import {
     isAssetError,
+    RatkoAssetRef,
     RatkoAssetType,
     RatkoPushError,
-    RatkoPushErrorAsset,
 } from 'ratko/ratko-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { useLayoutDesign, useLocationTrack, useSwitch, useTrackNumber } from 'track-layout/track-layout-react-utils';
@@ -32,23 +32,23 @@ const assetTranslationKeyByType = (assetType: RatkoAssetType) => {
     }
 };
 
-function useAssetName(errorAsset: RatkoPushErrorAsset | undefined): string | undefined {
+function useAssetName(assetRef: RatkoAssetRef | undefined): string | undefined {
     const context = officialMainLayoutContext();
     const locationTrack = useLocationTrack(
-        errorAsset?.assetType === RatkoAssetType.LOCATION_TRACK ? errorAsset.assetId : undefined,
+        assetRef?.type === RatkoAssetType.LOCATION_TRACK ? assetRef.id : undefined,
         context,
     );
     const layoutSwitch = useSwitch(
-        errorAsset?.assetType === RatkoAssetType.SWITCH ? errorAsset.assetId : undefined,
+        assetRef?.type === RatkoAssetType.SWITCH ? assetRef.id : undefined,
         context,
     );
     const trackNumber = useTrackNumber(
-        errorAsset?.assetType === RatkoAssetType.TRACK_NUMBER ? errorAsset.assetId : undefined,
+        assetRef?.type === RatkoAssetType.TRACK_NUMBER ? assetRef.id : undefined,
         context,
     );
 
-    if (!errorAsset) return undefined;
-    switch (errorAsset.assetType) {
+    if (!assetRef) return undefined;
+    switch (assetRef.type) {
         case RatkoAssetType.LOCATION_TRACK:
             return locationTrack?.name;
         case RatkoAssetType.SWITCH:
@@ -56,8 +56,13 @@ function useAssetName(errorAsset: RatkoPushErrorAsset | undefined): string | und
         case RatkoAssetType.TRACK_NUMBER:
             return trackNumber?.number;
         default:
-            return exhaustiveMatchingGuard(errorAsset);
+            return exhaustiveMatchingGuard(assetRef);
     }
+}
+
+function formatAssetLabel(name: string | undefined, oid: string | undefined): string | undefined {
+    if (name === undefined) return undefined;
+    return oid ? `${name} (${oid})` : name;
 }
 
 export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
@@ -73,7 +78,8 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
     )?.name;
 
     const errorAsset = isAssetError(error) ? error : undefined;
-    const assetName = useAssetName(errorAsset);
+    const assetName = useAssetName(errorAsset?.assetRef);
+    const assetLabel = formatAssetLabel(assetName, errorAsset?.assetRef.oid);
 
     const isConnectionIssue = failedPublication?.ratkoPushStatus === 'CONNECTION_ISSUE';
     const isInternalError = error.errorType === 'INTERNAL';
@@ -82,26 +88,26 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
     const ratkoFetchErrorString =
         errorAsset &&
         t('publication-card.push-error.ratko-fetch-error', {
-            assetType: t(assetTranslationKeyByType(errorAsset.assetType)),
-            name: assetName,
+            assetType: t(assetTranslationKeyByType(errorAsset.assetRef.type)),
+            name: assetLabel,
             operation: t(`enum.RatkoPushErrorOperation.${errorAsset.operation}`),
         });
 
     const ratkoErrorString =
         errorAsset &&
         t('publication-card.push-error.ratko-error', {
-            assetType: t(assetTranslationKeyByType(errorAsset.assetType)),
+            assetType: t(assetTranslationKeyByType(errorAsset.assetRef.type)),
             errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
-            name: assetName,
+            name: assetLabel,
             operation: t(`enum.RatkoPushErrorOperation.${errorAsset.operation}`),
         });
 
     const internalErrorString =
         errorAsset &&
         t('publication-card.push-error.internal-error', {
-            assetType: t(assetTranslationKeyByType(errorAsset.assetType)),
+            assetType: t(assetTranslationKeyByType(errorAsset.assetRef.type)),
             errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
-            name: assetName,
+            name: assetLabel,
             operation: t(`enum.RatkoPushErrorOperation.${errorAsset.operation}`),
             geoviiteSupportEmail: environmentInfo?.geoviiteSupportEmailAddress,
         });

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -2,19 +2,25 @@ import * as React from 'react';
 import { PublicationDetails } from 'publication/publication-model';
 import styles from 'ratko/ratko-push-error.scss';
 import { useTranslation } from 'react-i18next';
-import { RatkoAssetType, RatkoPushError, RatkoPushErrorAsset } from 'ratko/ratko-model';
+import {
+    isAssetError,
+    RatkoAssetType,
+    RatkoPushError,
+    RatkoPushErrorAsset,
+} from 'ratko/ratko-model';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
-import { useLayoutDesign } from 'track-layout/track-layout-react-utils';
+import { useLayoutDesign, useLocationTrack, useSwitch, useTrackNumber } from 'track-layout/track-layout-react-utils';
 import { getChangeTimes } from 'common/change-time-api';
 import { useEnvironmentInfo } from 'environment/environment-info';
+import { officialMainLayoutContext } from 'common/common-model';
 
 type RatkoPushErrorDetailsProps = {
     error: RatkoPushError;
-    failedPublication: PublicationDetails;
+    failedPublication: PublicationDetails | undefined;
 };
 
-const assetTranslationKeyByType = (errorAsset: RatkoPushErrorAsset) => {
-    switch (errorAsset.assetType) {
+const assetTranslationKeyByType = (assetType: RatkoAssetType) => {
+    switch (assetType) {
         case RatkoAssetType.LOCATION_TRACK:
             return `publication-card.push-error.location-track`;
         case RatkoAssetType.TRACK_NUMBER:
@@ -22,21 +28,37 @@ const assetTranslationKeyByType = (errorAsset: RatkoPushErrorAsset) => {
         case RatkoAssetType.SWITCH:
             return `publication-card.push-error.switch`;
         default:
-            return exhaustiveMatchingGuard(errorAsset);
+            return exhaustiveMatchingGuard(assetType);
     }
 };
 
-const assetNameByType = (errorAsset: RatkoPushErrorAsset) => {
+function useAssetName(errorAsset: RatkoPushErrorAsset | undefined): string | undefined {
+    const context = officialMainLayoutContext();
+    const locationTrack = useLocationTrack(
+        errorAsset?.assetType === RatkoAssetType.LOCATION_TRACK ? errorAsset.assetId : undefined,
+        context,
+    );
+    const layoutSwitch = useSwitch(
+        errorAsset?.assetType === RatkoAssetType.SWITCH ? errorAsset.assetId : undefined,
+        context,
+    );
+    const trackNumber = useTrackNumber(
+        errorAsset?.assetType === RatkoAssetType.TRACK_NUMBER ? errorAsset.assetId : undefined,
+        context,
+    );
+
+    if (!errorAsset) return undefined;
     switch (errorAsset.assetType) {
         case RatkoAssetType.LOCATION_TRACK:
+            return locationTrack?.name;
         case RatkoAssetType.SWITCH:
-            return errorAsset.asset.name;
+            return layoutSwitch?.name;
         case RatkoAssetType.TRACK_NUMBER:
-            return errorAsset.asset.number;
+            return trackNumber?.number;
         default:
             return exhaustiveMatchingGuard(errorAsset);
     }
-};
+}
 
 export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
     error,
@@ -47,39 +69,48 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
 
     const design = useLayoutDesign(
         getChangeTimes().layoutDesign,
-        failedPublication.layoutBranch.branch,
+        failedPublication?.layoutBranch.branch ?? 'MAIN',
     )?.name;
 
-    const isConnectionIssue = failedPublication.ratkoPushStatus === 'CONNECTION_ISSUE';
+    const errorAsset = isAssetError(error) ? error : undefined;
+    const assetName = useAssetName(errorAsset);
+
+    const isConnectionIssue = failedPublication?.ratkoPushStatus === 'CONNECTION_ISSUE';
     const isInternalError = error.errorType === 'INTERNAL';
-    const isFetchError = error.operation === 'FETCH_EXISTING';
+    const isFetchError = errorAsset?.operation === 'FETCH_EXISTING';
 
-    const ratkoFetchErrorString = t('publication-card.push-error.ratko-fetch-error', {
-        assetType: t(assetTranslationKeyByType(error)),
-        name: assetNameByType(error),
-        operation: t(`enum.RatkoPushErrorOperation.${error.operation}`),
-    });
+    const ratkoFetchErrorString =
+        errorAsset &&
+        t('publication-card.push-error.ratko-fetch-error', {
+            assetType: t(assetTranslationKeyByType(errorAsset.assetType)),
+            name: assetName,
+            operation: t(`enum.RatkoPushErrorOperation.${errorAsset.operation}`),
+        });
 
-    const ratkoErrorString = t('publication-card.push-error.ratko-error', {
-        assetType: t(assetTranslationKeyByType(error)),
-        errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
-        name: assetNameByType(error),
-        operation: t(`enum.RatkoPushErrorOperation.${error.operation}`),
-    });
+    const ratkoErrorString =
+        errorAsset &&
+        t('publication-card.push-error.ratko-error', {
+            assetType: t(assetTranslationKeyByType(errorAsset.assetType)),
+            errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
+            name: assetName,
+            operation: t(`enum.RatkoPushErrorOperation.${errorAsset.operation}`),
+        });
 
-    const internalErrorString = t('publication-card.push-error.internal-error', {
-        assetType: t(assetTranslationKeyByType(error)),
-        errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
-        name: assetNameByType(error),
-        operation: t(`enum.RatkoPushErrorOperation.${error.operation}`),
-        geoviiteSupportEmail: environmentInfo?.geoviiteSupportEmailAddress,
-    });
+    const internalErrorString =
+        errorAsset &&
+        t('publication-card.push-error.internal-error', {
+            assetType: t(assetTranslationKeyByType(errorAsset.assetType)),
+            errorType: t(`enum.RatkoPushErrorType.${error.errorType}`),
+            name: assetName,
+            operation: t(`enum.RatkoPushErrorOperation.${errorAsset.operation}`),
+            geoviiteSupportEmail: environmentInfo?.geoviiteSupportEmailAddress,
+        });
 
     const pushErrorString = (): string => {
-        if (isConnectionIssue) return 'publication-card.push-error.connection-issue';
-        else if (isInternalError) return internalErrorString;
-        else if (isFetchError) return ratkoFetchErrorString;
-        else return ratkoErrorString;
+        if (isConnectionIssue) return t('publication-card.push-error.connection-issue');
+        else if (isInternalError) return internalErrorString ?? t('publication-card.push-error.general-internal-error');
+        else if (isFetchError) return ratkoFetchErrorString ?? '';
+        else return ratkoErrorString ?? '';
     };
 
     return (

--- a/ui/src/ratko/ratko-push-error.tsx
+++ b/ui/src/ratko/ratko-push-error.tsx
@@ -12,7 +12,7 @@ import {
 } from 'track-layout/track-layout-react-utils';
 import { getChangeTimes } from 'common/change-time-api';
 import { useEnvironmentInfo } from 'environment/environment-info';
-import { officialMainLayoutContext } from 'common/common-model';
+import { LayoutBranch, officialContext } from 'common/common-model';
 
 type RatkoPushErrorDetailsProps = {
     error: RatkoPushError | undefined;
@@ -32,8 +32,8 @@ const assetTranslationKeyByType = (assetType: RatkoAssetType) => {
     }
 };
 
-function useAssetName(assetRef: RatkoAssetRef | undefined): string | undefined {
-    const context = officialMainLayoutContext();
+function useAssetName(assetRef: RatkoAssetRef, branch: LayoutBranch): string | undefined {
+    const context = officialContext(branch);
     const locationTrack = useLocationTrack(
         assetRef?.type === RatkoAssetType.LOCATION_TRACK ? assetRef.id : undefined,
         context,
@@ -47,8 +47,9 @@ function useAssetName(assetRef: RatkoAssetRef | undefined): string | undefined {
         context,
     );
 
-    if (!assetRef) return undefined;
-    switch (assetRef.type) {
+    switch (assetRef?.type) {
+        case undefined:
+            return undefined;
         case RatkoAssetType.LOCATION_TRACK:
             return locationTrack?.name;
         case RatkoAssetType.SWITCH:
@@ -61,8 +62,10 @@ function useAssetName(assetRef: RatkoAssetRef | undefined): string | undefined {
 }
 
 function formatAssetLabel(name: string | undefined, oid: string | undefined): string | undefined {
-    if (name === undefined) return undefined;
-    return oid ? `${name}, OID ${oid}` : name;
+    if (name === undefined && oid === undefined) return undefined;
+    else if (name === undefined) return `OID ${oid}`;
+    else if (oid === undefined) return name;
+    else return `${name}, OID ${oid}`;
 }
 
 export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
@@ -72,17 +75,19 @@ export const RatkoPushErrorDetails: React.FC<RatkoPushErrorDetailsProps> = ({
     const { t } = useTranslation();
     const environmentInfo = useEnvironmentInfo();
 
-    const design = useLayoutDesign(
-        getChangeTimes().layoutDesign,
-        failedPublication?.layoutBranch.branch ?? 'MAIN',
-    )?.name;
+    const branch = failedPublication?.layoutBranch.branch ?? 'MAIN';
+    const design = useLayoutDesign(getChangeTimes().layoutDesign, branch)?.name;
 
     const errorAsset = error && isAssetError(error) ? error : undefined;
-    const assetName = useAssetName(errorAsset?.assetRef);
+    const assetName = errorAsset ? useAssetName(errorAsset.assetRef, branch) : undefined;
     const assetLabel = formatAssetLabel(assetName, errorAsset?.assetRef.oid);
 
     if (!error) {
-        return <div className={styles['ratko-push-error']}>Ratkovienti epäonnistui</div>;
+        return (
+            <div className={styles['ratko-push-error']}>
+                {t('publication-card.push-error.general-error')}
+            </div>
+        );
     }
 
     const isConnectionIssue = failedPublication?.ratkoPushStatus === 'CONNECTION_ISSUE';


### PR DESCRIPTION
Sori taas megapullarista. Meinasin jo lähteä hajoittamaan tätä osiksi jälkikäteen mutta taitaisi vain lisätä virheen riskiä kun joutuisi tietyt jutut tekemään moneen otteeseen.

- UI ei enää hajoa jos rakopusku on epäonnistunut mutta sille ei ole kannassa virhettä. Näytetään default kovakoodattu virhe.
- Jos ratkopusku merkataan epäonnistuneeksi niin sille tallennetaan virhe kantaan (ylempi edelleen mukana koska tämä ei korjaa historiaa + ainahan voi jotain tapahtua). Lisätty mm. jumittuneen puskun putsaukseen sekä yleiseen "jotain lensi" failureen.
- Ratko failureista tallennetaan kantaan hiukan enemmän dataa, tärkeimpänä OID sekä ratkon mahdollisesti palauttama virhekoodi + viesti. Nämä näytetään myös UI:lla
- Yleisesti siistitty try-catch-rethrow:t pois ja sen sijaan napattaan kaikki poikkeukset puskun ylätasolla

Samalla tullutta refakkia ympäri ratko-koodia
- Poikkeuksen täytetietojen (operaatio, oid, jne) mukaan mahduttaminen tapahtuu nyt client-tasolla ja tämä vaati vähän jumppaa. Erityisesti poikkeukseen laitetaan nyt vain OID ja se resolvataan id:ksi kantaan tallennuksessa.
- RatkoOid-tyyppien sisäinen tyypitys on nyt geoviitteen olionimillä eikä ratkon. Tämä mahdollistaa tyyppiturvalliset mappaukset Oid <-> RatkoOid ja on muutenkin simppelimpää.
- Virheiden kysely backarista palauttaa nyt vain id-dataa niinkuin muissakin apeissa. Frontti hakekoon julkaisun/oliot (cachen läpi tarvittaessa).
- Virheiden tyyppihierarkiat puljattu niin että niiden sisällöt ei ole vain flatteja nullable-listoja