### PR TITLE
GVT-3126 Basic backend support for track boundary moves

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
@@ -50,7 +50,8 @@ constructor(
             val endMoment = publications.to.publicationTime
             val splits = getSplitData(branch, startMoment, endMoment)
             val moves = getBoundaryMoveData(branch, startMoment, endMoment)
-            val boundaryChanges = (splits + moves).map(::createBoundaryChange)
+            val boundaryChanges =
+                (splits + moves).sortedBy { it.publication.publicationTime }.map(::createBoundaryChange)
             ExtTrackBoundaryChangeResponseV1(
                 layoutVersionFrom = ExtLayoutVersionV1(publications.from.uuid),
                 layoutVersionTo = ExtLayoutVersionV1(publications.to.uuid),

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
@@ -45,13 +45,12 @@ constructor(
     ): ExtTrackBoundaryChangeResponseV1? {
         val publications = publicationService.getPublicationsToCompare(layoutVersionFrom.value, layoutVersionTo?.value)
         return if (publications.areDifferent()) {
-            val splits =
-                getSplitData(
-                    branch = publications.to.layoutBranch.branch,
-                    startMoment = publications.from.publicationTime,
-                    endMoment = publications.to.publicationTime,
-                )
-            val boundaryChanges = splits.map(::createBoundaryChange)
+            val branch = publications.to.layoutBranch.branch
+            val startMoment = publications.from.publicationTime
+            val endMoment = publications.to.publicationTime
+            val splits = getSplitData(branch, startMoment, endMoment)
+            val moves = getBoundaryMoveData(branch, startMoment, endMoment)
+            val boundaryChanges = (splits + moves).map(::createBoundaryChange)
             ExtTrackBoundaryChangeResponseV1(
                 layoutVersionFrom = ExtLayoutVersionV1(publications.from.uuid),
                 layoutVersionTo = ExtLayoutVersionV1(publications.to.uuid),
@@ -127,6 +126,67 @@ constructor(
                 trackNumberOid = trackNumberOid,
                 geocodingContext = geocodingContext,
                 segments = changeTargets,
+            )
+        }
+    }
+
+    private fun getBoundaryMoveData(
+        branch: LayoutBranch,
+        startMoment: Instant,
+        endMoment: Instant,
+    ): List<BoundaryChangeData> {
+        val moves = publicationDao.fetchPublishedBoundaryMovesBetween(startMoment, endMoment)
+        if (moves.isEmpty()) return emptyList()
+
+        val allTrackIds = moves.flatMap { it.allTrackIds }.distinct()
+        val locationTrackOids = locationTrackDao.fetchExternalIds(branch, allTrackIds)
+        val publications = publicationDao.getPublications(moves.map { it.publicationId }.toSet())
+        val getTrackOid = { id: DomainId<LocationTrack> -> locationTrackOids[id]?.oid ?: throwOidNotFound(branch, id) }
+
+        val sourceTracks: Map<LayoutRowVersion<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>> =
+            locationTrackService
+                .getManyWithGeometries(moves.map { it.shortenedTrackVersion }.distinct())
+                .associateBy { it.first.getVersionOrThrow() }
+        val targetTracks =
+            locationTrackDao.fetchManyByVersion(moves.map { it.lengthenedTrackVersion })
+
+        val geocodingContexts = geocodingService.getLazyGeocodingContextsByMoments(branch)
+
+        return moves.map { move ->
+            val publication =
+                requireNotNull(publications[move.publicationId]) { "Publication not found: ${move.publicationId}" }
+            val moment = publication.publicationTime
+            val (sourceTrack, sourceGeometry) =
+                sourceTracks[move.shortenedTrackVersion] ?: throwLocationTrackNotFound(move.shortenedTrackVersion)
+            val targetTrack =
+                targetTracks[move.lengthenedTrackVersion] ?: throwLocationTrackNotFound(move.lengthenedTrackVersion)
+
+            val segment =
+                BoundaryChangeSegmentData(
+                    sourceTrackOid = getTrackOid(sourceTrack.id),
+                    sourceTrack = sourceTrack,
+                    sourceGeometry = sourceGeometry,
+                    targetTrackOid = getTrackOid(targetTrack.id),
+                    targetTrack = targetTrack,
+                    splitOperation = null,
+                    sourceEdgeIndices = move.edgeRange,
+                )
+
+            val trackNumberId = sourceTrack.trackNumberId
+            val trackNumber =
+                trackNumberDao.getOfficialAtMoment(branch, trackNumberId, moment)
+                    ?: throwTrackNumberNotFound(branch, moment, trackNumberId)
+            val geocodingContext =
+                geocodingContexts(trackNumberId, moment) ?: throwGeocodingContextNotFound(branch, moment, trackNumberId)
+            val trackNumberOid = oidLookup(trackNumberDao, branch, trackNumberId)
+
+            BoundaryChangeData(
+                publication = publication,
+                type = ExtTrackBoundaryChangeTypeV1.BOUNDARY_MOVE,
+                trackNumber = trackNumber,
+                trackNumberOid = trackNumberOid,
+                geocodingContext = geocodingContext,
+                segments = listOf(segment),
             )
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -291,12 +291,12 @@ enum class ExtAreaTypeV1(val value: String) {
 }
 
 const val FI_SPLIT = "raiteen_jakaminen"
-const val FI_BOUNDARY_SHIFT = "vaihtumiskohdan_siirto"
+const val FI_BOUNDARY_MOVE = "vaihtumiskohdan_siirto"
 
-@Schema(name = "Hallinnollisen muutoksen tyyppi", type = "string", allowableValues = [FI_SPLIT, FI_BOUNDARY_SHIFT])
+@Schema(name = "Hallinnollisen muutoksen tyyppi", type = "string", allowableValues = [FI_SPLIT, FI_BOUNDARY_MOVE])
 enum class ExtTrackBoundaryChangeTypeV1(val value: String) {
     SPLIT(FI_SPLIT),
-    BOUNDARY_SHIFT(FI_BOUNDARY_SHIFT);
+    BOUNDARY_MOVE(FI_BOUNDARY_MOVE);
 
     @JsonValue override fun toString() = value
 }
@@ -355,11 +355,7 @@ enum class ExtVerticalCoordinateSystemV1(val value: String) {
 const val FI_TOP_OF_SLEEPER = "Korkeusviiva"
 const val FI_TOP_OF_RAIL = "Kiskon selkä"
 
-@Schema(
-    name = "Korkeusaseman mittaustapa",
-    type = "string",
-    allowableValues = [FI_TOP_OF_SLEEPER, FI_TOP_OF_RAIL],
-)
+@Schema(name = "Korkeusaseman mittaustapa", type = "string", allowableValues = [FI_TOP_OF_SLEEPER, FI_TOP_OF_RAIL])
 enum class ExtElevationMeasurementMethodV1(val value: String) {
     TOP_OF_SLEEPER(FI_TOP_OF_SLEEPER),
     TOP_OF_RAIL(FI_TOP_OF_RAIL);

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -293,6 +293,7 @@ class CalculatedChangesService(
                     kmPosts = getNonOverriddenVersions(branch, kmPosts, kmPostDao),
                     operationalPoints = getNonOverriddenVersions(branch, operationalPoints, operationalPointDao),
                     splits = listOf(),
+                    trackBoundaryMoves = listOf(),
                 )
             getCalculatedChanges(validationVersions).indirectChanges.let {
                 filterIndirectChangesByOidPresence(it, allOids)
@@ -357,6 +358,7 @@ class CalculatedChangesService(
                 kmPosts = completedKmPosts,
                 operationalPoints = completedOperationalPoints,
                 splits = listOf(),
+                trackBoundaryMoves = listOf(),
             )
 
         val directChanges =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/Linking.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.geometry.GeometryKmPost
 import fi.fta.geoviite.infra.geometry.GeometryPlan
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.Range
+import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostGkLocation
@@ -24,6 +25,8 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionStructure
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionSuffix
+import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameFreeTextPart
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameSpecifier
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameStructure
@@ -74,7 +77,13 @@ data class LocationTrackSaveRequest(
 
 enum class TrackEnd {
     START,
-    END,
+    END;
+
+    fun of(geometry: LocationTrackGeometry): AlignmentPoint<LocationTrackM>? =
+        when (this) {
+            START -> geometry.start
+            END -> geometry.end
+        }
 }
 
 data class TrackNumberSaveRequest(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -43,6 +43,7 @@ import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.split.SplitHeader
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
 import fi.fta.geoviite.infra.tracklayout.DesignAssetState
 import fi.fta.geoviite.infra.tracklayout.KmPostGkLocationSource
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
@@ -405,7 +406,11 @@ data class PublicationCandidates(
             operationalPoints.map { candidate -> candidate.id },
         )
 
-    fun getValidationVersions(transition: LayoutContextTransition, splitVersions: List<RowVersion<Split>>) =
+    fun getValidationVersions(
+        transition: LayoutContextTransition,
+        splitVersions: List<RowVersion<Split>>,
+        trackBoundaryMoves: List<RowVersion<TrackBoundaryMove>>,
+    ) =
         ValidationVersions(
             target = transition,
             trackNumbers = trackNumbers.map(TrackNumberPublicationCandidate::getPublicationVersion),
@@ -415,6 +420,7 @@ data class PublicationCandidates(
             kmPosts = kmPosts.map(KmPostPublicationCandidate::getPublicationVersion),
             operationalPoints = operationalPoints.map(OperationalPointPublicationCandidate::getPublicationVersion),
             splits = splitVersions,
+            trackBoundaryMoves = trackBoundaryMoves,
         )
 
     fun filter(request: PublicationRequestIds) =
@@ -450,10 +456,11 @@ data class ValidationVersions(
     val kmPosts: List<LayoutRowVersion<LayoutKmPost>>,
     val operationalPoints: List<LayoutRowVersion<OperationalPoint>>,
     val splits: List<RowVersion<Split>>,
+    val trackBoundaryMoves: List<RowVersion<TrackBoundaryMove>>,
 ) {
     companion object {
         fun emptyWithTarget(target: LayoutContextTransition) =
-            ValidationVersions(target, listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf())
+            ValidationVersions(target, listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf(), listOf())
     }
 
     fun containsLocationTrack(id: IntId<LocationTrack>) = locationTracks.any { it.id == id }
@@ -823,9 +830,8 @@ data class SwitchChanges(
     private fun getTrackNumberJointLocation(
         trackNumberId: IntId<LayoutTrackNumber>,
         jointNumber: JointNumber,
-    ): Change<Point?> = trackConnections.map { tracks ->
-        getTrackNumberJointLocation(tracks, trackNumberId, jointNumber)
-    }
+    ): Change<Point?> =
+        trackConnections.map { tracks -> getTrackNumberJointLocation(tracks, trackNumberId, jointNumber) }
 
     private fun getTrackNumberJointLocation(
         tracks: List<SwitchLocationTrack>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -103,11 +103,11 @@ import fi.fta.geoviite.infra.util.getUicCodeOrNull
 import fi.fta.geoviite.infra.util.getUuid
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Timestamp
-import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component
@@ -2577,7 +2577,7 @@ class PublicationDao(
         val operation: SplitTargetOperation,
     )
 
-    data class TrackBoundaryChange(
+    data class SplitTrackBoundaryChange(
         val publicationId: IntId<Publication>,
         val segments: List<TrackBoundaryChangeSegment>,
     ) {
@@ -2587,7 +2587,7 @@ class PublicationDao(
     fun fetchPublishedSplitsBetween(
         exclusiveStartMoment: Instant,
         inclusiveEndMoment: Instant,
-    ): List<TrackBoundaryChange> {
+    ): List<SplitTrackBoundaryChange> {
         val sql =
             """
             select
@@ -2642,8 +2642,68 @@ class PublicationDao(
                 publicationId to changeTarget
             }
             .groupBy({ it.first }, { it.second })
-            .map { (publicationId, targets) -> TrackBoundaryChange(publicationId, targets) }
-            .also { logger.daoAccess(FETCH, TrackBoundaryChange::class, it.map { it.publicationId }) }
+            .map { (publicationId, targets) -> SplitTrackBoundaryChange(publicationId, targets) }
+            .also { logger.daoAccess(FETCH, SplitTrackBoundaryChange::class, it.map { it.publicationId }) }
+    }
+
+    data class PublishedTrackBoundaryMove(
+        val publicationId: IntId<Publication>,
+        val shortenedTrackVersion: LayoutRowVersion<LocationTrack>,
+        val edgeRange: IntRange,
+        val lengthenedTrackVersion: LayoutRowVersion<LocationTrack>,
+    ) {
+        val allTrackIds = setOf(shortenedTrackVersion.id, lengthenedTrackVersion.id)
+    }
+
+    fun fetchPublishedBoundaryMovesBetween(
+        exclusiveStartMoment: Instant,
+        inclusiveEndMoment: Instant,
+    ): List<PublishedTrackBoundaryMove> {
+        val sql =
+            """
+            select
+              tbm.publication_id,
+              tbm.shortened_location_track_id,
+              tbm.shortened_location_track_layout_context_id,
+              tbm.shortened_location_track_version,
+              tbm.source_start_edge_index,
+              tbm.source_end_edge_index,
+              tbm.lengthened_location_track_id,
+              tbm.lengthened_location_track_layout_context_id,
+              tbm.lengthened_location_track_version
+            from publication.track_boundary_move tbm
+              inner join publication.publication on tbm.publication_id = publication.id
+            where publication.design_id is null
+                and publication.publication_time > :start_time
+                and publication.publication_time <= :end_time
+            order by tbm.publication_id
+            """
+                .trimIndent()
+        val params =
+            mapOf(
+                "start_time" to Timestamp.from(exclusiveStartMoment),
+                "end_time" to Timestamp.from(inclusiveEndMoment),
+            )
+        return jdbcTemplate
+            .query(sql, params) { rs, _ ->
+                PublishedTrackBoundaryMove(
+                    publicationId = rs.getIntId("publication_id"),
+                    shortenedTrackVersion =
+                        rs.getLayoutRowVersion(
+                            "shortened_location_track_id",
+                            "shortened_location_track_layout_context_id",
+                            "shortened_location_track_version",
+                        ),
+                    edgeRange = rs.getInt("source_start_edge_index")..rs.getInt("source_end_edge_index"),
+                    lengthenedTrackVersion =
+                        rs.getLayoutRowVersion(
+                            "lengthened_location_track_id",
+                            "lengthened_location_track_layout_context_id",
+                            "lengthened_location_track_version",
+                        ),
+                )
+            }
+            .also { logger.daoAccess(FETCH, PublishedTrackBoundaryMove::class, it.map { m -> m.publicationId }) }
     }
 
     fun fetchPublishedTrackNumberGeomsBetween(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -26,6 +26,7 @@ import fi.fta.geoviite.infra.ratko.SWITCH_FAKE_OID_CONTEXT
 import fi.fta.geoviite.infra.ratko.TRACK_NUMBER_FAKE_OID_CONTEXT
 import fi.fta.geoviite.infra.ratko.model.RatkoOid
 import fi.fta.geoviite.infra.split.SplitService
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutDesignDao
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
@@ -46,12 +47,12 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineService
+import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
 
 @GeoviiteService
 class PublicationService
@@ -77,6 +78,7 @@ constructor(
     private val transactionTemplate: TransactionTemplate,
     private val publicationGeometryChangeRemarksUpdateService: PublicationGeometryChangeRemarksUpdateService,
     private val splitService: SplitService,
+    private val trackBoundaryMoveService: TrackBoundaryMoveService,
     private val publicationValidationService: PublicationValidationService,
     private val layoutDesignDao: LayoutDesignDao,
 ) {
@@ -294,6 +296,8 @@ constructor(
                     request.locationTracks,
                     request.switches,
                 ),
+            trackBoundaryMoves =
+                trackBoundaryMoveService.fetchPublicationVersions(transition.candidateBranch, request.locationTracks),
         )
     }
 
@@ -497,6 +501,11 @@ constructor(
         )
 
         splitService.publishSplit(versions.splits, locationTracks.map { it.published }, publicationId)
+        trackBoundaryMoveService.publishTrackBoundaryMove(
+            versions.trackBoundaryMoves,
+            locationTracks.map { it.published },
+            publicationId,
+        )
 
         return PublicationResult(
             publicationId = publicationId,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.split.SplitLayoutValidationIssues
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.VALIDATION_SPLIT
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
@@ -51,6 +52,7 @@ constructor(
     private val trackNumberDao: LayoutTrackNumberDao,
     private val geocodingCacheService: GeocodingCacheService,
     private val splitService: SplitService,
+    private val trackBoundaryMoveService: TrackBoundaryMoveService,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -255,6 +257,7 @@ constructor(
                 kmPosts,
                 operationalPoints,
                 emptyList(),
+                emptyList(),
             )
         )
 
@@ -285,7 +288,12 @@ constructor(
                 locationTracks = candidates.locationTracks.map { it.id },
                 switches = candidates.switches.map { it.id },
             )
-        val versions = candidates.getValidationVersions(candidates.transition, splitVersions)
+        val boundaryMoveVersions =
+            trackBoundaryMoveService.fetchPublicationVersions(
+                branch = candidates.transition.candidateBranch,
+                locationTracks = candidates.locationTracks.map { it.id },
+            )
+        val versions = candidates.getValidationVersions(candidates.transition, splitVersions, boundaryMoveVersions)
 
         val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
         val splitIssues = splitService.validateSplit(versions, validationContext, allowMultipleSplits)
@@ -481,9 +489,10 @@ constructor(
             val jointConnectionsDifferIssues =
                 validateSwitchJointConnectionsOnDuplicateTracks(switch, jointConnections, linkedTracks)
 
-            val structureIssues = locationIssues.ifEmpty {
-                validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndGeometries)
-            }
+            val structureIssues =
+                locationIssues.ifEmpty {
+                    validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndGeometries)
+                }
 
             val duplicationIssues =
                 validateSwitchNameDuplication(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -1,0 +1,23 @@
+package fi.fta.geoviite.infra.trackBoundaryMove
+
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+
+data class TrackBoundaryMove(
+    val version: RowVersion<TrackBoundaryMove>,
+    val shortenedLocationTrack: LayoutRowVersion<LocationTrack>,
+    val edgeRange: IntRange,
+    val lengthenedLocationTrack: LayoutRowVersion<LocationTrack>,
+    val publicationId: IntId<Publication>?,
+) {
+    val id = version.id
+
+    fun containsLocationTrack(track: IntId<LocationTrack>) =
+        shortenedLocationTrack.id == track || lengthenedLocationTrack.id == track
+
+    val locationTracks
+        get() = listOf(shortenedLocationTrack, lengthenedLocationTrack)
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -6,6 +6,11 @@ import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 
+enum class LengtheningDirection {
+    ASCENDING,
+    DESCENDING,
+}
+
 data class TrackBoundaryMove(
     val version: RowVersion<TrackBoundaryMove>,
     val shortenedLocationTrack: LayoutRowVersion<LocationTrack>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
@@ -1,0 +1,165 @@
+package fi.fta.geoviite.infra.trackBoundaryMove
+
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.logging.AccessType
+import fi.fta.geoviite.infra.logging.daoAccess
+import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.util.DaoBase
+import fi.fta.geoviite.infra.util.getIntId
+import fi.fta.geoviite.infra.util.getIntIdOrNull
+import fi.fta.geoviite.infra.util.getLayoutRowVersion
+import fi.fta.geoviite.infra.util.getOne
+import fi.fta.geoviite.infra.util.getRowVersion
+import fi.fta.geoviite.infra.util.queryOptional
+import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+@Component
+class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcTemplateParam) {
+
+    @Transactional
+    fun save(
+        shortenedLocationTrack: LayoutRowVersion<LocationTrack>,
+        edgeRange: IntRange,
+        lengthenedLocationTrack: LayoutRowVersion<LocationTrack>,
+    ): IntId<TrackBoundaryMove> {
+        val sql =
+            """
+            insert into publication.track_boundary_move(
+              shortened_location_track_id,
+              shortened_location_track_version,
+              shortened_location_track_layout_context_id,
+              source_start_edge_index,
+              source_end_edge_index,
+              lengthened_location_track_id,
+              lengthened_location_track_version,
+              lengthened_location_track_layout_context_id,
+              publication_id
+            )
+            values (
+              :shortened_location_track_id,
+              :shortened_location_track_version,
+              :shortened_location_track_layout_context_id,
+              :source_start_edge_index,
+              :source_end_edge_index,
+              :lengthened_location_track_id,
+              :lengthened_location_track_version,
+              :lengthened_location_track_layout_context_id,
+              null
+            )
+            returning id
+            """
+                .trimIndent()
+
+        jdbcTemplate.setUser()
+        val params =
+            mapOf(
+                "shortened_location_track_id" to shortenedLocationTrack.id.intValue,
+                "shortened_location_track_version" to shortenedLocationTrack.version,
+                "shortened_location_track_layout_context_id" to shortenedLocationTrack.context.toSqlString(),
+                "source_start_edge_index" to edgeRange.first,
+                "source_end_edge_index" to edgeRange.last,
+                "lengthened_location_track_id" to lengthenedLocationTrack.id.intValue,
+                "lengthened_location_track_version" to lengthenedLocationTrack.version,
+                "lengthened_location_track_layout_context_id" to lengthenedLocationTrack.context.toSqlString(),
+            )
+        val id =
+            jdbcTemplate.queryForObject(sql, params) { rs, _ -> rs.getIntId<TrackBoundaryMove>("id") }
+                ?: error(
+                    "Failed to save track boundary move: shortened=$shortenedLocationTrack lengthened=$lengthenedLocationTrack"
+                )
+        logger.daoAccess(AccessType.INSERT, TrackBoundaryMove::class, id)
+        return id
+    }
+
+    fun get(id: IntId<TrackBoundaryMove>): TrackBoundaryMove? {
+        val sql =
+            """
+            select
+              id,
+              version,
+              shortened_location_track_id,
+              shortened_location_track_version,
+              shortened_location_track_layout_context_id,
+              source_start_edge_index,
+              source_end_edge_index,
+              lengthened_location_track_id,
+              lengthened_location_track_version,
+              lengthened_location_track_layout_context_id,
+              publication_id
+            from publication.track_boundary_move
+            where id = :id
+            """
+                .trimIndent()
+        return jdbcTemplate
+            .queryOptional(sql, mapOf("id" to id.intValue)) { rs, _ -> getTrackBoundaryMove(rs) }
+            ?.also { logger.daoAccess(AccessType.FETCH, TrackBoundaryMove::class, id) }
+    }
+
+    fun getOrThrow(id: IntId<TrackBoundaryMove>) = requireNotNull(get(id))
+
+    fun getUnPublished(): List<TrackBoundaryMove> {
+        val sql =
+            """
+            select
+              id,
+              version,
+              shortened_location_track_id,
+              shortened_location_track_version,
+              shortened_location_track_layout_context_id,
+              source_start_edge_index,
+              source_end_edge_index,
+              lengthened_location_track_id,
+              lengthened_location_track_version,
+              lengthened_location_track_layout_context_id,
+              publication_id
+            from publication.track_boundary_move
+            where publication_id is null
+            """
+                .trimIndent()
+        return jdbcTemplate.query(sql) { rs, _ -> getTrackBoundaryMove(rs) }
+    }
+
+    @Transactional
+    fun update(id: IntId<TrackBoundaryMove>, publicationId: IntId<Publication>?): RowVersion<TrackBoundaryMove> {
+        val sql =
+            """
+            update publication.track_boundary_move
+            set publication_id = coalesce(:publication_id, publication_id)
+            where id = :id
+            returning id, version
+            """
+                .trimIndent()
+
+        val params = mapOf("publication_id" to publicationId?.intValue, "id" to id.intValue)
+
+        jdbcTemplate.setUser()
+        return getOne(id, jdbcTemplate.query(sql, params) { rs, _ -> rs.getRowVersion("id", "version") })
+    }
+}
+
+private fun getTrackBoundaryMove(rs: ResultSet) =
+    TrackBoundaryMove(
+        version = rs.getRowVersion("id", "version"),
+        shortenedLocationTrack =
+            rs.getLayoutRowVersion(
+                "shortened_location_track_id",
+                "shortened_location_track_layout_context_id",
+                "shortened_location_track_version",
+            ),
+        edgeRange = IntRange(rs.getInt("source_start_edge_index"), rs.getInt("source_end_edge_index")),
+        lengthenedLocationTrack =
+            rs.getLayoutRowVersion(
+                "lengthened_location_track_id",
+                "lengthened_location_track_layout_context_id",
+                "lengthened_location_track_version",
+            ),
+        publicationId = rs.getIntIdOrNull("publication_id"),
+    )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -1,0 +1,150 @@
+package fi.fta.geoviite.infra.trackBoundaryMove
+
+import fi.fta.geoviite.infra.aspects.GeoviiteService
+import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.common.RowVersion
+import fi.fta.geoviite.infra.linking.TrackEnd
+import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
+import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
+import org.springframework.transaction.annotation.Transactional
+
+@GeoviiteService
+class TrackBoundaryMoveService(
+    private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
+    private val locationTrackDao: LocationTrackDao,
+    private val locationTrackService: LocationTrackService,
+) {
+    fun get(id: IntId<TrackBoundaryMove>): TrackBoundaryMove? {
+        return trackBoundaryMoveDao.get(id)
+    }
+
+    @Transactional
+    fun saveTrackBoundaryMove(
+        layoutBranch: LayoutBranch,
+        shorteningTrackId: IntId<LocationTrack>,
+        lengtheningTrackId: IntId<LocationTrack>,
+        switch: IntId<LayoutSwitch>,
+        switchJoint: JointNumber,
+    ): IntId<TrackBoundaryMove> {
+        val context = layoutBranch.draft
+        val shorteningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, shorteningTrackId)
+        val lengtheningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, lengtheningTrackId)
+
+        val (shorteningTrack, shorteningTrackGeometry) = locationTrackService.getWithGeometry(shorteningTrackVersion)
+        val (lengtheningTrack, lengtheningTrackGeometry) = locationTrackService.getWithGeometry(lengtheningTrackVersion)
+        val geometries =
+            getTrackBoundaryMoveGeometry(
+                shorteningTrackGeometry = shorteningTrackGeometry,
+                lengtheningTrackGeometry = lengtheningTrackGeometry,
+                shorteningTrackId = shorteningTrackVersion.id,
+                lengtheningTrackId = lengtheningTrackVersion.id,
+                switch,
+                switchJoint,
+            )
+        locationTrackService.saveDraft(layoutBranch, shorteningTrack, geometries.shortenedGeometry)
+        locationTrackService.saveDraft(layoutBranch, lengtheningTrack, geometries.lengthenedGeometry)
+        return trackBoundaryMoveDao.save(shorteningTrackVersion, geometries.movedEdgeRange, lengtheningTrackVersion)
+    }
+
+    fun fetchPublicationVersions(
+        branch: LayoutBranch,
+        locationTracks: List<IntId<LocationTrack>>,
+    ): List<RowVersion<TrackBoundaryMove>> =
+        findUnPublishedBoundaryMoves(branch, locationTracks).map { boundaryMove -> boundaryMove.version }
+
+    fun findUnPublishedBoundaryMoves(
+        branch: LayoutBranch,
+        locationTrackIds: List<IntId<LocationTrack>>? = null,
+    ): List<TrackBoundaryMove> =
+        trackBoundaryMoveDao.getUnPublished().filter { boundaryMove ->
+            locationTrackIds == null || locationTrackIds.any(boundaryMove::containsLocationTrack)
+        }
+
+    @Transactional
+    fun publishTrackBoundaryMove(
+        validatedVersions: List<RowVersion<TrackBoundaryMove>>,
+        locationTracks: Collection<LayoutRowVersion<LocationTrack>>,
+        publicationId: IntId<Publication>,
+    ): List<RowVersion<TrackBoundaryMove>> {
+        return validatedVersions.map { boundaryMoveVersion ->
+            val move = trackBoundaryMoveDao.getOrThrow(boundaryMoveVersion.id)
+            requireNotNull(locationTracks.find { t -> t.id == move.shortenedLocationTrack.id }) {
+                "Shortened track must be part of the same publication as the track boundary move: $move"
+            }
+            requireNotNull(locationTracks.find { t -> t.id == move.lengthenedLocationTrack.id }) {
+                "Lengthened track must be part of the same publication as the track boundary move: $move"
+            }
+
+            trackBoundaryMoveDao.update(id = move.id, publicationId = publicationId)
+        }
+    }
+}
+
+private data class TrackBoundaryMoveGeometry(
+    val movedEdgeRange: IntRange,
+    val shortenedGeometry: TmpLocationTrackGeometry,
+    val lengthenedGeometry: TmpLocationTrackGeometry,
+)
+
+private fun getTrackBoundaryMoveGeometry(
+    shorteningTrackGeometry: LocationTrackGeometry,
+    lengtheningTrackGeometry: LocationTrackGeometry,
+    shorteningTrackId: IntId<LocationTrack>,
+    lengtheningTrackId: IntId<LocationTrack>,
+    switch: IntId<LayoutSwitch>,
+    switchJoint: JointNumber,
+): TrackBoundaryMoveGeometry {
+    val closestEnds =
+        listOf(
+                TrackEnd.START to TrackEnd.START,
+                TrackEnd.START to TrackEnd.END,
+                TrackEnd.END to TrackEnd.START,
+                TrackEnd.END to TrackEnd.END,
+            )
+            .minBy { (shorteningEnd, lengtheningEnd) ->
+                lineLength(
+                    requireNotNull(shorteningEnd.of(shorteningTrackGeometry)),
+                    requireNotNull(lengtheningEnd.of(lengtheningTrackGeometry)),
+                )
+            }
+    val shorteningEnd = closestEnds.first
+    val lengtheningEnd = closestEnds.second
+
+    val shorteningEndPoint = requireNotNull(shorteningEnd.of(shorteningTrackGeometry))
+    val lengtheningEndPoint = requireNotNull(lengtheningEnd.of(lengtheningTrackGeometry))
+    require(lineLength(shorteningEndPoint, lengtheningEndPoint) < 1.0) { "endpoints to move must be near each other" }
+    require(shorteningEnd != lengtheningEnd) { "can't extend location tracks with geometry going to opposing sides" }
+    val switchNodeIndex = shorteningTrackGeometry.nodes.indexOfFirst { n -> n.containsJoint(switch, switchJoint) }
+    require(switchNodeIndex >= 0) {
+        "track to shorten $shorteningTrackId must contain switch $switch joint $switchJoint"
+    }
+    val edgeRangeToMove =
+        if (shorteningEnd == TrackEnd.START) IntRange(0, switchNodeIndex - 1)
+        else IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+    val edgesToMove = shorteningTrackGeometry.edges.slice(edgeRangeToMove)
+    val remainingEdgeRange =
+        if (shorteningEnd == TrackEnd.START) IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+        else IntRange(0, switchNodeIndex - 1)
+    val lengthenedGeometry =
+        TmpLocationTrackGeometry.of(
+            if (lengtheningEnd == TrackEnd.START) edgesToMove + lengtheningTrackGeometry.edges
+            else lengtheningTrackGeometry.edges + edgesToMove,
+            lengtheningTrackId,
+        )
+    val shortenedGeometry =
+        TmpLocationTrackGeometry.of(shorteningTrackGeometry.edges.slice(remainingEdgeRange), shorteningTrackId)
+    return TrackBoundaryMoveGeometry(
+        movedEdgeRange = edgeRangeToMove,
+        lengthenedGeometry = lengthenedGeometry,
+        shortenedGeometry = shortenedGeometry,
+    )
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -109,15 +109,18 @@ private fun getTrackBoundaryMoveGeometry(
     require(switchNodeIndex >= 0) {
         "track to shorten $shorteningTrackId must contain switch $switch joint $switchJoint"
     }
-    val edgeRangeToMove = when (direction) {
-        LengtheningDirection.ASCENDING -> IntRange(0, switchNodeIndex - 1)
-        LengtheningDirection.DESCENDING -> IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
-    }
+    val edgeRangeToMove =
+        when (direction) {
+            LengtheningDirection.ASCENDING -> IntRange(0, switchNodeIndex - 1)
+            LengtheningDirection.DESCENDING -> IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+        }
+    require(!edgeRangeToMove.isEmpty()) { "track boundary move must move track boundary" }
     val edgesToMove = shorteningTrackGeometry.edges.slice(edgeRangeToMove)
-    val remainingEdgeRange = when (direction) {
-        LengtheningDirection.ASCENDING -> IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
-        LengtheningDirection.DESCENDING -> IntRange(0, switchNodeIndex - 1)
-    }
+    val remainingEdgeRange =
+        when (direction) {
+            LengtheningDirection.ASCENDING -> IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+            LengtheningDirection.DESCENDING -> IntRange(0, switchNodeIndex - 1)
+        }
     val lengthenedGeometry =
         TmpLocationTrackGeometry.of(
             combineEdges(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.combineEdges
 import org.springframework.transaction.annotation.Transactional
 
 @GeoviiteService
@@ -136,8 +137,10 @@ private fun getTrackBoundaryMoveGeometry(
         else IntRange(0, switchNodeIndex - 1)
     val lengthenedGeometry =
         TmpLocationTrackGeometry.of(
-            if (lengtheningEnd == TrackEnd.START) edgesToMove + lengtheningTrackGeometry.edges
-            else lengtheningTrackGeometry.edges + edgesToMove,
+            combineEdges(
+                if (lengtheningEnd == TrackEnd.START) edgesToMove + lengtheningTrackGeometry.edges
+                else lengtheningTrackGeometry.edges + edgesToMove
+            ),
             lengtheningTrackId,
         )
     val shortenedGeometry =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -5,8 +5,6 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.linking.TrackEnd
-import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
@@ -35,6 +33,7 @@ class TrackBoundaryMoveService(
         lengtheningTrackId: IntId<LocationTrack>,
         switch: IntId<LayoutSwitch>,
         switchJoint: JointNumber,
+        direction: LengtheningDirection,
     ): IntId<TrackBoundaryMove> {
         val context = layoutBranch.draft
         val shorteningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, shorteningTrackId)
@@ -50,6 +49,7 @@ class TrackBoundaryMoveService(
                 lengtheningTrackId = lengtheningTrackVersion.id,
                 switch,
                 switchJoint,
+                direction,
             )
         locationTrackService.saveDraft(layoutBranch, shorteningTrack, geometries.shortenedGeometry)
         locationTrackService.saveDraft(layoutBranch, lengtheningTrack, geometries.lengthenedGeometry)
@@ -103,43 +103,28 @@ private fun getTrackBoundaryMoveGeometry(
     lengtheningTrackId: IntId<LocationTrack>,
     switch: IntId<LayoutSwitch>,
     switchJoint: JointNumber,
+    direction: LengtheningDirection,
 ): TrackBoundaryMoveGeometry {
-    val closestEnds =
-        listOf(
-                TrackEnd.START to TrackEnd.START,
-                TrackEnd.START to TrackEnd.END,
-                TrackEnd.END to TrackEnd.START,
-                TrackEnd.END to TrackEnd.END,
-            )
-            .minBy { (shorteningEnd, lengtheningEnd) ->
-                lineLength(
-                    requireNotNull(shorteningEnd.of(shorteningTrackGeometry)),
-                    requireNotNull(lengtheningEnd.of(lengtheningTrackGeometry)),
-                )
-            }
-    val shorteningEnd = closestEnds.first
-    val lengtheningEnd = closestEnds.second
-
-    val shorteningEndPoint = requireNotNull(shorteningEnd.of(shorteningTrackGeometry))
-    val lengtheningEndPoint = requireNotNull(lengtheningEnd.of(lengtheningTrackGeometry))
-    require(lineLength(shorteningEndPoint, lengtheningEndPoint) < 1.0) { "endpoints to move must be near each other" }
-    require(shorteningEnd != lengtheningEnd) { "can't extend location tracks with geometry going to opposing sides" }
     val switchNodeIndex = shorteningTrackGeometry.nodes.indexOfFirst { n -> n.containsJoint(switch, switchJoint) }
     require(switchNodeIndex >= 0) {
         "track to shorten $shorteningTrackId must contain switch $switch joint $switchJoint"
     }
-    val edgeRangeToMove =
-        if (shorteningEnd == TrackEnd.START) IntRange(0, switchNodeIndex - 1)
-        else IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+    val edgeRangeToMove = when (direction) {
+        LengtheningDirection.ASCENDING -> IntRange(0, switchNodeIndex - 1)
+        LengtheningDirection.DESCENDING -> IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+    }
     val edgesToMove = shorteningTrackGeometry.edges.slice(edgeRangeToMove)
-    val remainingEdgeRange =
-        if (shorteningEnd == TrackEnd.START) IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
-        else IntRange(0, switchNodeIndex - 1)
+    val remainingEdgeRange = when (direction) {
+        LengtheningDirection.ASCENDING -> IntRange(switchNodeIndex, shorteningTrackGeometry.edges.lastIndex)
+        LengtheningDirection.DESCENDING -> IntRange(0, switchNodeIndex - 1)
+    }
     val lengthenedGeometry =
         TmpLocationTrackGeometry.of(
             combineEdges(
-                if (lengtheningEnd == TrackEnd.START) edgesToMove + lengtheningTrackGeometry.edges
-                else lengtheningTrackGeometry.edges + edgesToMove
+                when (direction) {
+                    LengtheningDirection.ASCENDING -> lengtheningTrackGeometry.edges + edgesToMove
+                    LengtheningDirection.DESCENDING -> edgesToMove + lengtheningTrackGeometry.edges
+                }
             ),
             lengtheningTrackId,
         )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignService.kt
@@ -124,6 +124,7 @@ class LayoutDesignService(
                 kmPosts,
                 operationalPoints,
                 listOf(),
+                listOf(),
             )
 
         publicationService.publishChanges(

--- a/infra/src/main/resources/db/migration/prod/V147__add_track_boundary_moves.sql
+++ b/infra/src/main/resources/db/migration/prod/V147__add_track_boundary_moves.sql
@@ -1,0 +1,41 @@
+create table publication.track_boundary_move
+(
+  id                                          integer primary key generated always as identity,
+  shortened_location_track_id                 integer not null,
+  shortened_location_track_version            integer not null,
+  shortened_location_track_layout_context_id  text    not null,
+  source_start_edge_index                     integer not null,
+  source_end_edge_index                       integer not null,
+  lengthened_location_track_id                integer not null,
+  lengthened_location_track_version           integer not null,
+  lengthened_location_track_layout_context_id text    not null,
+  publication_id                              integer,
+
+  constraint track_boundary_move_shortened_track_version_fk
+    foreign key (shortened_location_track_id, shortened_location_track_version,
+                 shortened_location_track_layout_context_id)
+      references layout.location_track_version (id, version, layout_context_id),
+  constraint track_boundary_move_shortened_track_start_edge_fk
+    foreign key (shortened_location_track_id, shortened_location_track_version,
+                 shortened_location_track_layout_context_id,
+                 source_start_edge_index)
+      references layout.location_track_version_edge (location_track_id, location_track_version,
+                                                     location_track_layout_context_id, edge_index),
+  constraint track_boundary_move_shortened_track_end_edge_fk
+    foreign key (shortened_location_track_id, shortened_location_track_version,
+                 shortened_location_track_layout_context_id,
+                 source_end_edge_index)
+      references layout.location_track_version_edge (location_track_id, location_track_version,
+                                                     location_track_layout_context_id, edge_index),
+  constraint track_boundary_move_lengthened_track_version_fk
+    foreign key (lengthened_location_track_id, lengthened_location_track_version,
+                 lengthened_location_track_layout_context_id)
+      references layout.location_track_version (id, version, layout_context_id),
+  constraint track_boundary_move_publication_fk
+    foreign key (publication_id) references publication.publication
+);
+
+select common.add_metadata_columns('publication', 'track_boundary_move');
+select common.add_table_versioning('publication', 'track_boundary_move');
+
+

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -15,6 +15,7 @@ import fi.fta.geoviite.infra.split.SplitTargetDuplicateOperation.OVERWRITE
 import fi.fta.geoviite.infra.split.SplitTargetDuplicateOperation.TRANSFER
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.split.targetRequest
+import fi.fta.geoviite.infra.trackBoundaryMove.LengtheningDirection
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.locationTrack
@@ -265,6 +266,7 @@ constructor(
                 lengtheningId,
                 switch2Id,
                 JointNumber(1),
+                LengtheningDirection.ASCENDING,
             )
 
         val trackBoundaryChange = trackBoundaryMoveService.get(trackBoundaryChangeId)!!

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -3,8 +3,10 @@ package fi.fta.geoviite.api.tracklayout.v1
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.CREATE_NEW
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.REPLACE_DUPLICATE
 import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.REPLACE_DUPLICATE_PARTIAL
+import fi.fta.geoviite.api.tracklayout.v1.ExtTrackBoundaryGeometryChangeTypeV1.TRANSFER_GEOMETRY
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.InfraApplication
+import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.SplitRequest
@@ -13,6 +15,7 @@ import fi.fta.geoviite.infra.split.SplitTargetDuplicateOperation.OVERWRITE
 import fi.fta.geoviite.infra.split.SplitTargetDuplicateOperation.TRANSFER
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.split.targetRequest
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.referenceLine
@@ -37,8 +40,13 @@ import org.springframework.test.web.servlet.MockMvc
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
 @AutoConfigureMockMvc
-class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private val splitService: SplitService) :
-    DBTestBase() {
+class ExtTrackBoundaryChangeIT
+@Autowired
+constructor(
+    mockMvc: MockMvc,
+    private val splitService: SplitService,
+    private var trackBoundaryMoveService: TrackBoundaryMoveService,
+) : DBTestBase() {
     private val api = ExtTrackLayoutTestApiService(mockMvc)
 
     @BeforeEach
@@ -185,6 +193,102 @@ class ExtTrackBoundaryChangeIT @Autowired constructor(mockMvc: MockMvc, private 
                     assertEquals("0000+0300.000", change.alkuosoite)
                     assertEquals("0000+0400.000", change.loppuosoite)
                     assertEquals(REPLACE_DUPLICATE.value, change.geometrian_muutos)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Track boundary change shows up with vaihtumiskohdan_siirto type`() {
+        val tn = testDBService.getUnusedTrackNumber()
+        val (tnId, tnOid) = mainDraftContext.saveWithOid(trackNumber(tn))
+        val rlGeom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0)))
+        val rlId = mainDraftContext.save(referenceLine(tnId), rlGeom).id
+
+        // Switch1 at 100: current boundary between tracks
+        // Switch2 at 200: new boundary point (on shortening track)
+        val structureId = switchStructureYV60_300_1_9().id
+        val switch1Joints = listOf(switchJoint(1, Point(100.0, 0.0)), switchJoint(2, Point(110.0, 10.0)))
+        val switch1Id = mainDraftContext.save(switch(structureId, switch1Joints)).id
+        val switch2Joints = listOf(switchJoint(1, Point(200.0, 0.0)), switchJoint(2, Point(210.0, 10.0)))
+        val switch2Id = mainDraftContext.save(switch(structureId, switch2Joints)).id
+
+        // Lengthening track: 0 to 110, ending at switch1
+        val lengtheningTrackGeom =
+            trackGeometry(
+                edge(
+                    segments = listOf(segment(Point(0.0, 0.0), Point(100.0, 0.0))),
+                    endOuterSwitch = switchLinkYV(switch1Id, 1),
+                ),
+                edge(
+                    segments = listOf(segment(Point(100.0, 0.0), Point(110.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch1Id, 1),
+                    endInnerSwitch = switchLinkYV(switch1Id, 2),
+                ),
+            )
+        val (lengtheningId, lengtheningOid) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "LengtheningTrack"), lengtheningTrackGeom)
+
+        // Shortening track: 110 to 400, starts at switch1, has switch2
+        val shorteningTrackGeom =
+            trackGeometry(
+                edge(
+                    segments = listOf(segment(Point(110.0, 0.0), Point(200.0, 0.0))),
+                    startOuterSwitch = switchLinkYV(switch1Id, 2),
+                    endOuterSwitch = switchLinkYV(switch2Id, 1),
+                ),
+                edge(
+                    segments = listOf(segment(Point(200.0, 0.0), Point(210.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch2Id, 1),
+                    endInnerSwitch = switchLinkYV(switch2Id, 2),
+                ),
+                edge(
+                    segments = listOf(segment(Point(210.0, 0.0), Point(400.0, 0.0))),
+                    startOuterSwitch = switchLinkYV(switch2Id, 2),
+                ),
+            )
+        val (shorteningId, shorteningOid) =
+            mainDraftContext.saveWithOid(locationTrack(tnId, name = "ShorteningTrack"), shorteningTrackGeom)
+
+        val basePublication =
+            testDBService.publish(
+                trackNumbers = listOf(tnId),
+                referenceLines = listOf(rlId),
+                locationTracks = listOf(shorteningId, lengtheningId),
+                switches = listOf(switch1Id, switch2Id),
+            )
+
+        val trackBoundaryChangeId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.main,
+                shorteningId,
+                lengtheningId,
+                switch2Id,
+                JointNumber(1),
+            )
+
+        val trackBoundaryChange = trackBoundaryMoveService.get(trackBoundaryChangeId)!!
+
+        val changePublication = testDBService.publish(locationTracks = trackBoundaryChange.locationTracks.map { it.id })
+
+        api.trackBoundaryCollection.getModifiedBetween(basePublication.uuid, changePublication.uuid).let { response ->
+            assertEquals(basePublication.uuid.toString(), response.alkuversio)
+            assertEquals(changePublication.uuid.toString(), response.loppuversio)
+            assertEquals(1, response.rajojen_muutokset.size)
+            response.rajojen_muutokset[0].let { changeOperation ->
+                assertEquals(changePublication.uuid.toString(), changeOperation.rataverkon_versio)
+                assertEquals(tnOid.toString(), changeOperation.ratanumero_oid)
+                assertEquals(tn.toString(), changeOperation.ratanumero)
+                assertEquals("vaihtumiskohdan_siirto", changeOperation.tyyppi)
+                assertEquals(1, changeOperation.muutokset.size)
+                changeOperation.muutokset[0].also { change ->
+                    assertEquals(shorteningOid.toString(), change.geometrian_lahderaide_oid)
+                    assertEquals("ShorteningTrack", change.geometrian_lahderaide_tunnus)
+                    assertEquals(lengtheningOid.toString(), change.geometrian_kohderaide_oid)
+                    assertEquals("LengtheningTrack", change.geometrian_kohderaide_tunnus)
+                    assertEquals("0000+0110.000", change.alkuosoite)
+                    assertEquals("0000+0200.000", change.loppuosoite)
+                    assertEquals(TRANSFER_GEOMETRY.value, change.geometrian_muutos)
                 }
             }
         }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -70,11 +70,6 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -84,6 +79,11 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -1683,18 +1683,19 @@ constructor(
             layoutTrackNumberDao.fetch(
                 layoutTrackNumberDao.save(trackNumber(TrackNumber("TEST TN $sequence"), draft = false))
             )
-        val kmPosts = kmPostData.map { (kmNumber, location) ->
-            layoutKmPostDao.fetch(
-                layoutKmPostDao.save(
-                    kmPost(
-                        trackNumberId = trackNumber.id as IntId,
-                        km = kmNumber,
-                        gkLocation = kmPostGkLocation(refPoint + location),
-                        draft = false,
+        val kmPosts =
+            kmPostData.map { (kmNumber, location) ->
+                layoutKmPostDao.fetch(
+                    layoutKmPostDao.save(
+                        kmPost(
+                            trackNumberId = trackNumber.id as IntId,
+                            km = kmNumber,
+                            gkLocation = kmPostGkLocation(refPoint + location),
+                            draft = false,
+                        )
                     )
                 )
-            )
-        }
+            }
         val referenceLineGeometryVersion =
             layoutAlignmentDao.insert(
                 referenceLineGeometry(
@@ -1716,50 +1717,54 @@ constructor(
             )
 
         var locationTrackSequence = 0
-        val locationTracksAndGeometries = locationTrackData.map { line ->
-            locationTrackService.getWithGeometry(
-                locationTrackDao.save(
-                    locationTrack(
-                        trackNumberId = trackNumber.id as IntId,
-                        name = "TEST LocTr $sequence ${locationTrackSequence++}",
-                        draft = false,
-                    ),
-                    trackGeometryOfSegments(segments(refPoint + line.start, refPoint + line.end, 10.0)),
+        val locationTracksAndGeometries =
+            locationTrackData.map { line ->
+                locationTrackService.getWithGeometry(
+                    locationTrackDao.save(
+                        locationTrack(
+                            trackNumberId = trackNumber.id as IntId,
+                            name = "TEST LocTr $sequence ${locationTrackSequence++}",
+                            draft = false,
+                        ),
+                        trackGeometryOfSegments(segments(refPoint + line.start, refPoint + line.end, 10.0)),
+                    )
                 )
-            )
-        }
-
-        val switches = switchData.map { switch ->
-            linkTestSwitch(
-                refPoint + switch.location,
-                locationTracksAndGeometries[switch.locationTrackIndexA],
-                locationTracksAndGeometries[switch.locationTrackIndexB],
-                switch.name,
-            )
-        }
-
-        val publishedLocationTracksAndGeometries = locationTracksAndGeometries.map { (locationTrack, _) ->
-            val id = locationTrack.id as IntId
-            val rowVersion = locationTrackDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-            val (edited, editedGeometry) = locationTrackService.getWithGeometry(rowVersion)
-            if (edited.isDraft) {
-                val publicationResponse = locationTrackService.publish(LayoutBranch.main, rowVersion).published
-                locationTrackService.getWithGeometry(publicationResponse)
-            } else {
-                edited to editedGeometry
             }
-        }
-        val publishedSwitches = switches.map { switch ->
-            val id = switch.id as IntId
-            val rowVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
-            val edited = switchDao.fetch(rowVersion)
-            if (edited.isDraft) {
-                val publicationResponse = switchService.publish(LayoutBranch.main, rowVersion).published
-                switchDao.fetch(publicationResponse)
-            } else {
-                edited
+
+        val switches =
+            switchData.map { switch ->
+                linkTestSwitch(
+                    refPoint + switch.location,
+                    locationTracksAndGeometries[switch.locationTrackIndexA],
+                    locationTracksAndGeometries[switch.locationTrackIndexB],
+                    switch.name,
+                )
             }
-        }
+
+        val publishedLocationTracksAndGeometries =
+            locationTracksAndGeometries.map { (locationTrack, _) ->
+                val id = locationTrack.id as IntId
+                val rowVersion = locationTrackDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+                val (edited, editedGeometry) = locationTrackService.getWithGeometry(rowVersion)
+                if (edited.isDraft) {
+                    val publicationResponse = locationTrackService.publish(LayoutBranch.main, rowVersion).published
+                    locationTrackService.getWithGeometry(publicationResponse)
+                } else {
+                    edited to editedGeometry
+                }
+            }
+        val publishedSwitches =
+            switches.map { switch ->
+                val id = switch.id as IntId
+                val rowVersion = switchDao.fetchVersionOrThrow(MainLayoutContext.draft, id)
+                val edited = switchDao.fetch(rowVersion)
+                if (edited.isDraft) {
+                    val publicationResponse = switchService.publish(LayoutBranch.main, rowVersion).published
+                    switchDao.fetch(publicationResponse)
+                } else {
+                    edited
+                }
+            }
 
         return TestData(
             trackNumber = trackNumber,
@@ -1902,6 +1907,7 @@ constructor(
             operationalPoints =
                 operationalPointDao.fetchCandidateVersions(target.candidateContext, operationalPointIds),
             splits = listOf(),
+            trackBoundaryMoves = listOf(),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingDomainTestData.kt
@@ -51,6 +51,7 @@ fun validationVersions(
         switches = switches,
         operationalPoints = operationalPoints,
         splits = listOf(),
+        trackBoundaryMoves = listOf(),
     )
 
 fun publish(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -231,14 +231,15 @@ constructor(
         val switch = mainDraftContext.save(switch())
         val trackNumberIds =
             listOf(mainOfficialContext.createLayoutTrackNumber().id, mainOfficialContext.createLayoutTrackNumber().id)
-        val locationTracks = trackNumberIds.map { trackNumberId ->
-            val edge =
-                edge(
-                    startInnerSwitch = switchLinkYV(switch.id, 1),
-                    segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
-                )
-            mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
-        }
+        val locationTracks =
+            trackNumberIds.map { trackNumberId ->
+                val edge =
+                    edge(
+                        startInnerSwitch = switchLinkYV(switch.id, 1),
+                        segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+                    )
+                mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
+            }
 
         val publicationResult =
             publish(publicationService, locationTracks = locationTracks.map { it.id }, switches = listOf(switch.id))

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
@@ -40,12 +40,12 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Service
-import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @Service
@@ -234,9 +234,8 @@ data class SplitSetup(
     val targetTracks: List<Pair<LayoutRowVersion<LocationTrack>, IntRange>>,
 ) {
 
-    val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> = targetTracks.map { (track, range) ->
-        track.id to range
-    }
+    val targetParams: List<Pair<IntId<LocationTrack>, IntRange>> =
+        targetTracks.map { (track, range) -> track.id to range }
 
     val trackResponses = (listOf(sourceTrack) + targetTracks.map { it.first })
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -7,6 +7,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
@@ -47,6 +48,7 @@ constructor(
     val publicationDao: PublicationDao,
     val geocodingService: GeocodingService,
     val splitService: SplitService,
+    val trackBoundaryMoveService: TrackBoundaryMoveService,
 ) : DBTestBase() {
 
     @Test
@@ -201,6 +203,7 @@ constructor(
                     switches = switchDao.fetchCandidateVersions(candidateContext, switches),
                     operationalPoints = operationalPointDao.fetchCandidateVersions(candidateContext, operationalPoints),
                     splits = splitService.fetchPublicationVersions(branch, locationTracks, switches),
+                    trackBoundaryMoves = trackBoundaryMoveService.fetchPublicationVersions(branch, locationTracks),
                 ),
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -1,0 +1,234 @@
+package fi.fta.geoviite.infra.split
+
+import fi.fta.geoviite.infra.DBTestBase
+import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
+import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.edge
+import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.segment
+import fi.fta.geoviite.infra.tracklayout.switch
+import fi.fta.geoviite.infra.tracklayout.switchLinkYV
+import fi.fta.geoviite.infra.tracklayout.trackGeometry
+import fi.fta.geoviite.infra.tracklayout.trackNumber
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("dev", "test")
+@SpringBootTest
+class TrackBoundaryMoveIT
+@Autowired
+constructor(
+    private val trackBoundaryMoveService: TrackBoundaryMoveService,
+    private val locationTrackService: LocationTrackService,
+    private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
+) : DBTestBase() {
+    @BeforeEach
+    fun setup() {
+        testDBService.clearLayoutTables()
+    }
+
+    // todo: test publications, multiple publications with multiple boundary changes even
+    @Test
+    fun `move along ascending track`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        // three switches, all laid out to one physically continuous track, with each having just a joint 1 on the left,
+        // 2 on the right, and out-of-switch segments in between. lengtheningTrack contains switch 1, shorteningTrack
+        // contains switches 2 and 3.
+
+        val switch1 = testDBService.save(switch()).id
+        val switch2 = testDBService.save(switch()).id
+        val switch3 = testDBService.save(switch()).id
+
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                        endOuterSwitch = switchLinkYV(switch1, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch1, 1),
+                        endInnerSwitch = switchLinkYV(switch1, 2),
+                    ),
+                ),
+            )
+
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch1, 2),
+                        endOuterSwitch = switchLinkYV(switch2, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch2, 1),
+                        endInnerSwitch = switchLinkYV(switch2, 2),
+                    ),
+                    edge(
+                        listOf(segment(Point(40.0, 0.0), Point(50.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch2, 2),
+                        endOuterSwitch = switchLinkYV(switch3, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(50.0, 0.0), Point(60.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch3, 1),
+                        endInnerSwitch = switchLinkYV(switch3, 3),
+                    ),
+                    edge(
+                        listOf(segment(Point(60.0, 0.0), Point(70.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch3, 3),
+                    ),
+                ),
+            )
+
+        val splitId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.Companion.main,
+                shorteningTrack.id,
+                lengtheningTrack.id,
+                switch2,
+                JointNumber(1),
+            )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(splitId)
+        assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
+        assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
+
+        assertEquals(3, newLengthenedGeometry.edges.size)
+        assertEquals(switchLinkYV(switch2, 1), newLengthenedGeometry.edges.last().endNode.switchOut)
+        assertEquals(switchLinkYV(switch2, 1), newShortenedGeometry.edges.first().startNode.switchIn)
+        assertEquals(4, newShortenedGeometry.edges.size)
+    }
+
+    @Test
+    fun `move in descending direction on short track`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        val switch1 = testDBService.save(switch()).id
+
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch1, 1),
+                        endInnerSwitch = switchLinkYV(switch1, 3),
+                    )
+                ),
+            )
+
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch1, 3),
+                    )
+                ),
+            )
+
+        val splitId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.Companion.main,
+                shorteningTrack.id,
+                lengtheningTrack.id,
+                switch1,
+                JointNumber(1),
+            )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(splitId)
+        assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
+        assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
+        assertEquals(switchLinkYV(switch1, 1), newLengthenedGeometry.edges.first().startNode.switchIn)
+
+        assertEquals(2, newLengthenedGeometry.edges.size)
+        assertEquals(0, newShortenedGeometry.edges.size)
+    }
+
+    @Test
+    fun `shortened track remains with no geometry`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        // three switches, all laid out to one physically continuous track, with each having just a joint 1 on the left,
+        // 2 on the right, and out-of-switch segments in between. lengtheningTrack contains switch 1, shorteningTrack
+        // contains switches 2 and 3.
+
+        val switch1 = testDBService.save(switch()).id
+        val switch2 = testDBService.save(switch()).id
+        val switch3 = testDBService.save(switch()).id
+
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                        endOuterSwitch = switchLinkYV(switch1, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch1, 1),
+                        endInnerSwitch = switchLinkYV(switch1, 2),
+                    ),
+                ),
+            )
+
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(
+                        listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch1, 2),
+                        endOuterSwitch = switchLinkYV(switch2, 1),
+                    ),
+                    edge(
+                        listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
+                        startInnerSwitch = switchLinkYV(switch2, 1),
+                        endInnerSwitch = switchLinkYV(switch2, 2),
+                    ),
+                    edge(
+                        listOf(segment(Point(40.0, 0.0), Point(50.0, 0.0))),
+                        startOuterSwitch = switchLinkYV(switch2, 2),
+                        endOuterSwitch = switchLinkYV(switch3, 1),
+                    ),
+                ),
+            )
+
+        trackBoundaryMoveService.saveTrackBoundaryMove(
+            LayoutBranch.Companion.main,
+            shorteningTrack.id,
+            lengtheningTrack.id,
+            switch3,
+            JointNumber(1),
+        )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        assertEquals(5, newLengthenedGeometry.edges.size)
+        assertEquals(0, newShortenedGeometry.edges.size)
+    }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.trackBoundaryMove.LengtheningDirection
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
@@ -101,6 +102,7 @@ constructor(
                 lengtheningTrack.id,
                 switch2,
                 JointNumber(1),
+                LengtheningDirection.ASCENDING,
             )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
@@ -152,6 +154,7 @@ constructor(
                 lengtheningTrack.id,
                 switch1,
                 JointNumber(1),
+                LengtheningDirection.DESCENDING,
             )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
@@ -222,6 +225,7 @@ constructor(
             lengtheningTrack.id,
             switch3,
             JointNumber(1),
+            LengtheningDirection.ASCENDING,
         )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
@@ -255,6 +259,7 @@ constructor(
             lengtheningTrack.id,
             switch1,
             JointNumber(1),
+            LengtheningDirection.ASCENDING,
         )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -35,7 +35,6 @@ constructor(
         testDBService.clearLayoutTables()
     }
 
-    // todo: test publications, multiple publications with multiple boundary changes even
     @Test
     fun `move along ascending track`() {
         val trackNumber = testDBService.save(trackNumber()).id
@@ -229,6 +228,41 @@ constructor(
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
         assertEquals(5, newLengthenedGeometry.edges.size)
+        assertEquals(0, newShortenedGeometry.edges.size)
+    }
+
+    @Test
+    fun `combine unconnected tracks with combinable geometries`() {
+        val trackNumber = testDBService.save(trackNumber()).id
+
+        val switch1 = testDBService.save(switch()).id
+        // initially topologically disconnected tracks
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))),
+            )
+        val shorteningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    edge(listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1))
+                ),
+            )
+        trackBoundaryMoveService.saveTrackBoundaryMove(
+            LayoutBranch.Companion.main,
+            shorteningTrack.id,
+            lengtheningTrack.id,
+            switch1,
+            JointNumber(1),
+        )
+        val newLengthenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
+        val newShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
+        assertEquals(1, newLengthenedGeometry.edges.size)
+        assertEquals(Point(0.0, 0.0), newLengthenedGeometry.edges[0].start.toPoint())
+        assertEquals(Point(20.0, 0.0), newLengthenedGeometry.edges[0].end.toPoint())
         assertEquals(0, newShortenedGeometry.edges.size)
     }
 }


### PR DESCRIPTION
Oleellisimmat osat raiteen vaihtumiskohtien tallentamisista, ja ext-apissa näyttämisistä.

Julkaisun ja julkaisuvalidoinnin tuki vielä hyvin osittaista, siihen tulee perästä lisäyksiä. Julkaisukokonaisuuksia ei rakenneta vielä lainkaan, ts. PublicationGroup tuntee vain split-id:t.

Useissa kohti käytännössä tehty vaan samaa kuin mitä tehdään spliteillä, mutta ei lähdetty turhaan yhdistelemään rakenteita, joissa kuitenkin on paljon eroavaisuuksiakin.

Varsinainen :cut_of_meat: -koodi jättää myös vielä erottelematta tarkemmin, onko pyyntö itsessään järkevä. Yhdistellyn pidennetyn raiteen geometria luodaan ja tallennetaan, jos sen luominen ja tallentaminen ei itsessään räjähdä. Koska frontin pitää joka tapauksessa jo tietää tarkkaan, millaista vaihtumiskohtan siirtoa se pyytää, bäkkärikoodi ei myöskään tee omia ylimääräisiä päättelyitään, vaan vaatii jo pyynnössä mukana tarkan tiedon siitä, kumpaa raidetta ollaan pidentämässä ja että kumpaan suuntaan.