### PR TITLE
GVT-3581 Part 3: Testihuomioiden korjauksia

### DIFF
--- a/ui/src/selection-panel/selection-panel-container.tsx
+++ b/ui/src/selection-panel/selection-panel-container.tsx
@@ -29,7 +29,7 @@ export const SelectionPanelContainer: React.FC<SelectionPanelContainerProps> = (
 
     const selectableItemTypes = React.useMemo(() => {
         return getSelectableItemTypes(state.splittingState, state.linkingState);
-    }, [state.linkingState]);
+    }, [state.linkingState, state.splittingState]);
 
     const locationTracks = useLocationTracks(
         state.map.shownItems.locationTracks,

--- a/ui/src/selection-panel/selection-panel.tsx
+++ b/ui/src/selection-panel/selection-panel.tsx
@@ -300,7 +300,9 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedTrackNumberIds}
                         onSelectTrackNumber={onTrackNumberSelection}
                         onSelectColor={onTrackNumberColorSelection}
-                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('trackNumbers')}
+                        colorSelectorDisabled={
+                            isLinkingOrSplitting && !selectableItemTypes.includes('trackNumbers')
+                        }
                     />
                 </div>
             </section>
@@ -363,7 +365,9 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedTrackNumbers={selectedItems.trackNumbers}
                         canSelectReferenceLine={selectableItemTypes.includes('trackNumbers')}
                         onToggleReferenceLineSelection={onToggleReferenceLineSelection}
-                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('trackNumbers')}
+                        disabled={
+                            isLinkingOrSplitting && !selectableItemTypes.includes('trackNumbers')
+                        }
                     />
                 </div>
             </section>
@@ -378,7 +382,9 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         selectedLocationTracks={selectedItems.locationTracks}
                         canSelectLocationTrack={selectableItemTypes.includes('locationTracks')}
                         onToggleLocationTrackSelection={onToggleLocationTrackSelection}
-                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('locationTracks')}
+                        disabled={
+                            isLinkingOrSplitting && !selectableItemTypes.includes('locationTracks')
+                        }
                     />
                 </div>
             </section>
@@ -436,7 +442,10 @@ const SelectionPanel: React.FC<SelectionPanelProps> = ({
                         onToggleOperationalPointSelection={(op) =>
                             onToggleOperationalPointSelection(op.id)
                         }
-                        disabled={isLinkingOrSplitting && !selectableItemTypes.includes('operationalPoints')}
+                        disabled={
+                            isLinkingOrSplitting &&
+                            !selectableItemTypes.includes('operationalPoints')
+                        }
                     />
                 </div>
             </section>

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.scss
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.scss
@@ -32,10 +32,5 @@
         .radio {
             margin-right: 8px;
         }
-
-        &--disabled {
-            color: vayla-design.$color-black-lighter;
-            pointer-events: none;
-        }
     }
 }

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
@@ -19,7 +19,7 @@ type TrackNumberPanelProps = {
     onSelectColor: (trackNumberId: LayoutTrackNumberId, color: TrackNumberColorKey) => void;
     selectedTrackNumbers: LayoutTrackNumberId[];
     max?: number;
-    disabled?: boolean;
+    colorSelectorDisabled?: boolean;
 };
 
 const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
@@ -29,7 +29,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
     onSelectColor,
     selectedTrackNumbers,
     max = 16,
-    disabled = false,
+    colorSelectorDisabled = false,
 }: TrackNumberPanelProps) => {
     const { t } = useTranslation();
     const [sortedTrackNumbers, setSortedTrackNumbers] = React.useState<LayoutTrackNumber[]>([]);
@@ -61,7 +61,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
                                         />
                                         {trackNumber.number}
                                     </span>
-                                    {!disabled && (
+                                    {!colorSelectorDisabled && (
                                         <ColorSelector
                                             color={
                                                 settings[trackNumber.id]?.color ??

--- a/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
+++ b/ui/src/selection-panel/track-number-panel/track-number-panel.tsx
@@ -42,10 +42,7 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
 
         setSortedTrackNumbers(visibleTrackNumbers.sort(fieldComparator((tn) => tn.number)));
     }, [trackNumbers, selectedTrackNumbers]);
-    const trackNumberClassNames = createClassName(
-        styles['track-number-panel__track-number'],
-        disabled && styles['track-number-panel__track-number--disabled'],
-    );
+    const trackNumberClassNames = createClassName(styles['track-number-panel__track-number']);
 
     return (
         <div>
@@ -56,12 +53,8 @@ const TrackNumberPanel: React.FC<TrackNumberPanelProps> = ({
                         return (
                             <li className={trackNumberClassNames} key={trackNumber.id}>
                                 <div>
-                                    <span
-                                        onMouseUp={() =>
-                                            !disabled && onSelectTrackNumber(trackNumber)
-                                        }>
+                                    <span onMouseUp={() => onSelectTrackNumber(trackNumber)}>
                                         <Radio
-                                            disabled={disabled}
                                             checked={isSelected}
                                             readOnly={true}
                                             name={trackNumber.number}


### PR DESCRIPTION
Testauksessa oli löytynyt pari huomiota, täällä ne on korjattu. Elikkäs:

- Toiminnalliset pisteet eivät disabloituneet oikein vasemmasta paneelista kun splittaustilan laittoi päälle
- Vasemman paneelin filtteröinti ratanumeroilla oli disabloitunut epähuomiosssa. Nyt filtteröinti on mahdollistettu uudestaan, linkitys ja splittaus disabloi ainoastaan värivalinnat 