### PR TITLE
GVT-3126 Raiteiden muutoskohtien siirron pikkufiksejä

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
@@ -105,7 +105,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
 
     fun getOrThrow(id: IntId<TrackBoundaryMove>) = requireNotNull(get(id))
 
-    fun getUnPublished(): List<TrackBoundaryMove> {
+    fun getUnpublished(): List<TrackBoundaryMove> {
         val sql =
             """
             select

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -72,13 +72,13 @@ class TrackBoundaryMoveService(
         branch: LayoutBranch,
         locationTracks: List<IntId<LocationTrack>>,
     ): List<RowVersion<TrackBoundaryMove>> =
-        findUnPublishedBoundaryMoves(branch, locationTracks).map { boundaryMove -> boundaryMove.version }
+        findUnpublishedBoundaryMoves(branch, locationTracks).map { boundaryMove -> boundaryMove.version }
 
-    fun findUnPublishedBoundaryMoves(
+    fun findUnpublishedBoundaryMoves(
         branch: LayoutBranch,
         locationTrackIds: List<IntId<LocationTrack>>? = null,
     ): List<TrackBoundaryMove> =
-        trackBoundaryMoveDao.getUnPublished().filter { boundaryMove ->
+        trackBoundaryMoveDao.getUnpublished().filter { boundaryMove ->
             locationTrackIds == null || locationTrackIds.any(boundaryMove::containsLocationTrack)
         }
 

--- a/ui/src/environment/env-restricted.tsx
+++ b/ui/src/environment/env-restricted.tsx
@@ -6,6 +6,7 @@ type EnvRestrictedProps = {
     defaultShow?: boolean;
     strict?: boolean;
     children: React.ReactNode;
+    fallback?: React.ReactNode;
 };
 
 //Local is only shown in local environment,
@@ -22,6 +23,7 @@ export const EnvRestricted: React.FC<EnvRestrictedProps> = ({
     children,
     strict = false,
     defaultShow = false,
+    fallback = undefined,
 }: EnvRestrictedProps) => {
     const envName = useEnvironmentInfo()?.environmentName;
 
@@ -31,5 +33,5 @@ export const EnvRestricted: React.FC<EnvRestrictedProps> = ({
             : slackRestrictionRules[restrictTo].some((e) => e === envName)
         : defaultShow;
 
-    return <React.Fragment>{show && children}</React.Fragment>;
+    return <React.Fragment>{show ? children : fallback}</React.Fragment>;
 };

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -56,6 +56,7 @@ import { getSplitPointName } from 'tool-panel/location-track/splitting/location-
 import { SplitButton } from 'geoviite-design-lib/split-button/split-button';
 import { Menu, menuOption } from 'vayla-design-lib/menu/menu';
 import { filterNotEmpty, filterUniqueById } from 'utils/array-utils';
+import { EnvRestricted } from 'environment/env-restricted';
 
 type LocationTrackLocationInfoboxContainerProps = {
     locationTrack: LayoutLocationTrack;
@@ -404,6 +405,39 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         anySwitchesPartOfOtherSplits ||
         layoutContext.branch !== 'MAIN';
 
+    const modifyStartOrEndButton = (
+        <EnvRestricted
+            restrictTo={'dev'}
+            fallback={
+                <Button
+                    variant={ButtonVariant.SECONDARY}
+                    size={ButtonSize.SMALL}
+                    qa-id="modify-start-or-end"
+                    title={getModifyStartOrEndDisabledReasonTranslated()}
+                    disabled={shorteningDisabled}
+                    onClick={() => {
+                        getEndLinkPoints(
+                            locationTrack.id,
+                            layoutContext,
+                            MapAlignmentType.LocationTrack,
+                            changeTimes.layoutLocationTrack,
+                        ).then(onStartLocationTrackGeometryChange);
+                    }}>
+                    {t('tool-panel.location-track.modify-start-or-end')}
+                </Button>
+            }>
+            <Button
+                variant={ButtonVariant.SECONDARY}
+                size={ButtonSize.SMALL}
+                qa-id="modify-start-or-end"
+                title={getModifyStartOrEndDisabledReasonTranslated()}
+                disabled={shorteningDisabled}
+                onClick={() => setModifyMenuOpen(true)}>
+                {t('tool-panel.location-track.modify-start-or-end')}
+            </Button>
+        </EnvRestricted>
+    );
+
     return (
         startAndEndPoints &&
         coordinateSystem && (
@@ -449,17 +483,7 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                         </InfoboxContentSpread>
                                     )}
                                     <InfoboxButtons>
-                                        <div ref={modifyButtonRef}>
-                                            <Button
-                                                variant={ButtonVariant.SECONDARY}
-                                                size={ButtonSize.SMALL}
-                                                qa-id="modify-start-or-end"
-                                                title={getModifyStartOrEndDisabledReasonTranslated()}
-                                                disabled={shorteningDisabled}
-                                                onClick={() => setModifyMenuOpen(true)}>
-                                                {t('tool-panel.location-track.modify-start-or-end')}
-                                            </Button>
-                                        </div>
+                                        <div ref={modifyButtonRef}>{modifyStartOrEndButton}</div>
                                         {modifyMenuOpen && (
                                             <Menu
                                                 anchorElementRef={modifyButtonRef}


### PR DESCRIPTION
- Kohennettu aiempien katselmointikommenttien perusteella funktionimiä
- Siirretty vainoharhasta tämä ominaisuus näkymään ainakin tällä hetkellä vain dev-ympäristössä. Tämä siksi, että koodi ei yritä vielä millään tavalla oikeasti viedä tätä kokonaisuutta Ratkoon kokonaisuutena (edes senkään jälkeen kun laitan myöhemmässä puskussa mukaan varsinaisen julkaisuryhmittelyn ja validaation), eli vaikka muutkin ominaisuudet tulisi toteutettua valmiiksi asti, tätä ei haluttaisi vielä tuotantoon toimimaan. Totuttuun tapaan oletetaan, että käyttäjät ei hakkeroi asioita kälin ohi vaan että env-gate UI-tasolla riittää.