### PR TITLE
GVT-3115 Display counterpart track on map already pre-locking

### DIFF
--- a/ui/src/linking/linking-model.ts
+++ b/ui/src/linking/linking-model.ts
@@ -231,6 +231,7 @@ export type ChangingTrackBoundary = LinkingBaseType & {
     type: LinkingType.TrackBoundaryMove;
     headTrack: LocationTrackId;
     counterpart: BoundaryMoveCounterpart | undefined;
+    counterpartLocked: boolean;
     selectedJoint: SelectedBoundaryMoveJoint | undefined;
 };
 

--- a/ui/src/linking/linking-store.ts
+++ b/ui/src/linking/linking-store.ts
@@ -382,6 +382,7 @@ export const linkingReducers = {
             state: 'preliminary',
             issues: [],
             counterpart: undefined,
+            counterpartLocked: false,
             selectedJoint: undefined,
         };
     },
@@ -391,6 +392,14 @@ export const linkingReducers = {
     ) => {
         if (state.linkingState?.type === LinkingType.TrackBoundaryMove) {
             state.linkingState.counterpart = counterpart;
+        }
+    },
+    confirmTrackBoundaryMoveCounterpartSelection: (state: TrackLayoutState) => {
+        if (
+            state.linkingState?.type === LinkingType.TrackBoundaryMove &&
+            state.linkingState.counterpart !== undefined
+        ) {
+            state.linkingState.counterpartLocked = true;
         }
     },
     setTrackBoundaryMoveJoint: (

--- a/ui/src/map/layers/location-track-boundary-move-layer.ts
+++ b/ui/src/map/layers/location-track-boundary-move-layer.ts
@@ -349,7 +349,11 @@ export const createLocationTrackBoundaryMoveLayer = (
 
     const clickListenerKey = olMap.on('click', ({ coordinate }) => {
         const trackInfos = loadedTrackInfos;
-        if (trackInfos === undefined) {
+        if (
+            trackInfos === undefined ||
+            linkingState?.type !== 'TrackBoundaryMove' ||
+            !linkingState.counterpartLocked
+        ) {
             return;
         }
         const hitArea = getDefaultHitArea(olMap, coordinate);

--- a/ui/src/map/layers/location-track-boundary-move-layer.ts
+++ b/ui/src/map/layers/location-track-boundary-move-layer.ts
@@ -351,7 +351,7 @@ export const createLocationTrackBoundaryMoveLayer = (
         const trackInfos = loadedTrackInfos;
         if (
             trackInfos === undefined ||
-            linkingState?.type !== 'TrackBoundaryMove' ||
+            linkingState?.type !== LinkingType.TrackBoundaryMove ||
             !linkingState.counterpartLocked
         ) {
             return;

--- a/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
@@ -54,6 +54,9 @@ export const LocationTrackBoundaryMoveInfoboxContainer: React.FC<
                 delegates.removeForcedVisibleLayer(['alignment-linking-layer']);
                 delegates.stopLinking();
             }}
+            onConfirmCounterpartSelection={() =>
+                delegates.confirmTrackBoundaryMoveCounterpartSelection()
+            }
             onSaveTrackBoundaryMove={async (request) => {
                 await saveTrackBoundaryMove(layoutContext, request);
                 await updateLocationTrackChangeTime();
@@ -74,6 +77,7 @@ type LocationTrackBoundaryMoveInfoboxProps = {
     changeTimes: ChangeTimes;
     onStopTrackBoundaryMove: () => void;
     onSelectCounterpart: (counterpart: BoundaryMoveCounterpart) => void;
+    onConfirmCounterpartSelection: () => void;
     onSaveTrackBoundaryMove: (request: TrackBoundaryMoveRequest) => Promise<void>;
 };
 
@@ -83,6 +87,7 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
     layoutContext,
     changeTimes,
     onSelectCounterpart,
+    onConfirmCounterpartSelection,
     onStopTrackBoundaryMove,
     onSaveTrackBoundaryMove,
 }) => {
@@ -91,7 +96,6 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
     const [counterpartOptions, setCounterpartOptions] = React.useState<BoundaryMoveCounterpart[]>(
         [],
     );
-    const [pickedTrackId, setPickedTrackId] = React.useState<LocationTrackId>();
     const [saving, setSaving] = React.useState(false);
 
     const [candidates, candidatesLoaderStatus] = useLoaderWithStatus(async () => {
@@ -106,10 +110,10 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
     }, [locationTrack.id, layoutContext, changeTimes.layoutLocationTrack]);
 
     const counterpart = linkingState.counterpart;
-    const counterpartSelected = counterpart !== undefined;
+    const counterpartLocked = linkingState.counterpartLocked;
 
-    const lockSelection = () => {
-        const picked = counterpartOptions.find((o) => o.trackId === pickedTrackId);
+    const selectCounterpart = (selectedTrack: LocationTrackId) => {
+        const picked = counterpartOptions.find((o) => o.trackId === selectedTrack);
         if (picked) {
             onSelectCounterpart(picked);
         }
@@ -139,7 +143,7 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
     return (
         <Infobox
             title={
-                counterpartSelected
+                counterpartLocked
                     ? t('tool-panel.location-track.track-boundary-move.title-post-select')
                     : t('tool-panel.location-track.track-boundary-move.title-pre-select')
             }
@@ -153,7 +157,7 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
                     />
                 </InfoboxField>
 
-                {counterpartSelected ? (
+                {counterpartLocked ? (
                     <React.Fragment>
                         <InfoboxField
                             label={t('tool-panel.location-track.track-boundary-move.second-track')}>
@@ -199,12 +203,12 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
                         />
                         <LocationTrackCandidates
                             candidates={candidates || EMPTY_ARRAY}
-                            selectedId={pickedTrackId}
+                            selectedId={counterpart?.trackId}
                             isLoading={candidatesLoaderStatus === LoaderStatus.Loading}
                             emptyMessage={t(
                                 'tool-panel.location-track.track-boundary-move.no-candidates',
                             )}
-                            onSelect={setPickedTrackId}
+                            onSelect={selectCounterpart}
                         />
 
                         <MessageBox type={MessageBoxType.INFO}>
@@ -217,7 +221,9 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
                                 onClick={onStopTrackBoundaryMove}>
                                 {t('button.cancel')}
                             </Button>
-                            <Button disabled={pickedTrackId === undefined} onClick={lockSelection}>
+                            <Button
+                                disabled={counterpart === undefined}
+                                onClick={onConfirmCounterpartSelection}>
                                 {t('tool-panel.location-track.track-boundary-move.lock-selection')}
                             </Button>
                         </InfoboxButtons>


### PR DESCRIPTION
Alkutoteutus piti counterpart-raidevalintaa vain infoboksin sisäisenä tietona, mutta omassa testauksessa tuli aika äkkiä selväksi että pitäähän se nyt kartallakin visualisoida jo ennenkin kuin valinta on lukittu. Mutta tieto valinnan lukitsemisesta pitää myös tuoda Redux-tilaan, jotta sitten karttataso osaa olla reagoimatta, jos käyttäjä alkaa jo napsuttelemaan vaihteita siitä.