### PR TITLE
GVT-3639 Add conditions for track boundary moves being disabled

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -30,6 +30,7 @@ import fi.fta.geoviite.infra.publication.validateWithParams
 import fi.fta.geoviite.infra.publication.validationError
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
 import fi.fta.geoviite.infra.tracklayout.DuplicateEndPointType
 import fi.fta.geoviite.infra.tracklayout.EndpointSplitPoint
 import fi.fta.geoviite.infra.tracklayout.IAlignment
@@ -78,6 +79,7 @@ class SplitService(
     private val switchLibraryService: SwitchLibraryService,
     private val switchService: LayoutSwitchService,
     private val alignmentDao: LayoutAlignmentDao,
+    private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
 ) {
     fun getChangeTime(): Instant {
         return splitDao.fetchChangeTime()
@@ -588,6 +590,17 @@ class SplitService(
             throw SplitFailureException(
                 message = "Source track state is not IN_USE: id=${sourceTrack.id}",
                 localizedMessageKey = "source-track-state-not-in-use",
+            )
+        }
+
+        val sourceTrackInUnpublishedBoundaryMove =
+            trackBoundaryMoveDao.getUnpublished().any { move ->
+                move.branch == branch && move.containsLocationTrack(request.sourceTrackId)
+            }
+        if (sourceTrackInUnpublishedBoundaryMove) {
+            throw SplitFailureException(
+                message = "Source track is part of an unpublished track boundary move: id=${sourceTrack.id}",
+                localizedMessageKey = "source-track-in-unpublished-boundary-move",
             )
         }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -6,9 +6,11 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.split.AdministrativeChange
+import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 
 enum class BoundaryOrientation {
     HEAD_FIRST,
@@ -48,8 +50,40 @@ data class TrackBoundaryMoveRequest(
 
 data class SwitchJointId(val switchId: IntId<LayoutSwitch>, val jointNumber: JointNumber)
 
+enum class BoundaryMoveDisabledReason {
+    PART_OF_SPLIT,
+    PART_OF_BOUNDARY_MOVE,
+    TRACK_DRAFT_EXISTS,
+    NO_GEOMETRY,
+    SWITCHES_PART_OF_SPLIT,
+}
+
+fun boundaryMoveDisabledReasons(
+    track: LocationTrack,
+    geometry: LocationTrackGeometry,
+    unfinishedSplits: List<Split>,
+    unpublishedBoundaryMoves: List<TrackBoundaryMove>,
+): List<BoundaryMoveDisabledReason> {
+    val trackId = track.id as IntId
+    val unpublishedSplits = unfinishedSplits.filter { split -> split.publicationId == null }
+    return listOfNotNull(
+        BoundaryMoveDisabledReason.PART_OF_SPLIT.takeIf {
+            unfinishedSplits.any { split -> split.containsLocationTrack(trackId) }
+        },
+        BoundaryMoveDisabledReason.PART_OF_BOUNDARY_MOVE.takeIf {
+            unpublishedBoundaryMoves.any { move -> move.containsLocationTrack(trackId) }
+        },
+        BoundaryMoveDisabledReason.TRACK_DRAFT_EXISTS.takeIf { track.isDraft },
+        BoundaryMoveDisabledReason.NO_GEOMETRY.takeIf { geometry.isEmpty },
+        BoundaryMoveDisabledReason.SWITCHES_PART_OF_SPLIT.takeIf {
+            geometry.switchIds.any { switchId -> unpublishedSplits.any { split -> split.containsSwitch(switchId) } }
+        },
+    )
+}
+
 data class BoundaryMoveCounterpart(
     val trackId: IntId<LocationTrack>,
     val orientation: BoundaryOrientation,
     val connectingSwitchJoint: SwitchJointId?,
+    val disabledReasons: List<BoundaryMoveDisabledReason> = emptyList(),
 )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -7,9 +7,12 @@ import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.TrackBoundaryMoveFailureException
 import fi.fta.geoviite.infra.linking.TrackEnd
+import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
 import fi.fta.geoviite.infra.math.lineLength
 import fi.fta.geoviite.infra.publication.Publication
+import fi.fta.geoviite.infra.split.Split
+import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.DbLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
@@ -31,6 +34,7 @@ class TrackBoundaryMoveService(
     private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
     private val locationTrackDao: LocationTrackDao,
     private val locationTrackService: LocationTrackService,
+    private val splitDao: SplitDao,
 ) {
     fun get(id: IntId<TrackBoundaryMove>): TrackBoundaryMove? {
         return trackBoundaryMoveDao.get(id)
@@ -44,12 +48,33 @@ class TrackBoundaryMoveService(
         boundaryMoveDirection: BoundaryMoveDirection,
         upToSwitchJoint: SwitchJointId?,
     ): IntId<TrackBoundaryMove> {
+        if (layoutBranch != LayoutBranch.main) {
+            throw TrackBoundaryMoveFailureException(
+                "track boundary moves are only allowed in the main branch: branch=$layoutBranch",
+                localizedMessageKey = "branch-not-main",
+            )
+        }
         val context = layoutBranch.draft
         val shorteningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, shorteningTrackId)
         val lengtheningTrackVersion = locationTrackDao.fetchVersionOrThrow(context, lengtheningTrackId)
 
         val (shorteningTrack, shorteningTrackGeometry) = locationTrackService.getWithGeometry(shorteningTrackVersion)
         val (lengtheningTrack, lengtheningTrackGeometry) = locationTrackService.getWithGeometry(lengtheningTrackVersion)
+
+        val unfinishedSplits = splitDao.fetchUnfinishedSplits(layoutBranch)
+        val unpublishedBoundaryMoves = findUnpublishedBoundaryMoves(layoutBranch)
+        validateTrackForBoundaryMove(
+            shorteningTrack,
+            shorteningTrackGeometry,
+            unfinishedSplits,
+            unpublishedBoundaryMoves,
+        )
+        validateTrackForBoundaryMove(
+            lengtheningTrack,
+            lengtheningTrackGeometry,
+            unfinishedSplits,
+            unpublishedBoundaryMoves,
+        )
 
         val geometries =
             getTrackBoundaryMoveGeometry(
@@ -116,6 +141,12 @@ class TrackBoundaryMoveService(
 
         if (headStartPoint == null || headEndPoint == null) return emptyList()
 
+        val unfinishedSplits = splitDao.fetchUnfinishedSplits(layoutContext.branch)
+        val unpublishedBoundaryMoves = findUnpublishedBoundaryMoves(layoutContext.branch)
+        val getDisabledReasons = { track: LocationTrack, geometry: DbLocationTrackGeometry ->
+            boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves)
+        }
+
         val counterpartFirstOptions =
             locationTrackService
                 .listWithGeometries(
@@ -124,7 +155,14 @@ class TrackBoundaryMoveService(
                     boundingBox = boundingBoxAroundPoint(headStartPoint, ENDPOINT_MATCH_DISTANCE),
                 )
                 .let { candidates ->
-                    getCounterpartFirstOptions(candidates, headTrack, headStartPoint, headGeometry, headSwitchIds)
+                    getCounterpartFirstOptions(
+                        candidates,
+                        headTrack,
+                        headStartPoint,
+                        headGeometry,
+                        headSwitchIds,
+                        getDisabledReasons,
+                    )
                 }
 
         val headFirstOptions =
@@ -135,7 +173,14 @@ class TrackBoundaryMoveService(
                     boundingBox = boundingBoxAroundPoint(headEndPoint, ENDPOINT_MATCH_DISTANCE),
                 )
                 .let { candidates ->
-                    getHeadFirstOptions(candidates, headTrack, headEndPoint, headGeometry, headSwitchIds)
+                    getHeadFirstOptions(
+                        candidates,
+                        headTrack,
+                        headEndPoint,
+                        headGeometry,
+                        headSwitchIds,
+                        getDisabledReasons,
+                    )
                 }
 
         return counterpartFirstOptions + headFirstOptions
@@ -144,12 +189,37 @@ class TrackBoundaryMoveService(
     fun delete(id: IntId<TrackBoundaryMove>) = trackBoundaryMoveDao.delete(id)
 }
 
+private fun validateTrackForBoundaryMove(
+    track: LocationTrack,
+    geometry: LocationTrackGeometry,
+    unfinishedSplits: List<Split>,
+    unpublishedBoundaryMoves: List<TrackBoundaryMove>,
+) {
+    val reason =
+        boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves).firstOrNull()
+            ?: return
+    val messageKey =
+        when (reason) {
+            BoundaryMoveDisabledReason.PART_OF_SPLIT -> "track-part-of-split"
+            BoundaryMoveDisabledReason.PART_OF_BOUNDARY_MOVE -> "track-part-of-boundary-move"
+            BoundaryMoveDisabledReason.TRACK_DRAFT_EXISTS -> "track-draft-exists"
+            BoundaryMoveDisabledReason.NO_GEOMETRY -> "no-geometry"
+            BoundaryMoveDisabledReason.SWITCHES_PART_OF_SPLIT -> "switches-part-of-split"
+        }
+    throw TrackBoundaryMoveFailureException(
+        "track cannot take part in a boundary move: id=${track.id}, reason=$reason",
+        localizedMessageKey = messageKey,
+        localizationParams = localizationParams("name" to track.name),
+    )
+}
+
 private fun getHeadFirstOptions(
     candidates: List<Pair<LocationTrack, DbLocationTrackGeometry>>,
     headTrack: LocationTrack,
     headEndPoint: AlignmentPoint<LocationTrackM>,
     headGeometry: DbLocationTrackGeometry,
     headSwitchIds: Set<IntId<LayoutSwitch>>,
+    getDisabledReasons: (LocationTrack, DbLocationTrackGeometry) -> List<BoundaryMoveDisabledReason>,
 ): List<BoundaryMoveCounterpart> =
     candidates
         .filter { (track, _) -> track.id != headTrack.id && track.exists }
@@ -167,6 +237,7 @@ private fun getHeadFirstOptions(
                     candidateGeometry.switchIds.toSet(),
                     candidate.id as IntId,
                     BoundaryOrientation.HEAD_FIRST,
+                    getDisabledReasons(candidate, candidateGeometry),
                 )
         }
 
@@ -176,6 +247,7 @@ private fun getCounterpartFirstOptions(
     headStartPoint: AlignmentPoint<LocationTrackM>,
     headGeometry: DbLocationTrackGeometry,
     headSwitchIds: Set<IntId<LayoutSwitch>>,
+    getDisabledReasons: (LocationTrack, DbLocationTrackGeometry) -> List<BoundaryMoveDisabledReason>,
 ): List<BoundaryMoveCounterpart> =
     candidates
         .filter { (track, _) -> track.id != headTrack.id && track.exists }
@@ -193,6 +265,7 @@ private fun getCounterpartFirstOptions(
                     candidateGeometry.switchIds.toSet(),
                     candidate.id as IntId,
                     BoundaryOrientation.COUNTERPART_FIRST,
+                    getDisabledReasons(candidate, candidateGeometry),
                 )
         }
 
@@ -205,6 +278,7 @@ private fun getCounterpartOption(
     candidateSwitchIds: Set<IntId<LayoutSwitch>>,
     candidateId: IntId<LocationTrack>,
     orientation: BoundaryOrientation,
+    disabledReasons: List<BoundaryMoveDisabledReason>,
 ): BoundaryMoveCounterpart? {
     val outsideMatchDistance = lineLength(headPoint, candidatePoint) > ENDPOINT_MATCH_DISTANCE
     val linkingSwitches = (candidateNode.switches.map { it.id } + headNode.switches.map { it.id }).toSet()
@@ -217,6 +291,7 @@ private fun getCounterpartOption(
             trackId = candidateId,
             orientation = orientation,
             connectingSwitchJoint = linkingSwitchJoint,
+            disabledReasons = disabledReasons,
         )
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrack.kt
@@ -18,6 +18,7 @@ import fi.fta.geoviite.infra.localization.Translation
 import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.lineLength
+import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDisabledReason
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.StringSanitizer
 
@@ -300,6 +301,7 @@ data class LocationTrackInfoboxExtras(
     val duplicateOf: LocationTrackDuplicate?,
     val duplicates: List<LocationTrackDuplicate>,
     val partOfSplit: PartOfSplit,
+    val boundaryMoveDisabledReasons: List<BoundaryMoveDisabledReason>,
     val startSplitPoint: SplitPoint?,
     val endSplitPoint: SplitPoint?,
     val switches: List<LocationTrackInfoboxSwitch>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -42,6 +42,8 @@ import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitDuplicateTrack
 import fi.fta.geoviite.infra.split.SplittingInitializationParameters
 import fi.fta.geoviite.infra.switchLibrary.SwitchLibraryService
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
+import fi.fta.geoviite.infra.trackBoundaryMove.boundaryMoveDisabledReasons
 import fi.fta.geoviite.infra.tracklayout.DuplicateEndPointType.END
 import fi.fta.geoviite.infra.tracklayout.DuplicateEndPointType.START
 import fi.fta.geoviite.infra.util.FreeText
@@ -65,6 +67,7 @@ class LocationTrackService(
     private val switchDao: LayoutSwitchDao,
     private val switchLibraryService: SwitchLibraryService,
     private val splitDao: SplitDao,
+    private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
     private val operationalPointDao: OperationalPointDao,
     private val localizationService: LocalizationService,
     private val transactionTemplate: TransactionTemplate,
@@ -511,6 +514,11 @@ class LocationTrackService(
                     else -> PartOfSplit.NONE
                 }
 
+            val unpublishedBoundaryMoves =
+                trackBoundaryMoveDao.getUnpublished().filter { move -> move.branch == layoutContext.branch }
+            val boundaryMoveDisabledReasons =
+                boundaryMoveDisabledReasons(track, geometry, allUnfinishedSplits, unpublishedBoundaryMoves)
+
             val switches =
                 geometry.trackSwitchLinks
                     .groupBy { link -> link.switchId }
@@ -556,6 +564,7 @@ class LocationTrackService(
                 duplicateOf,
                 duplicates,
                 partOfSplit,
+                boundaryMoveDisabledReasons,
                 startSplitPoint,
                 endSplitPoint,
                 switches,

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -72,7 +72,13 @@
             "generic": "Vaihtumiskohdan siirrossa tapahtui virhe",
             "does-not-move-boundary": "Valittu vaihteen piste ei siirrä raiteiden vaihtumiskohtaa",
             "partial-revert": "Raiteen vaihtumiskohdan siirtoa ei voi perua osittain",
-            "tracks-do-not-connect": "Raiteet eivät kohtaa toisiaan, joten vaihtumiskohtaa ei voi siirtää"
+            "tracks-do-not-connect": "Raiteet eivät kohtaa toisiaan, joten vaihtumiskohtaa ei voi siirtää",
+            "branch-not-main": "Vaihtumiskohtaa voi siirtää vain luonnostilassa",
+            "track-draft-exists": "Raiteella {{name}} on julkaisemattomia muutoksia, joten vaihtumiskohtaa ei voi siirtää",
+            "no-geometry": "Raiteella {{name}} ei ole geometriaa, joten vaihtumiskohtaa ei voi siirtää",
+            "track-part-of-split": "Raide {{name}} on mukana keskeneräisessä raiteen jakamisessa, joten vaihtumiskohtaa ei voi siirtää",
+            "track-part-of-boundary-move": "Raide {{name}} on mukana julkaisemattomassa vaihtumiskohdan siirrossa, joten vaihtumiskohtaa ei voi siirtää",
+            "switches-part-of-split": "Raiteen {{name}} vaihteita on mukana julkaisemattomissa raiteen jakamisissa, joten vaihtumiskohtaa ei voi siirtää"
         },
         "split": {
             "source-track-state-not-in-use": "Jakamista ei voitu suorittaa, koska jaettava raide ei ole \"Käytössä\"-tilassa",
@@ -84,7 +90,8 @@
             "geocoding-failed": "Jakamista ei voitu suorittaa, koska jaettavan raiteen {{trackName}} geokoodaus epäonnistui",
             "new-duplicate-reference-assignment-failed": "Jakamista ei voitu suorittaa, koska käyttämättömälle duplikaattiraiteelle {{duplicate}} ei löydetty päällekkäisyyttä jakamisen seurauksena syntyvistä raiteista",
             "partial-revert": "Raiteen jakamista ei voi peruuttaa osittain",
-            "switches-in-unpublished-split": "Jaettavan raiteen vaihteita on osana muita julkaisemattomia raiteen jakamiskokonaisuuksia"
+            "switches-in-unpublished-split": "Jaettavan raiteen vaihteita on osana muita julkaisemattomia raiteen jakamiskokonaisuuksia",
+            "source-track-in-unpublished-boundary-move": "Jakamista ei voitu suorittaa, koska jaettava raide on mukana julkaisemattomassa vaihtumiskohdan siirrossa"
         },
         "publication": {
             "generic": "Julkaisu epäonnistui",
@@ -1000,7 +1007,8 @@
                     "has-errors": "Tiedoissa on virheitä",
                     "show": "näytä",
                     "branch-not-main": "Raiteita voi jakaa vain luonnostilassa",
-                    "switches-part-of-other-splits": "Osa raiteen vaihteista on mukana raiteen jakamiskokonaisuuksissa joita ei ole vielä julkaistu."
+                    "switches-part-of-other-splits": "Osa raiteen vaihteista on mukana raiteen jakamiskokonaisuuksissa joita ei ole vielä julkaistu.",
+                    "track-part-of-boundary-move": "Raiteen jakamista ei voi suorittaa, koska raide on mukana julkaisemattomassa vaihtumiskohdan siirrossa."
                 },
                 "validation-in-progress": "Raiteen vaihteita validoidaan...",
                 "relink-critical-errors": "Raiteen vaihteiden linkityksessä on kriittisiä ongelmia, jotka täytyy korjata ennen raiteen jakamista",
@@ -1033,7 +1041,14 @@
                 "select-boundary-on-map": "Valitse uusi vaihtumiskohta kartalta.",
                 "lock-selection": "Lukitse valinta",
                 "save-boundary-move": "Tallenna vaihtumiskohta",
-                "boundary-move-saved": "Raiteiden {{firstTrack}} ja {{secondTrack}} vaihtumiskohta siirretty osoitteeseen {{address}}"
+                "boundary-move-saved": "Raiteiden {{firstTrack}} ja {{secondTrack}} vaihtumiskohta siirretty osoitteeseen {{address}}",
+                "validation": {
+                    "branch-not-main": "Vaihtumiskohtaa voi siirtää vain luonnostilassa",
+                    "track-draft-exists": "Muokatun sijaintiraiteen vaihtumiskohtaa ei voi siirtää. Julkaise tai kumoa muutokset.",
+                    "part-of-split": "Raide on mukana keskeneräisessä raiteen jakamisessa",
+                    "part-of-boundary-move": "Raide on mukana julkaisemattomassa vaihtumiskohdan siirrossa",
+                    "switches-part-of-split": "Raiteen vaihteita on mukana julkaisemattomissa raiteen jakamisissa"
+                }
             }
         },
         "operational-point": {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -239,15 +239,14 @@ constructor(
         val switch = mainDraftContext.save(switch())
         val trackNumberIds =
             listOf(mainOfficialContext.createLayoutTrackNumber().id, mainOfficialContext.createLayoutTrackNumber().id)
-        val locationTracks =
-            trackNumberIds.map { trackNumberId ->
-                val edge =
-                    edge(
-                        startInnerSwitch = switchLinkYV(switch.id, 1),
-                        segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
-                    )
-                mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
-            }
+        val locationTracks = trackNumberIds.map { trackNumberId ->
+            val edge =
+                edge(
+                    startInnerSwitch = switchLinkYV(switch.id, 1),
+                    segments = listOf(segment(Point(0.0, 0.0), Point(1.0, 1.0))),
+                )
+            mainDraftContext.save(locationTrack(trackNumberId), trackGeometry(edge))
+        }
 
         val publicationResult =
             publish(publicationService, locationTracks = locationTracks.map { it.id }, switches = listOf(switch.id))
@@ -844,9 +843,9 @@ constructor(
         val boundaryMoveId: IntId<TrackBoundaryMove>,
     )
 
-    // Two tracks meeting at switch1 joint 2, laid out as one physically continuous track. The lengthening track holds
-    // switch1; the shortening track holds switch2. Moving the boundary to switch2 joint 1 shortens one track and
-    // lengthens the other, producing a draft change to both.
+    /*
+    Publishes a shortening and lengthening track, then saves a track boundary move over them
+     */
     private fun saveTrackBoundaryMoveSetup(): TrackBoundaryMoveSetup {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
         val switch1 = mainDraftContext.createSwitch().id
@@ -888,6 +887,8 @@ constructor(
                     ),
                 )
                 .id
+
+        testDBService.publish(locationTracks = listOf(lengtheningTrack, shorteningTrack))
 
         val boundaryMoveId =
             trackBoundaryMoveService.saveTrackBoundaryMove(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -4,10 +4,11 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.error.SplitFailureException
 import fi.fta.geoviite.infra.error.TrackBoundaryMoveFailureException
 import fi.fta.geoviite.infra.localization.LocalizationKey
 import fi.fta.geoviite.infra.math.Point
-import fi.fta.geoviite.infra.publication.PublicationInDesign
+import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.publication.PublicationInMain
 import fi.fta.geoviite.infra.publication.PublicationService
 import fi.fta.geoviite.infra.publication.PublicationValidationService
@@ -15,6 +16,7 @@ import fi.fta.geoviite.infra.publication.TrackBoundaryMovePublicationGroup
 import fi.fta.geoviite.infra.publication.publicationRequest
 import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveCounterpart
+import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDisabledReason
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDirection
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryOrientation
 import fi.fta.geoviite.infra.trackBoundaryMove.SwitchJointId
@@ -25,6 +27,7 @@ import fi.fta.geoviite.infra.tracklayout.LayoutEdge
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.edge
@@ -56,6 +59,9 @@ constructor(
     private val trackBoundaryMoveDao: TrackBoundaryMoveDao,
     private val publicationService: PublicationService,
     private val publicationValidationService: PublicationValidationService,
+    private val splitDao: SplitDao,
+    private val splitService: SplitService,
+    private val locationTrackDao: LocationTrackDao,
 ) : DBTestBase() {
     @BeforeEach
     fun setup() {
@@ -413,69 +419,218 @@ constructor(
     }
 
     @Test
-    fun `boundary moves on the same tracks in main and a design branch list and publish independently`() {
-        // The pair of tracks is published in main-official, so it is visible in both the main-draft and the
-        // design-draft context. Each context then gets its own boundary move on top of that shared official base. The
-        // two moves live in separate contexts and must list as candidates and publish without interfering.
+    fun `saving a boundary move in a design branch is an error`() {
         val setup = savePublishableConnectedTracks()
         val designBranch = testDBService.createDesignBranch()
-        testDBService.generateOid(setup.lengtheningTrack.id, designBranch)
-        testDBService.generateOid(setup.shorteningTrack.id, designBranch)
 
-        val affectedTrackIds = listOf(setup.shorteningTrack.id, setup.lengtheningTrack.id)
-
-        val mainBoundaryMoveId =
-            trackBoundaryMoveService.saveTrackBoundaryMove(
-                LayoutBranch.main,
-                shorteningTrackId = setup.shorteningTrack.id,
-                lengtheningTrackId = setup.lengtheningTrack.id,
-                upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
-                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
-            )
-
-        val designBoundaryMoveId =
-            trackBoundaryMoveService.saveTrackBoundaryMove(
-                designBranch,
-                shorteningTrackId = setup.shorteningTrack.id,
-                lengtheningTrackId = setup.lengtheningTrack.id,
-                upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
-                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
-            )
-
-        // Each context lists only its own boundary move's group on the affected tracks.
-        val mainCandidates = publicationService.collectPublicationCandidates(PublicationInMain)
-        mainCandidates.locationTracks
-            .filter { candidate -> candidate.id in affectedTrackIds }
-            .also { filtered -> assertEquals(2, filtered.size) }
-            .forEach { candidate ->
-                assertEquals(TrackBoundaryMovePublicationGroup(mainBoundaryMoveId), candidate.publicationGroup)
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    designBranch,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
             }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.branch-not-main"), exception.localizationKey)
+    }
 
-        val designCandidates = publicationService.collectPublicationCandidates(PublicationInDesign(designBranch))
-        designCandidates.locationTracks
-            .filter { candidate -> candidate.id in affectedTrackIds }
-            .also { filtered -> assertEquals(2, filtered.size) }
-            .forEach { candidate ->
-                assertEquals(TrackBoundaryMovePublicationGroup(designBoundaryMoveId), candidate.publicationGroup)
+    @Test
+    fun `track with unpublished changes cannot be part of a boundary move`() {
+        val setup = savePublishableConnectedTracks()
+        val (track, geometry) =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, setup.shorteningTrack.id)
+        locationTrackService.saveDraft(LayoutBranch.main, track, offsetGeometry(geometry, Point(0.0, 0.0)))
+
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
             }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.track-draft-exists"), exception.localizationKey)
+    }
 
-        // Publishing in each context pulls in only that context's boundary move and stamps its own publication.
-        val mainPublication =
-            publicationService.publishManualPublication(
-                LayoutBranch.main,
-                publicationRequest(locationTracks = affectedTrackIds),
+    @Test
+    fun `track with no geometry cannot be part of a boundary move`() {
+        val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        val shorteningTrack =
+            mainOfficialContext.save(
+                locationTrack(trackNumber),
+                trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))),
             )
-        assertEquals(mainPublication.publicationId, trackBoundaryMoveDao.getOrThrow(mainBoundaryMoveId).publicationId)
-        assertEquals(null, trackBoundaryMoveDao.getOrThrow(designBoundaryMoveId).publicationId)
+        val emptyTrack = mainOfficialContext.save(locationTrack(trackNumber), TmpLocationTrackGeometry.empty)
 
-        val designPublication =
-            publicationService.publishManualPublication(
-                designBranch,
-                publicationRequest(locationTracks = affectedTrackIds),
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = shorteningTrack.id,
+                    lengtheningTrackId = emptyTrack.id,
+                    upToSwitchJoint = null,
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.no-geometry"), exception.localizationKey)
+    }
+
+    @Test
+    fun `track that is part of an unpublished split cannot be part of a boundary move`() {
+        val setup = savePublishableConnectedTracks()
+        splitDao.saveSplit(setup.shorteningTrack, emptyList(), emptyList(), emptyList())
+
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.track-part-of-split"), exception.localizationKey)
+    }
+
+    @Test
+    fun `track in a published but still unfinished split cannot be part of a boundary move`() {
+        // A split stays unfinished after publication until its bulk transfer is done, and must keep blocking boundary
+        // moves on its tracks for that whole time.
+        val setup = savePublishableConnectedTracks()
+        val splitId = splitDao.saveSplit(setup.lengtheningTrack, emptyList(), emptyList(), emptyList())
+        splitDao.updateSplit(splitId, publicationId = setup.publicationId)
+
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.track-part-of-split"), exception.localizationKey)
+    }
+
+    @Test
+    fun `track that is part of an unpublished boundary move cannot be part of another boundary move`() {
+        val setup = savePublishableConnectedTracks()
+        trackBoundaryMoveService.saveTrackBoundaryMove(
+            LayoutBranch.main,
+            shorteningTrackId = setup.shorteningTrack.id,
+            lengtheningTrackId = setup.lengtheningTrack.id,
+            upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+            boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+        )
+
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = null,
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            }
+        assertEquals(
+            LocalizationKey.of("error.track-boundary-move.track-part-of-boundary-move"),
+            exception.localizationKey,
+        )
+    }
+
+    @Test
+    fun `track whose switch is part of an unpublished split cannot be part of a boundary move`() {
+        val setup = savePublishableConnectedTracks()
+        // A split on an unrelated track, but whose relinked switches include a switch on the shortening track.
+        val otherTrackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        val otherTrack =
+            mainOfficialContext.save(
+                locationTrack(otherTrackNumber),
+                trackGeometry(edge(listOf(segment(Point(0.0, 100.0), Point(10.0, 100.0))))),
+            )
+        splitDao.saveSplit(otherTrack, emptyList(), listOf(setup.shorteningOnlySwitch), emptyList())
+
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.switches-part-of-split"), exception.localizationKey)
+    }
+
+    @Test
+    fun `splitting a track that is part of an unpublished boundary move is an error`() {
+        val setup = savePublishableConnectedTracks()
+        trackBoundaryMoveService.saveTrackBoundaryMove(
+            LayoutBranch.main,
+            shorteningTrackId = setup.shorteningTrack.id,
+            lengtheningTrackId = setup.lengtheningTrack.id,
+            upToSwitchJoint = SwitchJointId(setup.shorteningOnlySwitch, JointNumber(1)),
+            boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+        )
+
+        val exception =
+            assertThrows<SplitFailureException> {
+                splitService.split(LayoutBranch.main, SplitRequest(setup.shorteningTrack.id, emptyList()))
+            }
+        assertEquals(
+            LocalizationKey.of("error.split.source-track-in-unpublished-boundary-move"),
+            exception.localizationKey,
+        )
+    }
+
+    @Test
+    fun `counterpart options flag counterparts with unpublished changes`() {
+        val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        val headTrack =
+            mainOfficialContext.save(
+                locationTrack(trackNumber),
+                trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))),
+            )
+        val draftCounterpart =
+            mainDraftContext.save(
+                locationTrack(trackNumber),
+                trackGeometry(edge(listOf(segment(Point(10.5, 0.0), Point(20.0, 0.0))))),
+            )
+
+        assertEquals(
+            listOf(
+                BoundaryMoveCounterpart(
+                    trackId = draftCounterpart.id,
+                    orientation = BoundaryOrientation.HEAD_FIRST,
+                    connectingSwitchJoint = null,
+                    disabledReasons = listOf(BoundaryMoveDisabledReason.TRACK_DRAFT_EXISTS),
+                )
+            ),
+            trackBoundaryMoveService.getBoundaryMoveCounterpartOptions(LayoutBranch.main.draft, headTrack.id),
+        )
+    }
+
+    @Test
+    fun `counterpart options flag counterparts in unpublished splits and boundary moves`() {
+        val setup = savePublishableConnectedTracks()
+        splitDao.saveSplit(setup.shorteningTrack, emptyList(), emptyList(), emptyList())
+
+        val options =
+            trackBoundaryMoveService.getBoundaryMoveCounterpartOptions(
+                LayoutBranch.main.draft,
+                setup.lengtheningTrack.id,
             )
         assertEquals(
-            designPublication.publicationId,
-            trackBoundaryMoveDao.getOrThrow(designBoundaryMoveId).publicationId,
+            listOf(BoundaryMoveDisabledReason.PART_OF_SPLIT),
+            options.single { option -> option.trackId == setup.shorteningTrack.id }.disabledReasons,
         )
     }
 
@@ -785,6 +940,8 @@ constructor(
         val connectingSwitch: IntId<LayoutSwitch>,
         // switch2 is on the shortening track only; its joint 1 is a valid target to move the boundary to.
         val shorteningOnlySwitch: IntId<LayoutSwitch>,
+        // The publication that made the tracks official, when they were saved as publishable.
+        val publicationId: IntId<Publication>? = null,
     )
 
     // Two tracks meeting at switch1 joint 2, laid out as one physically continuous track. The lengthening track holds
@@ -870,18 +1027,20 @@ constructor(
         mainDraftContext.generateOid(lengtheningTrack.id)
         mainDraftContext.generateOid(shorteningTrack.id)
 
-        publicationService.publishManualPublication(
-            LayoutBranch.main,
-            publicationRequest(locationTracks = listOf(lengtheningTrack.id, shorteningTrack.id)),
-        )
+        val publicationResult =
+            publicationService.publishManualPublication(
+                LayoutBranch.main,
+                publicationRequest(locationTracks = listOf(lengtheningTrack.id, shorteningTrack.id)),
+            )
 
         return ConnectedTracks(
-            lengtheningTrack = lengtheningTrack,
+            lengtheningTrack = locationTrackDao.fetchVersionOrThrow(LayoutBranch.main.official, lengtheningTrack.id),
             lengtheningGeometry = lengtheningGeometry,
-            shorteningTrack = shorteningTrack,
+            shorteningTrack = locationTrackDao.fetchVersionOrThrow(LayoutBranch.main.official, shorteningTrack.id),
             shorteningGeometry = shorteningGeometry,
             connectingSwitch = switch1,
             shorteningOnlySwitch = switch2,
+            publicationId = publicationResult.publicationId,
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -191,10 +191,9 @@ constructor(
 
         // drop(1) because the track number km lengths include the section before the first km post
         val expected = trackNumberService.getKmLengths(MainLayoutContext.draft, trackNumberId)!!.drop(1)
-        val actual =
-            kmPostSaveResults.mapNotNull { kmPost ->
-                kmPostService.getKmPostInfoboxExtras(MainLayoutContext.draft, kmPost).kmLength
-            }
+        val actual = kmPostSaveResults.mapNotNull { kmPost ->
+            kmPostService.getKmPostInfoboxExtras(MainLayoutContext.draft, kmPost).kmLength
+        }
         assertEquals(expected.size, actual.size)
         expected.zip(actual) { e, a -> assertEquals(e.length.toDouble(), a, 0.001) }
     }

--- a/ui/src/linking/alignment-linking-candidates.tsx
+++ b/ui/src/linking/alignment-linking-candidates.tsx
@@ -19,19 +19,24 @@ import {
 } from 'track-layout/track-layout-model';
 import { Spinner } from 'vayla-design-lib/spinner/spinner';
 import styles from 'tool-panel/geometry-alignment/geometry-alignment-infobox.scss';
+import { createClassName } from 'vayla-design-lib/utils';
 
 type SelectionCandidateProps = {
     isSelected: boolean;
+    // if non-undefined, the candidate is disabled and the reason shown as tooltip
+    disabledReason?: string;
     onClick: () => void;
     children: React.ReactNode;
 };
 
 const SelectionCandidate: React.FC<SelectionCandidateProps> = ({
     isSelected,
+    disabledReason,
     onClick,
     children,
 }) => {
     const ref = React.useRef<HTMLLIElement>(null);
+    const disabled = disabledReason !== undefined;
 
     React.useEffect(() => {
         if (isSelected) {
@@ -43,7 +48,14 @@ const SelectionCandidate: React.FC<SelectionCandidateProps> = ({
     }, [isSelected]);
 
     return (
-        <li ref={ref} className={styles['geometry-alignment-infobox__alignment']} onClick={onClick}>
+        <li
+            ref={ref}
+            className={createClassName(
+                styles['geometry-alignment-infobox__alignment'],
+                disabled && styles['geometry-alignment-infobox__alignment--disabled'],
+            )}
+            title={disabledReason}
+            onClick={() => !disabled && onClick()}>
             {children}
         </li>
     );
@@ -79,6 +91,8 @@ type LocationTrackCandidatesProps = {
     lockedAlignmentId?: LocationTrackId;
     isLoading: boolean;
     emptyMessage: React.ReactNode;
+    // A returned reason disables selecting the candidate and is shown as its tooltip
+    getDisabledReason?: (track: LayoutLocationTrack) => string | undefined;
     onSelect: (track: LocationTrackId) => void;
 };
 
@@ -88,6 +102,7 @@ export const LocationTrackCandidates: React.FC<LocationTrackCandidatesProps> = (
     lockedAlignmentId,
     isLoading,
     emptyMessage,
+    getDisabledReason,
     onSelect,
 }) => (
     <CandidatesList
@@ -96,17 +111,21 @@ export const LocationTrackCandidates: React.FC<LocationTrackCandidatesProps> = (
         emptyMessage={emptyMessage}>
         {candidates.map((track) => {
             const isSelected = track.id === selectedId;
+            const disabledReason = getDisabledReason?.(track);
             return (
                 <SelectionCandidate
                     key={track.id}
                     isSelected={isSelected}
+                    disabledReason={disabledReason}
                     onClick={() => onSelect(track.id)}>
                     <LocationTrackBadge
                         locationTrack={track}
                         status={
                             isSelected
                                 ? LocationTrackBadgeStatus.SELECTED
-                                : LocationTrackBadgeStatus.DEFAULT
+                                : disabledReason !== undefined
+                                  ? LocationTrackBadgeStatus.DISABLED
+                                  : LocationTrackBadgeStatus.DEFAULT
                         }
                     />
                     {lockedAlignmentId === track.id && (

--- a/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.scss
+++ b/ui/src/tool-panel/geometry-alignment/geometry-alignment-infobox.scss
@@ -61,6 +61,11 @@
         & > *:not(:last-child) {
             margin-right: 12px;
         }
+
+        &--disabled {
+            cursor: default;
+            color: vayla-design.$color-black-lighter;
+        }
     }
 
     &__connection-points {

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -251,7 +251,8 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     const [updatingLength, setUpdatingLength] = React.useState<boolean>(false);
     const [canUpdate, setCanUpdate] = React.useState<boolean>();
     const [startingSplitting, setStartingSplitting] = React.useState<boolean>(false);
-    const [modifyMenuOpen, setModifyMenuOpen] = React.useState<boolean>(false);
+    const [modifyTrackBoundariesMenuOpen, setModifyTrackBoundariesMenuOpen] =
+        React.useState<boolean>(false);
     const modifyButtonRef = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
@@ -432,10 +433,37 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                 qa-id="modify-start-or-end"
                 title={getModifyStartOrEndDisabledReasonTranslated()}
                 disabled={shorteningDisabled}
-                onClick={() => setModifyMenuOpen(true)}>
+                onClick={() => setModifyTrackBoundariesMenuOpen(true)}>
                 {t('tool-panel.location-track.modify-start-or-end')}
             </Button>
         </EnvRestricted>
+    );
+
+    const modifyTrackBoundariesMenu = () => (
+        <Menu
+            anchorElementRef={modifyButtonRef}
+            onClickOutside={() => setModifyTrackBoundariesMenuOpen(false)}
+            onClose={() => setModifyTrackBoundariesMenuOpen(false)}
+            items={[
+                menuOption(
+                    () => {
+                        getEndLinkPoints(
+                            locationTrack.id,
+                            layoutContext,
+                            MapAlignmentType.LocationTrack,
+                            changeTimes.layoutLocationTrack,
+                        ).then(onStartLocationTrackGeometryChange);
+                    },
+                    t('tool-panel.location-track.shorten-track-start-or-end'),
+                    'shorten-track-start-or-end',
+                ),
+                menuOption(
+                    () => onStartTrackBoundaryMove(locationTrack.id),
+                    t('tool-panel.location-track.move-track-boundary'),
+                    'move-track-boundary',
+                ),
+            ]}
+        />
     );
 
     return (
@@ -484,41 +512,8 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                                     )}
                                     <InfoboxButtons>
                                         <div ref={modifyButtonRef}>{modifyStartOrEndButton}</div>
-                                        {modifyMenuOpen && (
-                                            <Menu
-                                                anchorElementRef={modifyButtonRef}
-                                                onClickOutside={() => setModifyMenuOpen(false)}
-                                                onClose={() => setModifyMenuOpen(false)}
-                                                items={[
-                                                    menuOption(
-                                                        () => {
-                                                            getEndLinkPoints(
-                                                                locationTrack.id,
-                                                                layoutContext,
-                                                                MapAlignmentType.LocationTrack,
-                                                                changeTimes.layoutLocationTrack,
-                                                            ).then(
-                                                                onStartLocationTrackGeometryChange,
-                                                            );
-                                                        },
-                                                        t(
-                                                            'tool-panel.location-track.shorten-track-start-or-end',
-                                                        ),
-                                                        'shorten-track-start-or-end',
-                                                    ),
-                                                    menuOption(
-                                                        () =>
-                                                            onStartTrackBoundaryMove(
-                                                                locationTrack.id,
-                                                            ),
-                                                        t(
-                                                            'tool-panel.location-track.move-track-boundary',
-                                                        ),
-                                                        'move-track-boundary',
-                                                    ),
-                                                ]}
-                                            />
-                                        )}
+                                        {modifyTrackBoundariesMenuOpen &&
+                                            modifyTrackBoundariesMenu()}
                                     </InfoboxButtons>
                                 </PrivilegeRequired>
                             )}

--- a/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-location-infobox.tsx
@@ -53,6 +53,7 @@ import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { PrivilegeRequired } from 'user/privilege-required';
 import { EDIT_LAYOUT } from 'user/user-model';
 import { getSplitPointName } from 'tool-panel/location-track/splitting/location-track-splitting-infobox';
+import { translatedBoundaryMoveDisabledReasons } from 'tool-panel/location-track/location-track-track-boundary-move-infobox';
 import { SplitButton } from 'geoviite-design-lib/split-button/split-button';
 import { Menu, menuOption } from 'vayla-design-lib/menu/menu';
 import { filterNotEmpty, filterUniqueById } from 'utils/array-utils';
@@ -183,6 +184,8 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
     const anySwitchesPartOfOtherSplits = extraInfo?.switches?.some(
         (sw) => sw.partOfUnfinishedSplit,
     );
+    const partOfUnpublishedBoundaryMove =
+        extraInfo?.boundaryMoveDisabledReasons?.includes('PART_OF_BOUNDARY_MOVE');
 
     const getSplittingDisabledReasonsTranslated = () => {
         const reasons: string[] = [];
@@ -197,6 +200,10 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
 
         if (isPartOfUnfinishedSplit(extraInfo?.partOfSplit)) {
             return t('tool-panel.location-track.splitting-blocks-geometry-changes');
+        }
+
+        if (partOfUnpublishedBoundaryMove) {
+            return t('tool-panel.location-track.splitting.validation.track-part-of-boundary-move');
         }
 
         if (locationTrack.state !== 'IN_USE') {
@@ -401,10 +408,31 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
         duplicatesOnOtherTrackNumbers ||
         duplicatesOnOtherLocationTracks ||
         isPartOfUnfinishedSplit(extraInfo?.partOfSplit) ||
+        partOfUnpublishedBoundaryMove ||
         startingSplitting ||
         !startAndEndAddressDefined ||
         anySwitchesPartOfOtherSplits ||
         layoutContext.branch !== 'MAIN';
+
+    const trackBoundaryMoveDisabled =
+        !isDraft ||
+        layoutContext.branch !== 'MAIN' ||
+        !!splittingState ||
+        !extraInfo ||
+        extraInfo.boundaryMoveDisabledReasons.length > 0;
+
+    const getTrackBoundaryMoveDisabledReasonsTranslated = () => {
+        if (!isDraft) {
+            return t('tool-panel.disabled.activity-disabled-in-official-mode');
+        }
+        if (layoutContext.branch !== 'MAIN') {
+            return t('tool-panel.location-track.track-boundary-move.validation.branch-not-main');
+        }
+        return translatedBoundaryMoveDisabledReasons(
+            extraInfo?.boundaryMoveDisabledReasons ?? [],
+            t,
+        );
+    };
 
     const modifyStartOrEndButton = (
         <EnvRestricted
@@ -431,8 +459,12 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                 variant={ButtonVariant.SECONDARY}
                 size={ButtonSize.SMALL}
                 qa-id="modify-start-or-end"
-                title={getModifyStartOrEndDisabledReasonTranslated()}
-                disabled={shorteningDisabled}
+                title={
+                    shorteningDisabled && trackBoundaryMoveDisabled
+                        ? getModifyStartOrEndDisabledReasonTranslated()
+                        : undefined
+                }
+                disabled={shorteningDisabled && trackBoundaryMoveDisabled}
                 onClick={() => setModifyTrackBoundariesMenuOpen(true)}>
                 {t('tool-panel.location-track.modify-start-or-end')}
             </Button>
@@ -456,11 +488,19 @@ export const LocationTrackLocationInfobox: React.FC<LocationTrackLocationInfobox
                     },
                     t('tool-panel.location-track.shorten-track-start-or-end'),
                     'shorten-track-start-or-end',
+                    shorteningDisabled,
+                    'CLOSE_AFTER_SELECT',
+                    undefined,
+                    getModifyStartOrEndDisabledReasonTranslated(),
                 ),
                 menuOption(
                     () => onStartTrackBoundaryMove(locationTrack.id),
                     t('tool-panel.location-track.move-track-boundary'),
                     'move-track-boundary',
+                    trackBoundaryMoveDisabled,
+                    'CLOSE_AFTER_SELECT',
+                    undefined,
+                    getTrackBoundaryMoveDisabledReasonsTranslated(),
                 ),
             ]}
         />

--- a/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
@@ -1,4 +1,5 @@
 import {
+    BoundaryMoveDisabledReason,
     LayoutLocationTrack,
     LocationTrackId,
     SwitchJointId,
@@ -36,6 +37,7 @@ import {
 } from 'track-layout/track-boundary-move-api';
 import * as Snackbar from 'geoviite-design-lib/snackbar/snackbar';
 import { updateLocationTrackChangeTime } from 'common/change-time-api';
+import { TFunction } from 'i18next';
 
 type LocationTrackBoundaryMoveInfoboxContainerProps = {
     locationTrack: LayoutLocationTrack;
@@ -113,6 +115,27 @@ function switchJointIdEquals(a: SwitchJointId, b: SwitchJointId): boolean {
     return a.switchId === b.switchId && a.jointNumber === b.jointNumber;
 }
 
+const boundaryMoveDisabledReasonTranslationKeys: Record<BoundaryMoveDisabledReason, string> = {
+    PART_OF_SPLIT: 'tool-panel.location-track.track-boundary-move.validation.part-of-split',
+    PART_OF_BOUNDARY_MOVE:
+        'tool-panel.location-track.track-boundary-move.validation.part-of-boundary-move',
+    TRACK_DRAFT_EXISTS:
+        'tool-panel.location-track.track-boundary-move.validation.track-draft-exists',
+    NO_GEOMETRY: 'tool-panel.location-track.no-geometry',
+    SWITCHES_PART_OF_SPLIT:
+        'tool-panel.location-track.track-boundary-move.validation.switches-part-of-split',
+};
+
+export const translatedBoundaryMoveDisabledReasons = (
+    reasons: BoundaryMoveDisabledReason[],
+    t: TFunction<'translation', undefined>,
+): string | undefined =>
+    reasons.length === 0
+        ? undefined
+        : reasons
+              .map((reason) => t(boundaryMoveDisabledReasonTranslationKeys[reason]))
+              .join('\n\n');
+
 function canSave(linkingState: ChangingTrackBoundary): boolean {
     const selectedTarget = linkingState.selectedTarget;
     const counterpart = linkingState.counterpart;
@@ -161,10 +184,16 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
 
     const selectCounterpart = (selectedTrack: LocationTrackId) => {
         const picked = counterpartOptions.find((o) => o.trackId === selectedTrack);
-        if (picked) {
+        if (picked && picked.disabledReasons.length === 0) {
             onSelectCounterpart(picked);
         }
     };
+
+    const counterpartDisabledReason = (track: LayoutLocationTrack): string | undefined =>
+        translatedBoundaryMoveDisabledReasons(
+            counterpartOptions.find((o) => o.trackId === track.id)?.disabledReasons ?? [],
+            t,
+        );
 
     const selectedTarget = linkingState.selectedTarget;
     const saveBoundaryMove = () => {
@@ -254,6 +283,7 @@ const LocationTrackBoundaryMoveInfobox: React.FC<LocationTrackBoundaryMoveInfobo
                             emptyMessage={t(
                                 'tool-panel.location-track.track-boundary-move.no-candidates',
                             )}
+                            getDisabledReason={counterpartDisabledReason}
                             onSelect={selectCounterpart}
                         />
 

--- a/ui/src/track-layout/track-boundary-move-api.ts
+++ b/ui/src/track-layout/track-boundary-move-api.ts
@@ -1,4 +1,8 @@
-import { LocationTrackId, SwitchJointId } from 'track-layout/track-layout-model';
+import {
+    BoundaryMoveDisabledReason,
+    LocationTrackId,
+    SwitchJointId,
+} from 'track-layout/track-layout-model';
 import { LayoutContext } from 'common/common-model';
 import { Point } from 'model/geometry';
 import { getNonNull, postNonNull } from 'api/api-fetch';
@@ -29,6 +33,7 @@ export type BoundaryMoveCounterpart = {
     trackId: LocationTrackId;
     orientation: BoundaryOrientation;
     connectingSwitchJoint: SwitchJointId | undefined;
+    disabledReasons: BoundaryMoveDisabledReason[];
 };
 
 export type BoundaryMoveDirection = 'ASCENDING' | 'DESCENDING';

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -352,12 +352,20 @@ export function isPartOfUnfinishedSplit(partOfSplit: PartOfSplit | undefined): b
     return partOfSplit === 'UNFINISHED_SOURCE_TRACK' || partOfSplit === 'UNFINISHED_TARGET_TRACK';
 }
 
+export type BoundaryMoveDisabledReason =
+    | 'PART_OF_SPLIT'
+    | 'PART_OF_BOUNDARY_MOVE'
+    | 'TRACK_DRAFT_EXISTS'
+    | 'NO_GEOMETRY'
+    | 'SWITCHES_PART_OF_SPLIT';
+
 export type LocationTrackInfoboxExtras = {
     duplicateOf?: LocationTrackDuplicate;
     duplicates: LocationTrackDuplicate[];
     startSplitPoint?: SplitPoint;
     endSplitPoint?: SplitPoint;
     partOfSplit: PartOfSplit;
+    boundaryMoveDisabledReasons: BoundaryMoveDisabledReason[];
     switches: LocationTrackInfoboxSwitch[];
     operationalPoints: LocationTrackInfoboxOperationalPoint[];
 };

--- a/ui/src/track-layout/track-layout-slice.ts
+++ b/ui/src/track-layout/track-layout-slice.ts
@@ -387,7 +387,9 @@ function filterSelectOptionsByLinkingState(
         return options;
     }
     const counterpartTrackIds = new Set(
-        linkingState.counterpartOptions.map((option) => option.trackId),
+        linkingState.counterpartOptions
+            .filter((option) => option.disabledReasons.length === 0)
+            .map((option) => option.trackId),
     );
     return {
         ...options,
@@ -544,6 +546,7 @@ const trackLayoutSlice = createSlice({
                             state.linkingState.counterpart =
                                 state.linkingState.counterpartOptions.find(
                                     (option) =>
+                                        option.disabledReasons.length === 0 &&
                                         option.trackId === onSelectOptions.locationTracks?.[0],
                                 );
                         }

--- a/ui/src/vayla-design-lib/menu/menu.tsx
+++ b/ui/src/vayla-design-lib/menu/menu.tsx
@@ -16,6 +16,7 @@ export type MenuSelectOption = {
     onSelect: () => void;
     closingBehaviour: MenuClosingBehaviour;
     icon: IconComponent | undefined;
+    title: string | undefined;
 } & OptionBase;
 
 export type MenuDividerOption = {
@@ -33,6 +34,7 @@ export const menuOption = (
     disabled: boolean = false,
     closingBehaviour: MenuClosingBehaviour = 'CLOSE_AFTER_SELECT',
     icon: IconComponent | undefined = undefined,
+    title: string | undefined = undefined,
 ): MenuSelectOption => ({
     type: 'SELECT',
     onSelect,
@@ -41,6 +43,7 @@ export const menuOption = (
     closingBehaviour,
     qaId,
     icon,
+    title,
 });
 
 export const menuDivider = (): MenuDividerOption => ({
@@ -87,7 +90,7 @@ export const Menu = function ({
                             <li
                                 key={`${index}`}
                                 qa-id={item.qaId}
-                                title={`${item.name}`}
+                                title={item.title ?? `${item.name}`}
                                 className={createClassName(
                                     styles['menu__item'],
                                     item.disabled && styles['menu__item--disabled'],


### PR DESCRIPTION
Lisätty kasa ehtoja, joiden takia raiteiden muutoskohdan siirto saattaa olla estetty. Jotakuinkin ne jopa sai suht isoksi osaksi yhteen kasaan, mikä on ihan hyvä juttu kun ottaa huomioon että tieto siitä, kelpaako raide raiteiden vaihtumiskohdan siirtoon, menee yhtäältä infoboksiin `LocationTrackInfoboxExtras`in kautta, toisaalta counterpart-valintalistaan `BoundaryMoveCounterpart`in kautta, ja kolmanneksi tarkistetaan bäkkärillä sopivuus vielä tallennettaessakin.

Tosin kirjaan vielä erilliseksi taskikseen yhden omaa ärsytystään aiheuttavan epäsymmetrian. (Aiemmin mainitsemani periaatteen mukaan en ole lähtenyt siihen, että muutoskohdan siirroilla olisi omaa `BulkTransferState`aan vaan oletus on, että Ratko pullailee niitä sitten pull-maailmassa sellaisessa loogisessa järjestyksessä, että myöhempien julkaisujen muutokset ei enää vyöry entisten päälle; ja siksi siis niihin liittyvät tilavalidaatiot katsoo vain, että samaan julkaisuun ei päädy useampia siirtoja, ei splittien tapaan että puskunkin pitää olla finished-tilassa. Mutta tämähän tarkoittaa, että muutoskohtien siirtoja ei vaan voi tehdä ennen pull-APIa, ja pull-API:n jälkeen jos tähän BulkTransferState-hässäkkään ei ole muutoskohdan siirroilla tarvetta niin ei ole spliteilläkään. Mutta tämä siis vaan aiheuttaa koodissa rumaa epäsymmetriaa, ei varsinaista korrektiusongelmaa)