### PR TITLE
GVT-3645 Add address-range-relative m-values to ext geometry apis

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtCoordinateTransformsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtCoordinateTransformsV1.kt
@@ -7,7 +7,9 @@ import fi.fta.geoviite.infra.geocoding.GeocodingContext
 import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.math.IntersectType
+import fi.fta.geoviite.infra.tracklayout.AnyM
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 
 internal fun toExtAddressPoint(
@@ -41,3 +43,26 @@ fun toExtCoordinate(point: IPoint, targetCoordinateSystem: Srid): ExtCoordinateV
             else -> transformNonKKJCoordinate(LAYOUT_SRID, targetCoordinateSystem, point)
         }
     )
+
+fun toExtMeasuredAddressPoint(
+    addressPoint: AddressPoint<*>,
+    m: LineM<*>,
+    targetCoordinateSystem: Srid,
+): ExtMeasuredAddressPointV1 {
+    val point =
+        when (targetCoordinateSystem) {
+            LAYOUT_SRID -> addressPoint.point
+            else -> transformNonKKJCoordinate(LAYOUT_SRID, targetCoordinateSystem, addressPoint.point)
+        }
+    return ExtMeasuredAddressPointV1(point.x, point.y, m.distance, addressPoint.address.formatFixedDecimals(3))
+}
+
+fun <M : AnyM<M>> toExtMeasuredAddressPoints(
+    addressPoints: List<AddressPoint<M>>,
+    targetCoordinateSystem: Srid,
+): List<ExtMeasuredAddressPointV1> {
+    val startM = addressPoints.firstOrNull()?.point?.m ?: return emptyList()
+    return addressPoints.map { addressPoint ->
+        toExtMeasuredAddressPoint(addressPoint, addressPoint.point.m - startM, targetCoordinateSystem)
+    }
+}

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtGeometryDiff.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtGeometryDiff.kt
@@ -39,8 +39,7 @@ fun <M : AnyM<M>> createModifiedCenterLineIntervals(
                     startAddress = newPoints!!.startPoint.address.formatFixedDecimals(3),
                     endAddress = newPoints.endPoint.address.formatFixedDecimals(3),
                     changeType = ExtGeometryChangeTypeV1.GEOMETRY,
-                    addressPoints =
-                        newPoints.allPoints.map { addressPoint -> toExtAddressPoint(addressPoint, coordinateSystem) },
+                    addressPoints = toExtMeasuredAddressPoints(newPoints.allPoints, coordinateSystem),
                 )
             )
         }
@@ -133,7 +132,7 @@ private class RangeBuilder<M : AnyM<M>>(val coordinateSystem: Srid) {
     ): ExtModifiedCenterLineTrackIntervalV1? {
         val startAddress = start?.formatFixedDecimals(3)
         val endAddress = end?.formatFixedDecimals(3)
-        val addressPoints = points.map { addressPoint -> toExtAddressPoint(addressPoint, coordinateSystem) }
+        val addressPoints = toExtMeasuredAddressPoints(points, coordinateSystem)
         val changeType =
             if (points.isEmpty() || isGeometryChange(points.first().point, points.last().point)) {
                 ExtGeometryChangeTypeV1.GEOMETRY
@@ -155,10 +154,12 @@ private class RangeBuilder<M : AnyM<M>>(val coordinateSystem: Srid) {
     }
 }
 
-fun toExtInterval(addressPoints: AlignmentAddresses<*>, coordinateSystem: Srid): ExtCenterLineTrackIntervalV1 =
+fun <M : AnyM<M>> toExtInterval(
+    addressPoints: AlignmentAddresses<M>,
+    coordinateSystem: Srid,
+): ExtCenterLineTrackIntervalV1 =
     ExtCenterLineTrackIntervalV1(
         startAddress = addressPoints.startPoint.address.formatFixedDecimals(3),
         endAddress = addressPoints.endPoint.address.formatFixedDecimals(3),
-        addressPoints =
-            addressPoints.allPoints.map { addressPoint -> toExtAddressPoint(addressPoint, coordinateSystem) },
+        addressPoints = toExtMeasuredAddressPoints(addressPoints.allPoints, coordinateSystem),
     )

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -412,11 +412,20 @@ data class ExtAddressPointV1(
     @Schema(type = "string", example = "0012+0123.456") @JsonProperty(TRACK_ADDRESS) val trackAddress: String?,
 )
 
+@Schema(title = "Osoitepiste M-arvolla")
+@JsonInclude(JsonInclude.Include.ALWAYS)
+data class ExtMeasuredAddressPointV1(
+    val x: Double,
+    val y: Double,
+    @JsonProperty("osoitevali_m") val osoitevaliM: Double,
+    @Schema(type = "string", example = "0012+0123.456") @JsonProperty(TRACK_ADDRESS) val trackAddress: String?,
+)
+
 @Schema(title = "Osoiteväli")
 data class ExtCenterLineTrackIntervalV1(
     @Schema(type = "string", example = "0012+0123.456") @JsonProperty("alkuosoite") val startAddress: String,
     @Schema(type = "string", example = "0012+0123.456") @JsonProperty("loppuosoite") val endAddress: String,
-    @JsonProperty("pisteet") val addressPoints: List<ExtAddressPointV1>,
+    @JsonProperty("pisteet") val addressPoints: List<ExtMeasuredAddressPointV1>,
 )
 
 @Schema(title = "Muuttunut osoiteväli")
@@ -424,7 +433,7 @@ data class ExtModifiedCenterLineTrackIntervalV1(
     @Schema(type = "string", example = "0012+0123.456") @JsonProperty("alkuosoite") val startAddress: String,
     @Schema(type = "string", example = "0012+0123.456") @JsonProperty("loppuosoite") val endAddress: String,
     @JsonProperty("muutostyyppi") val changeType: ExtGeometryChangeTypeV1,
-    @JsonProperty("pisteet") val addressPoints: List<ExtAddressPointV1>,
+    @JsonProperty("pisteet") val addressPoints: List<ExtMeasuredAddressPointV1>,
 )
 
 @Schema(

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
@@ -125,14 +125,7 @@ constructor(
                         // Address points are null for example in case when the user provided
                         // address filter is outside the track boundaries.
                         filteredAddressPoints?.let { addressPoints ->
-                            ExtCenterLineTrackIntervalV1(
-                                startAddress = addressPoints.startPoint.address.toString(),
-                                endAddress = addressPoints.endPoint.address.toString(),
-                                addressPoints =
-                                    filteredAddressPoints.allPoints.map { point ->
-                                        toExtAddressPoint(point, coordinateSystem)
-                                    },
-                            )
+                            toExtInterval(addressPoints, coordinateSystem)
                         },
                 )
             }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutDataV1.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutDataV1.kt
@@ -14,6 +14,13 @@ data class ExtTestCoordinateV1(val x: Double, val y: Double)
 
 data class ExtTestAddressPointV1(override val x: Double, override val y: Double, val rataosoite: String?) : IPoint
 
+data class ExtTestMeasuredAddressPointV1(
+    override val x: Double,
+    override val y: Double,
+    val osoitevali_m: Double,
+    val rataosoite: String?,
+) : IPoint
+
 data class ExtTestLocationTrackV1(
     val sijaintiraide_oid: String,
     val sijaintiraidetunnus: String,
@@ -182,14 +189,14 @@ data class ExtTestErrorResponseV1(val virheviesti: String, val korrelaatiotunnus
 data class ExtTestGeometryIntervalV1(
     val alkuosoite: String,
     val loppuosoite: String,
-    val pisteet: List<ExtTestAddressPointV1>,
+    val pisteet: List<ExtTestMeasuredAddressPointV1>,
 )
 
 data class ExtTestModifiedGeometryIntervalV1(
     val alkuosoite: String,
     val loppuosoite: String,
     val muutostyyppi: String,
-    val pisteet: List<ExtTestAddressPointV1>,
+    val pisteet: List<ExtTestMeasuredAddressPointV1>,
 )
 
 data class ExtTestSwitchJointV1(val numero: Int, val sijainti: ExtTestCoordinateV1)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutAssertions.kt
@@ -142,10 +142,10 @@ fun assertIntervalPointsMatch(
             getError("point $i distance to line geometry", 0.0),
         )
         assertEquals(
-            pointOnLine.m.distance,
-            p.osoitevali_m + startM,
+            pointOnLine.m.distance - startM,
+            p.osoitevali_m,
             COORDINATE_DELTA,
-            getError("m-value", p.osoitevali_m),
+            getError("m-value", pointOnLine.m.distance - startM),
         )
         assertNotNull(p.rataosoite, getError("point should have an address at index $i", "not null"))
         previousAddress =

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutAssertions.kt
@@ -115,7 +115,7 @@ fun assertIntervalMatches(
 }
 
 fun assertIntervalPointsMatch(
-    points: List<ExtTestAddressPointV1>,
+    points: List<ExtTestMeasuredAddressPointV1>,
     startAddress: String,
     endAddress: String,
     geometry: IAlignment<*>,
@@ -128,6 +128,9 @@ fun assertIntervalPointsMatch(
     assertEquals(start.y, points.first().y, COORDINATE_DELTA, getError("start y coordinate", start.y))
     assertEquals(end.x, points.last().x, COORDINATE_DELTA, getError("end x coordinate", end.x))
     assertEquals(end.y, points.last().y, COORDINATE_DELTA, getError("end y coordinate", end.y))
+    // The interval's m-values are reported relative to the interval start, so the offset back to geometry
+    // m-values is just the geometry m at the start point.
+    val startM = geometry.getClosestPoint(start)!!.first.m.distance
     var previousAddress: TrackMeter? = null
     points.forEachIndexed { i, p ->
         val point = Point(p.x, p.y)
@@ -137,6 +140,12 @@ fun assertIntervalPointsMatch(
             lineLength(point, pointOnLine),
             COORDINATE_DELTA,
             getError("point $i distance to line geometry", 0.0),
+        )
+        assertEquals(
+            pointOnLine.m.distance,
+            p.osoitevali_m + startM,
+            COORDINATE_DELTA,
+            getError("m-value", p.osoitevali_m),
         )
         assertNotNull(p.rataosoite, getError("point should have an address at index $i", "not null"))
         previousAddress =


### PR DESCRIPTION
Lisätään ext-API:n geometriahakujen osoitepisteisiin uusi kenttä `osoitevali_m`, joka kertoo pisteen m-arvon suhteessa tämän osoitevälin alkuun. Päädyin tähän esitystapaan siis siksi, että tällä tavalla ei synny uutta ylimääräistä dynamiikkaa varsinaisiin API-kutsuihin, vaan että jos geometria-endpointteihin lähettää pyyntöjä, niin niistä tulee geometria-endpointtien tietoja; ja taas toisaalta ei jää oikein mahdollisuutta, ettei API:n käyttäjä ainakin jotenkin huomaisi, että nämä ei ole nyt välttämättä koko raiteen m-arvoja. Ja kun eivät ole koko raiteen m-arvoa, niins raiteiden eri kohtien haut ja muutokset on yhä toisistaan itsenäisiä.