### PR TITLE
GVT-3126 Backend for track boundary changes

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
@@ -122,7 +122,7 @@ constructor(
             val trackNumberOid = oidLookup(trackNumberDao, branch, trackNumberId)
             BoundaryChangeData(
                 publication = publication,
-                type = ExtTrackBoundaryChangeTypeV1.SPLIT,
+                type = ExtTrackBoundaryChangeTypeV1.of(split.administrativeChangeType),
                 trackNumber = trackNumber,
                 trackNumberOid = trackNumberOid,
                 geocodingContext = geocodingContext,

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -291,12 +291,12 @@ enum class ExtAreaTypeV1(val value: String) {
 }
 
 const val FI_SPLIT = "raiteen_jakaminen"
-const val FI_BOUNDARY_SHIFT = "vaihtumiskohdan_siirto"
+const val FI_BOUNDARY_CHANGE = "vaihtumiskohdan_siirto"
 
-@Schema(name = "Hallinnollisen muutoksen tyyppi", type = "string", allowableValues = [FI_SPLIT, FI_BOUNDARY_SHIFT])
+@Schema(name = "Hallinnollisen muutoksen tyyppi", type = "string", allowableValues = [FI_SPLIT, FI_BOUNDARY_CHANGE])
 enum class ExtTrackBoundaryChangeTypeV1(val value: String) {
     SPLIT(FI_SPLIT),
-    BOUNDARY_SHIFT(FI_BOUNDARY_SHIFT);
+    BOUNDARY_CHANGE(FI_BOUNDARY_CHANGE);
 
     @JsonValue override fun toString() = value
 }
@@ -355,11 +355,7 @@ enum class ExtVerticalCoordinateSystemV1(val value: String) {
 const val FI_TOP_OF_SLEEPER = "Korkeusviiva"
 const val FI_TOP_OF_RAIL = "Kiskon selkä"
 
-@Schema(
-    name = "Korkeusaseman mittaustapa",
-    type = "string",
-    allowableValues = [FI_TOP_OF_SLEEPER, FI_TOP_OF_RAIL],
-)
+@Schema(name = "Korkeusaseman mittaustapa", type = "string", allowableValues = [FI_TOP_OF_SLEEPER, FI_TOP_OF_RAIL])
 enum class ExtElevationMeasurementMethodV1(val value: String) {
     TOP_OF_SLEEPER(FI_TOP_OF_SLEEPER),
     TOP_OF_RAIL(FI_TOP_OF_RAIL);

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -18,6 +18,7 @@ import fi.fta.geoviite.infra.geography.isKKJ
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
+import fi.fta.geoviite.infra.split.SplitAdministrativeChangeType
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.switchLibrary.SwitchHand
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostGkLocation
@@ -297,6 +298,14 @@ const val FI_BOUNDARY_CHANGE = "vaihtumiskohdan_siirto"
 enum class ExtTrackBoundaryChangeTypeV1(val value: String) {
     SPLIT(FI_SPLIT),
     BOUNDARY_CHANGE(FI_BOUNDARY_CHANGE);
+
+    companion object {
+        fun of(splitType: SplitAdministrativeChangeType) =
+            when (splitType) {
+                SplitAdministrativeChangeType.SPLIT -> SPLIT
+                SplitAdministrativeChangeType.BOUNDARY_CHANGE -> BOUNDARY_CHANGE
+            }
+    }
 
     @JsonValue override fun toString() = value
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.geometry.GeometryKmPost
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.Range
+import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostGkLocation
@@ -24,6 +25,8 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionStructure
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionSuffix
+import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameFreeTextPart
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameSpecifier
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameStructure
@@ -74,7 +77,13 @@ data class LocationTrackSaveRequest(
 
 enum class TrackEnd {
     START,
-    END,
+    END;
+
+    fun of(geometry: LocationTrackGeometry): AlignmentPoint<LocationTrackM>? =
+        when (this) {
+            START -> geometry.start
+            END -> geometry.end
+        }
 }
 
 data class TrackNumberSaveRequest(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -32,6 +32,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
 import fi.fta.geoviite.infra.split.Split
+import fi.fta.geoviite.infra.split.SplitAdministrativeChangeType
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
 import fi.fta.geoviite.infra.tracklayout.DesignAssetState
@@ -103,11 +104,11 @@ import fi.fta.geoviite.infra.util.getUicCodeOrNull
 import fi.fta.geoviite.infra.util.getUuid
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Timestamp
-import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -2580,6 +2581,7 @@ class PublicationDao(
     data class TrackBoundaryChange(
         val publicationId: IntId<Publication>,
         val segments: List<TrackBoundaryChangeSegment>,
+        val administrativeChangeType: SplitAdministrativeChangeType,
     ) {
         val allTrackIds = segments.flatMap { listOf(it.sourceTrackVersion.id, it.targetTrackVersion.id) }.toSet()
     }
@@ -2595,6 +2597,7 @@ class PublicationDao(
               split.source_location_track_id source_track_id,
               split.layout_context_id source_track_layout_context_id,
               split.source_location_track_version source_track_version,
+              split.administrative_change_type,
               target_track.id target_track_id,
               target_track.layout_context_id target_track_layout_context_id,
               target_track.version target_track_version,
@@ -2639,10 +2642,15 @@ class PublicationDao(
                         operation = rs.getEnum("operation"),
                     )
                 val publicationId = rs.getIntId<Publication>("publication_id")
-                publicationId to changeTarget
+                val administrativeChangeType = rs.getEnum<SplitAdministrativeChangeType>("administrative_change_type")
+                val split = publicationId to administrativeChangeType
+                split to changeTarget
             }
             .groupBy({ it.first }, { it.second })
-            .map { (publicationId, targets) -> TrackBoundaryChange(publicationId, targets) }
+            .map { (splitInfo, targets) ->
+                val (publicationId, administrativeChangeType) = splitInfo
+                TrackBoundaryChange(publicationId, targets, administrativeChangeType)
+            }
             .also { logger.daoAccess(FETCH, TrackBoundaryChange::class, it.map { it.publicationId }) }
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -178,3 +178,8 @@ data class SplitDuplicateTrack(
     val length: LineM<LocationTrackM>,
     val status: DuplicateStatus,
 )
+
+enum class SplitAdministrativeChangeType {
+    SPLIT,
+    BOUNDARY_CHANGE,
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -3,6 +3,7 @@ package fi.fta.geoviite.infra.split
 import com.fasterxml.jackson.annotation.JsonIgnore
 import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.LayoutValidationIssue
@@ -63,6 +64,7 @@ data class Split(
     val targetLocationTracks: List<SplitTarget>,
     val relinkedSwitches: List<IntId<LayoutSwitch>>,
     val updatedDuplicates: List<IntId<LocationTrack>>,
+    val administrativeChangeType: SplitAdministrativeChangeType,
 ) {
     init {
         if (publicationId != null) {
@@ -163,6 +165,13 @@ data class SplitRequest(val sourceTrackId: IntId<LocationTrack>, val targetTrack
         }
     }
 }
+
+data class TrackBoundaryChangeRequest(
+    val shortenedTrackId: IntId<LocationTrack>,
+    val lengthenedTrackId: IntId<LocationTrack>,
+    val switchId: IntId<LayoutSwitch>,
+    val jointNumber: JointNumber,
+)
 
 data class SplittingInitializationParameters(
     val id: IntId<LocationTrack>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitController.kt
@@ -41,4 +41,19 @@ class SplitController(private val splitService: SplitService) {
     ): IntId<Split> {
         return splitService.updateSplit(id, state).id
     }
+
+    @PreAuthorize(AUTH_EDIT_LAYOUT)
+    @PostMapping("/{$LAYOUT_BRANCH}/boundary-change")
+    fun saveTrackBoundaryChange(
+        @PathVariable(LAYOUT_BRANCH) branch: LayoutBranch,
+        @RequestBody request: TrackBoundaryChangeRequest,
+    ): IntId<Split> {
+        return splitService.saveTrackBoundaryChange(
+            branch,
+            request.shortenedTrackId,
+            request.lengthenedTrackId,
+            request.switchId,
+            request.jointNumber,
+        )
+    }
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -58,6 +58,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
         splitTargets: Collection<SplitTarget>,
         relinkedSwitches: Collection<IntId<LayoutSwitch>>,
         updatedDuplicates: Collection<IntId<LocationTrack>>,
+        administrativeChangeType: SplitAdministrativeChangeType,
     ): IntId<Split> {
         val sql =
             """
@@ -65,6 +66,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
               source_location_track_id,
               layout_context_id,
               source_location_track_version,
+              administrative_change_type,
               bulk_transfer_state,
               bulk_transfer_id,
               publication_id
@@ -73,6 +75,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
               :source_location_track_id,
               :layout_context_id,
               :source_location_track_version,
+              :administrative_change_type::publication.split_administrative_change_type,
               'PENDING',
               null,
               null
@@ -87,6 +90,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
                 "source_location_track_id" to sourceLocationTrackVersion.id.intValue,
                 "layout_context_id" to sourceLocationTrackVersion.context.toSqlString(),
                 "source_location_track_version" to sourceLocationTrackVersion.version,
+                "administrative_change_type" to administrativeChangeType.name,
             )
         val splitId =
             jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getIntId<Split>("id") }
@@ -109,9 +113,8 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             """
                 .trimIndent()
 
-        val params = relinkedSwitches.map { switchId ->
-            mapOf("splitId" to splitId.intValue, "switchId" to switchId.intValue)
-        }
+        val params =
+            relinkedSwitches.map { switchId -> mapOf("splitId" to splitId.intValue, "switchId" to switchId.intValue) }
 
         jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }
@@ -124,9 +127,10 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             """
                 .trimIndent()
 
-        val params = updatedDuplicates.map { duplicateId ->
-            mapOf("splitId" to splitId.intValue, "duplicateLocationTrackId" to duplicateId.intValue)
-        }
+        val params =
+            updatedDuplicates.map { duplicateId ->
+                mapOf("splitId" to splitId.intValue, "duplicateLocationTrackId" to duplicateId.intValue)
+            }
 
         jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }
@@ -161,15 +165,16 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
             """
                 .trimIndent()
 
-        val params = splitTargets.map { st ->
-            mapOf(
-                "splitId" to splitId.intValue,
-                "trackId" to st.locationTrackId.intValue,
-                "edgeStart" to st.edgeIndices.first,
-                "edgeEnd" to st.edgeIndices.last,
-                "operation" to st.operation.name,
-            )
-        }
+        val params =
+            splitTargets.map { st ->
+                mapOf(
+                    "splitId" to splitId.intValue,
+                    "trackId" to st.locationTrackId.intValue,
+                    "edgeStart" to st.edgeIndices.first,
+                    "edgeEnd" to st.edgeIndices.last,
+                    "operation" to st.operation.name,
+                )
+            }
 
         jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitDao.kt
@@ -46,6 +46,7 @@ private fun toSplit(rs: ResultSet, targetLocationTracks: List<SplitTarget>) =
         targetLocationTracks = targetLocationTracks,
         relinkedSwitches = rs.getIntIdArray("switch_ids"),
         updatedDuplicates = rs.getIntIdArray("updated_duplicate_ids"),
+        administrativeChangeType = rs.getEnum("administrative_change_type"),
     )
 
 @Transactional(readOnly = true)
@@ -196,6 +197,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
                 source_track.design_id as source_location_track_design_id,
                 source_track.draft as source_location_track_draft,
                 split.source_location_track_version,
+                split.administrative_change_type,
                 (select coalesce(array_agg(split_relinked_switch.switch_id), '{}')
                  from publication.split_relinked_switch where split.id = split_relinked_switch.split_id) as switch_ids,
                 (select coalesce(array_agg(split_updated_duplicate.duplicate_location_track_id), '{}')
@@ -330,6 +332,7 @@ class SplitDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTem
                 split.source_location_track_id,
                 ltv.design_id as source_location_track_design_id,
                 ltv.draft as source_location_track_draft,
+                split.administrative_change_type,
                 split.source_location_track_version
             from publication.split 
                 left join publication.publication on split.publication_id = publication.id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -14,9 +14,11 @@ import fi.fta.geoviite.infra.error.SplitFailureException
 import fi.fta.geoviite.infra.geocoding.AddressPoint
 import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
+import fi.fta.geoviite.infra.linking.TrackEnd
 import fi.fta.geoviite.infra.linking.switches.SuggestedSwitch
 import fi.fta.geoviite.infra.linking.switches.SwitchLinkingService
 import fi.fta.geoviite.infra.localization.localizationParams
+import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.publication.Publication
@@ -512,6 +514,43 @@ class SplitService(
                     SplitAdministrativeChangeType.SPLIT,
                 )
             }
+    }
+
+    @Transactional
+    fun saveTrackBoundaryChange(
+        layoutBranch: LayoutBranch,
+        shorteningTrackId: IntId<LocationTrack>,
+        lengtheningTrackId: IntId<LocationTrack>,
+        switch: IntId<LayoutSwitch>,
+        switchJoint: JointNumber,
+    ): IntId<Split> {
+        val context = layoutBranch.draft
+        val shorteningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, shorteningTrackId)
+        val lengtheningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, lengtheningTrackId)
+
+        val (shorteningTrack, shorteningTrackGeometry) = locationTrackService.getWithGeometry(shorteningTrackVersion)
+        val (lengtheningTrack, lengtheningTrackGeometry) = locationTrackService.getWithGeometry(lengtheningTrackVersion)
+        val geometries =
+            getTrackBoundaryChangeGeometry(
+                shorteningTrackGeometry = shorteningTrackGeometry,
+                lengtheningTrackGeometry = lengtheningTrackGeometry,
+                shorteningTrackId = shorteningTrackVersion.id,
+                lengtheningTrackId = lengtheningTrackVersion.id,
+                switch,
+                switchJoint,
+            )
+        locationTrackService.saveDraft(layoutBranch, shorteningTrack, geometries.shortenedGeometry)
+        locationTrackService.saveDraft(layoutBranch, lengtheningTrack, geometries.lengthenedGeometry)
+        return splitDao.saveSplit(
+            sourceLocationTrackVersion = shorteningTrackVersion,
+            splitTargets =
+                listOf(
+                    SplitTarget(lengtheningTrackVersion.id, geometries.movedEdgeRange, SplitTargetOperation.TRANSFER)
+                ),
+            relinkedSwitches = listOf(),
+            updatedDuplicates = listOf(),
+            administrativeChangeType = SplitAdministrativeChangeType.BOUNDARY_CHANGE,
+        )
     }
 
     private fun updateUnusedDuplicateReferencesToSplitTargetTracks(
@@ -1012,4 +1051,64 @@ fun getSplitTargetTrackStartAndEndAddresses(
     val endAddress = listOf(endBySegments, endByTarget).min()
 
     return startAddress to endAddress
+}
+
+private data class TrackBoundaryChangeGeometry(
+    val movedEdgeRange: IntRange,
+    val shortenedGeometry: TmpLocationTrackGeometry,
+    val lengthenedGeometry: TmpLocationTrackGeometry,
+)
+
+private fun getTrackBoundaryChangeGeometry(
+    shorteningTrackGeometry: LocationTrackGeometry,
+    lengtheningTrackGeometry: LocationTrackGeometry,
+    shorteningTrackId: IntId<LocationTrack>,
+    lengtheningTrackId: IntId<LocationTrack>,
+    switch: IntId<LayoutSwitch>,
+    switchJoint: JointNumber,
+): TrackBoundaryChangeGeometry {
+    val closestEnds =
+        listOf(
+                TrackEnd.START to TrackEnd.START,
+                TrackEnd.START to TrackEnd.END,
+                TrackEnd.END to TrackEnd.START,
+                TrackEnd.END to TrackEnd.END,
+            )
+            .minBy { (shorteningEnd, lengtheningEnd) ->
+                lineLength(
+                    requireNotNull(shorteningEnd.of(shorteningTrackGeometry)),
+                    requireNotNull(lengtheningEnd.of(lengtheningTrackGeometry)),
+                )
+            }
+    val shorteningEnd = closestEnds.first
+    val lengtheningEnd = closestEnds.second
+
+    val shorteningEndPoint = requireNotNull(shorteningEnd.of(shorteningTrackGeometry))
+    val lengtheningEndPoint = requireNotNull(lengtheningEnd.of(lengtheningTrackGeometry))
+    require(lineLength(shorteningEndPoint, lengtheningEndPoint) < 1.0) { "endpoints to move must be near each other" }
+    require(shorteningEnd != lengtheningEnd) { "can't extend location tracks with geometry going to opposing sides" }
+    val switchNodeIndex = shorteningTrackGeometry.nodes.indexOfFirst { n -> n.containsJoint(switch, switchJoint) }
+    require(switchNodeIndex >= 0) {
+        "track to shorten $shorteningTrackId must contain switch $switch joint $switchJoint"
+    }
+    val edgeRangeToMove =
+        if (shorteningEnd == TrackEnd.START) IntRange(0, switchNodeIndex - 1)
+        else IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+    val edgesToMove = shorteningTrackGeometry.edges.slice(edgeRangeToMove)
+    val remainingEdgeRange =
+        if (shorteningEnd == TrackEnd.START) IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+        else IntRange(0, switchNodeIndex - 1)
+    val lengthenedGeometry =
+        TmpLocationTrackGeometry.of(
+            if (lengtheningEnd == TrackEnd.START) edgesToMove + lengtheningTrackGeometry.edges
+            else lengtheningTrackGeometry.edges + edgesToMove,
+            lengtheningTrackId,
+        )
+    val shortenedGeometry =
+        TmpLocationTrackGeometry.of(shorteningTrackGeometry.edges.slice(remainingEdgeRange), shorteningTrackId)
+    return TrackBoundaryChangeGeometry(
+        movedEdgeRange = edgeRangeToMove,
+        lengthenedGeometry = lengthenedGeometry,
+        shortenedGeometry = shortenedGeometry,
+    )
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -195,9 +195,10 @@ class SplitService(
             candidates.locationTracks
                 .associate { version ->
                     val ltSplitIssues = validateSplitForLocationTrack(version.id, context)
-                    val contentIssues = splitIssues.mapNotNull { (split, error) ->
-                        if (split.containsLocationTrack(version.id)) error else null
-                    }
+                    val contentIssues =
+                        splitIssues.mapNotNull { (split, error) ->
+                            if (split.containsLocationTrack(version.id)) error else null
+                        }
                     version.id to (ltSplitIssues + contentIssues).distinct()
                 }
                 .filterValues { it.isNotEmpty() }
@@ -205,9 +206,9 @@ class SplitService(
         val switchSplitIssues =
             candidates.switches.associate { version ->
                 val switchIssues = validateSplitForSwitch(version.id, context)
-                val contentIssues = splitIssues.mapNotNull { (split, error) -> if (split.containsSwitch(version.id)) error else null }
+                val contentIssues =
+                    splitIssues.mapNotNull { (split, error) -> if (split.containsSwitch(version.id)) error else null }
                 version.id to (switchIssues + contentIssues).distinct()
-
             }
 
         return SplitLayoutValidationIssues(
@@ -257,9 +258,9 @@ class SplitService(
         context: ValidationContext,
     ): List<LayoutValidationIssue> {
         val switchInMultipleSplits = context.getUnfinishedSplits().count { split -> split.containsSwitch(switchId) } > 1
-        return listOf(validate(!switchInMultipleSplits, ERROR) { "$VALIDATION_SPLIT.switch-in-multiple-split" }).filterNotNull()
+        return listOf(validate(!switchInMultipleSplits, ERROR) { "$VALIDATION_SPLIT.switch-in-multiple-split" })
+            .filterNotNull()
     }
-
 
     private fun validateLocationTrackAbsence(
         trackId: IntId<LocationTrack>,
@@ -287,9 +288,11 @@ class SplitService(
         splits: List<Pair<Split, LocationTrack>>,
         track: LocationTrack,
     ): List<LayoutValidationIssue> {
-        val splitSourceLocationTrackErrors = splits.flatMap { (split, _) ->
-            if (split.sourceLocationTrackId == trackId) validateSplitSourceLocationTrack(track, split) else emptyList()
-        }
+        val splitSourceLocationTrackErrors =
+            splits.flatMap { (split, _) ->
+                if (split.sourceLocationTrackId == trackId) validateSplitSourceLocationTrack(track, split)
+                else emptyList()
+            }
 
         val statusErrors = splits.mapNotNull { (split, sourceTrack) -> validateSplitStatus(track, sourceTrack, split) }
 
@@ -302,9 +305,12 @@ class SplitService(
         // - Changes to the geocoding context are blocked for any tracks associated with a split
         val draftSplits = splits.filter { (split, _) -> split.publicationId == null }
 
-        val trackNumberMismatchErrors = draftSplits.mapNotNull { (split, sourceTrack) ->
-            produceIf(split.containsTargetTrack(trackId)) { validateTargetTrackNumberIsUnchanged(sourceTrack, track) }
-        }
+        val trackNumberMismatchErrors =
+            draftSplits.mapNotNull { (split, sourceTrack) ->
+                produceIf(split.containsTargetTrack(trackId)) {
+                    validateTargetTrackNumberIsUnchanged(sourceTrack, track)
+                }
+            }
 
         // Geometry error checking is skipped if the track numbers are different between any source
         // & target tracks,
@@ -331,24 +337,27 @@ class SplitService(
         // addresspoints in
         // the validation context (that is: draft target geometry is a subset of draft source
         // geometry)
-        val targetGeometryErrors = splits.mapNotNull { (split, sourceTrack) ->
-            split.getTargetLocationTrack(trackId)?.let { target ->
-                val (sourceAddresses, targetAddresses) = getTargetValidationAddressPoints(sourceTrack, target, context)
-                validateTargetGeometry(target.operation, targetAddresses, sourceAddresses)
+        val targetGeometryErrors =
+            splits.mapNotNull { (split, sourceTrack) ->
+                split.getTargetLocationTrack(trackId)?.let { target ->
+                    val (sourceAddresses, targetAddresses) =
+                        getTargetValidationAddressPoints(sourceTrack, target, context)
+                    validateTargetGeometry(target.operation, targetAddresses, sourceAddresses)
+                }
             }
-        }
 
         // Source address validation ensures that the in-validationcontext source addresspoints are
         // unchanged from the
         // official ones (that is: draft source geometry == official source geometry)
-        val sourceGeometryErrors = splits.mapNotNull { (_, sourceTrack) ->
-            produceIf(trackId == sourceTrack.id) {
-                val draftAddresses = context.getAddressPoints(sourceTrack)?.addresses
-                val officialAddresses =
-                    geocodingService.getAddressPoints(context.target.baseContext, trackId)?.addresses
-                validateSourceGeometry(draftAddresses, officialAddresses)
+        val sourceGeometryErrors =
+            splits.mapNotNull { (_, sourceTrack) ->
+                produceIf(trackId == sourceTrack.id) {
+                    val draftAddresses = context.getAddressPoints(sourceTrack)?.addresses
+                    val officialAddresses =
+                        geocodingService.getAddressPoints(context.target.baseContext, trackId)?.addresses
+                    validateSourceGeometry(draftAddresses, officialAddresses)
+                }
             }
-        }
 
         return targetGeometryErrors + sourceGeometryErrors
     }
@@ -366,27 +375,31 @@ class SplitService(
                 val end = geocodingContext.toAddressPoint(sourceEndPoint)?.first
                 if (start != null && end != null) start to end else null
             }
-        val sourceAddresses: List<AddressPoint<LocationTrackM>>? = sourceAddressPointRange?.let { (start, end) ->
-            context
-                .getAddressPoints(sourceTrack)
-                ?.addresses
-                ?.midPoints
-                ?.filter { p -> p.address > start.address && p.address < end.address }
-                ?.let { midPoints ->
-                    listOfNotNull(start.withIntegerPrecision()) + midPoints + listOfNotNull(end.withIntegerPrecision())
-                }
-        }
+        val sourceAddresses: List<AddressPoint<LocationTrackM>>? =
+            sourceAddressPointRange?.let { (start, end) ->
+                context
+                    .getAddressPoints(sourceTrack)
+                    ?.addresses
+                    ?.midPoints
+                    ?.filter { p -> p.address > start.address && p.address < end.address }
+                    ?.let { midPoints ->
+                        listOfNotNull(start.withIntegerPrecision()) +
+                            midPoints +
+                            listOfNotNull(end.withIntegerPrecision())
+                    }
+            }
 
-        val targetAddresses = sourceAddressPointRange?.let { (sourceStart, sourceEnd) ->
-            val addressRange = sourceStart.address..sourceEnd.address
-            context.getAddressPoints(target.locationTrackId)?.addresses?.integerPrecisionPoints?.let { points ->
-                if (target.operation == SplitTargetOperation.TRANSFER) {
-                    points.filter { p -> p.address in addressRange }
-                } else {
-                    points
+        val targetAddresses =
+            sourceAddressPointRange?.let { (sourceStart, sourceEnd) ->
+                val addressRange = sourceStart.address..sourceEnd.address
+                context.getAddressPoints(target.locationTrackId)?.addresses?.integerPrecisionPoints?.let { points ->
+                    if (target.operation == SplitTargetOperation.TRANSFER) {
+                        points.filter { p -> p.address in addressRange }
+                    } else {
+                        points
+                    }
                 }
             }
-        }
 
         return sourceAddresses to targetAddresses
     }
@@ -459,11 +472,12 @@ class SplitService(
                 targets = collectSplitTargetParams(branch, request.targetTracks, suggestions),
             )
 
-        val savedSplitTargetLocationTracks = targetResults.map { result ->
-            val response = locationTrackService.saveDraft(branch, result.locationTrack, result.geometry)
-            val (resultTrack, resultGeometry) = locationTrackService.getWithGeometry(response)
-            result.copy(locationTrack = resultTrack, geometry = resultGeometry)
-        }
+        val savedSplitTargetLocationTracks =
+            targetResults.map { result ->
+                val response = locationTrackService.saveDraft(branch, result.locationTrack, result.geometry)
+                val (resultTrack, resultGeometry) = locationTrackService.getWithGeometry(response)
+                result.copy(locationTrack = resultTrack, geometry = resultGeometry)
+            }
 
         geocodingService.getGeocodingContext(branch.draft, sourceTrack.trackNumberId)?.let { geocodingContext ->
             updateUnusedDuplicateReferencesToSplitTargetTracks(
@@ -490,7 +504,13 @@ class SplitService(
                 )
             }
             .let { splitTargets ->
-                splitDao.saveSplit(savedSource, splitTargets, relinkedSwitches, sourceTrackDuplicateIds)
+                splitDao.saveSplit(
+                    savedSource,
+                    splitTargets,
+                    relinkedSwitches,
+                    sourceTrackDuplicateIds,
+                    SplitAdministrativeChangeType.SPLIT,
+                )
             }
     }
 
@@ -583,17 +603,18 @@ fun findPartialDuplicateCuttingPoint(
             },
             { "Failed to find a shared split point from split source and target tracks" },
         )
-    val splitPointByRequestedSwitch = requestedSwitch?.let {
-        val (switchId, jointNumber) = requestedSwitch
-        requireNotNull(
-            targetSplitPoints.find { targetSplitPoint ->
-                targetSplitPoint is SwitchSplitPoint &&
-                    targetSplitPoint.switchId == switchId &&
-                    targetSplitPoint.jointNumber == jointNumber
-            },
-            { "Failed to find a switch split point by requested switch" },
-        )
-    }
+    val splitPointByRequestedSwitch =
+        requestedSwitch?.let {
+            val (switchId, jointNumber) = requestedSwitch
+            requireNotNull(
+                targetSplitPoints.find { targetSplitPoint ->
+                    targetSplitPoint is SwitchSplitPoint &&
+                        targetSplitPoint.switchId == switchId &&
+                        targetSplitPoint.jointNumber == jointNumber
+                },
+                { "Failed to find a switch split point by requested switch" },
+            )
+        }
     return splitPointByRequestedSwitch ?: lastSharedSplitPoint
 }
 
@@ -876,16 +897,17 @@ private fun cutEdges(geometry: LocationTrackGeometry, indices: ClosedRange<Int>)
 
 private fun verifySwitchSuggestions(
     suggestions: List<Pair<IntId<LayoutSwitch>, SuggestedSwitch?>>
-): List<Pair<IntId<LayoutSwitch>, SuggestedSwitch>> = suggestions.map { (id, suggestion) ->
-    if (suggestion == null) {
-        throw SplitFailureException(
-            message = "Switch re-linking failed to produce a suggestion: switch=$id",
-            localizedMessageKey = "switch-linking-failed",
-        )
-    } else {
-        id to suggestion
+): List<Pair<IntId<LayoutSwitch>, SuggestedSwitch>> =
+    suggestions.map { (id, suggestion) ->
+        if (suggestion == null) {
+            throw SplitFailureException(
+                message = "Switch re-linking failed to produce a suggestion: switch=$id",
+                localizedMessageKey = "switch-linking-failed",
+            )
+        } else {
+            id to suggestion
+        }
     }
-}
 
 private data class GeocodedLocationTrack(
     val track: LocationTrack,
@@ -907,13 +929,11 @@ private fun findNewLocationTracksForUnusedDuplicates(
     unusedDuplicates: List<Pair<LocationTrack, LocationTrackGeometry>>,
     splitTargetLocationTracks: List<SplitTargetResult>,
 ): List<Pair<LocationTrack, LocationTrackGeometry>> {
-    val geocodedUnusedDuplicates = unusedDuplicates.mapNotNull { (track, geometry) ->
-        getGeocoded(geocodingContext, track, geometry)
-    }
+    val geocodedUnusedDuplicates =
+        unusedDuplicates.mapNotNull { (track, geometry) -> getGeocoded(geocodingContext, track, geometry) }
 
-    val geocodedSplitTargets = splitTargetLocationTracks.mapNotNull { (track, geometry) ->
-        getGeocoded(geocodingContext, track, geometry)
-    }
+    val geocodedSplitTargets =
+        splitTargetLocationTracks.mapNotNull { (track, geometry) -> getGeocoded(geocodingContext, track, geometry) }
 
     return geocodedUnusedDuplicates.map { duplicate ->
         geocodedSplitTargets

--- a/infra/src/main/resources/db/migration/prod/V147__extend_splits_with_track_boundary_changes.sql
+++ b/infra/src/main/resources/db/migration/prod/V147__extend_splits_with_track_boundary_changes.sql
@@ -1,0 +1,21 @@
+create type publication.split_administrative_change_type as enum ('SPLIT', 'BOUNDARY_CHANGE');
+
+alter table publication.split
+  disable trigger version_update_trigger;
+alter table publication.split
+  disable trigger version_row_trigger;
+
+alter table publication.split_version
+  add column administrative_change_type publication.split_administrative_change_type not null default 'SPLIT';
+alter table publication.split_version
+  alter column administrative_change_type drop default;
+
+alter table publication.split
+  add column administrative_change_type publication.split_administrative_change_type not null default 'SPLIT';
+alter table publication.split
+  alter column administrative_change_type drop default;
+
+alter table publication.split
+  enable trigger version_update_trigger;
+alter table publication.split
+  enable trigger version_row_trigger;

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.R
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.REPLACE_DUPLICATE_PARTIAL
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
+import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.SplitRequest
@@ -187,6 +188,84 @@ class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private 
                     assertEquals(REPLACE_DUPLICATE.value, change.geometrian_muutos)
                 }
             }
+        }
+    }
+
+    @Test
+    fun `Track boundary change shows up with vaihtumiskohdan_siirto type`() {
+        val tn = testDBService.getUnusedTrackNumber()
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(tn))
+        val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0)))
+        val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
+
+        // Switch1 at 100: current boundary between tracks
+        // Switch2 at 200: new boundary point (on shortening track)
+        val structureId = switchStructureYV60_300_1_9().id
+        val switch1Joints = listOf(switchJoint(1, Point(100.0, 0.0)), switchJoint(2, Point(110.0, 10.0)))
+        val switch1Id = mainDraftContext.save(switch(structureId, switch1Joints)).id
+        val switch2Joints = listOf(switchJoint(1, Point(200.0, 0.0)), switchJoint(2, Point(210.0, 10.0)))
+        val switch2Id = mainDraftContext.save(switch(structureId, switch2Joints)).id
+
+        // Lengthening track: 0 to 110, ending at switch1
+        val lengtheningTrackGeom =
+            trackGeometry(
+                edge(
+                    segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
+                    endOuterSwitch = switchLinkYV(switch1Id, 1),
+                ),
+                edge(
+                    segments = listOf(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch1Id, 1),
+                    endInnerSwitch = switchLinkYV(switch1Id, 2),
+                ),
+            )
+        val (lengtheningId) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "LengtheningTrack"), lengtheningTrackGeom)
+
+        // Shortening track: 110 to 400, starts at switch1, has switch2
+        val shorteningTrackGeom =
+            trackGeometry(
+                edge(
+                    segments = listOf(segment(Point(110.0, 0.0), Point(200.0, 0.0))),
+                    startOuterSwitch = switchLinkYV(switch1Id, 2),
+                    endOuterSwitch = switchLinkYV(switch2Id, 1),
+                ),
+                edge(
+                    segments = listOf(segment(Point(200.0, 0.0), Point(210.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch2Id, 1),
+                    endInnerSwitch = switchLinkYV(switch2Id, 2),
+                ),
+                edge(
+                    segments = listOf(segment(Point(210.0, 0.0), Point(400.0, 0.0))),
+                    startOuterSwitch = switchLinkYV(switch2Id, 2),
+                ),
+            )
+        val (shorteningId) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "ShorteningTrack"), shorteningTrackGeom)
+
+        val basePublication =
+            testDBService.publish(
+                trackNumbers = listOf(tnId),
+                referenceLines = listOf(rlId),
+                locationTracks = listOf(shorteningId, lengtheningId),
+                switches = listOf(switch1Id, switch2Id),
+            )
+
+        val splitId =
+            splitService.saveTrackBoundaryChange(
+                LayoutBranch.main,
+                shorteningId,
+                lengtheningId,
+                switch2Id,
+                JointNumber(1),
+            )
+        val split = splitService.get(splitId)!!
+
+        val changePublication = testDBService.publish(locationTracks = split.locationTracks)
+
+        api.trackBoundaryCollection.getModifiedBetween(basePublication.uuid, changePublication.uuid).let { response ->
+            assertEquals(1, response.rajojen_muutokset.size)
+            assertEquals("vaihtumiskohdan_siirto", response.rajojen_muutokset[0].tyyppi)
         }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -29,6 +29,7 @@ import fi.fta.geoviite.infra.geometry.testFile
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.split.BulkTransferState
+import fi.fta.geoviite.infra.split.SplitAdministrativeChangeType
 import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitTarget
 import fi.fta.geoviite.infra.split.SplitTargetOperation
@@ -287,6 +288,7 @@ constructor(
             listOf(SplitTarget(locationTrackResponse.id, 0..1, SplitTargetOperation.CREATE)),
             relinkedSwitches = emptyList(),
             updatedDuplicates = emptyList(),
+            administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
         )
 
         val ex =
@@ -357,6 +359,7 @@ constructor(
                     listOf(SplitTarget(locationTrackResponse.id, 0..1, SplitTargetOperation.CREATE)),
                     relinkedSwitches = emptyList(),
                     updatedDuplicates = emptyList(),
+                    administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
                 )
             )
         splitDao.updateSplit(split.id, bulkTransferState = BulkTransferState.DONE)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -24,6 +24,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.RatkoTestService
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
+import fi.fta.geoviite.infra.split.SplitAdministrativeChangeType
 import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTarget
@@ -231,14 +232,15 @@ constructor(
         val switch = mainDraftContext.save(switch())
         val trackNumberIds =
             listOf(mainOfficialContext.createLayoutTrackNumber().id, mainOfficialContext.createLayoutTrackNumber().id)
-        val locationTracks = trackNumberIds.map { trackNumberId ->
-            val edge =
-                edge(
-                    startInnerSwitch = switchLinkYV(switch.id, 1),
-                    segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
-                )
-            mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
-        }
+        val locationTracks =
+            trackNumberIds.map { trackNumberId ->
+                val edge =
+                    edge(
+                        startInnerSwitch = switchLinkYV(switch.id, 1),
+                        segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+                    )
+                mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
+            }
 
         val publicationResult =
             publish(publicationService, locationTracks = locationTracks.map { it.id }, switches = listOf(switch.id))
@@ -2282,6 +2284,7 @@ constructor(
             ),
             relinkedSwitches = someSwitches,
             updatedDuplicates = someDuplicates,
+            administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
         )
 
         return PublicationGroupTestData(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.integration.LocationTrackChange
 import fi.fta.geoviite.infra.integration.TrackNumberChange
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.Split
+import fi.fta.geoviite.infra.split.SplitAdministrativeChangeType
 import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitTarget
 import fi.fta.geoviite.infra.split.SplitTargetOperation
@@ -40,12 +41,12 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Service
-import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @Service
@@ -163,6 +164,7 @@ constructor(
             splitTargets = targetTracks.map { (id, indices) -> SplitTarget(id, indices, SplitTargetOperation.CREATE) },
             relinkedSwitches = switches,
             updatedDuplicates = emptyList(),
+            administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
         )
     }
 
@@ -234,9 +236,8 @@ data class SplitSetup(
     val targetTracks: List<Pair<LayoutRowVersion<LocationTrack>, IntRange>>,
 ) {
 
-    val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> = targetTracks.map { (track, range) ->
-        track.id to range
-    }
+    val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> =
+        targetTracks.map { (track, range) -> track.id to range }
 
     val trackResponses = (listOf(sourceTrack) + targetTracks.map { it.first })
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitDaoIT.kt
@@ -43,6 +43,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                     listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
                     listOf(relinkedSwitchId),
                     updatedDuplicates = emptyList(),
+                    administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
                 )
                 .let(splitDao::getOrThrow)
 
@@ -71,6 +72,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                     listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
                     listOf(relinkedSwitchId),
                     updatedDuplicates = emptyList(),
+                    administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
                 )
                 .let(splitDao::getOrThrow)
 
@@ -115,6 +117,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                     listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
                     listOf(relinkedSwitchId1),
                     updatedDuplicates = emptyList(),
+                    administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
                 )
                 .also { splitId ->
                     val split = splitDao.getOrThrow(splitId)
@@ -127,6 +130,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 listOf(SplitTarget(targetTrack2.id, 0..0, SplitTargetOperation.CREATE)),
                 listOf(relinkedSwitchId2),
                 updatedDuplicates = emptyList(),
+                administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
             )
 
         val splits = splitDao.fetchUnfinishedSplits(LayoutBranch.main)
@@ -150,6 +154,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
                 listOf(mainOfficialContext.createSwitch().id),
                 updatedDuplicates = emptyList(),
+                administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
             )
 
         assertFalse(splitDao.isSplitSource(LayoutBranch.main, sourceTrack.id))
@@ -179,6 +184,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.OVERWRITE)),
                 listOf(relinkedSwitchId),
                 updatedDuplicates = listOf(someDuplicateTrack.id),
+                administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
             )
 
         assertTrue { splitDao.fetchUnfinishedSplits(LayoutBranch.main).any { it.id == splitId } }
@@ -204,6 +210,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
                 listOf(SplitTarget(targetTrack1.id, 0..0, SplitTargetOperation.CREATE)),
                 listOf(relinkedSwitchId),
                 updatedDuplicates = emptyList(),
+                administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
             )
 
         val splitHeader = splitDao.getSplitHeader(splitId)
@@ -284,6 +291,7 @@ class SplitDaoIT @Autowired constructor(val splitDao: SplitDao, val publicationD
             listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.OVERWRITE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = listOf(someDuplicateTrack.id),
+            administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
         )
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -463,6 +463,7 @@ constructor(
             listOf(SplitTarget(endTrack.id, 0..0, SplitTargetOperation.CREATE)),
             listOf(relinkedSwitchId),
             updatedDuplicates = emptyList(),
+            administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTestDataService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTestDataService.kt
@@ -73,6 +73,7 @@ constructor(
             splitTargets = listOf(SplitTarget(targetTrack.id, 0..0, SplitTargetOperation.CREATE)),
             relinkedSwitches = listOf(mainOfficialContext.createSwitch().id),
             updatedDuplicates = emptyList(),
+            administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryChangeIT.kt
@@ -1,0 +1,235 @@
+package fi.fta.geoviite.infra.split
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.edge
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.switchLinkYV
+import fi.fta.geoviite.infra.tracklayout.trackGeometry
+import fi.fta.geoviite.infra.tracklayout.trackNumber
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class TrackBoundaryChangeIT
+@Autowired
+constructor(
+    private val splitService: SplitService,
+    private val locationTrackService: LocationTrackService,
+    private val splitDao: SplitDao,
+) : DBTestBase() {
+    @BeforeEach
+    fun setup() {
+        testDBService.clearLayoutTables()
+    }
+
+    @Test
+    fun `move along ascending track`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        // three switches, all laid out to one physically continuous track, with each having just a joint 1 on the left,
+        // 2 on the right, and out-of-switch segments in between. lengtheningTrack contains switch 1, shorteningTrack
+        // contains switches 2 and 3.
+
+        val switch1 = testDBService.save(switch()).id
+        val switch2 = testDBService.save(switch()).id
+        val switch3 = testDBService.save(switch()).id
+
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                        endOuterSwitch = switchLinkYV(switch1, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch1, 1),
+                        endInnerSwitch = switchLinkYV(switch1, 2),
+                    ),
+                ),
+            )
+
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch1, 2),
+                        endOuterSwitch = switchLinkYV(switch2, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch2, 1),
+                        endInnerSwitch = switchLinkYV(switch2, 2),
+                    ),
+                    edge(
+                        listOf(segment(Point(40.0, 0.0), Point(50.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch2, 2),
+                        endOuterSwitch = switchLinkYV(switch3, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(50.0, 0.0), Point(60.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch3, 1),
+                        endInnerSwitch = switchLinkYV(switch3, 3),
+                    ),
+                    edge(
+                        listOf(segment(Point(60.0, 0.0), Point(70.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch3, 3),
+                    ),
+                ),
+            )
+
+        val splitId =
+            splitService.saveTrackBoundaryChange(
+                LayoutBranch.Companion.main,
+                shorteningTrack.id,
+                lengtheningTrack.id,
+                switch2,
+                JointNumber(1),
+            )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        val split = splitDao.getOrThrow(splitId)
+        assertEquals(shorteningTrack, split.sourceLocationTrackVersion)
+        assertEquals(1, split.targetLocationTracks.size)
+        assertEquals(lengtheningTrack.id, split.targetLocationTracks[0].locationTrackId)
+        assertEquals(SplitAdministrativeChangeType.BOUNDARY_CHANGE, split.administrativeChangeType)
+
+        assertEquals(3, newLengthenedGeometry.edges.size)
+        assertEquals(switchLinkYV(switch2, 1), newLengthenedGeometry.edges.last().endNode.switchOut)
+        assertEquals(switchLinkYV(switch2, 1), newShortenedGeometry.edges.first().startNode.switchIn)
+        assertEquals(4, newShortenedGeometry.edges.size)
+    }
+
+    @Test
+    fun `move in descending direction on short track`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        val switch1 = testDBService.save(switch()).id
+
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch1, 1),
+                        endInnerSwitch = switchLinkYV(switch1, 3),
+                    )
+                ),
+            )
+
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch1, 3),
+                    )
+                ),
+            )
+
+        val splitId =
+            splitService.saveTrackBoundaryChange(
+                LayoutBranch.Companion.main,
+                shorteningTrack.id,
+                lengtheningTrack.id,
+                switch1,
+                JointNumber(1),
+            )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        val split = splitDao.getOrThrow(splitId)
+        assertEquals(shorteningTrack, split.sourceLocationTrackVersion)
+        assertEquals(1, split.targetLocationTracks.size)
+        assertEquals(lengtheningTrack.id, split.targetLocationTracks[0].locationTrackId)
+        assertEquals(SplitAdministrativeChangeType.BOUNDARY_CHANGE, split.administrativeChangeType)
+        assertEquals(switchLinkYV(switch1, 1), newLengthenedGeometry.edges.first().startNode.switchIn)
+
+        assertEquals(2, newLengthenedGeometry.edges.size)
+        assertEquals(0, newShortenedGeometry.edges.size)
+    }
+
+    @Test
+    fun `shortened track remains with no geometry`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        // three switches, all laid out to one physically continuous track, with each having just a joint 1 on the left,
+        // 2 on the right, and out-of-switch segments in between. lengtheningTrack contains switch 1, shorteningTrack
+        // contains switches 2 and 3.
+
+        val switch1 = testDBService.save(switch()).id
+        val switch2 = testDBService.save(switch()).id
+        val switch3 = testDBService.save(switch()).id
+
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                        endOuterSwitch = switchLinkYV(switch1, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch1, 1),
+                        endInnerSwitch = switchLinkYV(switch1, 2),
+                    ),
+                ),
+            )
+
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch1, 2),
+                        endOuterSwitch = switchLinkYV(switch2, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch2, 1),
+                        endInnerSwitch = switchLinkYV(switch2, 2),
+                    ),
+                    edge(
+                        listOf(segment(Point(40.0, 0.0), Point(50.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch2, 2),
+                        endOuterSwitch = switchLinkYV(switch3, 1),
+                    ),
+                ),
+            )
+
+        splitService.saveTrackBoundaryChange(
+            LayoutBranch.Companion.main,
+            shorteningTrack.id,
+            lengtheningTrack.id,
+            switch3,
+            JointNumber(1),
+        )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        assertEquals(5, newLengthenedGeometry.edges.size)
+        assertEquals(0, newShortenedGeometry.edges.size)
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -20,10 +20,12 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.MultiPoint
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
+import fi.fta.geoviite.infra.split.SplitAdministrativeChangeType
 import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -36,7 +38,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1245,6 +1246,7 @@ constructor(
                 ),
                 listOf(mainOfficialContext.createSwitch().id),
                 updatedDuplicates = emptyList(),
+                administrativeChangeType = SplitAdministrativeChangeType.SPLIT,
             )
 
         locationTrackService.getInfoboxExtras(MainLayoutContext.official, sourceTrack.id).also { extrasSourceUnfinished
@@ -1391,10 +1393,15 @@ constructor(
         }
 }
 
-fun assertContains(polygon: Polygon, vararg points: Point) = points.forEach { p ->
-    assertTrue(contains(polygon, p, LAYOUT_SRID), "Expected polygon to overlap location: point=$p polygon=$polygon")
-}
+fun assertContains(polygon: Polygon, vararg points: Point) =
+    points.forEach { p ->
+        assertTrue(contains(polygon, p, LAYOUT_SRID), "Expected polygon to overlap location: point=$p polygon=$polygon")
+    }
 
-fun assertDoesntContain(polygon: Polygon, vararg points: Point) = points.forEach { p ->
-    assertFalse(contains(polygon, p, LAYOUT_SRID), "Expected polygon to overlap location: point=$p polygon=$polygon")
-}
+fun assertDoesntContain(polygon: Polygon, vararg points: Point) =
+    points.forEach { p ->
+        assertFalse(
+            contains(polygon, p, LAYOUT_SRID),
+            "Expected polygon to overlap location: point=$p polygon=$polygon",
+        )
+    }


### PR DESCRIPTION
Lopulta varsin yksinkertaiseksi vedetty bäkkäri.

- Koodi ei sinällään ota itsessään vielä kantaa siihen, onko siirto järkevä, kunhan vaan on tunnistettavissa, mihin suuntaan se yleensäkään pitää tehdä. Jos uudet geometrian saa luotua ja tallennettua, niin ne saa luotua ja tallennettua.
- Frontin toimintaan kuuluu joka tapauksessa tietää, kumpi raide lyhenee ja kumpi pitenee, joten sama on vaatia jo rajapinnassa annettavaksi tämä tieto.
- Muutoskohtien siirrot esitetään kannassa splitteinä, joille lisätty tieto, minkälaisesta muutoksesta oli kyse