### PR TITLE
GVT-3644 Relink switches within track boundary move

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -308,13 +308,17 @@ constructor(
     }
 
     @Transactional
-    fun relinkTrack(branch: LayoutBranch, trackId: IntId<LocationTrack>): List<TrackSwitchRelinkingResult> {
+    fun  relinkTrack(
+        branch: LayoutBranch,
+        trackId: IntId<LocationTrack>,
+        restrictToSwitches: Set<IntId<LayoutSwitch>>? = null,
+    ): List<TrackSwitchRelinkingResult> {
         val (track, geometry) = locationTrackService.getWithGeometryOrThrow(branch.draft, trackId)
 
         val originalSwitches =
-            collectAllSwitchesOnTrackAndNearby(branch, track, geometry).let { nearbySwitchIds ->
-                nearbySwitchIds.zip(switchService.getMany(branch.draft, nearbySwitchIds))
-            }
+            collectAllSwitchesOnTrackAndNearby(branch, track, geometry)
+                .filter { switchId -> restrictToSwitches == null || restrictToSwitches.contains(switchId) }
+                .let { nearbySwitchIds -> nearbySwitchIds.zip(switchService.getMany(branch.draft, nearbySwitchIds)) }
 
         val originallyLinkedLocationTracksByIndex =
             collectOriginallyLinkedLocationTracks(branch, originalSwitches.map { (switchId) -> switchId })

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationDao.kt
@@ -261,6 +261,17 @@ class PublicationDao(
                         on split_relinked_switches.split_id = split.id
                 where split.publication_id is null
                 group by split.id
+            ),
+            track_boundary_moves as (
+                select
+                    track_boundary_move.id as track_boundary_move_id,
+                    array_agg(move_relinked_switches.switch_id) as move_relinked_switch_ids
+                from publication.track_boundary_move
+                    inner join publication.track_boundary_move_relinked_switch move_relinked_switches
+                        on move_relinked_switches.track_boundary_move_id = track_boundary_move.id
+                where track_boundary_move.publication_id is null
+                  and track_boundary_move.design_id is not distinct from :candidate_design_id
+                group by track_boundary_move.id
             )
             select
               candidate_switch.id,
@@ -288,9 +299,14 @@ class PublicationDao(
               -- We should not have such cases, but they're not actually blocked either!
               (
                 select min(splits.split_id)
-                  from splits 
+                  from splits
                   where candidate_switch.id = any(splits.split_relinked_switch_ids)
-              ) as split_id
+              ) as split_id,
+              (
+                select track_boundary_moves.track_boundary_move_id
+                  from track_boundary_moves
+                  where candidate_switch.id = any(track_boundary_moves.move_relinked_switch_ids)
+              ) as track_boundary_move_id
             from layout.switch candidate_switch
               left join common.switch_structure on candidate_switch.switch_structure_id = switch_structure.id
               left join layout.switch_version_joint joint_version
@@ -320,7 +336,10 @@ class PublicationDao(
                     trackNumberIds = rs.getIntIdArray("track_numbers"),
                     location = rs.getPointOrNull("point_x", "point_y"),
                     designAssetState = rs.getEnumOrNull<DesignAssetState>("design_asset_state"),
-                    publicationGroup = rs.getIntIdOrNull<Split>("split_id")?.let(::SplitPublicationGroup),
+                    publicationGroup =
+                        rs.getIntIdOrNull<Split>("split_id")?.let(::SplitPublicationGroup)
+                            ?: rs.getIntIdOrNull<TrackBoundaryMove>("track_boundary_move_id")
+                                ?.let(::TrackBoundaryMovePublicationGroup),
                 )
             }
         logger.daoAccess(FETCH, SwitchPublicationCandidate::class, candidates.map(SwitchPublicationCandidate::id))

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -180,13 +180,14 @@ constructor(
         val revertSplitSwitches = revertSplits.flatMap { s -> s.relinkedSwitches }.distinct()
 
         val trackBoundaryMoves =
-            trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, locationTrackIds.toList())
+            trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, locationTrackIds.toList(), requestIds.switches)
         val trackBoundaryMoveTracks = trackBoundaryMoves.flatMap { s -> s.locationTracks.map { it.id } }.distinct()
+        val trackBoundaryMoveSwitches = trackBoundaryMoves.flatMap { move -> move.relinkedSwitches }.distinct()
 
         return PublicationRequestIds(
             trackNumbers = trackNumbers.map { it.id as IntId },
             locationTracks = (locationTrackIds + revertSplitTracks + trackBoundaryMoveTracks).distinct(),
-            switches = (switchIds + revertSplitSwitches).distinct(),
+            switches = (switchIds + revertSplitSwitches + trackBoundaryMoveSwitches).distinct(),
             kmPosts = kmPostIds.toList(),
             operationalPoints = operationalPointIds.toList(),
         )
@@ -215,19 +216,22 @@ constructor(
             splitService.deleteSplit(split.id)
         }
 
-        trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, toDelete.locationTracks).forEach {
-            trackBoundaryMove ->
-            val shortenedTrackIncluded = toDelete.locationTracks.contains(trackBoundaryMove.shortenedLocationTrack.id)
-            val lengthenedTrackIncluded = toDelete.locationTracks.contains(trackBoundaryMove.lengthenedLocationTrack.id)
-            if (!shortenedTrackIncluded || !lengthenedTrackIncluded) {
-                throw PartialTrackBoundaryMoveRevertException(
-                    message =
-                        "Cannot partially revert track boundary move ${trackBoundaryMove.id}: " +
-                            "both shortened and lengthened track must be included in the revert request"
-                )
+        trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, toDelete.locationTracks, toDelete.switches)
+            .forEach { trackBoundaryMove ->
+                val shortenedTrackIncluded =
+                    toDelete.locationTracks.contains(trackBoundaryMove.shortenedLocationTrack.id)
+                val lengthenedTrackIncluded =
+                    toDelete.locationTracks.contains(trackBoundaryMove.lengthenedLocationTrack.id)
+                val allSwitchesIncluded = toDeleteSwitches.containsAll(trackBoundaryMove.relinkedSwitches)
+                if (!shortenedTrackIncluded || !lengthenedTrackIncluded || !allSwitchesIncluded) {
+                    throw PartialTrackBoundaryMoveRevertException(
+                        message =
+                            "Cannot partially revert track boundary move ${trackBoundaryMove.id}: " +
+                                "both moved tracks and all relinked switches must be included in the revert request"
+                    )
+                }
+                trackBoundaryMoveService.delete(trackBoundaryMove.id)
             }
-            trackBoundaryMoveService.delete(trackBoundaryMove.id)
-        }
 
         val locationTrackIds = toDelete.locationTracks.toSet()
         val locationTrackCount = toDelete.locationTracks.map { id -> locationTrackService.deleteDraft(branch, id) }.size
@@ -296,7 +300,11 @@ constructor(
                     request.switches,
                 ),
             trackBoundaryMoves =
-                trackBoundaryMoveService.fetchPublicationVersions(transition.candidateBranch, request.locationTracks),
+                trackBoundaryMoveService.fetchPublicationVersions(
+                    transition.candidateBranch,
+                    request.locationTracks,
+                    request.switches,
+                ),
         )
     }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -273,6 +273,7 @@ constructor(
             trackBoundaryMoveService.fetchPublicationVersions(
                 branch = candidates.transition.candidateBranch,
                 locationTracks = candidates.locationTracks.map { it.id },
+                switches = candidates.switches.map { it.id },
             )
         val versions = candidates.getValidationVersions(candidates.transition, splitVersions, boundaryMoveVersions)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -77,10 +77,12 @@ internal fun validateAdministrativeChangeContent(
         publicationTrackBoundaryMoves.flatMap { move ->
             val containsShortened = trackVersions.any { it.id == move.shortenedLocationTrack.id }
             val containsLengthened = trackVersions.any { it.id == move.lengthenedLocationTrack.id }
+            val containsSwitches = move.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
             listOfNotNull(
                     validate(containsShortened && containsLengthened, ERROR) {
                         "$VALIDATION_BOUNDARY_MOVE.missing-location-tracks"
-                    }
+                    },
+                    validate(containsSwitches, ERROR) { "$VALIDATION_BOUNDARY_MOVE.missing-switches" },
                 )
                 .map { e -> move to e }
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -28,6 +28,7 @@ data class TrackBoundaryMove(
     val shortenedLocationTrack: LayoutRowVersion<LocationTrack>,
     val edgeRange: IntRange,
     val lengthenedLocationTrack: LayoutRowVersion<LocationTrack>,
+    val relinkedSwitches: List<IntId<LayoutSwitch>>,
     val publicationId: IntId<Publication>?,
 ) : AdministrativeChange {
     val id = version.id
@@ -35,7 +36,7 @@ data class TrackBoundaryMove(
     override fun containsLocationTrack(id: IntId<LocationTrack>) =
         shortenedLocationTrack.id == id || lengthenedLocationTrack.id == id
 
-    override fun containsSwitch(id: IntId<LayoutSwitch>) = false
+    override fun containsSwitch(id: IntId<LayoutSwitch>) = relinkedSwitches.contains(id)
 
     val locationTracks
         get() = listOf(shortenedLocationTrack, lengthenedLocationTrack)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -57,6 +57,7 @@ enum class BoundaryMoveDisabledReason {
     TRACK_DRAFT_EXISTS,
     NO_GEOMETRY,
     SWITCHES_PART_OF_SPLIT,
+    ON_DIFFERENT_TRACK_NUMBER,
 }
 
 fun boundaryMoveDisabledReasons(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMove.kt
@@ -9,6 +9,7 @@ import fi.fta.geoviite.infra.split.AdministrativeChange
 import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 
@@ -65,6 +66,7 @@ fun boundaryMoveDisabledReasons(
     geometry: LocationTrackGeometry,
     unfinishedSplits: List<Split>,
     unpublishedBoundaryMoves: List<TrackBoundaryMove>,
+    expectedTrackNumberId: IntId<LayoutTrackNumber>,
 ): List<BoundaryMoveDisabledReason> {
     val trackId = track.id as IntId
     val unpublishedSplits = unfinishedSplits.filter { split -> split.publicationId == null }
@@ -80,6 +82,7 @@ fun boundaryMoveDisabledReasons(
         BoundaryMoveDisabledReason.SWITCHES_PART_OF_SPLIT.takeIf {
             geometry.switchIds.any { switchId -> unpublishedSplits.any { split -> split.containsSwitch(switchId) } }
         },
+        BoundaryMoveDisabledReason.ON_DIFFERENT_TRACK_NUMBER.takeIf { track.trackNumberId != expectedTrackNumberId },
     )
 }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveDao.kt
@@ -7,9 +7,11 @@ import fi.fta.geoviite.infra.logging.AccessType
 import fi.fta.geoviite.infra.logging.daoAccess
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.getIntId
+import fi.fta.geoviite.infra.util.getIntIdArray
 import fi.fta.geoviite.infra.util.getIntIdOrNull
 import fi.fta.geoviite.infra.util.getLayoutBranch
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
@@ -32,6 +34,7 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
         shortenedLocationTrack: LayoutRowVersion<LocationTrack>,
         edgeRange: IntRange,
         lengthenedLocationTrack: LayoutRowVersion<LocationTrack>,
+        relinkedSwitches: Collection<IntId<LayoutSwitch>>,
     ): IntId<TrackBoundaryMove> {
         val sql =
             """
@@ -81,8 +84,27 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
                 ?: error(
                     "Failed to save track boundary move: shortened=$shortenedLocationTrack lengthened=$lengthenedLocationTrack"
                 )
+        saveRelinkedSwitches(id, relinkedSwitches)
         logger.daoAccess(AccessType.INSERT, TrackBoundaryMove::class, id)
         return id
+    }
+
+    private fun saveRelinkedSwitches(
+        moveId: IntId<TrackBoundaryMove>,
+        relinkedSwitches: Collection<IntId<LayoutSwitch>>,
+    ) {
+        val sql =
+            """
+            insert into publication.track_boundary_move_relinked_switch(track_boundary_move_id, switch_id)
+            values (:moveId, :switchId)
+            """
+                .trimIndent()
+
+        val params = relinkedSwitches.map { switchId ->
+            mapOf("moveId" to moveId.intValue, "switchId" to switchId.intValue)
+        }
+
+        jdbcTemplate.batchUpdate(sql, params.toTypedArray())
     }
 
     fun get(id: IntId<TrackBoundaryMove>): TrackBoundaryMove? {
@@ -100,7 +122,10 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
               lengthened_location_track_id,
               lengthened_location_track_version,
               lengthened_location_track_layout_context_id,
-              publication_id
+              publication_id,
+              (select coalesce(array_agg(relinked_switch.switch_id), '{}')
+               from publication.track_boundary_move_relinked_switch relinked_switch
+               where relinked_switch.track_boundary_move_id = track_boundary_move.id) as relinked_switch_ids
             from publication.track_boundary_move
             where id = :id
             """
@@ -127,7 +152,10 @@ class TrackBoundaryMoveDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : Dao
               lengthened_location_track_id,
               lengthened_location_track_version,
               lengthened_location_track_layout_context_id,
-              publication_id
+              publication_id,
+              (select coalesce(array_agg(relinked_switch.switch_id), '{}')
+               from publication.track_boundary_move_relinked_switch relinked_switch
+               where relinked_switch.track_boundary_move_id = track_boundary_move.id) as relinked_switch_ids
             from publication.track_boundary_move
             where publication_id is null
             """
@@ -179,6 +207,7 @@ private fun getTrackBoundaryMove(rs: ResultSet) =
                 "lengthened_location_track_layout_context_id",
                 "lengthened_location_track_version",
             ),
+        relinkedSwitches = rs.getIntIdArray("relinked_switch_ids"),
         publicationId = rs.getIntIdOrNull("publication_id"),
         branch = rs.getLayoutBranch("design_id"),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -194,14 +194,14 @@ class TrackBoundaryMoveService(
         val unfinishedSplits = splitDao.fetchUnfinishedSplits(layoutContext.branch)
         val unpublishedBoundaryMoves = findUnpublishedBoundaryMoves(layoutContext.branch)
         val getDisabledReasons = { track: LocationTrack, geometry: DbLocationTrackGeometry ->
-            boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves)
+            boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves) +
+                listOfNotNull(BoundaryMoveDisabledReason.ON_DIFFERENT_TRACK_NUMBER.takeIf { track.trackNumberId != headTrack.trackNumberId })
         }
 
         val counterpartFirstOptions =
             locationTrackService
                 .listWithGeometries(
                     layoutContext = layoutContext,
-                    trackNumberId = headTrack.trackNumberId,
                     boundingBox = boundingBoxAroundPoint(headStartPoint, ENDPOINT_MATCH_DISTANCE),
                 )
                 .let { candidates ->
@@ -219,7 +219,6 @@ class TrackBoundaryMoveService(
             locationTrackService
                 .listWithGeometries(
                     layoutContext = layoutContext,
-                    trackNumberId = headTrack.trackNumberId,
                     boundingBox = boundingBoxAroundPoint(headEndPoint, ENDPOINT_MATCH_DISTANCE),
                 )
                 .let { candidates ->
@@ -255,6 +254,7 @@ private fun validateTrackForBoundaryMove(
             BoundaryMoveDisabledReason.TRACK_DRAFT_EXISTS -> "track-draft-exists"
             BoundaryMoveDisabledReason.NO_GEOMETRY -> "no-geometry"
             BoundaryMoveDisabledReason.SWITCHES_PART_OF_SPLIT -> "switches-part-of-split"
+            BoundaryMoveDisabledReason.ON_DIFFERENT_TRACK_NUMBER -> "on-different-track-number"
         }
     throw TrackBoundaryMoveFailureException(
         "track cannot take part in a boundary move: id=${track.id}, reason=$reason",

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -19,6 +19,7 @@ import fi.fta.geoviite.infra.tracklayout.AlignmentPoint
 import fi.fta.geoviite.infra.tracklayout.DbLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
@@ -66,17 +67,20 @@ class TrackBoundaryMoveService(
 
         val unfinishedSplits = splitDao.fetchUnfinishedSplits(layoutBranch)
         val unpublishedBoundaryMoves = findUnpublishedBoundaryMoves(layoutBranch)
+        val expectedTrackNumberId = lengtheningTrack.trackNumberId
         validateTrackForBoundaryMove(
             shorteningTrack,
             shorteningTrackGeometry,
             unfinishedSplits,
             unpublishedBoundaryMoves,
+            expectedTrackNumberId,
         )
         validateTrackForBoundaryMove(
             lengtheningTrack,
             lengtheningTrackGeometry,
             unfinishedSplits,
             unpublishedBoundaryMoves,
+            expectedTrackNumberId,
         )
 
         val geometries =
@@ -194,8 +198,13 @@ class TrackBoundaryMoveService(
         val unfinishedSplits = splitDao.fetchUnfinishedSplits(layoutContext.branch)
         val unpublishedBoundaryMoves = findUnpublishedBoundaryMoves(layoutContext.branch)
         val getDisabledReasons = { track: LocationTrack, geometry: DbLocationTrackGeometry ->
-            boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves) +
-                listOfNotNull(BoundaryMoveDisabledReason.ON_DIFFERENT_TRACK_NUMBER.takeIf { track.trackNumberId != headTrack.trackNumberId })
+            boundaryMoveDisabledReasons(
+                track,
+                geometry,
+                unfinishedSplits,
+                unpublishedBoundaryMoves,
+                headTrack.trackNumberId,
+            )
         }
 
         val counterpartFirstOptions =
@@ -243,10 +252,11 @@ private fun validateTrackForBoundaryMove(
     geometry: LocationTrackGeometry,
     unfinishedSplits: List<Split>,
     unpublishedBoundaryMoves: List<TrackBoundaryMove>,
+    expectedTrackNumberId: IntId<LayoutTrackNumber>,
 ) {
     val reason =
-        boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves).firstOrNull()
-            ?: return
+        boundaryMoveDisabledReasons(track, geometry, unfinishedSplits, unpublishedBoundaryMoves, expectedTrackNumberId)
+            .firstOrNull() ?: return
     val messageKey =
         when (reason) {
             BoundaryMoveDisabledReason.PART_OF_SPLIT -> "track-part-of-split"

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -7,6 +7,8 @@ import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.RowVersion
 import fi.fta.geoviite.infra.error.TrackBoundaryMoveFailureException
 import fi.fta.geoviite.infra.linking.TrackEnd
+import fi.fta.geoviite.infra.linking.TrackSwitchRelinkingResultType
+import fi.fta.geoviite.infra.linking.switches.SwitchLinkingService
 import fi.fta.geoviite.infra.localization.localizationParams
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
 import fi.fta.geoviite.infra.math.lineLength
@@ -35,6 +37,7 @@ class TrackBoundaryMoveService(
     private val locationTrackDao: LocationTrackDao,
     private val locationTrackService: LocationTrackService,
     private val splitDao: SplitDao,
+    private val switchLinkingService: SwitchLinkingService,
 ) {
     fun get(id: IntId<TrackBoundaryMove>): TrackBoundaryMove? {
         return trackBoundaryMoveDao.get(id)
@@ -87,27 +90,74 @@ class TrackBoundaryMoveService(
             )
         locationTrackService.saveDraft(layoutBranch, shorteningTrack, geometries.shortenedGeometry)
         locationTrackService.saveDraft(layoutBranch, lengtheningTrack, geometries.lengthenedGeometry)
+        val relinkedSwitches =
+            relinkMovedSwitches(
+                layoutBranch,
+                lengtheningTrackVersion.id,
+                shorteningTrackGeometry,
+                geometries.movedEdgeRange,
+            )
         return trackBoundaryMoveDao.save(
             layoutBranch,
             shorteningTrackVersion,
             geometries.movedEdgeRange,
             lengtheningTrackVersion,
+            relinkedSwitches,
         )
+    }
+
+    private fun relinkMovedSwitches(
+        layoutBranch: LayoutBranch,
+        lengtheningTrackId: IntId<LocationTrack>,
+        shorteningTrackGeometry: LocationTrackGeometry,
+        movedEdgeRange: IntRange,
+    ): List<IntId<LayoutSwitch>> {
+        val movedInnerSwitches =
+            shorteningTrackGeometry.edges
+                .slice(movedEdgeRange)
+                .flatMap { edge -> listOfNotNull(edge.startNode.switchIn?.id, edge.endNode.switchIn?.id) }
+                .toSet()
+        if (movedInnerSwitches.isEmpty()) return emptyList()
+        val relinkingResults = switchLinkingService.relinkTrack(layoutBranch, lengtheningTrackId, movedInnerSwitches)
+        val failedSwitches =
+            relinkingResults
+                .filter { result -> result.outcome != TrackSwitchRelinkingResultType.RELINKED }
+                .map { result -> result.id }
+        if (failedSwitches.isNotEmpty()) {
+            throw TrackBoundaryMoveFailureException(
+                "switches could not be relinked after moving the track boundary: switches=$failedSwitches",
+                localizedMessageKey = "switch-linking-failed",
+            )
+        }
+        return relinkingResults.map { result -> result.id }
     }
 
     fun fetchPublicationVersions(
         branch: LayoutBranch,
         locationTracks: List<IntId<LocationTrack>>,
+        switches: List<IntId<LayoutSwitch>>,
     ): List<RowVersion<TrackBoundaryMove>> =
-        findUnpublishedBoundaryMoves(branch, locationTracks).map { boundaryMove -> boundaryMove.version }
+        findUnpublishedBoundaryMoves(branch, locationTracks, switches).map { boundaryMove -> boundaryMove.version }
 
+    /**
+     * Fetches all boundary moves that are not published. Can be filtered by location tracks or relinked switches. If
+     * both filters are defined, the result is combined by OR (match by either).
+     */
     fun findUnpublishedBoundaryMoves(
         branch: LayoutBranch,
         locationTrackIds: List<IntId<LocationTrack>>? = null,
+        switchIds: List<IntId<LayoutSwitch>>? = null,
     ): List<TrackBoundaryMove> =
         trackBoundaryMoveDao.getUnpublished().filter { boundaryMove ->
+            val containsTrack = locationTrackIds?.any(boundaryMove::containsLocationTrack)
+            val containsSwitch = switchIds?.any(boundaryMove::containsSwitch)
             boundaryMove.branch == branch &&
-                (locationTrackIds == null || locationTrackIds.any(boundaryMove::containsLocationTrack))
+                when {
+                    containsTrack != null && containsSwitch != null -> containsTrack || containsSwitch
+                    containsTrack != null -> containsTrack
+                    containsSwitch != null -> containsSwitch
+                    else -> true
+                }
         }
 
     @Transactional

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -517,7 +517,13 @@ class LocationTrackService(
             val unpublishedBoundaryMoves =
                 trackBoundaryMoveDao.getUnpublished().filter { move -> move.branch == layoutContext.branch }
             val boundaryMoveDisabledReasons =
-                boundaryMoveDisabledReasons(track, geometry, allUnfinishedSplits, unpublishedBoundaryMoves)
+                boundaryMoveDisabledReasons(
+                    track,
+                    geometry,
+                    allUnfinishedSplits,
+                    unpublishedBoundaryMoves,
+                    track.trackNumberId,
+                )
 
             val switches =
                 geometry.trackSwitchLinks

--- a/infra/src/main/resources/db/migration/prod/V150__add_track_boundary_move_relinked_switch_table.sql
+++ b/infra/src/main/resources/db/migration/prod/V150__add_track_boundary_move_relinked_switch_table.sql
@@ -1,0 +1,16 @@
+create table publication.track_boundary_move_relinked_switch
+(
+  track_boundary_move_id int not null,
+  switch_id              int not null,
+
+  primary key (track_boundary_move_id, switch_id),
+
+  constraint track_boundary_move_relinked_switch_move_fkey foreign key (track_boundary_move_id)
+    references publication.track_boundary_move (id) on delete cascade,
+  constraint track_boundary_move_relinked_switch_switch_fkey foreign key (switch_id) references layout.switch_id (id)
+);
+
+comment on table publication.track_boundary_move_relinked_switch is 'Switches that were re-linked during a track boundary move';
+
+select common.add_metadata_columns('publication', 'track_boundary_move_relinked_switch');
+select common.add_table_versioning('publication', 'track_boundary_move_relinked_switch');

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -78,7 +78,8 @@
             "no-geometry": "Raiteella {{name}} ei ole geometriaa, joten vaihtumiskohtaa ei voi siirtää",
             "track-part-of-split": "Raide {{name}} on mukana keskeneräisessä raiteen jakamisessa, joten vaihtumiskohtaa ei voi siirtää",
             "track-part-of-boundary-move": "Raide {{name}} on mukana julkaisemattomassa vaihtumiskohdan siirrossa, joten vaihtumiskohtaa ei voi siirtää",
-            "switches-part-of-split": "Raiteen {{name}} vaihteita on mukana julkaisemattomissa raiteen jakamisissa, joten vaihtumiskohtaa ei voi siirtää"
+            "switches-part-of-split": "Raiteen {{name}} vaihteita on mukana julkaisemattomissa raiteen jakamisissa, joten vaihtumiskohtaa ei voi siirtää",
+            "switch-linking-failed": "Vaihtumiskohtaa ei voitu siirtää, koska vaihteiden uudelleenlinkitys epäonnistui"
         },
         "split": {
             "source-track-state-not-in-use": "Jakamista ei voitu suorittaa, koska jaettava raide ei ole \"Käytössä\"-tilassa",
@@ -1978,6 +1979,7 @@
             },
             "track-boundary-move": {
                 "missing-location-tracks": "Julkaisussa ei ole mukana muutoskohdan siirrosta lyhenevää tai pitenevää raidetta",
+                "missing-switches": "Kaikki vaihtumiskohdan siirrossa uudelleenlinkitetyt vaihteet eivät ole mukana julkaisussa",
                 "affected-move-in-progress": "Muutos voi vaikuttaa osoitteistoon raiteilla, joiden vaihtumiskohdan siirtoa ei ole julkaistu: {{tracks}}",
                 "track-is-cancelled": "Raiteen vaihtumiskohdan siirrossa mukana olevaa raidetta {{name}} ei voi perua julkaisusta",
                 "track-number-updated": "Vaihtumiskohdan siirtoon liittyvää raidetta {{track}} ei voi siirtää eri ratanumerolle ennen siirron julkaisua",

--- a/infra/src/main/resources/i18n/translations.fi.json
+++ b/infra/src/main/resources/i18n/translations.fi.json
@@ -1047,7 +1047,8 @@
                     "track-draft-exists": "Muokatun sijaintiraiteen vaihtumiskohtaa ei voi siirtää. Julkaise tai kumoa muutokset.",
                     "part-of-split": "Raide on mukana keskeneräisessä raiteen jakamisessa",
                     "part-of-boundary-move": "Raide on mukana julkaisemattomassa vaihtumiskohdan siirrossa",
-                    "switches-part-of-split": "Raiteen vaihteita on mukana julkaisemattomissa raiteen jakamisissa"
+                    "switches-part-of-split": "Raiteen vaihteita on mukana julkaisemattomissa raiteen jakamisissa",
+                    "on-different-track-number": "Raide on eri ratanumerolla kuin ensimmäinen raide"
                 }
             }
         },

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -222,6 +222,8 @@ class TestDBService(
                     "switch_location_tracks",
                     "track_number",
                     "track_number_km",
+                    "track_boundary_move_relinked_switch",
+                    "track_boundary_move_relinked_switch_version",
                     "track_boundary_move",
                     "track_boundary_move_version",
                 ),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -107,7 +107,12 @@ constructor(
 ) : DBTestBase() {
     @BeforeEach
     fun cleanup() {
-        publicationTestSupportService.cleanupPublicationTables()
+        testDBService.clearPublicationTables()
+        testDBService.clearLayoutTables()
+        testDBService.deleteFromTables(
+            "layout",
+            "operational_point_id",
+        )
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/ValidationContextIT.kt
@@ -198,7 +198,8 @@ constructor(
                     switches = switchDao.fetchCandidateVersions(candidateContext, switches),
                     operationalPoints = operationalPointDao.fetchCandidateVersions(candidateContext, operationalPoints),
                     splits = splitService.fetchPublicationVersions(branch, locationTracks, switches),
-                    trackBoundaryMoves = trackBoundaryMoveService.fetchPublicationVersions(branch, locationTracks),
+                    trackBoundaryMoves =
+                        trackBoundaryMoveService.fetchPublicationVersions(branch, locationTracks, switches),
                 ),
         )
     }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -929,7 +929,7 @@ constructor(
                     trackId = otherTrackNumberTrack.id,
                     orientation = BoundaryOrientation.HEAD_FIRST,
                     connectingSwitchJoint = null,
-                    disabledReasons = listOf(BoundaryMoveCounterpartDisabledReason.ON_DIFFERENT_TRACK_NUMBER),
+                    disabledReasons = listOf(BoundaryMoveDisabledReason.ON_DIFFERENT_TRACK_NUMBER),
                 )
             ),
             trackBoundaryMoveService.getBoundaryMoveCounterpartOptions(LayoutBranch.main.draft, headTrack.id),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -4,6 +4,7 @@ import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.IntId
 import fi.fta.geoviite.infra.common.JointNumber
 import fi.fta.geoviite.infra.common.LayoutBranch
+import fi.fta.geoviite.infra.error.PartialTrackBoundaryMoveRevertException
 import fi.fta.geoviite.infra.error.SplitFailureException
 import fi.fta.geoviite.infra.error.TrackBoundaryMoveFailureException
 import fi.fta.geoviite.infra.localization.LocalizationKey
@@ -16,20 +17,24 @@ import fi.fta.geoviite.infra.publication.TrackBoundaryMovePublicationGroup
 import fi.fta.geoviite.infra.publication.publicationRequest
 import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveCounterpart
-import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDisabledReason
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDirection
+import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDisabledReason
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryOrientation
 import fi.fta.geoviite.infra.trackBoundaryMove.SwitchJointId
+import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
 import fi.fta.geoviite.infra.tracklayout.EdgeContentKey
 import fi.fta.geoviite.infra.tracklayout.LayoutEdge
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
+import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import fi.fta.geoviite.infra.tracklayout.SwitchJointRole
 import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.combineEdges
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.locationTrack
 import fi.fta.geoviite.infra.tracklayout.offsetGeometry
@@ -40,7 +45,10 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkRR
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -62,6 +70,7 @@ constructor(
     private val splitDao: SplitDao,
     private val splitService: SplitService,
     private val locationTrackDao: LocationTrackDao,
+    private val splitTestDataService: SplitTestDataService,
 ) : DBTestBase() {
     @BeforeEach
     fun setup() {
@@ -143,6 +152,8 @@ constructor(
         val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId)
         assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
         assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
+        // the only moved edge touches switches 1 and 2 through outer links only, so nothing gets relinked
+        assertEquals(emptyList<IntId<LayoutSwitch>>(), savedBoundaryMove.relinkedSwitches)
 
         assertEquals(3, newLengthenedGeometry.edges.size)
         assertEquals(switchLinkYV(switch2, 1), newLengthenedGeometry.edges.last().endNode.switchOut)
@@ -154,27 +165,22 @@ constructor(
     fun `move in descending direction on short track`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
 
-        val switch1 = testDBService.save(switch()).id
+        // The shortening track lies entirely inside the switch, so the whole track gets moved and its switch relinked.
+        val (switchVersion, straightSwitchEdges, turningSwitchEdges) =
+            splitTestDataService.createSwitchAndGeometry(Point(0.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(turningSwitchEdges))
+        val switch1 = switchVersion.id
+        val switchEnd = straightSwitchEdges.last().lastSegmentEnd
 
-        val shorteningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                trackGeometry(
-                    edge(
-                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
-                        startInnerSwitch = switchLinkYV(switch1, 1),
-                        endInnerSwitch = switchLinkYV(switch1, 3),
-                    )
-                ),
-            )
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), trackGeometry(straightSwitchEdges))
 
         val lengtheningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
                 trackGeometry(
                     edge(
-                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                        startOuterSwitch = switchLinkYV(switch1, 3),
+                        listOf(segment(Point(switchEnd.x, switchEnd.y), Point(switchEnd.x + 10.0, switchEnd.y))),
+                        startOuterSwitch = switchLinkYV(switch1, 2),
                     )
                 ),
             )
@@ -194,9 +200,10 @@ constructor(
         val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId)
         assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
         assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
-        assertEquals(switchLinkYV(switch1, 1), newLengthenedGeometry.edges.first().startNode.switchIn)
+        assertEquals(listOf(switch1), savedBoundaryMove.relinkedSwitches)
+        assertEquals(switch1, newLengthenedGeometry.edges.first().startNode.switchIn?.id)
 
-        assertEquals(2, newLengthenedGeometry.edges.size)
+        assertEquals(straightSwitchEdges.size + 1, newLengthenedGeometry.edges.size)
         assertEquals(0, newShortenedGeometry.edges.size)
     }
 
@@ -204,12 +211,15 @@ constructor(
     fun `shortened track remains with no geometry`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
 
-        // three switches, all laid out to one physically continuous track, with each having just a joint 1 on the left,
-        // 2 on the right, and out-of-switch segments in between. lengtheningTrack contains switch 1, shorteningTrack
-        // contains switches 2 and 3.
+        // three switches, all laid out to one physically continuous track. lengtheningTrack contains switch 1,
+        // shorteningTrack contains switches 2 and 3; switch 2 is inside the moved edge range and gets relinked.
 
         val switch1 = testDBService.save(switch()).id
-        val switch2 = testDBService.save(switch()).id
+        val (switch2Version, switch2StraightEdges, switch2TurningEdges) =
+            splitTestDataService.createSwitchAndGeometry(Point(30.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(switch2TurningEdges))
+        val switch2 = switch2Version.id
+        val switch2End = switch2StraightEdges.last().lastSegmentEnd
         val switch3 = testDBService.save(switch()).id
 
         val lengtheningTrack =
@@ -232,36 +242,41 @@ constructor(
             testDBService.save(
                 locationTrack(trackNumber),
                 trackGeometry(
-                    edge(
-                        listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
-                        startOuterSwitch = switchLinkYV(switch1, 2),
-                        endOuterSwitch = switchLinkYV(switch2, 1),
-                    ),
-                    edge(
-                        listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
-                        startInnerSwitch = switchLinkYV(switch2, 1),
-                        endInnerSwitch = switchLinkYV(switch2, 2),
-                    ),
-                    edge(
-                        listOf(segment(Point(40.0, 0.0), Point(50.0, 0.0))),
-                        startOuterSwitch = switchLinkYV(switch2, 2),
-                        endOuterSwitch = switchLinkYV(switch3, 1),
-                    ),
+                    combineEdges(
+                        listOf(
+                            edge(
+                                listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
+                                startOuterSwitch = switchLinkYV(switch1, 2),
+                            )
+                        ) +
+                            switch2StraightEdges +
+                            edge(
+                                listOf(
+                                    segment(
+                                        Point(switch2End.x, switch2End.y),
+                                        Point(switch2End.x + 10.0, switch2End.y),
+                                    )
+                                ),
+                                endOuterSwitch = switchLinkYV(switch3, 1),
+                            )
+                    )
                 ),
             )
 
-        trackBoundaryMoveService.saveTrackBoundaryMove(
-            LayoutBranch.Companion.main,
-            shorteningTrackId = shorteningTrack.id,
-            lengtheningTrackId = lengtheningTrack.id,
-            upToSwitchJoint = SwitchJointId(switch3, JointNumber(1)),
-            boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
-        )
+        val trackBoundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.Companion.main,
+                shorteningTrackId = shorteningTrack.id,
+                lengtheningTrackId = lengtheningTrack.id,
+                upToSwitchJoint = SwitchJointId(switch3, JointNumber(1)),
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
-        assertEquals(5, newLengthenedGeometry.edges.size)
+        assertEquals(listOf(switch2), trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId).relinkedSwitches)
+        assertEquals(4 + switch2StraightEdges.size, newLengthenedGeometry.edges.size)
         assertEquals(0, newShortenedGeometry.edges.size)
     }
 
@@ -302,24 +317,45 @@ constructor(
 
     @Test
     fun `upToSwitchJoint=null with descending move appends shortening geometry`() {
-        val setup = saveConnectedTracks()
+        val trackNumber = mainDraftContext.createLayoutTrackNumber().id
+        val switch1 = testDBService.save(switch()).id
 
-        trackBoundaryMoveService.saveTrackBoundaryMove(
-            LayoutBranch.main,
-            shorteningTrackId = setup.shorteningTrack.id,
-            lengtheningTrackId = setup.lengtheningTrack.id,
-            upToSwitchJoint = null,
-            boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
-        )
+        val lengtheningGeometry =
+            trackGeometry(
+                edge(listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1)),
+                edge(
+                    listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
+                    startInnerSwitch = switchLinkYV(switch1, 1),
+                    endInnerSwitch = switchLinkYV(switch1, 2),
+                ),
+            )
+        val shorteningGeometry =
+            trackGeometry(
+                edge(listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))), startOuterSwitch = switchLinkYV(switch1, 2))
+            )
+
+        val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
+
+        val boundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.main,
+                shorteningTrackId = shorteningTrack.id,
+                lengtheningTrackId = lengtheningTrack.id,
+                upToSwitchJoint = null,
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
         val newLengthenedGeometry =
-            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, setup.lengtheningTrack.id).second
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
-            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, setup.shorteningTrack.id).second
-        assertSameEdgeContent(
-            setup.lengtheningGeometry.edges + setup.shorteningGeometry.edges,
-            newLengthenedGeometry.edges,
-        )
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, shorteningTrack.id).second
+        assertSameEdgeContent(lengtheningGeometry.edges + shorteningGeometry.edges, newLengthenedGeometry.edges)
         assertEquals(0, newShortenedGeometry.edges.size)
+        // the moved edge only touches switch1 through an outer link, so nothing needed relinking
+        assertEquals(
+            emptyList<IntId<LayoutSwitch>>(),
+            trackBoundaryMoveDao.getOrThrow(boundaryMoveId).relinkedSwitches,
+        )
     }
 
     @Test
@@ -329,16 +365,11 @@ constructor(
 
         val shorteningGeometry =
             trackGeometry(
-                edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))), endInnerSwitch = switchLinkYV(switch1, 1)),
-                edge(
-                    listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                    startInnerSwitch = switchLinkYV(switch1, 1),
-                    endInnerSwitch = switchLinkYV(switch1, 3),
-                ),
+                edge(listOf(segment(Point(0.0, 0.0), Point(20.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1))
             )
         val lengtheningGeometry =
             trackGeometry(
-                edge(listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))), startOuterSwitch = switchLinkYV(switch1, 3))
+                edge(listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))), startOuterSwitch = switchLinkYV(switch1, 1))
             )
 
         val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
@@ -930,6 +961,164 @@ constructor(
         }
     }
 
+    @Test
+    fun `boundary move relinks inner switches of the moved edges`() {
+        val (boundaryMoveId, switchId) = saveBoundaryMoveOverRelinkableSwitch()
+        assertEquals(listOf(switchId), trackBoundaryMoveDao.getOrThrow(boundaryMoveId).relinkedSwitches)
+    }
+
+    @Test
+    fun `relinked switches get grouped per their boundary move in publication candidates`() {
+        val (boundaryMoveId, switchId) = saveBoundaryMoveOverRelinkableSwitch()
+
+        // relinking the switch drafted it, so it shows up as a publication candidate grouped with the move
+        val candidates = publicationService.collectPublicationCandidates(PublicationInMain)
+        val switchCandidate = candidates.switches.single { candidate -> candidate.id == switchId }
+        assertEquals(TrackBoundaryMovePublicationGroup(boundaryMoveId), switchCandidate.publicationGroup)
+    }
+
+    @Test
+    fun `boundary move relinked switches are pulled into revert requests with the move`() {
+        val (boundaryMoveId, switchId) = saveBoundaryMoveOverRelinkableSwitch()
+        val move = trackBoundaryMoveDao.getOrThrow(boundaryMoveId)
+
+        val dependenciesOfTrack =
+            publicationService.getRevertRequestDependencies(
+                LayoutBranch.main,
+                publicationRequestIds(locationTracks = listOf(move.shortenedLocationTrack.id)),
+            )
+        assertContains(dependenciesOfTrack.switches, switchId)
+
+        val dependenciesOfSwitch =
+            publicationService.getRevertRequestDependencies(
+                LayoutBranch.main,
+                publicationRequestIds(switches = listOf(switchId)),
+            )
+        assertContains(dependenciesOfSwitch.locationTracks, move.shortenedLocationTrack.id)
+        assertContains(dependenciesOfSwitch.locationTracks, move.lengthenedLocationTrack.id)
+    }
+
+    @Test
+    fun `reverting a boundary move without its relinked switches throws`() {
+        val (boundaryMoveId, switchId) = saveBoundaryMoveOverRelinkableSwitch()
+        val move = trackBoundaryMoveDao.getOrThrow(boundaryMoveId)
+        val moveTracks = listOf(move.shortenedLocationTrack.id, move.lengthenedLocationTrack.id)
+
+        assertThrows<PartialTrackBoundaryMoveRevertException> {
+            publicationService.revertPublicationCandidates(
+                LayoutBranch.main,
+                publicationRequestIds(locationTracks = moveTracks),
+            )
+        }
+        assertNotNull(trackBoundaryMoveDao.get(boundaryMoveId))
+
+        publicationService.revertPublicationCandidates(
+            LayoutBranch.main,
+            publicationRequestIds(locationTracks = moveTracks, switches = listOf(switchId)),
+        )
+        assertNull(trackBoundaryMoveDao.get(boundaryMoveId))
+    }
+
+    @Test
+    fun `publication validation requires relinked switches to be staged with the boundary move`() {
+        val (_, switchId) = saveBoundaryMoveOverRelinkableSwitch()
+        val candidates = publicationService.collectPublicationCandidates(PublicationInMain)
+        val trackIds = candidates.locationTracks.map { candidate -> candidate.id }
+        val missingSwitchesKey = LocalizationKey.of("validation.layout.track-boundary-move.missing-switches")
+
+        val issuesWithoutSwitch =
+            publicationValidationService
+                .validatePublicationCandidates(candidates, publicationRequestIds(locationTracks = trackIds))
+                .validatedAsPublicationUnit
+                .locationTracks
+                .flatMap { candidate -> candidate.issues }
+        assertTrue(
+            issuesWithoutSwitch.any { issue -> issue.localizationKey == missingSwitchesKey },
+            "Expected a track boundary move missing-switches error, but got: $issuesWithoutSwitch",
+        )
+
+        val issuesWithSwitch =
+            publicationValidationService
+                .validatePublicationCandidates(
+                    candidates,
+                    publicationRequestIds(locationTracks = trackIds, switches = listOf(switchId)),
+                )
+                .validatedAsPublicationUnit
+                .locationTracks
+                .flatMap { candidate -> candidate.issues }
+        assertTrue(
+            issuesWithSwitch.none { issue -> issue.localizationKey == missingSwitchesKey },
+            "Expected no track boundary move missing-switches error, but got: $issuesWithSwitch",
+        )
+    }
+
+    @Test
+    fun `boundary move over a switch that cannot be relinked is an error`() {
+        val setup = saveConnectedTracks()
+
+        // upToSwitchJoint=null moves all of the shortening track's edges, including the ones holding the unlinkable
+        // switch2 as an inner switch
+        val exception =
+            assertThrows<TrackBoundaryMoveFailureException> {
+                trackBoundaryMoveService.saveTrackBoundaryMove(
+                    LayoutBranch.main,
+                    shorteningTrackId = setup.shorteningTrack.id,
+                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    upToSwitchJoint = null,
+                    boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+                )
+            }
+        assertEquals(LocalizationKey.of("error.track-boundary-move.switch-linking-failed"), exception.localizationKey)
+
+        // the whole move was rolled back: no boundary move exists and the tracks kept their geometries
+        assertEquals(
+            emptyList<TrackBoundaryMove>(),
+            trackBoundaryMoveService.findUnpublishedBoundaryMoves(LayoutBranch.main),
+        )
+        val unchangedShortenedGeometry =
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, setup.shorteningTrack.id).second
+        assertSameEdgeContent(setup.shorteningGeometry.edges, unchangedShortenedGeometry.edges)
+    }
+
+    private fun saveBoundaryMoveOverRelinkableSwitch(): Pair<IntId<TrackBoundaryMove>, IntId<LayoutSwitch>> {
+        val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
+        val (switchVersion, straightSwitchEdges, turningSwitchEdges) =
+            splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(turningSwitchEdges))
+
+        val lengtheningTrack =
+            mainOfficialContext.save(
+                locationTrack(trackNumber),
+                trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))),
+            )
+        val switchEnd = straightSwitchEdges.last().lastSegmentEnd
+        val shorteningTrack =
+            mainOfficialContext.save(
+                locationTrack(trackNumber),
+                trackGeometry(
+                    combineEdges(
+                        straightSwitchEdges +
+                            edge(
+                                listOf(segment(Point(switchEnd.x, switchEnd.y), Point(switchEnd.x + 10.0, switchEnd.y)))
+                            )
+                    )
+                ),
+            )
+
+        val boundaryMoveId =
+            trackBoundaryMoveService.saveTrackBoundaryMove(
+                LayoutBranch.main,
+                shorteningTrackId = shorteningTrack.id,
+                lengtheningTrackId = lengtheningTrack.id,
+                upToSwitchJoint = SwitchJointId(switchVersion.id, JointNumber(2)),
+                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+            )
+        return boundaryMoveId to switchVersion.id
+    }
+
+    private fun unlinkableSwitch() =
+        switch(joints = listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(1000.0, 1000.0), null)))
+
     private data class ConnectedTracks(
         val lengtheningTrack: LayoutRowVersion<LocationTrack>,
         val lengtheningGeometry: TmpLocationTrackGeometry,
@@ -949,7 +1138,7 @@ constructor(
     private fun saveConnectedTracks(): ConnectedTracks {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
         val switch1 = testDBService.save(switch()).id
-        val switch2 = testDBService.save(switch()).id
+        val switch2 = testDBService.save(unlinkableSwitch()).id
 
         val lengtheningGeometry =
             trackGeometry(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -908,7 +908,7 @@ constructor(
     }
 
     @Test
-    fun `counterpart options excludes tracks on a different track number`() {
+    fun `counterpart options flag tracks on a different track number`() {
         val trackNumberA = mainDraftContext.createLayoutTrackNumber().id
         val trackNumberB = mainDraftContext.createLayoutTrackNumber().id
 
@@ -917,13 +917,21 @@ constructor(
                 locationTrack(trackNumberA),
                 trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))),
             )
-        testDBService.save(
-            locationTrack(trackNumberB),
-            trackGeometry(edge(listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))))),
-        )
+        val otherTrackNumberTrack =
+            testDBService.save(
+                locationTrack(trackNumberB),
+                trackGeometry(edge(listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))))),
+            )
 
         assertEquals(
-            emptyList<BoundaryMoveCounterpart>(),
+            listOf(
+                BoundaryMoveCounterpart(
+                    trackId = otherTrackNumberTrack.id,
+                    orientation = BoundaryOrientation.HEAD_FIRST,
+                    connectingSwitchJoint = null,
+                    disabledReasons = listOf(BoundaryMoveCounterpartDisabledReason.ON_DIFFERENT_TRACK_NUMBER),
+                )
+            ),
             trackBoundaryMoveService.getBoundaryMoveCounterpartOptions(LayoutBranch.main.draft, headTrack.id),
         )
     }

--- a/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
+++ b/ui/src/tool-panel/location-track/location-track-track-boundary-move-infobox.tsx
@@ -124,6 +124,8 @@ const boundaryMoveDisabledReasonTranslationKeys: Record<BoundaryMoveDisabledReas
     NO_GEOMETRY: 'tool-panel.location-track.no-geometry',
     SWITCHES_PART_OF_SPLIT:
         'tool-panel.location-track.track-boundary-move.validation.switches-part-of-split',
+    ON_DIFFERENT_TRACK_NUMBER:
+        'tool-panel.location-track.track-boundary-move.validation.on-different-track-number',
 };
 
 export const translatedBoundaryMoveDisabledReasons = (

--- a/ui/src/track-layout/track-layout-model.tsx
+++ b/ui/src/track-layout/track-layout-model.tsx
@@ -340,7 +340,8 @@ export type BoundaryMoveDisabledReason =
     | 'PART_OF_BOUNDARY_MOVE'
     | 'TRACK_DRAFT_EXISTS'
     | 'NO_GEOMETRY'
-    | 'SWITCHES_PART_OF_SPLIT';
+    | 'SWITCHES_PART_OF_SPLIT'
+    | 'ON_DIFFERENT_TRACK_NUMBER';
 
 export type LocationTrackInfoboxExtras = {
     duplicateOf?: LocationTrackDuplicate;


### PR DESCRIPTION
Teoriassa uudelleenlinkitys ei meille olisi ihan totaalisen välttämätön juttu, teoriassa vaihteet saisi samaan pompsiin kunhan niille vaan luo draftin millään tavalla. Mutta onhan tässä yhteydessä hyvä varmistaa, että raidegeometriat on siirron jälkeen kunnossa, ja sen tietää sillä, että vaihteiden uudelleenlinkitys onnistuu.