### PR TITLE
General: Remove the now-useless sourceId field from ReferenceLine

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -272,7 +272,7 @@ data class LocationTrack(
     val operationalPointIds: Set<IntId<OperationalPoint>>,
     @JsonIgnore override val contextData: LayoutContextData<LocationTrack>,
     @JsonIgnore val switchIds: List<IntId<LayoutSwitch>> = listOf(),
-) : PolyLineLayoutAsset<LocationTrack>(contextData) {
+) : LayoutAsset<LocationTrack>(contextData) {
 
     @JsonIgnore val exists = !state.isRemoved()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLine.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLine.kt
@@ -5,13 +5,11 @@ import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.common.TrackMeter
-import fi.fta.geoviite.infra.geometry.GeometryAlignment
 import fi.fta.geoviite.infra.math.BoundingBox
 
 data class ReferenceLine(
     val trackNumberId: IntId<LayoutTrackNumber>,
     val startAddress: TrackMeter,
-    val sourceId: IntId<GeometryAlignment>?,
     val boundingBox: BoundingBox? = null,
     val length: LineM<ReferenceLineM> = LineM(0.0),
     val segmentCount: Int = 0,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLine.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLine.kt
@@ -15,7 +15,7 @@ data class ReferenceLine(
     val segmentCount: Int = 0,
     @JsonIgnore override val contextData: LayoutContextData<ReferenceLine>,
     @JsonIgnore val geometryVersion: RowVersion<ReferenceLineGeometry>? = null,
-) : PolyLineLayoutAsset<ReferenceLine>(contextData) {
+) : LayoutAsset<ReferenceLine>(contextData) {
 
     init {
         require(dataType == DataType.TEMP || geometryVersion != null) { "ReferenceLine in DB must have a geometry" }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineDao.kt
@@ -15,11 +15,11 @@ import fi.fta.geoviite.infra.util.getTrackMeter
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setForceCustomPlan
 import fi.fta.geoviite.infra.util.setUser
-import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.sql.ResultSet
 
 const val REFERENCE_LINE_CACHE_SIZE = 1000L
 
@@ -117,14 +117,20 @@ class ReferenceLineDao(
     private fun getReferenceLine(rs: ResultSet): ReferenceLine =
         ReferenceLine(
             geometryVersion = rs.getRowVersion("alignment_id", "alignment_version"),
-            sourceId = null,
             trackNumberId = rs.getIntId("track_number_id"),
             startAddress = rs.getTrackMeter("start_address"),
             boundingBox = rs.getBboxOrNull("bounding_box"),
             length = LineM(rs.getDouble("length")),
             segmentCount = rs.getInt("segment_count"),
             contextData =
-                rs.getLayoutContextData("id", "design_id", "draft", "version", "design_asset_state", "origin_design_id"),
+                rs.getLayoutContextData(
+                    "id",
+                    "design_id",
+                    "draft",
+                    "version",
+                    "design_asset_state",
+                    "origin_design_id",
+                ),
         )
 
     @Transactional fun save(item: ReferenceLine): LayoutRowVersion<ReferenceLine> = save(item, NoParams.instance)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/ReferenceLineService.kt
@@ -35,7 +35,6 @@ class ReferenceLineService(
             ReferenceLine(
                 trackNumberId = trackNumberId,
                 startAddress = startAddress,
-                sourceId = null,
                 contextData = LayoutContextData.newDraft(branch, dao.createId()),
             ),
             emptyAlignment(),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayout.kt
@@ -51,10 +51,6 @@ sealed class LayoutAsset<T : LayoutAsset<T>>(contextData: LayoutContextData<T>) 
         }
 }
 
-// TODO: GVT-2935 This is likely no longer needed as LocationTrack and ReferenceLine are now different
-sealed class PolyLineLayoutAsset<T : PolyLineLayoutAsset<T>>(contextData: LayoutContextData<T>) :
-    LayoutAsset<T>(contextData) {}
-
 data class LayoutAssetChangeInfo(val created: Instant, val changed: Instant?)
 
 fun <T : LayoutAsset<T>> idMatches(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -63,7 +63,6 @@ import fi.fta.geoviite.infra.tracklayout.MainDraftContextData
 import fi.fta.geoviite.infra.tracklayout.MainOfficialContextData
 import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
-import fi.fta.geoviite.infra.tracklayout.PolyLineLayoutAsset
 import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineGeometry
@@ -86,10 +85,10 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.setUser
-import java.time.Instant
-import kotlin.reflect.KClass
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.transaction.support.TransactionTemplate
+import java.time.Instant
+import kotlin.reflect.KClass
 
 interface TestDB {
     val jdbc: NamedParameterJdbcTemplate
@@ -580,7 +579,6 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
             // Also copy geometry for polyline assets
             is LocationTrack -> save(withNewContext, alignmentDao.fetch(rowVersion as LayoutRowVersion<LocationTrack>))
             is ReferenceLine -> save(withNewContext, alignmentDao.fetch(withNewContext.getGeometryVersionOrThrow()))
-            is PolyLineLayoutAsset<*> -> error("Unhandled PolyLineAsset type: ${T::class.simpleName}")
             else -> save(withNewContext)
         }
             as LayoutRowVersion<T>
@@ -606,7 +604,6 @@ data class TestLayoutContext(val context: LayoutContext, val testService: TestDB
             // Also move geometry for polyline assets
             is LocationTrack -> save(withNewContext, alignmentDao.fetch(rowVersion as LayoutRowVersion<LocationTrack>))
             is ReferenceLine -> save(withNewContext, alignmentDao.fetch(withNewContext.getGeometryVersionOrThrow()))
-            is PolyLineLayoutAsset<*> -> error("Unhandled PolyLineAsset type: ${T::class.simpleName}")
             else -> save(withNewContext)
         }
             as LayoutRowVersion<T>

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDomainTestData.kt
@@ -358,7 +358,6 @@ fun referenceLine(
     ReferenceLine(
         trackNumberId = trackNumberId,
         startAddress = startAddress.round(3),
-        sourceId = null,
         boundingBox = geometry?.boundingBox,
         segmentCount = geometry?.segments?.size ?: 0,
         length = geometry?.length ?: LineM(0.0),

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -138,7 +138,6 @@ export type LayoutReferenceLine = {
     trackNumberId: LayoutTrackNumberId;
     boundingBox?: BoundingBox;
     length: number;
-    sourceId?: GeometryAlignmentId;
     segmentCount: number;
 } & LayoutAssetFields;
 


### PR DESCRIPTION
Bongattu vanha jäänne ajalta ennen plan-layout-muunnosten erottelua omiksi tyypeikseen. ReferenceLine-tyypin vanhaan sourceId kenttään ei koskaan laiteta mitään eikä sitä tallenneta tai käytetä mihinkään.

Edit: Poistettu myös tarpeeton välityyppi PolyLineLayoutAsset jolla oli arvoa vielä silloin kun raiteen ja ratanumeron geometriat jakoivat samoja tyyppejä, mutta joka on sittemmin turha (kuten TODO-kommentti vihjasikin).