### PR TITLE
GVT-3115 Lisää vaihtumiskohdan siirron frontin säätöjä

### DIFF
--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1032,7 +1032,7 @@
                 "select-boundary-on-map": "Valitse uusi vaihtumiskohta kartalta.",
                 "lock-selection": "Lukitse valinta",
                 "save-boundary-move": "Tallenna vaihtumiskohta",
-                "boundary-move-saved": "Vaihtumiskohta tallennettu"
+                "boundary-move-saved": "Raiteiden {{firstTrack}} ja {{secondTrack}} vaihtumiskohta siirretty osoitteeseen {{address}}"
             }
         },
         "operational-point": {

--- a/ui/src/map/layers/location-track-boundary-move-layer.ts
+++ b/ui/src/map/layers/location-track-boundary-move-layer.ts
@@ -424,6 +424,7 @@ export const createLocationTrackBoundaryMoveLayer = (
                 kind: 'joint',
                 role: onHead !== undefined ? 'head' : 'counterpart',
                 joint: { switchId: foundJoint.switchId, jointNumber: foundJoint.jointNumber },
+                location: foundJoint.location,
             });
             return;
         }
@@ -435,7 +436,7 @@ export const createLocationTrackBoundaryMoveLayer = (
                       hitArea.containsXY(e.location.x, e.location.y),
                   );
         if (end !== undefined) {
-            onSelectTarget({ kind: 'end', role: end.role });
+            onSelectTarget({ kind: 'end', role: end.role, location: end.location });
         }
     });
 

--- a/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
@@ -1,4 +1,8 @@
-import { LayoutLocationTrack, LocationTrackId } from 'track-layout/track-layout-model';
+import {
+    LayoutLocationTrack,
+    LocationTrackId,
+    SwitchJointId,
+} from 'track-layout/track-layout-model';
 import { ChangingTrackBoundary } from 'linking/linking-model';
 import { LayoutContext } from 'common/common-model';
 import { createDelegates } from 'store/store-utils';
@@ -80,6 +84,23 @@ type LocationTrackBoundaryMoveInfoboxProps = {
     onConfirmCounterpartSelection: () => void;
     onSaveTrackBoundaryMove: (request: TrackBoundaryMoveRequest) => Promise<void>;
 };
+
+function switchJointIdEquals(a: SwitchJointId, b: SwitchJointId): boolean {
+    return a.switchId === b.switchId && a.jointNumber === b.jointNumber;
+}
+
+function canSave(linkingState: ChangingTrackBoundary): boolean {
+    const selectedTarget = linkingState.selectedTarget;
+    const counterpart = linkingState.counterpart;
+    return (
+        selectedTarget !== undefined &&
+        counterpart !== undefined &&
+        (selectedTarget.kind === 'joint'
+            ? counterpart.connectingSwitchJoint === undefined ||
+              !switchJointIdEquals(selectedTarget.joint, counterpart.connectingSwitchJoint)
+            : true)
+    );
+}
 
 const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfoboxProps> = ({
     locationTrack,
@@ -184,7 +205,7 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
                                 {t('button.cancel')}
                             </Button>
                             <Button
-                                disabled={selectedTarget === undefined || saving}
+                                disabled={saving || !canSave(linkingState)}
                                 isProcessing={saving}
                                 onClick={saveBoundaryMove}>
                                 {t(

--- a/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
@@ -8,7 +8,9 @@ import { LayoutContext } from 'common/common-model';
 import { createDelegates } from 'store/store-utils';
 import { trackLayoutActionCreators as TrackLayoutActions } from 'track-layout/track-layout-slice';
 import { useCommonDataAppSelector } from 'store/hooks';
-import { getLocationTracks } from 'track-layout/layout-location-track-api';
+import { getLocationTrack, getLocationTracks } from 'track-layout/layout-location-track-api';
+import { getAddress } from 'common/geocoding-api';
+import { formatTrackMeter } from 'utils/geography-utils';
 import { EMPTY_ARRAY } from 'utils/array-utils';
 import { ChangeTimes } from 'common/common-slice';
 import React from 'react';
@@ -44,6 +46,7 @@ type LocationTrackBoundaryMoveInfoboxContainerProps = {
 export const LocationTrackBoundaryMoveInfoboxContainer: React.FC<
     LocationTrackBoundaryMoveInfoboxContainerProps
 > = ({ locationTrack, linkingState, layoutContext }) => {
+    const { t } = useTranslation();
     const delegates = createDelegates(TrackLayoutActions);
     const changeTimes = useCommonDataAppSelector((state) => state.changeTimes);
 
@@ -64,8 +67,27 @@ export const LocationTrackBoundaryMoveInfoboxContainer: React.FC<
             onSaveTrackBoundaryMove={async (request) => {
                 await saveTrackBoundaryMove(layoutContext, request);
                 await updateLocationTrackChangeTime();
+
+                const counterpart = linkingState.counterpart;
+                const selectedTarget = linkingState.selectedTarget;
+                const counterpartTrack =
+                    counterpart === undefined
+                        ? undefined
+                        : await getLocationTrack(counterpart.trackId, layoutContext);
+                const address =
+                    selectedTarget === undefined
+                        ? undefined
+                        : await getAddress(
+                              locationTrack.trackNumberId,
+                              selectedTarget.location,
+                              layoutContext,
+                          );
                 Snackbar.success(
-                    'tool-panel.location-track.track-boundary-move.boundary-move-saved',
+                    t('tool-panel.location-track.track-boundary-move.boundary-move-saved', {
+                        firstTrack: locationTrack.name,
+                        secondTrack: counterpartTrack?.name ?? '',
+                        address: address === undefined ? '' : formatTrackMeter(address),
+                    }),
                 );
                 delegates.removeForcedVisibleLayer(['alignment-linking-layer']);
                 delegates.stopLinking();

--- a/ui/src/track-layout/track-boundary-move-api.ts
+++ b/ui/src/track-layout/track-boundary-move-api.ts
@@ -1,16 +1,11 @@
-import { LayoutSwitchId, LocationTrackId } from 'track-layout/track-layout-model';
-import { JointNumber, LayoutContext } from 'common/common-model';
+import { LocationTrackId, SwitchJointId } from 'track-layout/track-layout-model';
+import { LayoutContext } from 'common/common-model';
 import { Point } from 'model/geometry';
 import { getNonNull, postNonNull } from 'api/api-fetch';
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { BoundaryMoveTrackRole } from 'map/layers/utils/location-track-boundary-move-layer-utils';
 
 export type BoundaryOrientation = 'HEAD_FIRST' | 'COUNTERPART_FIRST';
-
-type SwitchJointId = {
-    switchId: LayoutSwitchId;
-    jointNumber: JointNumber;
-};
 
 // The user picks where the boundary between the two tracks should end up: either at a switch joint
 // somewhere along one of the tracks, or all the way at the far end of one of the tracks (which leaves

--- a/ui/src/track-layout/track-boundary-move-api.ts
+++ b/ui/src/track-layout/track-boundary-move-api.ts
@@ -1,5 +1,6 @@
 import { LayoutSwitchId, LocationTrackId } from 'track-layout/track-layout-model';
 import { JointNumber, LayoutContext } from 'common/common-model';
+import { Point } from 'model/geometry';
 import { getNonNull, postNonNull } from 'api/api-fetch';
 import { TRACK_LAYOUT_URI } from 'track-layout/track-layout-api';
 import { BoundaryMoveTrackRole } from 'map/layers/utils/location-track-boundary-move-layer-utils';
@@ -18,11 +19,13 @@ export type SelectedBoundaryMoveJoint = {
     kind: 'joint';
     role: BoundaryMoveTrackRole;
     joint: SwitchJointId;
+    location: Point;
 };
 
 export type SelectedBoundaryMoveEnd = {
     kind: 'end';
     role: BoundaryMoveTrackRole;
+    location: Point;
 };
 
 export type SelectedBoundaryMoveTarget = SelectedBoundaryMoveJoint | SelectedBoundaryMoveEnd;

--- a/ui/test/map/layers/utils/location-track-boundary-move-layer-utils.test.ts
+++ b/ui/test/map/layers/utils/location-track-boundary-move-layer-utils.test.ts
@@ -68,11 +68,13 @@ const selectedJoint = (
     kind: 'joint',
     role,
     joint: jointId(sId, jNumber),
+    location: { x: 0, y: 0 },
 });
 
 const selectedEnd = (role: BoundaryMoveTrackRole): SelectedBoundaryMoveEnd => ({
     kind: 'end',
     role,
+    location: { x: 0, y: 0 },
 });
 
 const trackInfo = (opts: {


### PR DESCRIPTION
- Selkeytetty hilkun verran infoboksin toimintaa niin, että jos yrittää valita vaihtumiskohdaksi nykyisen vaihtumiskohdan, tallentamista ei sallita (tämähän on meillä tavallinen toimintatapa, että mitään tekemätön muutos on periaatteessa mahdollista valita tehtäväksi, mutta tällöin ei sallita muutoksen tallennusta; ja tässä tapauksessahan bäkkäri heittäisi mitään tekemättömästä muutoksesta virheen)
- Laajennettu success-toast alkuperäisen speksin mukaiseksi