### PR TITLE
General: Fix various query orderings

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -2173,6 +2173,7 @@ class PublicationDao(
                 where pltk.location_track_id = plt.id and pltk.publication_id = plt.publication_id
               ) pltk on (true)
             where plt.publication_id = any(array[:publication_ids]::int[])
+            order by publication_id, id
             """
                 .trimIndent()
 
@@ -2228,6 +2229,7 @@ class PublicationDao(
                             and tn_old.layout_context_id = ptn.base_layout_context_id
                             and tn_old.version = ptn.base_version
               where prl.publication_id = any(array[:publication_ids]::int[])
+            order by publication_id, id
             """
                 .trimIndent()
         return jdbcTemplate
@@ -2265,6 +2267,7 @@ class PublicationDao(
               inner join layout.km_post_version kmp using (id, layout_context_id, version)
               inner join layout.km_post_change_view kpc using (id, layout_context_id, version)
             where publication_id = any(array[:publication_ids]::int[])
+            order by publication_id, id
             """
                 .trimIndent()
 
@@ -2311,6 +2314,7 @@ class PublicationDao(
               inner join layout.switch_version sv using (id, layout_context_id, version)
               inner join layout.switch_change_view sc using (id, layout_context_id, version)
             where ps.publication_id = any(array[:publication_ids]::int[])
+            order by publication_id, id
             """
                 .trimIndent()
 
@@ -2360,6 +2364,7 @@ class PublicationDao(
               track_number_external_id
             from publication.switch_joint
             where publication_id = any(array[:publication_ids]::int[])
+            order by publication_id, id, joint_number
             """
                 .trimIndent()
 
@@ -2410,6 +2415,7 @@ class PublicationDao(
               join publication.publication
                 on ptn.publication_id = publication.id
             where ptn.publication_id = any(array[:publication_ids]::int[])
+            order by publication_id, id
             """
                 .trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -710,6 +710,7 @@ class LayoutAlignmentDao(
                              and ltve.location_track_version = lt.version
                 join target_edge using (edge_id)
               where lt.state != 'DELETED'
+              order by lt.id
             """
                 .trimIndent()
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -710,7 +710,7 @@ class LayoutAlignmentDao(
                              and ltve.location_track_version = lt.version
                 join target_edge using (edge_id)
               where lt.state != 'DELETED'
-              order by lt.id
+              order by target_edge.ix, lt.id, target_edge.node_id
             """
                 .trimIndent()
 


### PR DESCRIPTION
Muutama testifleikkejä aiheuttanut kohta. Tai tarkkaan ottaen ainoat näistä käytännössä näkemäni räsähdykset tulivat julkaistujen sijaintiraiteiden järjestelystä, ja tuosta LayoutAlignmentDaon järjestelystä, mutta on kai tässä hyvä olla jotain yhdenmukaisuutta. Pikakokeilujen mukaan ainakin RatkoServiceIT#pushSwitch() on myös testi, joka räjähtäisi, jos julkaistut vaihteet sattuisivat joskus tulemaan kannasta odottamattomassa järjestyksessä, mutta tämän myötä eivät tule.