### PR TITLE
GVT-3126 Attempt to fix UI tests

### DIFF
--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelInfobox.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/ToolPanelInfobox.kt
@@ -114,7 +114,8 @@ class E2ELocationTrackLocationInfobox(infoboxBy: By) : E2EInfoBox(infoboxBy) {
     fun startLinking(): E2ELocationTrackLocationInfobox = apply {
         logger.info("Edit start/end point")
 
-        childButton(byQaId("modify-start-or-end")).clickAndWaitToDisappear()
+        childButton(byQaId("modify-start-or-end")).click()
+        clickWhenClickable(byQaId("shorten-track-start-or-end"))
     }
 
     fun startSplitting(): E2ELocationTrackSplittingInfobox {


### PR DESCRIPTION
Käli on muuttunut ihan oikeasti -> pitää muuttaa kälitestejäkin ihan oikeasti. Uusi shorten-track-or-end -namiska on menu-elementin sisällä, eli portaalin kautta renderöity, eli vaikka onkin React-puussa tässä paikassa niin DOM-puussa ei ole, ja siksi pitää hakea globaalisti eikä infobox-elementin alta.