### PR TITLE
GVT-3619: Estetään raiteen jakaminen jos jokin raiteeseen liittyvä vaihde on osa aiempaa julkaisematonta jakoa

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -450,6 +450,18 @@ class SplitService(
             switchLinkingService.getTrackSwitchSuggestions(branch.draft, sourceTrack).let(::verifySwitchSuggestions)
         val relinkedSwitches = switchLinkingService.relinkTrack(branch, request.sourceTrackId).map { it.id }
 
+        val existingSplitsWithSwitches = findUnpublishedSplits(branch, switchIds = relinkedSwitches)
+        if (existingSplitsWithSwitches.isNotEmpty()) {
+            val conflictingSwitchIds = relinkedSwitches.filter { switchId ->
+                existingSplitsWithSwitches.any { split -> split.containsSwitch(switchId) }
+            }
+            throw SplitFailureException(
+                message = "Switches already part of an unpublished split: $conflictingSwitchIds",
+                localizedMessageKey = "switches-in-unpublished-split",
+                localizationParams = localizationParams("switchIds" to conflictingSwitchIds.map { it.intValue }),
+            )
+        }
+
         // Fetch post-re-linking track & alignment
         val (track, geometry) = locationTrackService.getWithGeometryOrThrow(branch.draft, request.sourceTrackId)
         val targetResults =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -310,6 +310,7 @@ data class LocationTrackInfoboxSwitch(
     val switchId: IntId<LayoutSwitch>,
     val location: Point,
     val displayAddress: TrackMeter?,
+    val partOfUnfinishedSplit: Boolean,
 )
 
 data class LocationTrackInfoboxOperationalPoint(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -500,8 +500,8 @@ class LocationTrackService(
             val startSplitPoint = createSplitPoint(start, startSwitchLink?.id, START, geocodingContext)
             val endSplitPoint = createSplitPoint(end, endSwitchLink?.id, END, geocodingContext)
 
-            val unfinishedSplits =
-                splitDao.getUnfinishedSplitsContainingLocationTracks(layoutContext.branch, listOf(id))
+            val allUnfinishedSplits = splitDao.fetchUnfinishedSplits(layoutContext.branch)
+            val unfinishedSplits = allUnfinishedSplits.filter { split -> split.containsLocationTrack(id) }
 
             val partOfSplit =
                 when {
@@ -514,15 +514,16 @@ class LocationTrackService(
             val switches =
                 geometry.trackSwitchLinks
                     .groupBy { link -> link.switchId }
-                    .mapValues { (id, links) ->
+                    .mapValues { (switchId, links) ->
                         val location = links.minBy { it.jointRole }.location.toPoint()
                         LocationTrackInfoboxSwitch(
-                            id,
+                            switchId,
                             location,
                             geocodingContext
                                 ?.getAddress(location)
                                 ?.takeIf { (_, intersectType) -> intersectType == IntersectType.WITHIN }
                                 ?.first,
+                            partOfUnfinishedSplit = allUnfinishedSplits.any { split -> split.containsSwitch(switchId) },
                         )
                     }
                     .values

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -523,7 +523,10 @@ class LocationTrackService(
                                 ?.getAddress(location)
                                 ?.takeIf { (_, intersectType) -> intersectType == IntersectType.WITHIN }
                                 ?.first,
-                            partOfUnfinishedSplit = allUnfinishedSplits.any { split -> split.containsSwitch(switchId) },
+                            partOfUnfinishedSplit =
+                                allUnfinishedSplits
+                                    .filter { split -> split.publicationId == null }
+                                    .any { split -> split.containsSwitch(switchId) },
                         )
                     }
                     .values

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -77,7 +77,8 @@
             "no-switch-suggestion": "Jakamista ei voitu suorittaa, koska uudelleenlinkityksen vaihde-ehdotusten muodostus epäonnistui",
             "geocoding-failed": "Jakamista ei voitu suorittaa, koska jaettavan raiteen {{trackName}} geokoodaus epäonnistui",
             "new-duplicate-reference-assignment-failed": "Jakamista ei voitu suorittaa, koska käyttämättömälle duplikaattiraiteelle {{duplicate}} ei löydetty päällekkäisyyttä jakamisen seurauksena syntyvistä raiteista",
-            "partial-revert": "Raiteen jakamista ei voi peruuttaa osittain"
+            "partial-revert": "Raiteen jakamista ei voi peruuttaa osittain",
+            "switches-in-unpublished-split": "Jaettavan raiteen vaihteita on osana muita julkaisemattomia raiteen jakamisiskokonaisuuksia"
         },
         "publication": {
             "generic": "Julkaisu epäonnistui",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -991,7 +991,7 @@
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä",
                     "branch-not-main": "Raiteita voi jakaa vain luonnostilassa",
-                    "switches-part-of-other-splits": "Osa raiteen vaihteista on mukana julkaisemattomissa raiteiden jakamisissa."
+                    "switches-part-of-other-splits": "Osa raiteen vaihteista on mukana raiteen jakamiskokonaisuuksissa joita ei ole vielä julkaistu."
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
                 "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -990,7 +990,8 @@
                     "publish-duplicate": "Julkaise tai hylkää duplikaattiraiteen muutokset ja yritä jakamista sitten uudestaan.",
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä",
-                    "branch-not-main": "Raiteita voi jakaa vain luonnostilassa"
+                    "branch-not-main": "Raiteita voi jakaa vain luonnostilassa",
+                    "switches-part-of-other-splits": "Osa raiteen vaihteista on mukana julkaisemattomissa raiteiden jakamisissa."
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
                 "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -78,7 +78,7 @@
             "geocoding-failed": "Jakamista ei voitu suorittaa, koska jaettavan raiteen {{trackName}} geokoodaus epäonnistui",
             "new-duplicate-reference-assignment-failed": "Jakamista ei voitu suorittaa, koska käyttämättömälle duplikaattiraiteelle {{duplicate}} ei löydetty päällekkäisyyttä jakamisen seurauksena syntyvistä raiteista",
             "partial-revert": "Raiteen jakamista ei voi peruuttaa osittain",
-            "switches-in-unpublished-split": "Jaettavan raiteen vaihteita on osana muita julkaisemattomia raiteen jakamisiskokonaisuuksia"
+            "switches-in-unpublished-split": "Jaettavan raiteen vaihteita on osana muita julkaisemattomia raiteen jakamiskokonaisuuksia"
         },
         "publication": {
             "generic": "Julkaisu epäonnistui",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -29,12 +29,14 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.verticalEdge
+import fi.fta.geoviite.infra.error.SplitFailureException
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -432,6 +434,95 @@ constructor(
             splitResult.targetLocationTracks[3].locationTrackId,
             unusedDuplicateWithFlippedPartialOverlap.duplicateOf,
         )
+    }
+
+    @Test
+    fun `split should fail when a switch is already part of an unpublished split`() {
+        val preEdge = verticalEdge(Point(0.0, 0.0), 3)
+
+        val (switch1, straightEdges1, turningEdges1) =
+            splitTestDataService.createSwitchAndGeometry(preEdge.lastSegmentEnd)
+        mainOfficialContext.createLocationTrack(trackGeometry(turningEdges1))
+
+        val edge1To2 = verticalEdge(straightEdges1.last().lastSegmentEnd, 2)
+
+        val (switch2, straightEdges2, turningEdges2) =
+            splitTestDataService.createSwitchAndGeometry(edge1To2.lastSegmentEnd)
+        mainOfficialContext.createLocationTrack(trackGeometry(turningEdges2))
+
+        val postEdge = verticalEdge(straightEdges2.last().lastSegmentEnd, 4)
+        val track =
+            mainOfficialContext.createLocationTrackWithReferenceLine(
+                trackGeometry(combineEdges(listOf(preEdge) + straightEdges1 + edge1To2 + straightEdges2 + postEdge))
+            )
+
+        // Create an existing unpublished split that contains switch1
+        val otherTrack = mainOfficialContext.save(
+            locationTrack(mainOfficialContext.createLayoutTrackNumber().id),
+            trackGeometryOfSegments(segment(Point(200.0, 0.0), Point(210.0, 0.0))),
+        )
+        splitDao.saveSplit(
+            otherTrack,
+            listOf(SplitTarget(otherTrack.id, 0..0, SplitTargetOperation.CREATE)),
+            listOf(switch1.id),
+            updatedDuplicates = emptyList(),
+        )
+
+        // Splitting the track should fail because switch1 is in an existing unpublished split
+        val request = splitRequest(
+            track.id,
+            targetRequest(null, "part1"),
+            targetRequest(switch1.id, "part2"),
+            targetRequest(switch2.id, "part3"),
+        )
+        assertThrows<SplitFailureException> {
+            splitService.split(LayoutBranch.main, request)
+        }
+    }
+
+    @Test
+    fun `split should succeed when a switch is part of an already published split`() {
+        val preEdge = verticalEdge(Point(0.0, 0.0), 3)
+
+        val (switch1, straightEdges1, turningEdges1) =
+            splitTestDataService.createSwitchAndGeometry(preEdge.lastSegmentEnd)
+        mainOfficialContext.createLocationTrack(trackGeometry(turningEdges1))
+
+        val edge1To2 = verticalEdge(straightEdges1.last().lastSegmentEnd, 2)
+
+        val (switch2, straightEdges2, turningEdges2) =
+            splitTestDataService.createSwitchAndGeometry(edge1To2.lastSegmentEnd)
+        mainOfficialContext.createLocationTrack(trackGeometry(turningEdges2))
+
+        val postEdge = verticalEdge(straightEdges2.last().lastSegmentEnd, 4)
+        val track =
+            mainOfficialContext.createLocationTrackWithReferenceLine(
+                trackGeometry(combineEdges(listOf(preEdge) + straightEdges1 + edge1To2 + straightEdges2 + postEdge))
+            )
+
+        // Create an existing split that contains switch1, but mark it as published
+        val otherTrack = mainOfficialContext.save(
+            locationTrack(mainOfficialContext.createLayoutTrackNumber().id),
+            trackGeometryOfSegments(segment(Point(200.0, 0.0), Point(210.0, 0.0))),
+        )
+        val existingSplitId = splitDao.saveSplit(
+            otherTrack,
+            listOf(SplitTarget(otherTrack.id, 0..0, SplitTargetOperation.CREATE)),
+            listOf(switch1.id),
+            updatedDuplicates = emptyList(),
+        )
+        val publicationId = testDBService.createPublication()
+        splitDao.updateSplit(existingSplitId, publicationId = publicationId, sourceTrackVersion = otherTrack)
+
+        // Splitting should succeed because the existing split is already published
+        val request = splitRequest(
+            track.id,
+            targetRequest(null, "part1"),
+            targetRequest(switch1.id, "part2"),
+            targetRequest(switch2.id, "part3"),
+        )
+        val result = splitDao.getOrThrow(splitService.split(LayoutBranch.main, request))
+        assertSplitMatchesRequest(request, result)
     }
 
     private fun getYvStructure(): SwitchStructure =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -24,6 +24,7 @@ import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1284,12 +1284,7 @@ constructor(
         val trackVersion =
             mainOfficialContext.save(
                 locationTrack(trackNumberId),
-                trackGeometry(
-                    edge(
-                        listOf(segment(point1, point2)),
-                        startInnerSwitch = switchLinkYV(switchId, 1),
-                    )
-                ),
+                trackGeometry(edge(listOf(segment(point1, point2)), startInnerSwitch = switchLinkYV(switchId, 1))),
             )
 
         // Before any split, switch should not be part of unfinished split
@@ -1300,30 +1295,32 @@ constructor(
             assertFalse(s!!.partOfUnfinishedSplit)
         }
 
-        // Create a different location track and an unfinished split for it, with the switch as relinked
-        val otherTrackVersion = mainOfficialContext.save(
-            locationTrack(trackNumberId),
-            trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
-        )
-        val targetTrackVersion = mainDraftContext.save(
-            locationTrack(trackNumberId),
-            trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
-        )
+        val otherTrackVersion =
+            mainOfficialContext.save(
+                locationTrack(trackNumberId),
+                trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
+            )
+        val targetTrackVersion =
+            mainDraftContext.save(
+                locationTrack(trackNumberId),
+                trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
+            )
 
-        val splitId = splitDao.saveSplit(
-            otherTrackVersion,
-            listOf(
-                fi.fta.geoviite.infra.split.SplitTarget(
-                    targetTrackVersion.id,
-                    0..0,
-                    fi.fta.geoviite.infra.split.SplitTargetOperation.CREATE,
-                )
-            ),
-            listOf(switchId),
-            updatedDuplicates = emptyList(),
-        )
+        val splitId =
+            splitDao.saveSplit(
+                otherTrackVersion,
+                listOf(
+                    fi.fta.geoviite.infra.split.SplitTarget(
+                        targetTrackVersion.id,
+                        0..0,
+                        fi.fta.geoviite.infra.split.SplitTargetOperation.CREATE,
+                    )
+                ),
+                listOf(switchId),
+                updatedDuplicates = emptyList(),
+            )
 
-        // After split, switch should be part of unfinished split (on a different track)
+        // Switch should now be a part of an unfinished split
         locationTrackService.getInfoboxExtras(MainLayoutContext.official, trackVersion.id).also { extras ->
             assertNotNull(extras)
             val s = extras!!.switches.find { it.switchId == switchId }
@@ -1331,11 +1328,10 @@ constructor(
             assertTrue(s!!.partOfUnfinishedSplit)
         }
 
-        // Publish the split target and mark split as finished (simulates full publish + bulk transfer)
-        publish(targetTrackVersion.id)
-        splitDao.updateSplit(splitId, bulkTransferState = fi.fta.geoviite.infra.split.BulkTransferState.DONE)
+        // Mark the split as published, switch should no longer be a part of an unfinished split after that
+        val publicationId = testDBService.createPublication()
+        splitDao.updateSplit(splitId, publicationId = publicationId, sourceTrackVersion = otherTrackVersion)
 
-        // After split is finished, switch should no longer be part of unfinished split
         locationTrackService.getInfoboxExtras(MainLayoutContext.official, trackVersion.id).also { extras ->
             assertNotNull(extras)
             val s = extras!!.switches.find { it.switchId == switchId }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -1271,6 +1271,79 @@ constructor(
         }
     }
 
+    @Test
+    fun `getInfoboxExtras sets partOfUnfinishedSplit for switches in unfinished splits`() {
+        val trackNumberId = mainOfficialContext.createLayoutTrackNumber().id
+
+        val point1 = Point(0.0, 0.0)
+        val point2 = Point(10.0, 0.0)
+
+        val switchId =
+            mainOfficialContext.createSwitch(joints = listOf(switchJoint(1, point1), switchJoint(2, point2))).id
+
+        val trackVersion =
+            mainOfficialContext.save(
+                locationTrack(trackNumberId),
+                trackGeometry(
+                    edge(
+                        listOf(segment(point1, point2)),
+                        startInnerSwitch = switchLinkYV(switchId, 1),
+                    )
+                ),
+            )
+
+        // Before any split, switch should not be part of unfinished split
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, trackVersion.id).also { extras ->
+            assertNotNull(extras)
+            val s = extras!!.switches.find { it.switchId == switchId }
+            assertNotNull(s)
+            assertFalse(s!!.partOfUnfinishedSplit)
+        }
+
+        // Create a different location track and an unfinished split for it, with the switch as relinked
+        val otherTrackVersion = mainOfficialContext.save(
+            locationTrack(trackNumberId),
+            trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
+        )
+        val targetTrackVersion = mainDraftContext.save(
+            locationTrack(trackNumberId),
+            trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
+        )
+
+        val splitId = splitDao.saveSplit(
+            otherTrackVersion,
+            listOf(
+                fi.fta.geoviite.infra.split.SplitTarget(
+                    targetTrackVersion.id,
+                    0..0,
+                    fi.fta.geoviite.infra.split.SplitTargetOperation.CREATE,
+                )
+            ),
+            listOf(switchId),
+            updatedDuplicates = emptyList(),
+        )
+
+        // After split, switch should be part of unfinished split (on a different track)
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, trackVersion.id).also { extras ->
+            assertNotNull(extras)
+            val s = extras!!.switches.find { it.switchId == switchId }
+            assertNotNull(s)
+            assertTrue(s!!.partOfUnfinishedSplit)
+        }
+
+        // Publish the split target and mark split as finished (simulates full publish + bulk transfer)
+        publish(targetTrackVersion.id)
+        splitDao.updateSplit(splitId, bulkTransferState = fi.fta.geoviite.infra.split.BulkTransferState.DONE)
+
+        // After split is finished, switch should no longer be part of unfinished split
+        locationTrackService.getInfoboxExtras(MainLayoutContext.official, trackVersion.id).also { extras ->
+            assertNotNull(extras)
+            val s = extras!!.switches.find { it.switchId == switchId }
+            assertNotNull(s)
+            assertFalse(s!!.partOfUnfinishedSplit)
+        }
+    }
+
     private fun updateDraft(
         id: IntId<LocationTrack>,
         op: (LocationTrack, LocationTrackGeometry) -> Pair<LocationTrack, LocationTrackGeometry>,

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -172,6 +172,9 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     );
     const startAndEndAddressDefined =
         startAndEndPoints?.start?.address && startAndEndPoints?.end?.address;
+    const anySwitchesPartOfOtherSplits = extraInfo?.switches?.some(
+        (sw) => sw.partOfUnfinishedSplit,
+    );
 
     const getSplittingDisabledReasonsTranslated = () => {
         const reasons: string[] = [];
@@ -212,6 +215,11 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         if (!startAndEndAddressDefined) {
             reasons.push(
                 t('tool-panel.location-track.splitting.validation.unresolved-start-or-end-address'),
+            );
+        }
+        if (anySwitchesPartOfOtherSplits) {
+            reasons.push(
+                t('tool-panel.location-track.splitting.validation.switches-part-of-other-splits'),
             );
         }
 
@@ -384,6 +392,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         isPartOfUnfinishedSplit(extraInfo?.partOfSplit) ||
         startingSplitting ||
         !startAndEndAddressDefined ||
+        anySwitchesPartOfOtherSplits ||
         layoutContext.branch !== 'MAIN';
 
     return (

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -367,6 +367,7 @@ export type LocationTrackInfoboxSwitch = {
     switchId: LayoutSwitchId;
     location: Point;
     displayAddress?: TrackMeter;
+    partOfUnfinishedSplit: boolean;
 };
 
 export type LocationTrackInfoboxOperationalPoint = {


### PR DESCRIPTION
Alunperin heitin tämän idean ehdotuksena paikkaamaan sitä melko ikävää tilannetta, missä yksi vaihde voi olla yhtä aikaa useammassa splitissä. Käytännössä täällä tehty nyt seuraavat:

- Lisätty sijaintiraiteen extrainfoissa tuleviin vaihdetietoihin tieto siitä, että onko ka. vaihde osa splittiä jota ei ole vielä julkaistu.
  - Disabloidaan tämän tiedon perusteella splittauksen aloitusnappi raiteen sijaintitietoinfoboksista
  - Tehty tälle myös testit
- Lisätty takalaudaksi splitin tallentamiseen bäkkärille tarkastus, että mikään splitin vaihde ei varmasti ole osa toista julkaisematonta splittiä
  - Tämä siksi, että jos splittauskäliin on päässyt niin sinne en lähtenyt enää rakentamaan mitään disablointeja (toisaalta siellä on myös ihan ok kököttää siihen saakka kunnes aiempi splitti on saatu julkaistua -- sen jälkeen kälissä tehtävä splittaushan on taas ihan kurantti tallennettavaksi)
  - Lisätty tällekin testit