### PR TITLE
GVT-3126/GVT-3630 Implement design and publication support for track boundary moves

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -135,6 +135,24 @@ class PartialSplitRevertException(
     }
 }
 
+class PartialTrackBoundaryMoveRevertException(
+    message: String,
+    cause: Throwable? = null,
+    localizedMessageKey: String = "partial-revert",
+    localizationParams: LocalizationParams = LocalizationParams.empty,
+) :
+    ClientException(
+        BAD_REQUEST,
+        "Split revert failed: $message",
+        cause,
+        "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
+        localizationParams,
+    ) {
+    companion object {
+        const val LOCALIZATION_KEY_BASE = "error.track-boundary-move"
+    }
+}
+
 class PublicationFailureException(
     message: String,
     cause: Throwable? = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/error/ClientException.kt
@@ -143,7 +143,7 @@ class PartialTrackBoundaryMoveRevertException(
 ) :
     ClientException(
         BAD_REQUEST,
-        "Split revert failed: $message",
+        "Track boundary move revert failed: $message",
         cause,
         "$LOCALIZATION_KEY_BASE.$localizedMessageKey",
         localizationParams,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -471,6 +471,8 @@ data class ValidationVersions(
 
     fun containsSplit(id: IntId<Split>): Boolean = splits.any { it.id == id }
 
+    fun containsTrackBoundaryMove(id: IntId<TrackBoundaryMove>) = trackBoundaryMoves.any { it.id == id }
+
     fun findTrackNumber(id: IntId<LayoutTrackNumber>) = trackNumbers.find { it.id == id }
 
     fun findLocationTrack(id: IntId<LocationTrack>) = locationTracks.find { it.id == id }
@@ -494,7 +496,17 @@ data class ValidationVersions(
     fun getSplitIds() = splits.map { v -> v.id }
 }
 
-data class PublicationGroup(val id: IntId<Split>)
+sealed class PublicationGroup {
+    abstract val id: String
+}
+
+data class SplitPublicationGroup(val splitId: IntId<Split>) : PublicationGroup() {
+    override val id = "SPLIT_${splitId}"
+}
+
+data class TrackBoundaryMovePublicationGroup(val trackBoundaryMoveId: IntId<TrackBoundaryMove>) : PublicationGroup() {
+    override val id = "TRACK_BOUNDARY_MOVE_${trackBoundaryMoveId}"
+}
 
 data class PublicationRequestIds(
     val trackNumbers: List<IntId<LayoutTrackNumber>>,
@@ -833,8 +845,9 @@ data class SwitchChanges(
     private fun getTrackNumberJointLocation(
         trackNumberId: IntId<LayoutTrackNumber>,
         jointNumber: JointNumber,
-    ): Change<Point?> =
-        trackConnections.map { tracks -> getTrackNumberJointLocation(tracks, trackNumberId, jointNumber) }
+    ): Change<Point?> = trackConnections.map { tracks ->
+        getTrackNumberJointLocation(tracks, trackNumberId, jointNumber)
+    }
 
     private fun getTrackNumberJointLocation(
         tracks: List<SwitchLocationTrack>,
@@ -1026,4 +1039,16 @@ data class PublicationComparison(val from: Publication, val to: Publication) {
     fun areDifferent(): Boolean {
         return from.id.intValue != to.id.intValue
     }
+}
+
+data class AdministrativeChangeLayoutValidationIssues(
+    val trackNumbers: Map<IntId<LayoutTrackNumber>, List<LayoutValidationIssue>>,
+    val referenceLines: Map<IntId<ReferenceLine>, List<LayoutValidationIssue>>,
+    val kmPosts: Map<IntId<LayoutKmPost>, List<LayoutValidationIssue>>,
+    val locationTracks: Map<IntId<LocationTrack>, List<LayoutValidationIssue>>,
+    val switches: Map<IntId<LayoutSwitch>, List<LayoutValidationIssue>>,
+) {
+    fun allIssues(): List<LayoutValidationIssue> =
+        (trackNumbers.values + referenceLines.values + kmPosts.values + locationTracks.values + switches.values)
+            .flatten()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -34,6 +34,7 @@ import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.switchLibrary.SwitchType
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
 import fi.fta.geoviite.infra.tracklayout.DesignAssetState
 import fi.fta.geoviite.infra.tracklayout.KmPostGkLocationSource
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
@@ -277,6 +278,12 @@ class PublicationDao(
                 candidate_location_track.state
               ) as operation,
               postgis.st_astext(candidate_location_track.bounding_box) as bounding_box,
+              (select id as track_boundary_move_id
+               from publication.track_boundary_move tbm
+               where tbm.publication_id is null
+                 and tbm.design_id is not distinct from :candidate_design_id
+                 and (tbm.shortened_location_track_id = candidate_location_track.id
+                      or tbm.lengthened_location_track_id = candidate_location_track.id)),
               splits.split_id
             from layout.location_track candidate_location_track
                 left join splits
@@ -306,7 +313,10 @@ class PublicationDao(
                     operation = rs.getEnum("operation"),
                     boundingBox = rs.getBboxOrNull("bounding_box"),
                     designAssetState = rs.getEnumOrNull<DesignAssetState>("design_asset_state"),
-                    publicationGroup = rs.getIntIdOrNull<Split>("split_id")?.let(::PublicationGroup),
+                    publicationGroup =
+                        rs.getIntIdOrNull<Split>("split_id")?.let(::SplitPublicationGroup)
+                            ?: rs.getIntIdOrNull<TrackBoundaryMove>("track_boundary_move_id")
+                                ?.let(::TrackBoundaryMovePublicationGroup),
                     geometryChanges = null,
                 )
             }
@@ -390,7 +400,7 @@ class PublicationDao(
                     trackNumberIds = rs.getIntIdArray("track_numbers"),
                     location = rs.getPointOrNull("point_x", "point_y"),
                     designAssetState = rs.getEnumOrNull<DesignAssetState>("design_asset_state"),
-                    publicationGroup = rs.getIntIdOrNull<Split>("split_id")?.let(::PublicationGroup),
+                    publicationGroup = rs.getIntIdOrNull<Split>("split_id")?.let(::SplitPublicationGroup),
                 )
             }
         logger.daoAccess(FETCH, SwitchPublicationCandidate::class, candidates.map(SwitchPublicationCandidate::id))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -13,6 +13,7 @@ import fi.fta.geoviite.infra.error.DuplicateLocationTrackNameInPublicationExcept
 import fi.fta.geoviite.infra.error.DuplicateNameInPublication
 import fi.fta.geoviite.infra.error.DuplicateNameInPublicationException
 import fi.fta.geoviite.infra.error.PartialSplitRevertException
+import fi.fta.geoviite.infra.error.PartialTrackBoundaryMoveRevertException
 import fi.fta.geoviite.infra.error.PublicationFailureException
 import fi.fta.geoviite.infra.error.TrackLayoutVersionNotFound
 import fi.fta.geoviite.infra.error.getPSQLExceptionConstraintAndDetailOrRethrow
@@ -192,10 +193,14 @@ constructor(
         val revertSplitTracks = revertSplits.flatMap { s -> s.locationTracks }.distinct()
         val revertSplitSwitches = revertSplits.flatMap { s -> s.relinkedSwitches }.distinct()
 
+        val trackBoundaryMoves =
+            trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, locationTrackIds.toList())
+        val trackBoundaryMoveTracks = trackBoundaryMoves.flatMap { s -> s.locationTracks.map { it.id } }.distinct()
+
         return PublicationRequestIds(
             trackNumbers = trackNumbers.map { it.id as IntId },
             referenceLines = referenceLineIds.toList(),
-            locationTracks = (locationTrackIds + revertSplitTracks).distinct(),
+            locationTracks = (locationTrackIds + revertSplitTracks + trackBoundaryMoveTracks).distinct(),
             switches = (switchIds + revertSplitSwitches).distinct(),
             kmPosts = kmPostIds.toList(),
             operationalPoints = operationalPointIds.toList(),
@@ -223,6 +228,20 @@ constructor(
                 )
             }
             splitService.deleteSplit(split.id)
+        }
+
+        trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, toDelete.locationTracks).forEach {
+            trackBoundaryMove ->
+            val shortenedTrackIncluded = toDelete.locationTracks.contains(trackBoundaryMove.shortenedLocationTrack.id)
+            val lengthenedTrackIncluded = toDelete.locationTracks.contains(trackBoundaryMove.lengthenedLocationTrack.id)
+            if (!shortenedTrackIncluded || !lengthenedTrackIncluded) {
+                throw PartialTrackBoundaryMoveRevertException(
+                    message =
+                        "Cannot partially revert track boundary move ${trackBoundaryMove.id}: " +
+                            "both shortened and lengthened track must be included in the revert request"
+                )
+            }
+            trackBoundaryMoveService.delete(trackBoundaryMove.id)
         }
 
         val locationTrackIds = toDelete.locationTracks.toSet()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -11,7 +11,6 @@ import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.geocoding.LayoutGeocodingContextCacheKey
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
-import fi.fta.geoviite.infra.split.SplitLayoutValidationIssues
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.VALIDATION_SPLIT
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
@@ -274,6 +273,7 @@ constructor(
             publicationDao = publicationDao,
             switchLibraryService = switchLibraryService,
             splitService = splitService,
+            trackBoundaryMoveService = trackBoundaryMoveService,
             publicationSet = publicationSet,
         )
 
@@ -296,37 +296,40 @@ constructor(
         val versions = candidates.getValidationVersions(candidates.transition, splitVersions, boundaryMoveVersions)
 
         val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
-        val splitIssues = splitService.validateSplit(versions, validationContext, allowMultipleSplits)
+        val administrativeChangeIssues =
+            splitService.validateAdministrativeChange(versions, validationContext, allowMultipleSplits)
 
         return PublicationCandidates(
             transition = candidates.transition,
             trackNumbers =
                 candidates.trackNumbers.map { candidate ->
-                    val trackNumberSplitIssues = splitIssues.trackNumbers[candidate.id] ?: emptyList()
+                    val trackNumberSplitIssues = administrativeChangeIssues.trackNumbers[candidate.id] ?: emptyList()
                     val validationIssues = validateTrackNumber(candidate.id, validationContext) ?: emptyList()
                     candidate.copy(issues = trackNumberSplitIssues + validationIssues)
                 },
             referenceLines =
                 candidates.referenceLines.map { candidate ->
-                    val referenceLineSplitIssues = splitIssues.referenceLines[candidate.id] ?: emptyList()
+                    val referenceLineSplitIssues =
+                        administrativeChangeIssues.referenceLines[candidate.id] ?: emptyList()
                     val validationIssues = validateReferenceLine(candidate.id, validationContext) ?: emptyList()
                     candidate.copy(issues = referenceLineSplitIssues + validationIssues)
                 },
             locationTracks =
                 candidates.locationTracks.map { candidate ->
-                    val locationTrackSplitIssues = splitIssues.locationTracks[candidate.id] ?: emptyList()
+                    val locationTrackSplitIssues =
+                        administrativeChangeIssues.locationTracks[candidate.id] ?: emptyList()
                     val validationIssues = validateLocationTrack(candidate.id, validationContext) ?: emptyList()
                     candidate.copy(issues = validationIssues + locationTrackSplitIssues)
                 },
             switches =
                 candidates.switches.map { candidate ->
-                    val switchSplitIssues = splitIssues.switches[candidate.id] ?: emptyList()
+                    val switchSplitIssues = administrativeChangeIssues.switches[candidate.id] ?: emptyList()
                     val validationIssues = validateSwitch(candidate.id, validationContext) ?: emptyList()
                     candidate.copy(issues = validationIssues + switchSplitIssues)
                 },
             kmPosts =
                 candidates.kmPosts.map { candidate ->
-                    val kmPostSplitIssues = splitIssues.kmPosts[candidate.id] ?: emptyList()
+                    val kmPostSplitIssues = administrativeChangeIssues.kmPosts[candidate.id] ?: emptyList()
                     val validationIssues = validateKmPost(candidate.id, validationContext) ?: emptyList()
                     candidate.copy(issues = validationIssues + kmPostSplitIssues)
                 },
@@ -340,7 +343,9 @@ constructor(
     @Transactional(readOnly = true)
     fun validatePublicationRequest(versions: ValidationVersions) {
         val validationContext = createValidationContext(versions).also { ctx -> ctx.preloadByPublicationSet() }
-        splitService.validateSplit(versions, validationContext, allowMultipleSplits = false).also(::assertNoSplitErrors)
+        splitService
+            .validateAdministrativeChange(versions, validationContext, allowMultipleAdministrativeChanges = false)
+            .also(::assertNoSplitErrors)
 
         versions.trackNumbers.forEach { version ->
             assertNoErrors(version, requireNotNull(validateTrackNumber(version.id, validationContext)))
@@ -376,7 +381,7 @@ constructor(
         }
     }
 
-    private fun assertNoSplitErrors(issues: SplitLayoutValidationIssues) {
+    private fun assertNoSplitErrors(issues: AdministrativeChangeLayoutValidationIssues) {
         val splitErrors = issues.allIssues().filter { error -> error.type == ERROR }
 
         if (splitErrors.isNotEmpty()) {
@@ -489,10 +494,9 @@ constructor(
             val jointConnectionsDifferIssues =
                 validateSwitchJointConnectionsOnDuplicateTracks(switch, jointConnections, linkedTracks)
 
-            val structureIssues =
-                locationIssues.ifEmpty {
-                    validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndGeometries)
-                }
+            val structureIssues = locationIssues.ifEmpty {
+                validateSwitchLocationTrackLinkStructure(switch, structure, linkedTracksAndGeometries)
+            }
 
             val nameIssues = validateSwitchNameParts(switch)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -13,6 +13,8 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.ILayoutAssetDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
@@ -96,6 +98,7 @@ class ValidationContext(
     val publicationDao: PublicationDao,
     val geocodingService: GeocodingService,
     val splitService: SplitService,
+    val trackBoundaryMoveService: TrackBoundaryMoveService,
     val publicationSet: ValidationVersions,
 ) {
     val target = publicationSet.target
@@ -131,6 +134,9 @@ class ValidationContext(
         NameCache<RinfId, OperationalPoint>(::fetchOperationalPointsByRinfIdGenerated)
 
     private val allUnfinishedSplits: List<Split> by lazy { splitService.findUnfinishedSplits(target.candidateBranch) }
+    val allUnpublishedTrackBoundaryMoves: List<TrackBoundaryMove> by lazy {
+        trackBoundaryMoveService.findUnpublishedBoundaryMoves(target.candidateBranch)
+    }
 
     fun getTrackNumber(id: IntId<LayoutTrackNumber>): LayoutTrackNumber? =
         getObject(target.baseContext, id, publicationSet.trackNumbers, trackNumberDao, trackNumberVersionCache)
@@ -291,6 +297,9 @@ class ValidationContext(
 
     fun getPublicationSplits(): List<Split> =
         allUnfinishedSplits.filter { split -> publicationSet.containsSplit(split.id) }
+
+    fun getPublicationTrackBoundaryMoves(): List<TrackBoundaryMove> =
+        allUnpublishedTrackBoundaryMoves.filter { move -> publicationSet.containsTrackBoundaryMove(move.id) }
 
     fun getUnfinishedSplits(): List<Split> =
         allUnfinishedSplits.filter { split -> split.publicationId != null || publicationSet.containsSplit(split.id) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -5,13 +5,10 @@ import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.LocationTrackDescriptionBase
 import fi.fta.geoviite.infra.common.RowVersion
-import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.DuplicateStatus
-import fi.fta.geoviite.infra.tracklayout.LayoutKmPost
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
-import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDescriptionStructure
@@ -21,7 +18,6 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackNameFreeTextPart
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameSpecifier
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNameStructure
 import fi.fta.geoviite.infra.tracklayout.LocationTrackNamingScheme
-import fi.fta.geoviite.infra.tracklayout.ReferenceLine
 import fi.fta.geoviite.infra.tracklayout.SwitchOnLocationTrack
 import java.time.Instant
 
@@ -51,6 +47,12 @@ data class SplitHeader(
     )
 }
 
+interface AdministrativeChange {
+    fun containsLocationTrack(id: IntId<LocationTrack>): Boolean
+
+    fun containsSwitch(id: IntId<LayoutSwitch>): Boolean
+}
+
 data class Split(
     val id: IntId<Split>,
     val rowVersion: RowVersion<Split>,
@@ -63,7 +65,7 @@ data class Split(
     val targetLocationTracks: List<SplitTarget>,
     val relinkedSwitches: List<IntId<LayoutSwitch>>,
     val updatedDuplicates: List<IntId<LocationTrack>>,
-) {
+) : AdministrativeChange {
     init {
         if (publicationId != null) {
             require(id == rowVersion.id) { "Split source row version must refer to official row, once published" }
@@ -88,12 +90,12 @@ data class Split(
     fun containsTargetTrack(trackId: IntId<LocationTrack>): Boolean =
         targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId }
 
-    fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean = locationTracks.contains(trackId)
+    override fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean = locationTracks.contains(trackId)
 
     fun getTargetLocationTrack(trackId: IntId<LocationTrack>): SplitTarget? =
         targetLocationTracks.find { track -> track.locationTrackId == trackId }
 
-    fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean = relinkedSwitches.contains(switchId)
+    override fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean = relinkedSwitches.contains(switchId)
 }
 
 enum class SplitTargetOperation {
@@ -118,18 +120,6 @@ data class SplitTarget(
     val edgeIndices: IntRange,
     val operation: SplitTargetOperation,
 )
-
-data class SplitLayoutValidationIssues(
-    val trackNumbers: Map<IntId<LayoutTrackNumber>, List<LayoutValidationIssue>>,
-    val referenceLines: Map<IntId<ReferenceLine>, List<LayoutValidationIssue>>,
-    val kmPosts: Map<IntId<LayoutKmPost>, List<LayoutValidationIssue>>,
-    val locationTracks: Map<IntId<LocationTrack>, List<LayoutValidationIssue>>,
-    val switches: Map<IntId<LayoutSwitch>, List<LayoutValidationIssue>>,
-) {
-    fun allIssues(): List<LayoutValidationIssue> =
-        (trackNumbers.values + referenceLines.values + kmPosts.values + locationTracks.values + switches.values)
-            .flatten()
-}
 
 data class SplitRequestTargetDuplicate(val id: IntId<LocationTrack>, val operation: SplitTargetDuplicateOperation)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -337,7 +337,7 @@ class SplitService(
                 context,
                 splits.map { split -> split to locationTrackDao.fetch(split.sourceLocationTrackVersion) },
                 track,
-            ) + validateTrackBoundaryMovesForFoundLocationTrack(trackId, track, context, trackBoundaryMoves)
+            ) + validateTrackBoundaryMovesForFoundLocationTrack(trackId, track, trackBoundaryMoves)
     }
 
     private fun validateSplitForSwitch(
@@ -382,7 +382,6 @@ class SplitService(
     private fun validateTrackBoundaryMovesForFoundLocationTrack(
         trackId: IntId<LocationTrack>,
         track: LocationTrack,
-        context: ValidationContext,
         trackBoundaryMoves: List<TrackBoundaryMove>,
     ): List<LayoutValidationIssue> = trackBoundaryMoves.flatMap { move ->
         if (move.containsLocationTrack(trackId)) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -16,15 +16,20 @@ import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geocoding.GeocodingService
 import fi.fta.geoviite.infra.linking.switches.SuggestedSwitch
 import fi.fta.geoviite.infra.linking.switches.SwitchLinkingService
+import fi.fta.geoviite.infra.localization.LocalizationParams
 import fi.fta.geoviite.infra.localization.localizationParams
+import fi.fta.geoviite.infra.publication.AdministrativeChangeLayoutValidationIssues
+import fi.fta.geoviite.infra.publication.LayoutContextTransition
 import fi.fta.geoviite.infra.publication.LayoutValidationIssue
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.ValidationContext
 import fi.fta.geoviite.infra.publication.ValidationVersions
 import fi.fta.geoviite.infra.publication.validate
+import fi.fta.geoviite.infra.publication.validateWithParams
 import fi.fta.geoviite.infra.publication.validationError
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
 import fi.fta.geoviite.infra.tracklayout.DuplicateEndPointType
 import fi.fta.geoviite.infra.tracklayout.EndpointSplitPoint
 import fi.fta.geoviite.infra.tracklayout.IAlignment
@@ -151,32 +156,113 @@ class SplitService(
         splitDao.deleteSplit(splitId)
     }
 
+    private fun validateTrackBoundaryChangeGeometries(
+        transition: LayoutContextTransition,
+        trackVersions: List<LayoutRowVersion<LocationTrack>>,
+        unpublishedTrackBoundaryMoves: List<TrackBoundaryMove>,
+    ): Map<IntId<LocationTrack>, LayoutValidationIssue> {
+        val tracksById = trackVersions.associateBy { it.id }
+        val moveIsOkay = unpublishedTrackBoundaryMoves.associateWith { move ->
+            trackBoundaryMovePreservesGeometry(tracksById, move, transition)
+        }
+        val moveByTrack =
+            unpublishedTrackBoundaryMoves
+                .flatMap { move ->
+                    listOf(move.shortenedLocationTrack.id to move, move.lengthenedLocationTrack.id to move)
+                }
+                .associate { it }
+        return tracksById.keys
+            .mapNotNull { track ->
+                moveByTrack[track]
+                    ?.let { move -> moveIsOkay[move] }
+                    ?.let { okay ->
+                        if (!okay) {
+                            validationError("$VALIDATION_BOUNDARY_MOVE.changed-geometry")
+                        } else null
+                    }
+                    ?.let { track to it }
+            }
+            .associate { it }
+    }
+
+    private fun trackBoundaryMovePreservesGeometry(
+        tracksById: Map<IntId<LocationTrack>, LayoutRowVersion<LocationTrack>>,
+        move: TrackBoundaryMove,
+        transition: LayoutContextTransition,
+    ): Boolean? {
+        val publicationShortenedTrackVersion = tracksById[move.shortenedLocationTrack.id]
+        val publicationLengthenedTrackVersion = tracksById[move.lengthenedLocationTrack.id]
+        val trackNumberId = locationTrackDao.fetch(move.shortenedLocationTrack).trackNumberId
+        val geocodingContext = geocodingService.getGeocodingContext(transition.baseContext, trackNumberId)
+        return if (
+            publicationShortenedTrackVersion == null ||
+                publicationLengthenedTrackVersion == null ||
+                geocodingContext == null
+        )
+            null
+        else {
+            val originalPoints =
+                combinedAddressPoints(
+                    geocodingContext,
+                    alignmentDao.fetch(move.shortenedLocationTrack),
+                    alignmentDao.fetch(move.lengthenedLocationTrack),
+                )
+            val afterMovePoints =
+                combinedAddressPoints(
+                    geocodingContext,
+                    alignmentDao.fetch(publicationShortenedTrackVersion),
+                    alignmentDao.fetch(publicationLengthenedTrackVersion),
+                )
+
+            originalPoints.size == afterMovePoints.size &&
+                originalPoints.zip(afterMovePoints).all { (original, afterMove) ->
+                    original.address.compareTo(afterMove.address) == 0 && original.point.isSameXY(afterMove.point)
+                }
+        }
+    }
+
+    private fun combinedAddressPoints(
+        geocodingContext: GeocodingContext<*>,
+        firstGeometry: LocationTrackGeometry,
+        secondGeometry: LocationTrackGeometry,
+    ): List<AddressPoint<LocationTrackM>> =
+        ((geocodingContext.getAddressPoints(firstGeometry).addresses?.integerPrecisionPoints ?: listOf()) +
+                (geocodingContext.getAddressPoints(secondGeometry).addresses?.integerPrecisionPoints ?: listOf()))
+            .distinctBy { it.address }
+            .sortedBy { it.address }
+
     @Transactional(readOnly = true)
-    fun validateSplit(
+    fun validateAdministrativeChange(
         candidates: ValidationVersions,
         context: ValidationContext,
-        allowMultipleSplits: Boolean,
-    ): SplitLayoutValidationIssues {
-        val splitIssues =
-            validateSplitContent(
+        allowMultipleAdministrativeChanges: Boolean,
+    ): AdministrativeChangeLayoutValidationIssues {
+        val administrativeChangeContentIssues =
+            validateAdministrativeChangeContent(
                 trackVersions = candidates.locationTracks,
                 switchVersions = candidates.switches,
                 publicationSplits = context.getPublicationSplits(),
-                allowMultipleSplits = allowMultipleSplits,
+                publicationTrackBoundaryMoves = context.getPublicationTrackBoundaryMoves(),
+                allowMultipleAdministrativeChanges = allowMultipleAdministrativeChanges,
+            )
+
+        val trackBoundaryChangeGeometryIssues =
+            validateTrackBoundaryChangeGeometries(
+                transition = context.target,
+                trackVersions = candidates.locationTracks,
+                unpublishedTrackBoundaryMoves = context.allUnpublishedTrackBoundaryMoves,
             )
 
         val tnSplitIssues =
             candidates.trackNumbers
-                .associate { version ->
-                    version.id to listOfNotNull(validateSplitReferencesByTrackNumber(version.id, context))
-                }
+                .associate { version -> version.id to validateReferencesByTrackNumber(version.id, context) }
                 .filterValues { it.isNotEmpty() }
 
         val rlSplitIssues =
             candidates.referenceLines
                 .associate { version ->
                     val trackNumberId = referenceLineDao.fetch(version).trackNumberId
-                    version.id to listOfNotNull(validateSplitReferencesByTrackNumber(trackNumberId, context))
+                    version.id to validateReferencesByTrackNumber(trackNumberId, context)
                 }
                 .filterValues { it.isNotEmpty() }
 
@@ -185,32 +271,32 @@ class SplitService(
                 .associate { version ->
                     val trackNumberId = kmPostDao.fetch(version).trackNumberId
                     version.id to
-                        listOfNotNull(
-                            trackNumberId?.let { tnId -> validateSplitReferencesByTrackNumber(tnId, context) }
-                        )
+                        trackNumberId?.let { tnId -> validateReferencesByTrackNumber(tnId, context) }.orEmpty()
                 }
                 .filterValues { it.isNotEmpty() }
 
         val trackSplitIssues =
             candidates.locationTracks
                 .associate { version ->
-                    val ltSplitIssues = validateSplitForLocationTrack(version.id, context)
-                    val contentIssues = splitIssues.mapNotNull { (split, error) ->
+                    val ltSplitIssues = validateAdministrativeChangesForLocationTrack(version.id, context)
+                    val contentIssues = administrativeChangeContentIssues.mapNotNull { (split, error) ->
                         if (split.containsLocationTrack(version.id)) error else null
                     }
-                    version.id to (ltSplitIssues + contentIssues).distinct()
+                    val boundaryMoveGeometryIssues = listOfNotNull(trackBoundaryChangeGeometryIssues[version.id])
+                    version.id to (ltSplitIssues + contentIssues + boundaryMoveGeometryIssues).distinct()
                 }
                 .filterValues { it.isNotEmpty() }
 
         val switchSplitIssues =
             candidates.switches.associate { version ->
                 val switchIssues = validateSplitForSwitch(version.id, context)
-                val contentIssues = splitIssues.mapNotNull { (split, error) -> if (split.containsSwitch(version.id)) error else null }
+                val contentIssues = administrativeChangeContentIssues.mapNotNull { (split, error) ->
+                    if (split.containsSwitch(version.id)) error else null
+                }
                 version.id to (switchIssues + contentIssues).distinct()
-
             }
 
-        return SplitLayoutValidationIssues(
+        return AdministrativeChangeLayoutValidationIssues(
             tnSplitIssues,
             rlSplitIssues,
             kpSplitIssues,
@@ -235,21 +321,23 @@ class SplitService(
         return splitDao.getOrThrow(splitId)
     }
 
-    private fun validateSplitForLocationTrack(
+    private fun validateAdministrativeChangesForLocationTrack(
         trackId: IntId<LocationTrack>,
         context: ValidationContext,
     ): List<LayoutValidationIssue> {
         val splits = context.getUnfinishedSplits().filter { split -> split.locationTracks.contains(trackId) }
+        val trackBoundaryMoves =
+            context.allUnpublishedTrackBoundaryMoves.filter { move -> move.containsLocationTrack(trackId) }
         val track = context.getLocationTrack(trackId)
 
-        return if (track == null) validateLocationTrackAbsence(trackId, context, splits)
+        return if (track == null) validateLocationTrackAbsence(trackId, context, splits, trackBoundaryMoves)
         else
             validateSplitForFoundLocationTrack(
                 trackId,
                 context,
                 splits.map { split -> split to locationTrackDao.fetch(split.sourceLocationTrackVersion) },
                 track,
-            )
+            ) + validateTrackBoundaryMovesForFoundLocationTrack(trackId, track, context, trackBoundaryMoves)
     }
 
     private fun validateSplitForSwitch(
@@ -257,28 +345,66 @@ class SplitService(
         context: ValidationContext,
     ): List<LayoutValidationIssue> {
         val switchInMultipleSplits = context.getUnfinishedSplits().count { split -> split.containsSwitch(switchId) } > 1
-        return listOf(validate(!switchInMultipleSplits, ERROR) { "$VALIDATION_SPLIT.switch-in-multiple-split" }).filterNotNull()
+        return listOf(validate(!switchInMultipleSplits, ERROR) { "$VALIDATION_SPLIT.switch-in-multiple-split" })
+            .filterNotNull()
     }
-
 
     private fun validateLocationTrackAbsence(
         trackId: IntId<LocationTrack>,
         context: ValidationContext,
         splits: List<Split>,
+        trackBoundaryMoves: List<TrackBoundaryMove>,
     ): List<LayoutValidationIssue> {
         if (!context.locationTrackIsCancelled(trackId)) {
             throw IllegalArgumentException("The track to validate must exist in the validation context: id=$trackId")
         }
-        return splits.flatMap { split ->
-            if (trackId == split.sourceLocationTrackId || split.locationTracks.contains(trackId)) {
-                listOf(
-                    validationError(
-                        "$VALIDATION_SPLIT.track-is-cancelled",
-                        "name" to context.getCandidateLocationTrack(trackId)?.name,
+        return splits.mapNotNull { split ->
+            validateWithParams(
+                trackId != split.sourceLocationTrackId && !split.locationTracks.contains(trackId),
+                ERROR,
+            ) {
+                "$VALIDATION_SPLIT.track-is-cancelled" to
+                    LocalizationParams(
+                        mapOf("name" to (context.getCandidateLocationTrack(trackId)?.name?.toString() ?: ""))
                     )
-                )
-            } else listOf()
-        }
+            }
+        } +
+            trackBoundaryMoves.mapNotNull { move ->
+                validateWithParams(move.locationTracks.none { it.id == trackId }, ERROR) {
+                    "$VALIDATION_BOUNDARY_MOVE.track-is-cancelled" to
+                        LocalizationParams(
+                            mapOf("name" to (context.getCandidateLocationTrack(trackId)?.name?.toString() ?: ""))
+                        )
+                }
+            }
+    }
+
+    private fun validateTrackBoundaryMovesForFoundLocationTrack(
+        trackId: IntId<LocationTrack>,
+        track: LocationTrack,
+        context: ValidationContext,
+        trackBoundaryMoves: List<TrackBoundaryMove>,
+    ): List<LayoutValidationIssue> = trackBoundaryMoves.flatMap { move ->
+        if (move.containsLocationTrack(trackId)) {
+            validateTrackBoundaryMoveForFoundLocationTrack(move, trackId, track)
+        } else listOf()
+    }
+
+    private fun validateTrackBoundaryMoveForFoundLocationTrack(
+        move: TrackBoundaryMove,
+        trackId: IntId<LocationTrack>,
+        track: LocationTrack,
+    ): List<LayoutValidationIssue> {
+        val originalTrackVersion =
+            if (trackId == move.shortenedLocationTrack.id) move.shortenedLocationTrack else move.lengthenedLocationTrack
+        val originalTrack = locationTrackDao.fetch(originalTrackVersion)
+
+        return listOfNotNull(
+            validateWithParams(track.trackNumberId == originalTrack.trackNumberId) {
+                "$VALIDATION_BOUNDARY_MOVE.track-number-updated" to
+                    LocalizationParams(mapOf("track" to track.name.toString()))
+            }
+        )
     }
 
     private fun validateSplitForFoundLocationTrack(
@@ -391,24 +517,44 @@ class SplitService(
         return sourceAddresses to targetAddresses
     }
 
-    private fun validateSplitReferencesByTrackNumber(
+    private fun validateReferencesByTrackNumber(
         trackNumberId: IntId<LayoutTrackNumber>,
         context: ValidationContext,
-    ): LayoutValidationIssue? {
+    ): List<LayoutValidationIssue> {
         val affectedTracks = context.getLocationTracksByTrackNumber(trackNumberId)
         val affectedSplits =
             context.getUnfinishedSplits().filter { split ->
                 split.locationTracks.any { ltId -> affectedTracks.any { a -> a.id == ltId } }
             }
-        return if (affectedSplits.isNotEmpty()) {
-            val sourceTrackNames =
-                affectedSplits
-                    .mapNotNull { split -> context.getLocationTrack(split.sourceLocationTrackId)?.name }
-                    .joinToString(", ")
-            validationError("$VALIDATION_SPLIT.affected-split-in-progress", "sourceName" to sourceTrackNames)
-        } else {
-            null
-        }
+
+        val affectedTracksFromTrackBoundaryMoves =
+            context.allUnpublishedTrackBoundaryMoves.flatMap { move ->
+                move.locationTracks.filter { ltId -> affectedTracks.any { a -> a.id == ltId } }
+            }
+        return listOfNotNull(
+            validateWithParams(affectedSplits.isEmpty(), ERROR) {
+                "$VALIDATION_SPLIT.affected-split-in-progress" to
+                    LocalizationParams(
+                        mapOf(
+                            "sourceName" to
+                                affectedSplits
+                                    .mapNotNull { split -> context.getLocationTrack(split.sourceLocationTrackId)?.name }
+                                    .joinToString(", ")
+                        )
+                    )
+            },
+            validateWithParams(affectedTracksFromTrackBoundaryMoves.isEmpty(), ERROR) {
+                "$VALIDATION_BOUNDARY_MOVE.affected-move-in-progress" to
+                    LocalizationParams(
+                        mapOf(
+                            "tracks" to
+                                affectedTracksFromTrackBoundaryMoves
+                                    .mapNotNull { track -> context.getLocationTrack(track.id)?.name }
+                                    .joinToString(", ")
+                        )
+                    )
+            },
+        )
     }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -8,6 +8,7 @@ import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.ERROR
 import fi.fta.geoviite.infra.publication.VALIDATION
 import fi.fta.geoviite.infra.publication.validate
 import fi.fta.geoviite.infra.publication.validationError
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
@@ -15,6 +16,8 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.util.produceIf
 import kotlin.math.min
 
+const val VALIDATION_ADMINISTRATIVE_CHANGE = "$VALIDATION.administrative-change"
+const val VALIDATION_BOUNDARY_MOVE = "$VALIDATION.track-boundary-move"
 const val VALIDATION_SPLIT = "$VALIDATION.split"
 
 internal fun validateSourceGeometry(
@@ -38,41 +41,56 @@ internal fun validateSourceGeometry(
     }
 }
 
-internal fun validateSplitContent(
+internal fun validateAdministrativeChangeContent(
     trackVersions: List<LayoutRowVersion<LocationTrack>>,
     switchVersions: List<LayoutRowVersion<LayoutSwitch>>,
     publicationSplits: Collection<Split>,
-    allowMultipleSplits: Boolean,
-): List<Pair<Split, LayoutValidationIssue>> {
-    val multipleSplitsStagedErrors =
-        if (!allowMultipleSplits && publicationSplits.size > 1) {
-            publicationSplits.map { split ->
-                split to LayoutValidationIssue(ERROR, "$VALIDATION_SPLIT.multiple-splits-not-allowed")
+    publicationTrackBoundaryMoves: Collection<TrackBoundaryMove>,
+    allowMultipleAdministrativeChanges: Boolean,
+): List<Pair<AdministrativeChange, LayoutValidationIssue>> {
+    val multipleChangesStagedErrors =
+        if (allowMultipleAdministrativeChanges) listOf()
+        else if ((publicationSplits.size + publicationTrackBoundaryMoves.size) > 1) {
+            (publicationSplits + publicationTrackBoundaryMoves).map { change ->
+                change to LayoutValidationIssue(ERROR, "$VALIDATION_ADMINISTRATIVE_CHANGE.multiple-changes-not-allowed")
             }
         } else {
             emptyList()
         }
 
-    val contentErrors = publicationSplits.flatMap { split ->
-        val containsSource = trackVersions.any { it.id == split.sourceLocationTrackId }
-        val containsTargets =
-            split.targetLocationTracks.all { tlt -> trackVersions.any { it.id == tlt.locationTrackId } }
-        val containsSwitches = split.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
-        listOfNotNull(
-                validate(containsSource && containsTargets, ERROR) {
-                    "$VALIDATION_SPLIT.split-missing-location-tracks"
-                },
-                validate(containsSwitches, ERROR) { "$VALIDATION_SPLIT.split-missing-switches" },
-            )
-            .map { e -> split to e }
-    }
+    val splitContentErrors =
+        publicationSplits.flatMap { split ->
+            val containsSource = trackVersions.any { it.id == split.sourceLocationTrackId }
+            val containsTargets =
+                split.targetLocationTracks.all { tlt -> trackVersions.any { it.id == tlt.locationTrackId } }
+            val containsSwitches = split.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
+            listOfNotNull(
+                    validate(containsSource && containsTargets, ERROR) {
+                        "$VALIDATION_SPLIT.split-missing-location-tracks"
+                    },
+                    validate(containsSwitches, ERROR) { "$VALIDATION_SPLIT.split-missing-switches" },
+                )
+                .map { e -> split to e }
+        }
 
-    return listOf(multipleSplitsStagedErrors, contentErrors).flatten()
+    val boundaryMoveContentErrors =
+        publicationTrackBoundaryMoves.flatMap { move ->
+            val containsShortened = trackVersions.any { it.id == move.shortenedLocationTrack.id }
+            val containsLengthened = trackVersions.any { it.id == move.lengthenedLocationTrack.id }
+            listOfNotNull(
+                    validate(containsShortened && containsLengthened, ERROR) {
+                        "$VALIDATION_BOUNDARY_MOVE.missing-location-tracks"
+                    }
+                )
+                .map { e -> move to e }
+        }
+
+    return listOf(multipleChangesStagedErrors, splitContentErrors, boundaryMoveContentErrors).flatten()
 }
 
 const val MAX_SPLIT_POINT_OFFSET = 1.0
 
-internal fun validateTargetGeometry(
+fun validateTargetGeometry(
     operation: SplitTargetOperation,
     targetPoints: List<AddressPoint<LocationTrackM>>?,
     sourcePoints: List<AddressPoint<LocationTrackM>>?,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -2,8 +2,10 @@ package fi.fta.geoviite.infra.trackBoundaryMove
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.split.AdministrativeChange
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
@@ -20,15 +22,18 @@ enum class BoundaryMoveDirection {
 
 data class TrackBoundaryMove(
     val version: RowVersion<TrackBoundaryMove>,
+    val branch: LayoutBranch,
     val shortenedLocationTrack: LayoutRowVersion<LocationTrack>,
     val edgeRange: IntRange,
     val lengthenedLocationTrack: LayoutRowVersion<LocationTrack>,
     val publicationId: IntId<Publication>?,
-) {
+) : AdministrativeChange {
     val id = version.id
 
-    fun containsLocationTrack(track: IntId<LocationTrack>) =
-        shortenedLocationTrack.id == track || lengthenedLocationTrack.id == track
+    override fun containsLocationTrack(id: IntId<LocationTrack>) =
+        shortenedLocationTrack.id == id || lengthenedLocationTrack.id == id
+
+    override fun containsSwitch(id: IntId<LayoutSwitch>) = false
 
     val locationTracks
         get() = listOf(shortenedLocationTrack, lengthenedLocationTrack)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
@@ -1,6 +1,7 @@
 package fi.fta.geoviite.infra.trackBoundaryMove
 
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
@@ -10,6 +11,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getIntIdOrNull
+import fi.fta.geoviite.infra.util.getLayoutBranch
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.getOne
 import fi.fta.geoviite.infra.util.getRowVersion
@@ -26,6 +28,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
 
     @Transactional
     fun save(
+        layoutBranch: LayoutBranch,
         shortenedLocationTrack: LayoutRowVersion<LocationTrack>,
         edgeRange: IntRange,
         lengthenedLocationTrack: LayoutRowVersion<LocationTrack>,
@@ -33,6 +36,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
         val sql =
             """
             insert into publication.track_boundary_move(
+              design_id,
               shortened_location_track_id,
               shortened_location_track_version,
               shortened_location_track_layout_context_id,
@@ -44,6 +48,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
               publication_id
             )
             values (
+              :design_id::int,
               :shortened_location_track_id,
               :shortened_location_track_version,
               :shortened_location_track_layout_context_id,
@@ -61,6 +66,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
         jdbcTemplate.setUser()
         val params =
             mapOf(
+                "design_id" to layoutBranch.designId?.intValue,
                 "shortened_location_track_id" to shortenedLocationTrack.id.intValue,
                 "shortened_location_track_version" to shortenedLocationTrack.version,
                 "shortened_location_track_layout_context_id" to shortenedLocationTrack.context.toSqlString(),
@@ -85,6 +91,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
             select
               id,
               version,
+              design_id,
               shortened_location_track_id,
               shortened_location_track_version,
               shortened_location_track_layout_context_id,
@@ -111,6 +118,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
             select
               id,
               version,
+              design_id,
               shortened_location_track_id,
               shortened_location_track_version,
               shortened_location_track_layout_context_id,
@@ -143,6 +151,16 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
         jdbcTemplate.setUser()
         return getOne(id, jdbcTemplate.query(sql, params) { rs, _ -> rs.getRowVersion("id", "version") })
     }
+
+    @Transactional
+    fun delete(id: IntId<TrackBoundaryMove>) {
+        val sql = "delete from publication.track_boundary_move where id = :id"
+
+        jdbcTemplate.setUser()
+        jdbcTemplate.update(sql, mapOf("id" to id.intValue)).also {
+            logger.daoAccess(AccessType.DELETE, TrackBoundaryMove::class, id)
+        }
+    }
 }
 
 private fun getTrackBoundaryMove(rs: ResultSet) =
@@ -162,4 +180,5 @@ private fun getTrackBoundaryMove(rs: ResultSet) =
                 "lengthened_location_track_version",
             ),
         publicationId = rs.getIntIdOrNull("publication_id"),
+        branch = rs.getLayoutBranch("design_id"),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -62,7 +62,12 @@ class TrackBoundaryMoveService(
             )
         locationTrackService.saveDraft(layoutBranch, shorteningTrack, geometries.shortenedGeometry)
         locationTrackService.saveDraft(layoutBranch, lengtheningTrack, geometries.lengthenedGeometry)
-        return trackBoundaryMoveDao.save(shorteningTrackVersion, geometries.movedEdgeRange, lengtheningTrackVersion)
+        return trackBoundaryMoveDao.save(
+            layoutBranch,
+            shorteningTrackVersion,
+            geometries.movedEdgeRange,
+            lengtheningTrackVersion,
+        )
     }
 
     fun fetchPublicationVersions(
@@ -76,7 +81,8 @@ class TrackBoundaryMoveService(
         locationTrackIds: List<IntId<LocationTrack>>? = null,
     ): List<TrackBoundaryMove> =
         trackBoundaryMoveDao.getUnpublished().filter { boundaryMove ->
-            locationTrackIds == null || locationTrackIds.any(boundaryMove::containsLocationTrack)
+            boundaryMove.branch == branch &&
+                (locationTrackIds == null || locationTrackIds.any(boundaryMove::containsLocationTrack))
         }
 
     @Transactional
@@ -134,6 +140,8 @@ class TrackBoundaryMoveService(
 
         return counterpartFirstOptions + headFirstOptions
     }
+
+    fun delete(id: IntId<TrackBoundaryMove>) = trackBoundaryMoveDao.delete(id)
 }
 
 private fun getHeadFirstOptions(

--- a/infra/src/main/resources/db/migration/prod/V148__add_design_id_to_track_boundary_moves.sql
+++ b/infra/src/main/resources/db/migration/prod/V148__add_design_id_to_track_boundary_moves.sql
@@ -1,0 +1,6 @@
+alter table publication.track_boundary_move
+  add column design_id int,
+  add constraint track_boundary_move_design_fk foreign key (design_id) references layout.design (id);
+
+alter table publication.track_boundary_move_version
+  add column design_id int;

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1980,8 +1980,8 @@
             "track-boundary-move": {
                 "missing-location-tracks": "Julkaisussa ei ole mukana muutoskohdan siirrosta lyhenevää tai pitenevää raidetta",
                 "affected-move-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteilla, joiden vaihtumiskohdan siirtoa ei ole julkaistu: {{tracks}}",
-                "track-is-cancelled": "Raiteen vaihtumiskohdan siirrossa mukanaa olevaa raidetta {{name}} ei voi perua julkaisusta",
-                "track-number-updated": "Vaihtumiskohdan siirtoon liittyvän raidetta {{track}} ei voi siirtää eri ratanumerolle ennen siirron julkaisua",
+                "track-is-cancelled": "Raiteen vaihtumiskohdan siirrossa mukana olevaa raidetta {{name}} ei voi perua julkaisusta",
+                "track-number-updated": "Vaihtumiskohdan siirtoon liittyvää raidetta {{track}} ei voi siirtää eri ratanumerolle ennen siirron julkaisua",
                 "changed-geometry": "Raiteen vaihtumiskohdan siirtoon liittyvän raiteen geometria on muuttunut alkuperäisestä"
             },
             "administrative-change": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -71,7 +71,7 @@
         "track-boundary-move": {
             "generic": "Vaihtumiskohdan siirrossa tapahtui virhe",
             "does-not-move-boundary": "Valittu vaihteen piste ei siirrä raiteiden vaihtumiskohtaa",
-            "partial-revert": "Raiteen vaihtumiskohdan siirtoa ei voi peruuttaa osittain",
+            "partial-revert": "Raiteen vaihtumiskohdan siirtoa ei voi perua osittain",
             "tracks-do-not-connect": "Raiteet eivät kohtaa toisiaan, joten vaihtumiskohtaa ei voi siirtää"
         },
         "split": {

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -71,6 +71,7 @@
         "track-boundary-move": {
             "generic": "Vaihtumiskohdan siirrossa tapahtui virhe",
             "does-not-move-boundary": "Valittu vaihteen piste ei siirrä raiteiden vaihtumiskohtaa",
+            "partial-revert": "Raiteen vaihtumiskohdan siirtoa ei voi peruuttaa osittain",
             "tracks-do-not-connect": "Raiteet eivät kohtaa toisiaan, joten vaihtumiskohtaa ei voi siirtää"
         },
         "split": {
@@ -1975,6 +1976,16 @@
                 "km-post-smaller-than-track-number-start": "Tasakilometripiste ({{kmNumber}}) on pienempi kuin ratanumeron {{trackNumber}} aloitusarvo",
                 "km-posts-wrong-order": "Ratanumeron {{trackNumber}} kilometrit ({{kmNumbers}}) ovat väärässä järjestyksessä",
                 "km-post-too-far-from-reference-line": "Ratanumeron {{trackNumber}} tasakilometripiste {{kmNumber}} sijaitsee liian kaukana pituusmittauslinjalta"
+            },
+            "track-boundary-move": {
+                "missing-location-tracks": "Julkaisussa ei ole mukana muutoskohdan siirrosta lyhenevää tai pitenevää raidetta",
+                "affected-move-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteilla, joiden vaihtumiskohdan siirtoa ei ole julkaistu: {{tracks}}",
+                "track-is-cancelled": "Raiteen vaihtumiskohdan siirrossa mukanaa olevaa raidetta {{name}} ei voi perua julkaisusta",
+                "track-number-updated": "Vaihtumiskohdan siirtoon liittyvän raidetta {{track}} ei voi siirtää eri ratanumerolle ennen siirron julkaisua",
+                "changed-geometry": "Raiteen vaihtumiskohdan siirtoon liittyvän raiteen geometria on muuttunut alkuperäisestä"
+            },
+            "administrative-change": {
+                "multiple-changes-not-allowed": "Julkaisussa on mukana useampi hallinnollinen muutos (raiteen jakaminen tai vaihtumiskohtien muutos)"
             },
             "split": {
                 "source-not-deleted": "Raide on jaettu, mutta se ei ole Poistettu-tilassa",

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -232,6 +232,8 @@ class TestDBService(
                     "switch_location_tracks",
                     "track_number",
                     "track_number_km",
+                    "track_boundary_move",
+                    "track_boundary_move_version",
                 ),
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -5,6 +5,7 @@ import fi.fta.geoviite.infra.common.AlignmentName
 import fi.fta.geoviite.infra.common.DataType
 import fi.fta.geoviite.infra.common.DesignBranch
 import fi.fta.geoviite.infra.common.IntId
+import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.KmNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutBranchType
@@ -20,6 +21,7 @@ import fi.fta.geoviite.infra.common.TrackNumberDescription
 import fi.fta.geoviite.infra.error.DuplicateLocationTrackNameInPublicationException
 import fi.fta.geoviite.infra.error.DuplicateNameInPublicationException
 import fi.fta.geoviite.infra.error.PartialSplitRevertException
+import fi.fta.geoviite.infra.error.PartialTrackBoundaryMoveRevertException
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.RatkoTestService
@@ -29,6 +31,11 @@ import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTarget
 import fi.fta.geoviite.infra.split.SplitTargetOperation
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
+import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDirection
+import fi.fta.geoviite.infra.trackBoundaryMove.SwitchJointId
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutAssetDao
@@ -126,11 +133,12 @@ constructor(
     val switchStructureDao: SwitchStructureDao,
     val splitDao: SplitDao,
     val splitService: SplitService,
+    val trackBoundaryMoveService: TrackBoundaryMoveService,
+    val trackBoundaryMoveDao: TrackBoundaryMoveDao,
     val layoutDesignDao: LayoutDesignDao,
     val ratkoTestService: RatkoTestService,
+    val operationalPointService: OperationalPointService,
 ) : DBTestBase() {
-
-    @Autowired private lateinit var operationalPointService: OperationalPointService
 
     @BeforeEach
     fun cleanup() {
@@ -771,6 +779,130 @@ constructor(
         }
 
         assertNotNull(splitDao.get(splitId))
+    }
+
+    @Test
+    fun `track boundary move shortened and lengthened tracks depend on each other`() {
+        val setup = saveTrackBoundaryMoveSetup()
+
+        val bothTracks = listOf(setup.shorteningTrackId, setup.lengtheningTrackId)
+        for (id in bothTracks) {
+            val dependencies =
+                publicationService.getRevertRequestDependencies(
+                    LayoutBranch.main,
+                    publicationRequest(locationTracks = listOf(id)),
+                )
+            for (otherId in bothTracks) {
+                assertContains(dependencies.locationTracks, otherId)
+            }
+        }
+    }
+
+    @Test
+    fun `reverting only the shortened track of a track boundary move throws`() {
+        val setup = saveTrackBoundaryMoveSetup()
+
+        assertThrows<PartialTrackBoundaryMoveRevertException> {
+            publicationService.revertPublicationCandidates(
+                LayoutBranch.main,
+                publicationRequest(locationTracks = listOf(setup.shorteningTrackId)),
+            )
+        }
+
+        assertNotNull(trackBoundaryMoveDao.get(setup.boundaryMoveId))
+    }
+
+    @Test
+    fun `reverting only the lengthened track of a track boundary move throws`() {
+        val setup = saveTrackBoundaryMoveSetup()
+
+        assertThrows<PartialTrackBoundaryMoveRevertException> {
+            publicationService.revertPublicationCandidates(
+                LayoutBranch.main,
+                publicationRequest(locationTracks = listOf(setup.lengtheningTrackId)),
+            )
+        }
+
+        assertNotNull(trackBoundaryMoveDao.get(setup.boundaryMoveId))
+    }
+
+    @Test
+    fun `reverting both tracks of a track boundary move deletes the boundary move`() {
+        val setup = saveTrackBoundaryMoveSetup()
+
+        publicationService.revertPublicationCandidates(
+            LayoutBranch.main,
+            publicationRequest(locationTracks = listOf(setup.shorteningTrackId, setup.lengtheningTrackId)),
+        )
+
+        assertNull(trackBoundaryMoveDao.get(setup.boundaryMoveId))
+    }
+
+    private data class TrackBoundaryMoveSetup(
+        val shorteningTrackId: IntId<LocationTrack>,
+        val lengtheningTrackId: IntId<LocationTrack>,
+        val boundaryMoveId: IntId<TrackBoundaryMove>,
+    )
+
+    // Two tracks meeting at switch1 joint 2, laid out as one physically continuous track. The lengthening track holds
+    // switch1; the shortening track holds switch2. Moving the boundary to switch2 joint 1 shortens one track and
+    // lengthens the other, producing a draft change to both.
+    private fun saveTrackBoundaryMoveSetup(): TrackBoundaryMoveSetup {
+        val trackNumber = mainDraftContext.createLayoutTrackNumber().id
+        val switch1 = mainDraftContext.createSwitch().id
+        val switch2 = mainDraftContext.createSwitch().id
+
+        val lengtheningTrack =
+            mainDraftContext
+                .save(
+                    locationTrack(trackNumber),
+                    trackGeometry(
+                        edge(
+                            listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
+                            endOuterSwitch = switchLinkYV(switch1, 1),
+                        ),
+                        edge(
+                            listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                            startInnerSwitch = switchLinkYV(switch1, 1),
+                            endInnerSwitch = switchLinkYV(switch1, 2),
+                        ),
+                    ),
+                )
+                .id
+
+        val shorteningTrack =
+            mainDraftContext
+                .save(
+                    locationTrack(trackNumber),
+                    trackGeometry(
+                        edge(
+                            listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                            startOuterSwitch = switchLinkYV(switch1, 2),
+                            endOuterSwitch = switchLinkYV(switch2, 1),
+                        ),
+                        edge(
+                            listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
+                            startInnerSwitch = switchLinkYV(switch2, 1),
+                            endInnerSwitch = switchLinkYV(switch2, 2),
+                        ),
+                    ),
+                )
+                .id
+
+        val boundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.main,
+                shorteningTrackId = shorteningTrack,
+                lengtheningTrackId = lengtheningTrack,
+                upToSwitchJoint = SwitchJointId(switch2, JointNumber(1)),
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
+
+        return TrackBoundaryMoveSetup(
+            shorteningTrackId = shorteningTrack,
+            lengtheningTrackId = lengtheningTrack,
+            boundaryMoveId = boundaryMoveId,
+        )
     }
 
     @Test
@@ -1449,7 +1581,7 @@ constructor(
                         filteredCandidates.size,
                     )
                 }
-                .forEach { candidate -> assertEquals(splitId, candidate.publicationGroup?.id) }
+                .forEach { candidate -> assertEquals("SPLIT_$splitId", candidate.publicationGroup?.id) }
 
             val amountOfSwitchesInCurrentTest = 6
             val expectedTotalUnpublishedSwitchAmount = testIndex * amountOfSwitchesInCurrentTest
@@ -1458,7 +1590,7 @@ constructor(
             publicationCandidates.switches
                 .filter { candidate -> candidate.id in testData.switchIds }
                 .also { filteredCandidates -> assertEquals(amountOfSwitchesInCurrentTest, filteredCandidates.size) }
-                .forEach { candidate -> assertEquals(splitId, candidate.publicationGroup?.id) }
+                .forEach { candidate -> assertEquals("SPLIT_$splitId", candidate.publicationGroup?.id) }
         }
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -20,7 +20,7 @@ import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.RatkoTestService
 import fi.fta.geoviite.infra.split.BulkTransferState
 import fi.fta.geoviite.infra.split.SplitDao
-import fi.fta.geoviite.infra.split.validateSplitContent
+import fi.fta.geoviite.infra.split.validateAdministrativeChangeContent
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.tracklayout.LayoutAlignmentDao
 import fi.fta.geoviite.infra.tracklayout.LayoutKmPostDao
@@ -1571,13 +1571,28 @@ constructor(
         val trackValidationVersions = splitSetup.trackResponses + splitSetup2.trackResponses
 
         assertContains(
-            validateSplitContent(trackValidationVersions, emptyList(), listOf(split, split2), false).map { it.second },
-            validationError("validation.layout.split.multiple-splits-not-allowed"),
+            validateAdministrativeChangeContent(
+                    trackValidationVersions,
+                    emptyList(),
+                    listOf(split, split2),
+                    listOf(),
+                    false,
+                )
+                .map { it.second },
+            validationError("validation.layout.administrative-change.multiple-changes-not-allowed"),
         )
         assertTrue(
-            validateSplitContent(trackValidationVersions, emptyList(), listOf(split, split2), true)
+            validateAdministrativeChangeContent(
+                    trackValidationVersions,
+                    emptyList(),
+                    listOf(split, split2),
+                    listOf(),
+                    true,
+                )
                 .map { it.second }
-                .none { error -> error == validationError("validation.layout.split.multiple-splits-not-allowed") }
+                .none { error ->
+                    error == validationError("validation.layout.administrative-change.multiple-changes-not-allowed")
+                }
         )
     }
 
@@ -1595,7 +1610,8 @@ constructor(
                 .let(splitDao::getOrThrow)
 
         assertContains(
-            validateSplitContent(splitSetup.trackResponses, emptyList(), listOf(split), false).map { it.second },
+            validateAdministrativeChangeContent(splitSetup.trackResponses, emptyList(), listOf(split), listOf(), false)
+                .map { it.second },
             validationError("validation.layout.split.split-missing-switches"),
         )
     }
@@ -1614,7 +1630,9 @@ constructor(
                 .let(splitDao::getOrThrow)
 
         assertContains(
-            validateSplitContent(emptyList(), listOf(switch), listOf(split), false).map { it.second },
+            validateAdministrativeChangeContent(emptyList(), listOf(switch), listOf(split), listOf(), false).map {
+                it.second
+            },
             validationError("validation.layout.split.split-missing-location-tracks"),
         )
     }
@@ -1632,7 +1650,17 @@ constructor(
                 )
                 .let(splitDao::getOrThrow)
 
-        assertEquals(0, validateSplitContent(splitSetup.trackResponses, listOf(switch), listOf(split), false).size)
+        assertEquals(
+            0,
+            validateAdministrativeChangeContent(
+                    splitSetup.trackResponses,
+                    listOf(switch),
+                    listOf(split),
+                    listOf(),
+                    false,
+                )
+                .size,
+        )
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -192,6 +192,7 @@ constructor(
             publicationDao = publicationDao,
             switchLibraryService = switchLibraryService,
             splitService = splitService,
+            trackBoundaryMoveService = trackBoundaryMoveService,
             operationalPointDao = operationalPointDao,
             publicationSet =
                 ValidationVersions(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -5,7 +5,15 @@ import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.error.TrackBoundaryMoveFailureException
+import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.publication.PublicationInDesign
+import fi.fta.geoviite.infra.publication.PublicationInMain
+import fi.fta.geoviite.infra.publication.PublicationService
+import fi.fta.geoviite.infra.publication.PublicationValidationService
+import fi.fta.geoviite.infra.publication.TrackBoundaryMovePublicationGroup
+import fi.fta.geoviite.infra.publication.publicationRequest
+import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveCounterpart
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDirection
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryOrientation
@@ -21,12 +29,16 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.locationTrack
+import fi.fta.geoviite.infra.tracklayout.offsetGeometry
+import fi.fta.geoviite.infra.tracklayout.referenceLine
+import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchLinkRR
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -42,9 +54,12 @@ constructor(
     private val trackBoundaryMoveService: TrackBoundaryMoveService,
     private val locationTrackService: LocationTrackService,
     private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
+    private val publicationService: PublicationService,
+    private val publicationValidationService: PublicationValidationService,
 ) : DBTestBase() {
     @BeforeEach
     fun setup() {
+        testDBService.clearPublicationTables()
         testDBService.clearLayoutTables()
     }
 
@@ -107,7 +122,7 @@ constructor(
                 ),
             )
 
-        val splitId =
+        val trackBoundaryMoveId =
             trackBoundaryMoveService.saveTrackBoundaryMove(
                 LayoutBranch.Companion.main,
                 shorteningTrackId = shorteningTrack.id,
@@ -119,7 +134,7 @@ constructor(
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
-        val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(splitId)
+        val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId)
         assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
         assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
 
@@ -158,7 +173,7 @@ constructor(
                 ),
             )
 
-        val splitId =
+        val trackBoundaryMoveId =
             trackBoundaryMoveService.saveTrackBoundaryMove(
                 LayoutBranch.Companion.main,
                 shorteningTrackId = shorteningTrack.id,
@@ -170,7 +185,7 @@ constructor(
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
-        val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(splitId)
+        val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId)
         assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
         assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
         assertEquals(switchLinkYV(switch1, 1), newLengthenedGeometry.edges.first().startNode.switchIn)
@@ -336,6 +351,170 @@ constructor(
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, shorteningTrack.id).second
         assertSameEdgeContent(shorteningGeometry.edges + lengtheningGeometry.edges, newLengthenedGeometry.edges)
         assertEquals(0, newShortenedGeometry.edges.size)
+    }
+
+    @Test
+    fun `location tracks get grouped per their boundary move`() {
+        val setup = saveConnectedTracks()
+
+        val boundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.main,
+                shorteningTrackId = setup.shorteningTrack.id,
+                lengtheningTrackId = setup.lengtheningTrack.id,
+                upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
+
+        val candidates = publicationService.collectPublicationCandidates(PublicationInMain)
+        val expectedGroup = TrackBoundaryMovePublicationGroup(boundaryMoveId)
+
+        val affectedTrackIds = listOf(setup.shorteningTrack.id, setup.lengtheningTrack.id)
+        candidates.locationTracks
+            .filter { candidate -> candidate.id in affectedTrackIds }
+            .also { filtered -> assertEquals(2, filtered.size) }
+            .forEach { candidate -> assertEquals(expectedGroup, candidate.publicationGroup) }
+    }
+
+    @Test
+    fun `successive boundary moves are grouped and stamped with their own publication`() {
+        // Two independent boundary moves, each saved -> verified as a publication group -> published in turn. The
+        // second move only exists after the first has been published, so the candidate groups and the publication ids
+        // stamped onto the boundary moves must stay distinct between the rounds.
+        repeat(2) {
+            val setup = savePublishableConnectedTracks()
+            val boundaryMoveId =
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            assertEquals(null, trackBoundaryMoveDao.getOrThrow(boundaryMoveId).publicationId)
+
+            val affectedTrackIds = listOf(setup.shorteningTrack.id, setup.lengtheningTrack.id)
+            val candidates = publicationService.collectPublicationCandidates(PublicationInMain)
+            candidates.locationTracks
+                .filter { candidate -> candidate.id in affectedTrackIds }
+                .also { filtered -> assertEquals(2, filtered.size) }
+                .forEach { candidate ->
+                    assertEquals(TrackBoundaryMovePublicationGroup(boundaryMoveId), candidate.publicationGroup)
+                }
+
+            // Publishing the two affected tracks pulls the boundary move into the publication automatically.
+            val publicationResult =
+                publicationService.publishManualPublication(
+                    LayoutBranch.main,
+                    publicationRequest(locationTracks = affectedTrackIds),
+                )
+            assertEquals(publicationResult.publicationId, trackBoundaryMoveDao.getOrThrow(boundaryMoveId).publicationId)
+        }
+    }
+
+    @Test
+    fun `boundary moves on the same tracks in main and a design branch list and publish independently`() {
+        // The pair of tracks is published in main-official, so it is visible in both the main-draft and the
+        // design-draft context. Each context then gets its own boundary move on top of that shared official base. The
+        // two moves live in separate contexts and must list as candidates and publish without interfering.
+        val setup = savePublishableConnectedTracks()
+        val designBranch = testDBService.createDesignBranch()
+        testDBService.generateOid(setup.lengtheningTrack.id, designBranch)
+        testDBService.generateOid(setup.shorteningTrack.id, designBranch)
+
+        val affectedTrackIds = listOf(setup.shorteningTrack.id, setup.lengtheningTrack.id)
+
+        val mainBoundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.main,
+                shorteningTrackId = setup.shorteningTrack.id,
+                lengtheningTrackId = setup.lengtheningTrack.id,
+                upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
+
+        val designBoundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                designBranch,
+                shorteningTrackId = setup.shorteningTrack.id,
+                lengtheningTrackId = setup.lengtheningTrack.id,
+                upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
+
+        // Each context lists only its own boundary move's group on the affected tracks.
+        val mainCandidates = publicationService.collectPublicationCandidates(PublicationInMain)
+        mainCandidates.locationTracks
+            .filter { candidate -> candidate.id in affectedTrackIds }
+            .also { filtered -> assertEquals(2, filtered.size) }
+            .forEach { candidate ->
+                assertEquals(TrackBoundaryMovePublicationGroup(mainBoundaryMoveId), candidate.publicationGroup)
+            }
+
+        val designCandidates = publicationService.collectPublicationCandidates(PublicationInDesign(designBranch))
+        designCandidates.locationTracks
+            .filter { candidate -> candidate.id in affectedTrackIds }
+            .also { filtered -> assertEquals(2, filtered.size) }
+            .forEach { candidate ->
+                assertEquals(TrackBoundaryMovePublicationGroup(designBoundaryMoveId), candidate.publicationGroup)
+            }
+
+        // Publishing in each context pulls in only that context's boundary move and stamps its own publication.
+        val mainPublication =
+            publicationService.publishManualPublication(
+                LayoutBranch.main,
+                publicationRequest(locationTracks = affectedTrackIds),
+            )
+        assertEquals(mainPublication.publicationId, trackBoundaryMoveDao.getOrThrow(mainBoundaryMoveId).publicationId)
+        assertEquals(null, trackBoundaryMoveDao.getOrThrow(designBoundaryMoveId).publicationId)
+
+        val designPublication =
+            publicationService.publishManualPublication(
+                designBranch,
+                publicationRequest(locationTracks = affectedTrackIds),
+            )
+        assertEquals(
+            designPublication.publicationId,
+            trackBoundaryMoveDao.getOrThrow(designBoundaryMoveId).publicationId,
+        )
+    }
+
+    @Test
+    fun `publication validation catches geometry changes made after the boundary move`() {
+        val setup = savePublishableConnectedTracks()
+
+        trackBoundaryMoveService.saveTrackBoundaryMove(
+            LayoutBranch.main,
+            shorteningTrackId = setup.shorteningTrack.id,
+            lengtheningTrackId = setup.lengtheningTrack.id,
+            upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+            boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+        )
+
+        // The boundary move itself preserves the combined geometry of the two tracks. Tamper with the lengthened
+        // track's geometry afterwards so that the combined geometry no longer matches what it was before the move.
+        val (lengthenedTrack, lengthenedGeometry) =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, setup.lengtheningTrack.id)
+        locationTrackService.saveDraft(
+            LayoutBranch.main,
+            lengthenedTrack,
+            offsetGeometry(lengthenedGeometry, Point(0.0, 5.0)),
+        )
+
+        val candidates = publicationService.collectPublicationCandidates(PublicationInMain)
+        val validation =
+            publicationValidationService.validatePublicationCandidates(
+                candidates,
+                publicationRequestIds(locationTracks = listOf(setup.shorteningTrack.id, setup.lengtheningTrack.id)),
+            )
+        val issues = validation.validatedAsPublicationUnit.locationTracks.flatMap { it.issues }
+
+        assertTrue(
+            issues.any {
+                it.localizationKey == LocalizationKey.of("validation.layout.track-boundary-move.changed-geometry")
+            },
+            "Expected a track boundary move changed-geometry error, but got: $issues",
+        )
     }
 
     @Test
@@ -641,6 +820,60 @@ constructor(
 
         val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
         val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
+
+        return ConnectedTracks(
+            lengtheningTrack = lengtheningTrack,
+            lengtheningGeometry = lengtheningGeometry,
+            shorteningTrack = shorteningTrack,
+            shorteningGeometry = shorteningGeometry,
+            connectingSwitch = switch1,
+            shorteningOnlySwitch = switch2,
+        )
+    }
+
+    private fun savePublishableConnectedTracks(): ConnectedTracks {
+        val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        mainOfficialContext.save(
+            referenceLine(trackNumber),
+            referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))),
+        )
+        val switch1 = mainOfficialContext.createSwitch().id
+        val switch2 = mainOfficialContext.createSwitch().id
+
+        val lengtheningGeometry =
+            trackGeometry(
+                edge(listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1)),
+                edge(
+                    listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch1, 1),
+                    endInnerSwitch = switchLinkYV(switch1, 2),
+                ),
+            )
+
+        val shorteningGeometry =
+            trackGeometry(
+                edge(
+                    listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                    startOuterSwitch = switchLinkYV(switch1, 2),
+                    endOuterSwitch = switchLinkYV(switch2, 1),
+                ),
+                edge(
+                    listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch2, 1),
+                    endInnerSwitch = switchLinkYV(switch2, 2),
+                ),
+            )
+
+        val lengtheningTrack = mainDraftContext.save(locationTrack(trackNumber), lengtheningGeometry)
+        val shorteningTrack = mainDraftContext.save(locationTrack(trackNumber), shorteningGeometry)
+
+        mainDraftContext.generateOid(lengtheningTrack.id)
+        mainDraftContext.generateOid(shorteningTrack.id)
+
+        publicationService.publishManualPublication(
+            LayoutBranch.main,
+            publicationRequest(locationTracks = listOf(lengtheningTrack.id, shorteningTrack.id)),
+        )
 
         return ConnectedTracks(
             lengtheningTrack = lengtheningTrack,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
@@ -4,7 +4,7 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.publication.PublicationGroup
+import fi.fta.geoviite.infra.publication.SplitPublicationGroup
 import fi.fta.geoviite.infra.ratko.FakeRatko
 import fi.fta.geoviite.infra.ratko.FakeRatkoService
 import fi.fta.geoviite.infra.split.SplitService
@@ -138,7 +138,7 @@ constructor(
 
         val previewView = trackLayoutPage.goToPreview().waitForAllTableValidationsToComplete()
 
-        val splitPublicationGroup = PublicationGroup(id = unpublishedSplit.id)
+        val splitPublicationGroup = SplitPublicationGroup(unpublishedSplit.id)
         previewView.changesTable.movePublicationGroup(splitPublicationGroup)
 
         val trackLayoutPageAfterPublishing = previewView.waitForAllTableValidationsToComplete().publish()


### PR DESCRIPTION
- Varsinainen design-tuki oli lopulta aika erillinen mötikkänsä, tosin tässä sumassa se tulee samassa kommitissa kuin muukin osa julkaisuprosessin tuesta. Koska TrackBoundaryMove itsessään sisältää vain tiedot siitä, minkä versioiden perusteella siirto tehtiin, se tarvitsi vielä omana erillisenä tietonaan varsinaisen design_id:n. Sen lisäämisen jälkeen kaikki designeihin liittyvä toiminnallisuus suht triviaalia
- Suurin osa varsinaisesta muuttuneesta koodista on validaatiota, missä käytännössä heijastettu splittien validaatiomekaniikasta suurin osa näillekin otuksille; mutta sillä erolla, että oletan, että näitä ei push-API:n aikaan ikinä viedä Ratkoon. Pull-API:n kanssa käsittääkseni ei pitäisi enää tarvita seurata sitä, onko siirto viety Ratkoon vai ei: Riittää seurata vain varsinaista suhdetta julkaisuihin. Mutta tämä pitää ehkä vielä miettiä läpi.
- Lisätty julkaisuryhmänä käsittely: PublicationGroupId:n luonti (omalla prefiksillä koska muutenhan olisi frontissa mahdollista mennä splittien ja siirtojen id:t sekaisin), revertti yhdessä, validointi että julkaisut tapahtuu yhdessä

SplitService on tietoisesti vielä tässä vaiheessa jätetty nyt vähän skitsofreeniseksi sen suhteen, missä se käsittelee splittejä, ja missä siirtoja. Periaatteessa ainoa asia, mikä näiden välillä oikeasti on päällekkäistä on sen validointi, että yhdessä julkaisussa saa olla enintään yksi hallinnollinen muutos. Tarkistuksissa on kuitenkin muutenkin niin paljon yhteistä olemusta, että arvelisin että tässä saatetaan päätyä siirtämään vaan molemmat uudeksi `AdministrativeChangeValidationService`ksi.