### PR TITLE
GVT-3318 Useita siivouksia vaihteiden linkitystopologian validointiin

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchMatching.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchMatching.kt
@@ -5,7 +5,7 @@ import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
-import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
+import fi.fta.geoviite.infra.switchLibrary.linkableSwitchAlignments
 import fi.fta.geoviite.infra.tracklayout.LayoutEdge
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
@@ -159,7 +159,7 @@ private fun completeIncompleteJointSequences(
     jointsOnEdge: Map<EdgeId, List<JointOnEdge>>,
     clearedTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>>,
 ): Map<EdgeId, List<List<JointOnEdge>>> {
-    val structureAlignments = switchConnectivity(fittedSwitch.switchStructure).alignments
+    val structureAlignments = linkableSwitchAlignments(fittedSwitch.switchStructure)
 
     return mapNonNullValues(jointsOnEdge) { (edgeId, jointsFromSwitchFit) ->
         fun isValidInnerJointLinkSequence(
@@ -167,10 +167,9 @@ private fun completeIncompleteJointSequences(
             joints: List<JointOnEdge>,
         ) = validateJointSequence(fittedSwitch.switchStructure, structureAlignment, joints, edgeId, clearedTracks)
 
-        val validStructureAlignmentsForSequence =
-            structureAlignments.filter { structureAlignment ->
-                isValidInnerJointLinkSequence(structureAlignment, jointsFromSwitchFit)
-            }
+        val validStructureAlignmentsForSequence = structureAlignments.filter { structureAlignment ->
+            isValidInnerJointLinkSequence(structureAlignment, jointsFromSwitchFit)
+        }
         listOfNotNull(
                 validStructureAlignmentsForSequence.map { validStructureAlignment ->
                     tossExtraJoints(validStructureAlignment, jointsFromSwitchFit)
@@ -210,7 +209,9 @@ private fun validateJointSequence(
 }
 
 private fun tossExtraJoints(structureAlignment: LinkableSwitchStructureAlignment, joints: List<JointOnEdge>) =
-    joints.filter { joint -> structureAlignment.joints.any { it == joint.jointNumber } }
+    joints.filter { joint ->
+        structureAlignment.joints.any { it == joint.jointNumber }
+    }
 
 private fun jointSequenceFitsPossibleSplitAlignment(
     alignmentToLink: LinkableSwitchStructureAlignment,
@@ -309,8 +310,9 @@ private fun candidateJointLocationIsValid(jointCandidate: JointOnEdge, fittedSwi
 
 private fun suggestDelinking(
     clearedTracks: Map<IntId<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>>
-): Map<IntId<LocationTrack>, SwitchLinkingTrackLinks> =
-    clearedTracks.mapValues { (_, track) -> SwitchLinkingTrackLinks(track.first.getVersionOrThrow().version, null) }
+): Map<IntId<LocationTrack>, SwitchLinkingTrackLinks> = clearedTracks.mapValues { (_, track) ->
+    SwitchLinkingTrackLinks(track.first.getVersionOrThrow().version, null)
+}
 
 private fun suggestLinking(
     validatedJoints: Map<EdgeId, List<JointOnEdge>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/Publication.kt
@@ -593,14 +593,12 @@ data class LayoutValidationIssue(
     val type: LayoutValidationIssueType,
     val localizationKey: LocalizationKey,
     val params: LocalizationParams = LocalizationParams.empty,
-    val inRelationTo: Set<PublicationLogAsset> = setOf(),
 ) {
     constructor(
         type: LayoutValidationIssueType,
         key: String,
         params: Map<String, Any?> = emptyMap(),
-        inRelationTo: Set<PublicationLogAsset> = setOf(),
-    ) : this(type, LocalizationKey.of(key), localizationParams(params), inRelationTo)
+    ) : this(type, LocalizationKey.of(key), localizationParams(params))
 }
 
 interface PublicationCandidate<T : LayoutAsset<T>> {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -350,7 +350,6 @@ fun validateSwitchJointConnectionsOnDuplicateTracks(
                         "duplicateTrackName" to duplicateTrack.name,
                         "jointNumbers" to jointsStr,
                     ),
-                    inRelationTo = setOf(PublicationLogAsset(switch.id as IntId, PublicationLogAssetType.SWITCH)),
                 )
             }
     return validationIssues
@@ -637,9 +636,6 @@ fun validateSwitchTopologicalConnectivity(
             validateSwitchAlignmentTopology(switch.id as IntId, structure, existingTracks, switch.name, validatingTrack),
         )
         .flatten()
-        .let { issues ->
-            relateIssuesTo(issues, switches = listOf(switch.id), locationTracks = listOfNotNull(validatingTrack?.id))
-        }
 }
 
 fun switchOrTrackLinkageKey(validatingTrack: LocationTrack?) =
@@ -1176,10 +1172,6 @@ fun validateEdges(
         .distinct()
         .map { partial ->
             validationWarning("$VALIDATION_LOCATION_TRACK.edge-switch-partial", "switch" to getSwitchName(partial))
-                .copy(
-                    inRelationTo =
-                        relateTo(switches = listOf(partial), locationTracks = listOfNotNull(geometry.trackId))
-                )
         }
 
 fun getEdgePartialSwitchIds(edge: LayoutEdge): List<IntId<LayoutSwitch>> =
@@ -1293,30 +1285,8 @@ fun validationError(key: String, params: LocalizationParams): LayoutValidationIs
 fun validationWarning(key: String, vararg params: Pair<String, Any?>): LayoutValidationIssue =
     LayoutValidationIssue(WARNING, key, params.associate { it })
 
-fun validationWarning(
-    key: String,
-    params: LocalizationParams,
-    inRelationTo: Set<PublicationLogAsset> = setOf(),
-): LayoutValidationIssue = LayoutValidationIssue(WARNING, LocalizationKey.of(key), params, inRelationTo)
-
-private fun relateTo(
-    switches: List<DomainId<LayoutSwitch>> = listOf(),
-    locationTracks: List<DomainId<LocationTrack>> = listOf(),
-) =
-    listOf(
-            switches.map { switch -> PublicationLogAsset(switch as IntId, PublicationLogAssetType.SWITCH) },
-            locationTracks.map { lt -> PublicationLogAsset(lt as IntId, PublicationLogAssetType.LOCATION_TRACK) },
-        )
-        .flatten()
-        .toSet()
-
-private fun relateIssuesTo(
-    issues: List<LayoutValidationIssue>,
-    switches: List<DomainId<LayoutSwitch>> = listOf(),
-    locationTracks: List<DomainId<LocationTrack>> = listOf(),
-): List<LayoutValidationIssue> = issues.map { issue ->
-    issue.copy(inRelationTo = relateTo(switches = switches, locationTracks = locationTracks))
-}
+fun validationWarning(key: String, params: LocalizationParams): LayoutValidationIssue =
+    LayoutValidationIssue(WARNING, LocalizationKey.of(key), params)
 
 private fun validateReferenceFromByTrackNumber(
     keyPrefix: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -695,7 +695,7 @@ private fun summarizeSwitchAlignmentLocationTrackLinks(
         links
             .map { it.second.switchAlignment.partialAlignmentOf }
             .reduceOrNull { common, partials -> common intersect partials }
-            ?.firstOrNull()
+            ?.singleOrNull()
 
     return if (commonStructureAlignment != null) {
         "${printAlignment(commonStructureAlignment.jointNumbers)} (${printTracks(links.map { it.first })})"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -26,7 +26,6 @@ import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.FATAL
 import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.WARNING
 import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
-import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.frontJoint
 import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
 import fi.fta.geoviite.infra.tracklayout.EU_RINF_ID_OVERRIDE_REGEX
@@ -634,7 +633,13 @@ fun validateSwitchTopologicalConnectivity(
     val existingTracks = locationTracksAndGeometries.filter { it.first.exists }
     return listOf(
             listOfNotNull(validateFrontJointTopology(switch, structure, existingTracks, validatingTrack)),
-            validateSwitchAlignmentTopology(switch.id as IntId, structure, existingTracks, switch.name, validatingTrack),
+            validateSwitchAlignmentTopology(
+                switch.id as IntId,
+                structure,
+                existingTracks,
+                switch.name,
+                validatingTrack,
+            ),
         )
         .flatten()
 }
@@ -684,16 +689,31 @@ private fun tracksWithOutsideConnection(
 }
 
 private fun summarizeSwitchAlignmentLocationTrackLinks(
-    links: List<Pair<LocationTrack, SwitchStructureAlignment>>
-): String =
-    links
-        .groupBy { it.second }
-        .entries
-        .joinToString(", ") { (originalAlignment, linksOnAlignment) ->
-            val alignmentString = originalAlignment.jointNumbers.joinToString("-") { j -> j.intValue.toString() }
-            val tracksString = linksOnAlignment.map { it.first.name.toString() }.sorted().distinct().joinToString(", ")
-            "$alignmentString ($tracksString)"
-        }
+    links: List<Pair<LocationTrack, SwitchAlignmentLinkingQuality>>
+): String {
+    val commonStructureAlignment =
+        links
+            .map { it.second.switchAlignment.partialAlignmentOf }
+            .reduceOrNull { common, partials -> common intersect partials }
+            ?.firstOrNull()
+
+    return if (commonStructureAlignment != null) {
+        "${printAlignment(commonStructureAlignment.jointNumbers)} (${printTracks(links.map { it.first })})"
+    } else {
+        links
+            .groupBy { it.second.switchAlignment }
+            .entries
+            .joinToString(", ") { (alignment, linksOnAlignment) ->
+                "${printAlignment(alignment.joints)} (${printTracks(linksOnAlignment.map { it.first })})"
+            }
+    }
+}
+
+private fun printAlignment(jointNumbers: List<JointNumber>) =
+    jointNumbers.joinToString("-") { j -> j.intValue.toString() }
+
+private fun printTracks(tracks: List<LocationTrack>) =
+    tracks.map { it.name.toString() }.sorted().distinct().joinToString(", ")
 
 fun validateSwitchAlignmentTopology(
     switchId: IntId<LayoutSwitch>,
@@ -714,14 +734,14 @@ fun validateSwitchAlignmentTopology(
     val linkedOnlyToDuplicates =
         qualitiesToValidate
             .filter { it.nonDuplicateTracks.isEmpty() }
-            .flatMap { alignment -> alignment.duplicateTracks.map { dup -> dup to alignment.originalAlignment } }
+            .flatMap { alignment -> alignment.duplicateTracks.map { dup -> dup to alignment } }
     val linkedPartially = qualitiesToValidate.flatMap { alignment ->
-        alignment.partiallyLinked.map { part -> part to alignment.originalAlignment }
+        alignment.partiallyLinked.map { part -> part to alignment }
     }
     val linkedMultiply =
         qualitiesToValidate
             .filter { it.nonDuplicateTracks.size > 1 }
-            .flatMap { alignment -> alignment.nonDuplicateTracks.map { track -> track to alignment.originalAlignment } }
+            .flatMap { alignment -> alignment.nonDuplicateTracks.map { track -> track to alignment } }
 
     return listOfNotNull(
         validateWithParams(
@@ -817,8 +837,6 @@ private data class SwitchAlignmentLinkingQuality(
     val partiallyLinked: List<LocationTrack>,
 ) {
 
-    val originalAlignment = switchAlignment.originalAlignment
-
     fun hasSomethingLinked() = nonDuplicateTracks.isNotEmpty() || duplicateTracks.isNotEmpty()
 }
 
@@ -840,10 +858,12 @@ private fun alignmentLinkingQuality(
 
         val isPartiallyLinkedWithoutOtherLinks = (hasStart || hasEnd) && !trackAlignmentHasOtherLinks
         val isFullyLinkedToSplitAlignment = hasStart && hasEnd
-        val isFullyLinkedToOriginalAlignment =
-            trackSwitchJoints.contains(switchAlignment.originalAlignment.jointNumbers.first()) &&
-                trackSwitchJoints.contains(switchAlignment.originalAlignment.jointNumbers.last())
-        val isFullyLinked = isFullyLinkedToOriginalAlignment || isFullyLinkedToSplitAlignment
+        val isFullyLinkedToAnOriginalAlignment =
+            switchAlignment.partialAlignmentOf.any { originalAlignment ->
+                trackSwitchJoints.contains(originalAlignment.jointNumbers.first()) &&
+                    trackSwitchJoints.contains(originalAlignment.jointNumbers.last())
+            }
+        val isFullyLinked = isFullyLinkedToAnOriginalAlignment || isFullyLinkedToSplitAlignment
 
         if (isPartiallyLinkedWithoutOtherLinks || isFullyLinked) {
             if (isFullyLinked) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -27,6 +27,7 @@ import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.WARNING
 import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureAlignment
+import fi.fta.geoviite.infra.switchLibrary.frontJoint
 import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
 import fi.fta.geoviite.infra.tracklayout.EU_RINF_ID_OVERRIDE_REGEX
 import fi.fta.geoviite.infra.tracklayout.IAlignment
@@ -647,16 +648,16 @@ private fun validateFrontJointTopology(
     locationTracksAndGeometries: List<Pair<LocationTrack, LocationTrackGeometry>>,
     validatingTrack: LocationTrack?,
 ): LayoutValidationIssue? {
-    val connectivity = switchConnectivity(switchStructure)
+    val frontJoint = frontJoint(switchStructure)
     val frontJointConnections =
-        connectivity.frontJoint?.let { frontJoint ->
+        frontJoint?.let { frontJoint ->
             tracksWithOutsideConnection(switch.id as IntId, frontJoint, locationTracksAndGeometries)
         } ?: emptyList()
 
     val someFrontJointLink = frontJointConnections.isNotEmpty()
     val frontJointLinkInNonDuplicates = frontJointConnections.any { track -> track.duplicateOf == null }
 
-    return validateWithParams(connectivity.frontJoint == null || frontJointLinkInNonDuplicates, WARNING) {
+    return validateWithParams(frontJoint == null || frontJointLinkInNonDuplicates, WARNING) {
         val key =
             "${switchOrTrackLinkageKey(validatingTrack)}.${
             if (someFrontJointLink) "front-joint-only-duplicate-connected"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -27,7 +27,7 @@ import fi.fta.geoviite.infra.publication.LayoutValidationIssueType.WARNING
 import fi.fta.geoviite.infra.switchLibrary.LinkableSwitchStructureAlignment
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
 import fi.fta.geoviite.infra.switchLibrary.frontJoint
-import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
+import fi.fta.geoviite.infra.switchLibrary.linkableSwitchAlignments
 import fi.fta.geoviite.infra.tracklayout.EU_RINF_ID_OVERRIDE_REGEX
 import fi.fta.geoviite.infra.tracklayout.IAlignment
 import fi.fta.geoviite.infra.tracklayout.LayoutAsset
@@ -722,7 +722,7 @@ fun validateSwitchAlignmentTopology(
     switchName: SwitchName,
     validatingTrack: LocationTrack?,
 ): List<LayoutValidationIssue> {
-    val structureAlignmentsToCheck = switchConnectivity(switchStructure).alignments.filter { !it.isSplittable }
+    val structureAlignmentsToCheck = linkableSwitchAlignments(switchStructure).filter { !it.isSplittable }
     val qualitiesToValidate = structureAlignmentsToCheck.map { alignment ->
         alignmentLinkingQuality(switchId, alignment, locationTracksAndGeometries)
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -384,7 +384,21 @@ data class LinkableSwitchStructureAlignment(
     val isSplittable: Boolean,
 )
 
-data class SwitchConnectivity(val alignments: List<LinkableSwitchStructureAlignment>, val frontJoint: JointNumber?)
+data class SwitchConnectivity(val alignments: List<LinkableSwitchStructureAlignment>)
+
+fun frontJoint(structure: SwitchStructure): JointNumber? =
+    when (structure.baseType) {
+        SwitchBaseType.YV,
+        SwitchBaseType.TYV,
+        SwitchBaseType.YRV,
+        SwitchBaseType.SKV,
+        SwitchBaseType.UKV,
+        SwitchBaseType.EV,
+        SwitchBaseType.KV -> JointNumber(1)
+        SwitchBaseType.KRV,
+        SwitchBaseType.RR,
+        SwitchBaseType.SRR -> null
+    }
 
 fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
     when (structure.baseType) {
@@ -404,8 +418,7 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
                             innerJointOfSplitAlignment = null,
                             isSplittable = false,
                         )
-                    },
-                frontJoint = JointNumber(1),
+                    }
             )
 
         SwitchBaseType.KRV,
@@ -437,9 +450,6 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
                     ),
                 )
             }
-            SwitchConnectivity(
-                alignments = linkableFullAlignments + linkableSplitAlignments.distinctBy { it.joints },
-                frontJoint = null,
-            )
+            SwitchConnectivity(alignments = linkableFullAlignments + linkableSplitAlignments.distinctBy { it.joints })
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -345,12 +345,11 @@ fun calculateSwitchLocationDelta(
     joints: List<ISwitchJoint>,
     switchStructure: SwitchStructure,
 ): SwitchPositionTransformation? {
-    val jointPairs =
-        joints.mapNotNull { joint ->
-            switchStructure.alignmentJoints
-                .find { structureJoint -> joint.number == structureJoint.number }
-                ?.let { match -> joint to match }
-        }
+    val jointPairs = joints.mapNotNull { joint ->
+        switchStructure.alignmentJoints
+            .find { structureJoint -> joint.number == structureJoint.number }
+            ?.let { match -> joint to match }
+    }
 
     if (
         jointPairs.size < 2 ||
@@ -413,33 +412,31 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
         SwitchBaseType.RR,
         SwitchBaseType.SRR -> {
             val throughAlignments = structure.alignments.filter { it.jointNumbers.size == 3 }
-            val linkableFullAlignments =
-                throughAlignments.map {
+            val linkableFullAlignments = throughAlignments.map {
+                LinkableSwitchStructureAlignment(
+                    it.jointNumbers,
+                    it,
+                    innerJointOfSplitAlignment = null,
+                    isSplittable = true,
+                )
+            }
+            val linkableSplitAlignments = throughAlignments.flatMap { alignment ->
+                val joints = alignment.jointNumbers
+                listOf(
                     LinkableSwitchStructureAlignment(
-                        it.jointNumbers,
-                        it,
-                        innerJointOfSplitAlignment = null,
-                        isSplittable = true,
-                    )
-                }
-            val linkableSplitAlignments =
-                throughAlignments.flatMap { alignment ->
-                    val joints = alignment.jointNumbers
-                    listOf(
-                        LinkableSwitchStructureAlignment(
-                            listOf(joints[0], joints[1]),
-                            alignment,
-                            innerJointOfSplitAlignment = joints[1],
-                            isSplittable = false,
-                        ),
-                        LinkableSwitchStructureAlignment(
-                            listOf(joints[1], joints[2]),
-                            alignment,
-                            innerJointOfSplitAlignment = joints[1],
-                            isSplittable = false,
-                        ),
-                    )
-                }
+                        listOf(joints[0], joints[1]),
+                        alignment,
+                        innerJointOfSplitAlignment = joints[1],
+                        isSplittable = false,
+                    ),
+                    LinkableSwitchStructureAlignment(
+                        listOf(joints[1], joints[2]),
+                        alignment,
+                        innerJointOfSplitAlignment = joints[1],
+                        isSplittable = false,
+                    ),
+                )
+            }
             SwitchConnectivity(
                 alignments = linkableFullAlignments + linkableSplitAlignments.distinctBy { it.joints },
                 frontJoint = null,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -454,7 +454,7 @@ fun linkableSwitchAlignments(structure: SwitchStructure): List<LinkableSwitchStr
                         LinkableSwitchStructureAlignment(
                             joints,
                             originalAlignments.flatMap { it.partialAlignmentOf }.toSet(),
-                            joints[1],
+                            originalAlignments[0].innerJointOfSplitAlignment,
                             false,
                         )
                     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -379,7 +379,9 @@ fun transformSwitchPoint(transformation: SwitchPositionTransformation, point: Po
 
 data class LinkableSwitchStructureAlignment(
     val joints: List<JointNumber>,
-    val originalAlignment: SwitchStructureAlignment,
+    // at least on KRV switches, there are both alignments 1-5-2/4-5-3 as usual but *also* 1-5-3/4-5-2; hence the split
+    // alignments need to know all alignments that they are a part of
+    val partialAlignmentOf: Set<SwitchStructureAlignment>,
     val innerJointOfSplitAlignment: JointNumber?,
     val isSplittable: Boolean,
 )
@@ -414,7 +416,7 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
                     structure.alignments.map {
                         LinkableSwitchStructureAlignment(
                             it.jointNumbers,
-                            it,
+                            setOf(it),
                             innerJointOfSplitAlignment = null,
                             isSplittable = false,
                         )
@@ -428,7 +430,7 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
             val linkableFullAlignments = throughAlignments.map {
                 LinkableSwitchStructureAlignment(
                     it.jointNumbers,
-                    it,
+                    setOf(it),
                     innerJointOfSplitAlignment = null,
                     isSplittable = true,
                 )
@@ -438,18 +440,31 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
                 listOf(
                     LinkableSwitchStructureAlignment(
                         listOf(joints[0], joints[1]),
-                        alignment,
+                        setOf(alignment),
                         innerJointOfSplitAlignment = joints[1],
                         isSplittable = false,
                     ),
                     LinkableSwitchStructureAlignment(
                         listOf(joints[1], joints[2]),
-                        alignment,
+                        setOf(alignment),
                         innerJointOfSplitAlignment = joints[1],
                         isSplittable = false,
                     ),
                 )
             }
-            SwitchConnectivity(alignments = linkableFullAlignments + linkableSplitAlignments.distinctBy { it.joints })
+            SwitchConnectivity(
+                alignments =
+                    linkableFullAlignments +
+                        linkableSplitAlignments
+                            .groupBy { it.joints }
+                            .map { (joints, originalAlignments) ->
+                                LinkableSwitchStructureAlignment(
+                                    joints,
+                                    originalAlignments.flatMap { it.partialAlignmentOf }.toSet(),
+                                    joints[1],
+                                    false,
+                                )
+                            }
+            )
         }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchStructure.kt
@@ -386,8 +386,6 @@ data class LinkableSwitchStructureAlignment(
     val isSplittable: Boolean,
 )
 
-data class SwitchConnectivity(val alignments: List<LinkableSwitchStructureAlignment>)
-
 fun frontJoint(structure: SwitchStructure): JointNumber? =
     when (structure.baseType) {
         SwitchBaseType.YV,
@@ -402,7 +400,7 @@ fun frontJoint(structure: SwitchStructure): JointNumber? =
         SwitchBaseType.SRR -> null
     }
 
-fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
+fun linkableSwitchAlignments(structure: SwitchStructure): List<LinkableSwitchStructureAlignment> =
     when (structure.baseType) {
         SwitchBaseType.YV,
         SwitchBaseType.TYV,
@@ -411,17 +409,14 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
         SwitchBaseType.UKV,
         SwitchBaseType.EV,
         SwitchBaseType.KV ->
-            SwitchConnectivity(
-                alignments =
-                    structure.alignments.map {
-                        LinkableSwitchStructureAlignment(
-                            it.jointNumbers,
-                            setOf(it),
-                            innerJointOfSplitAlignment = null,
-                            isSplittable = false,
-                        )
-                    }
-            )
+            structure.alignments.map {
+                LinkableSwitchStructureAlignment(
+                    it.jointNumbers,
+                    setOf(it),
+                    innerJointOfSplitAlignment = null,
+                    isSplittable = false,
+                )
+            }
 
         SwitchBaseType.KRV,
         SwitchBaseType.RR,
@@ -452,19 +447,16 @@ fun switchConnectivity(structure: SwitchStructure): SwitchConnectivity =
                     ),
                 )
             }
-            SwitchConnectivity(
-                alignments =
-                    linkableFullAlignments +
-                        linkableSplitAlignments
-                            .groupBy { it.joints }
-                            .map { (joints, originalAlignments) ->
-                                LinkableSwitchStructureAlignment(
-                                    joints,
-                                    originalAlignments.flatMap { it.partialAlignmentOf }.toSet(),
-                                    joints[1],
-                                    false,
-                                )
-                            }
-            )
+            linkableFullAlignments +
+                linkableSplitAlignments
+                    .groupBy { it.joints }
+                    .map { (joints, originalAlignments) ->
+                        LinkableSwitchStructureAlignment(
+                            joints,
+                            originalAlignments.flatMap { it.partialAlignmentOf }.toSet(),
+                            joints[1],
+                            false,
+                        )
+                    }
         }
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTestData.kt
@@ -12,7 +12,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureData
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureJoint
-import fi.fta.geoviite.infra.switchLibrary.switchConnectivity
+import fi.fta.geoviite.infra.switchLibrary.linkableSwitchAlignments
 import fi.fta.geoviite.infra.tracklayout.LayoutRowId
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSegment
@@ -45,7 +45,7 @@ fun createTrack(
 ): TrackForSwitchFitting {
     val jointSequences =
         asSwitchStructure(switchStructure).let { switchStructure ->
-            switchConnectivity(switchStructure).alignments.map { it.joints }
+            linkableSwitchAlignments(switchStructure).map { it.joints }
         }
     if (!skipValidation) {
         require(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -1055,7 +1055,6 @@ constructor(
                     "locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})",
                     "switch" to "TV123",
                 ),
-                inRelationTo = setOf(PublicationLogAsset(switchId, PublicationLogAssetType.SWITCH)),
             ),
         )
     }
@@ -1132,7 +1131,6 @@ constructor(
                 LayoutValidationIssueType.WARNING,
                 LocalizationKey.of("validation.layout.switch.track-linkage.front-joint-not-connected"),
                 LocalizationParams(mapOf("switch" to "TV123")),
-                inRelationTo = setOf(PublicationLogAsset(switchId, PublicationLogAssetType.SWITCH)),
             ),
         )
 
@@ -1158,7 +1156,6 @@ constructor(
                 LayoutValidationIssueType.WARNING,
                 "validation.layout.switch.track-linkage.front-joint-only-duplicate-connected",
                 mapOf("switch" to "TV123"),
-                inRelationTo = setOf(PublicationLogAsset(switchId, PublicationLogAssetType.SWITCH)),
             ),
         )
 
@@ -1825,7 +1822,6 @@ constructor(
                         LocalizationKey.of("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
                     type = LayoutValidationIssueType.WARNING,
                     params = LocalizationParams(mapOf("switch" to switchName, "alignments" to "1-3")),
-                    inRelationTo = setOf(PublicationLogAsset(switch, PublicationLogAssetType.SWITCH)),
                 )
             ),
             validateCancellation.validatedAsPublicationUnit.switches[0].issues,
@@ -1839,11 +1835,6 @@ constructor(
                     ),
                 type = LayoutValidationIssueType.WARNING,
                 params = LocalizationParams(mapOf("switch" to switchName, "alignments" to "1-3")),
-                inRelationTo =
-                    setOf(
-                        PublicationLogAsset(switch, PublicationLogAssetType.SWITCH),
-                        PublicationLogAsset(branchingTrack, PublicationLogAssetType.LOCATION_TRACK),
-                    ),
             ),
         )
         assertEquals(
@@ -1855,11 +1846,6 @@ constructor(
                         ),
                     type = LayoutValidationIssueType.WARNING,
                     params = LocalizationParams(mapOf("switch" to switchName, "alignments" to "1-3")),
-                    inRelationTo =
-                        setOf(
-                            PublicationLogAsset(switch, PublicationLogAssetType.SWITCH),
-                            PublicationLogAsset(throughTrack, PublicationLogAssetType.LOCATION_TRACK),
-                        ),
                 )
             ),
             validateCancellation.validatedAsPublicationUnit.locationTracks.find { it.id == throughTrack }!!.issues,
@@ -2352,21 +2338,11 @@ constructor(
                     LayoutValidationIssueType.WARNING,
                     "$VALIDATION_LOCATION_TRACK.switch-linkage.front-joint-not-connected",
                     mapOf("switch" to "impossiboru switch name"),
-                    inRelationTo =
-                        setOf(
-                            PublicationLogAsset(switch, PublicationLogAssetType.SWITCH),
-                            PublicationLogAsset(locationTrack, PublicationLogAssetType.LOCATION_TRACK),
-                        ),
                 ),
                 LayoutValidationIssue(
                     LayoutValidationIssueType.ERROR,
                     "$VALIDATION_LOCATION_TRACK.switch-linkage.switch-no-alignments-connected",
                     mapOf("switch" to "impossiboru switch name"),
-                    inRelationTo =
-                        setOf(
-                            PublicationLogAsset(switch, PublicationLogAssetType.SWITCH),
-                            PublicationLogAsset(locationTrack, PublicationLogAssetType.LOCATION_TRACK),
-                        ),
                 ),
             ),
             validatedDeleted.validatedAsPublicationUnit.locationTracks[0].issues,
@@ -3132,7 +3108,6 @@ constructor(
                     "duplicateTrackName" to "dup",
                     "jointNumbers" to "1, 5, 2",
                 ),
-                inRelationTo = setOf(PublicationLogAsset(switchId, PublicationLogAssetType.SWITCH)),
             )
 
         assertContains(locationTrackValidations.find { it.id == mainTrack.id }!!.errors, expectedError)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -1267,8 +1267,6 @@ class PublicationValidationTest {
                 validationWarning(
                     "validation.layout.location-track.edge-switch-partial",
                     localizationParams("switch" to IntId<LayoutSwitch>(1)),
-                    inRelationTo =
-                        setOf(PublicationLogAsset(id = IntId<LayoutSwitch>(1), type = PublicationLogAssetType.SWITCH)),
                 )
             ),
             validateEdges(
@@ -1287,14 +1285,10 @@ class PublicationValidationTest {
                 validationWarning(
                     "validation.layout.location-track.edge-switch-partial",
                     localizationParams("switch" to IntId<LayoutSwitch>(1)),
-                    inRelationTo =
-                        setOf(PublicationLogAsset(id = IntId<LayoutSwitch>(1), type = PublicationLogAssetType.SWITCH)),
                 ),
                 validationWarning(
                     "validation.layout.location-track.edge-switch-partial",
                     localizationParams("switch" to IntId<LayoutSwitch>(2)),
-                    inRelationTo =
-                        setOf(PublicationLogAsset(id = IntId<LayoutSwitch>(2), type = PublicationLogAssetType.SWITCH)),
                 ),
             ),
             validateEdges(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
@@ -135,8 +135,6 @@ class SwitchTopologicalConnectivityTest {
                 LayoutValidationIssueType.ERROR,
                 "validation.layout.switch.track-linkage.switch-no-alignments-connected",
                 mapOf("switch" to switch.name.toString()),
-                inRelationTo =
-                    setOf(PublicationLogAsset(id = IntId<LayoutSwitch>(0), type = PublicationLogAssetType.SWITCH)),
             ),
         )
     }
@@ -158,11 +156,6 @@ class SwitchTopologicalConnectivityTest {
                     LayoutValidationIssueType.WARNING,
                     "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
                     mapOf("switch" to switch.name.toString(), "alignments" to "1-3"),
-                    inRelationTo =
-                        setOf(
-                            PublicationLogAsset(switch.id as IntId, PublicationLogAssetType.SWITCH),
-                            PublicationLogAsset(throughTrack.first.id as IntId, PublicationLogAssetType.LOCATION_TRACK),
-                        ),
                 )
             ),
             issues,
@@ -196,11 +189,6 @@ class SwitchTopologicalConnectivityTest {
                     LayoutValidationIssueType.WARNING,
                     "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
                     mapOf("switch" to switch.name.toString(), "alignments" to "4-5, 5-3"),
-                    inRelationTo =
-                        setOf(
-                            PublicationLogAsset(switch.id as IntId, PublicationLogAssetType.SWITCH),
-                            PublicationLogAsset(track152.first.id as IntId, PublicationLogAssetType.LOCATION_TRACK),
-                        ),
                 )
             ),
             issues,
@@ -256,11 +244,6 @@ class SwitchTopologicalConnectivityTest {
                     LayoutValidationIssueType.WARNING,
                     "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
                     mapOf("switch" to switch.name.toString(), "alignments" to "5-3"),
-                    inRelationTo =
-                        setOf(
-                            PublicationLogAsset(switch.id as IntId, PublicationLogAssetType.SWITCH),
-                            PublicationLogAsset(track15.first.id as IntId, PublicationLogAssetType.LOCATION_TRACK),
-                        ),
                 )
             ),
             issues,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
@@ -199,12 +199,37 @@ class SwitchTopologicalConnectivityTest {
     fun `track partially through rail crossing is responsible for non-full link on its switch alignment`() {
         val (switch, link) = switchAndLink(switchStructureRR54_4x1_9())
         val track53 = track("track 53", link(5, 3))
-        val tracks = listOf(track("track 152", link(1, 5), link(5, 2)), track53)
+        val track152 = track("track 152", link(1, 5), link(5, 2))
+        val tracks = listOf(track152, track53)
 
-        val issues = validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, track53.first)
+        val expectedOnTracks =
+            listOf(
+                LayoutValidationIssue(
+                    LayoutValidationIssueType.WARNING,
+                    "validation.layout.location-track.switch-linkage.switch-alignment-not-connected",
+                    mapOf("switch" to switch.name.toString(), "alignments" to "4-5"),
+                )
+            )
+        val expectedOnSwitch =
+            listOf(
+                LayoutValidationIssue(
+                    LayoutValidationIssueType.WARNING,
+                    "validation.layout.switch.track-linkage.switch-alignment-not-connected",
+                    mapOf("switch" to switch.name.toString(), "alignments" to "4-5"),
+                )
+            )
+
         assertEquals(
-            listOf("validation.layout.location-track.switch-linkage.switch-alignment-not-connected"),
-            issues.map { it.localizationKey.toString() },
+            expectedOnTracks,
+            validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, track53.first),
+        )
+        assertEquals(
+            expectedOnTracks,
+            validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, track152.first),
+        )
+        assertEquals(
+            expectedOnSwitch,
+            validateSwitchTopologicalConnectivity(switch, switchStructureRR54_4x1_9(), tracks, null),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
@@ -2,9 +2,11 @@ package fi.fta.geoviite.infra.publication
 
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
+import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.publication.SwitchTopologicalConnectivityTest.MakeSwitchLinkPair
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructure
+import fi.fta.geoviite.infra.switchLibrary.data.KRV54_200_1_9
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
@@ -333,6 +335,31 @@ class SwitchTopologicalConnectivityTest {
         assertEquals(
             setOf("validation.layout.switch.track-linkage.switch-alignment-not-connected"),
             issues.map { it.localizationKey.toString() }.toSet(),
+        )
+    }
+
+    @Test
+    fun `multiply linked alignments through a KRV switch 1-5-3 alignment are reported as one problem`() {
+        val switchStructure = SwitchStructure(RowVersion(IntId(123456), 1), KRV54_200_1_9())
+        val (switch, link) = switchAndLink(switchStructure)
+        val oneTrack153 = track("one track 153", link(1, 5), link(5, 3))
+        val twoTrack153 = track("two track 153", link(1, 5), link(5, 3))
+        val track254 = track("track 254", link(2, 5), link(5, 4))
+        val tracks = listOf(oneTrack153, twoTrack153, track254)
+        val expected =
+            listOf(
+                LayoutValidationIssue(
+                    LayoutValidationIssueType.WARNING,
+                    "validation.layout.switch.track-linkage.switch-alignment-multiply-connected",
+                    mapOf(
+                        "switch" to switch.name.toString(),
+                        "locationTracks" to "1-5-3 (one track 153, two track 153)",
+                    ),
+                )
+            )
+        assertEquals(
+            expected,
+            validateSwitchTopologicalConnectivity(switch, switchStructure, tracks, null),
         )
     }
 

--- a/ui/src/publication/publication-model.ts
+++ b/ui/src/publication/publication-model.ts
@@ -27,13 +27,12 @@ import { LocalizationParams } from 'i18n/config';
 import { SplitTargetOperation } from 'tool-panel/location-track/split-store';
 import { exhaustiveMatchingGuard } from 'utils/type-utils';
 import { SearchItemType, SearchItemValue } from 'asset-search/search-dropdown';
-import { PublishableObjectIdAndType, PublishedAsset } from 'publication/publication-api';
+import { PublishedAsset } from 'publication/publication-api';
 
 export type LayoutValidationIssue = {
     type: LayoutValidationIssueType;
     localizationKey: string;
     params: LocalizationParams;
-    inRelationTo?: PublishableObjectIdAndType[];
 };
 
 export type LayoutValidationIssueType = 'FATAL' | 'ERROR' | 'WARNING';

--- a/ui/src/tool-panel/location-track/location-track-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-infobox.tsx
@@ -183,8 +183,6 @@ const LocationTrackInfobox: React.FC<LocationTrackInfoboxProps> = ({
                 contentVisible={visibilities.switchLinks}
                 onContentVisibilityChange={() => visibilityChange('switchLinks')}
                 locationTrack={locationTrack}
-                validation={validation}
-                validationLoaderStatus={validationLoaderStatus}
                 layoutContext={layoutContext}
                 changeTimes={changeTimes}
                 onSelect={onSelect}

--- a/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-switch-links-infobox.tsx
@@ -8,13 +8,13 @@ import styles from './location-track-switch-links-infobox.scss';
 import { ChangeTimes } from 'common/common-slice';
 import { OnSelectOptions } from 'selection/selection-model';
 import { ShowMoreButton } from 'show-more-button/show-more-button';
-import { LayoutValidationIssue, ValidatedLocationTrack } from 'publication/publication-model';
+import { LayoutValidationIssue, ValidatedSwitch } from 'publication/publication-model';
 import {
     ProgressIndicatorType,
     ProgressIndicatorWrapper,
 } from 'vayla-design-lib/progress/progress-indicator-wrapper';
 import { LoaderStatus, useLoaderWithStatus } from 'utils/react-utils';
-import { getSwitches } from 'track-layout/layout-switch-api';
+import { getSwitches, getSwitchesValidation } from 'track-layout/layout-switch-api';
 import InfoboxContent from 'tool-panel/infobox/infobox-content';
 import { LocationTrackSwitchRow } from './location-track-switch-row';
 import { useTrackLayoutAppSelector } from 'store/hooks';
@@ -25,25 +25,17 @@ type LocationTrackVerticalGeometryInfoboxProps = {
     contentVisible: boolean;
     onContentVisibilityChange: () => void;
     locationTrack: LayoutLocationTrack;
-    validation: ValidatedLocationTrack | undefined;
-    validationLoaderStatus: LoaderStatus;
     layoutContext: LayoutContext;
     changeTimes: ChangeTimes;
     onSelect: (items: OnSelectOptions) => void;
 };
 
-function collectValidationBySwitch(validation: ValidatedLocationTrack | undefined): {
+function collectValidationBySwitch(validatedSwitches: ValidatedSwitch[]): {
     [p: LayoutSwitchId]: LayoutValidationIssue[];
 } {
     const validationBySwitch: { [switchId: LayoutSwitchId]: LayoutValidationIssue[] } = {};
-    (validation?.errors ?? []).forEach((issue) => {
-        (issue.inRelationTo ?? []).forEach((inRelationTo) => {
-            if (inRelationTo.type === 'SWITCH') {
-                const switchId = inRelationTo.id as LayoutSwitchId;
-                validationBySwitch[switchId] ??= [];
-                validationBySwitch[switchId].push(issue);
-            }
-        });
+    validatedSwitches.forEach((validatedSwitch) => {
+        validationBySwitch[validatedSwitch.id] = validatedSwitch.errors;
     });
     return validationBySwitch;
 }
@@ -54,8 +46,6 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
     contentVisible,
     onContentVisibilityChange,
     locationTrack,
-    validation,
-    validationLoaderStatus,
     layoutContext,
     changeTimes,
     onSelect,
@@ -68,25 +58,28 @@ export const LocationTrackSwitchLinksInfobox: React.FC<
     const linkingState = useTrackLayoutAppSelector((s) => s.linkingState);
     const splittingState = useTrackLayoutAppSelector((s) => s.splittingState);
 
+    const loaderDeps = [
+        JSON.stringify(switchIds),
+        locationTrack.id,
+        layoutContext.branch,
+        layoutContext.publicationState,
+        changeTimes.layoutLocationTrack,
+        changeTimes.layoutSwitch,
+        changeTimes.layoutTrackNumber,
+        changeTimes.layoutReferenceLine,
+        changeTimes.layoutKmPost,
+    ];
+
     const [switchItems, switchItemLoadStatus] = useLoaderWithStatus(
-        () =>
-            getSwitches(
-                switches.map((s) => s.switchId),
-                layoutContext,
-            ),
-        [
-            JSON.stringify(switchIds),
-            locationTrack.id,
-            layoutContext.branch,
-            layoutContext.publicationState,
-            changeTimes.layoutLocationTrack,
-            changeTimes.layoutSwitch,
-            changeTimes.layoutTrackNumber,
-            changeTimes.layoutReferenceLine,
-            changeTimes.layoutKmPost,
-        ],
+        () => getSwitches(switchIds, layoutContext),
+        loaderDeps,
     );
-    const validationBySwitch = collectValidationBySwitch(validation);
+
+    const [validatedSwitches, validationLoaderStatus] = useLoaderWithStatus(
+        () => getSwitchesValidation(layoutContext, switchIds),
+        loaderDeps,
+    );
+    const validationBySwitch = collectValidationBySwitch(validatedSwitches ?? []);
 
     const switchesAll = (switchItems ?? []).map((switchItem) => {
         // have to find() rather than zip the arrays together by index, as switchItems and switches can be out of sync


### PR DESCRIPTION
- Poistettu kokonaan inRelationTo-hässäkkä, joka oli jo alkuaan niin huono ajatus, että tarvitsen siitä synninpäästön. Se ei siis tehnyt mitään muuta kuin että sillä vältti vaihteiden validoinnin omina otuksinaan raiteen vaihdelistaa näytettäessä, koska raiteen validaatiovirheillä oli muka tieto siitä, mihin vaihteeseen ne kuuluivat. Mutta tämä oli aina buginen änkyrä, ja vaihteiden validointi on joka tapauksessa meillä niin halpa operaatio, että sitä ole tarvetta vältellä, eritoten nykymaailmassa kun kovin pitkiäkään raiteita ei enää juuri ole.
- Vaihderakennetta eri tarkoituksiin jauhanut SwitchConnectivity on heitetty pois, koska mikään switchConnectivity-funktion kutsujista ei tarvinnut tästä luokasta useampaa kuin yhtä jäsentä => sama selkiyttää siis eri tietojen haut eri funktioiksi
- :cut_of_meat: Vaihdetopologian validointi tutkailee nyt, onko olemassa jokin sellainen vaihderakenteen linja, johon kaikki mainittavat ongelmat liittyvät, ja mainitsee validaatio-ongelman tähän linjaan liittyen, jos on.

Tällä on siis vaikutusta KRV-vaihteisiin, joilla on olemassa normaalin raideristeyksen tapaan linjat 1-5-2 ja 4-5-3, mutta lisäksi myös mallinnuksen yksinkertaistuksen nimissä keksityt linjat 1-5-3 ja 4-5-2. Sanotaan vaikkapa että tällaisen vaihteen läpi on linkitetty kaksi ei-duplikaatiksi-merkittyä raidetta, menemään molemmat menevät linjan 1-5-3 läpi: Aiemmin validointikoodi olisi tehnyt jotain hähmää sillä perusteella, että "todelliset" linjat olivat validoinnissa etuarvoisia (ts. `distinctBy` heitti loput pois), nyt virhe osuu tarkemmin oikealle linjalle.