### PR TITLE
Add startup script to run backend with gradlew

### DIFF
--- a/infra/start_back.sh
+++ b/infra/start_back.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd $(dirname $0)
+
+./gradlew bootRun --args='--spring.profiles.active=dev,noauth,backend'


### PR DESCRIPTION
Wanted to add a more streamlined way to run the backend locally. Now the backend service can be run locally with it's Gradle wrapper, similarily to the `frontend_start.sh` script.