### PR TITLE
GVT-3637 Fix track number segment context_id column name

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryDao.kt
@@ -1904,7 +1904,7 @@ constructor(
                   from layout.track_number_version tnv
                     inner join layout.track_number_version_segment sv
                                on sv.track_number_id = tnv.id
-                               and sv.track_layout_context_id = tnv.layout_context_id
+                               and sv.track_number_layout_context_id = tnv.layout_context_id
                                and sv.track_number_version = tnv.version
                     inner join geometry.alignment on alignment.id = sv.geometry_alignment_id
                     left join layout.track_number current

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingDao.kt
@@ -91,7 +91,7 @@ class LinkingDao(jdbcTemplateParam: NamedParameterJdbcTemplate?) : DaoBase(jdbcT
                             and element.element_index = tnvs.geometry_element_index
                 left join layout.track_number_in_layout_context(:publication_state::layout.publication_state, :design_id) track_number
                           on track_number.id = tnvs.track_number_id
-                            and track_number.layout_context_id = tnvs.track_layout_context_id
+                            and track_number.layout_context_id = tnvs.track_number_layout_context_id
                             and track_number.version = tnvs.track_number_version
                             and track_number.state != 'DELETED'
               where geometry_alignment.plan_id in (:plan_ids)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -46,14 +46,14 @@ import fi.fta.geoviite.infra.util.getPoint3DMOrNull
 import fi.fta.geoviite.infra.util.getSridOrNull
 import fi.fta.geoviite.infra.util.setNullableBigDecimal
 import fi.fta.geoviite.infra.util.setNullableInt
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.sql.ResultSet
 import java.util.stream.Collectors
 import kotlin.math.abs
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 const val NODE_CACHE_SIZE = 50000L
 const val EDGE_CACHE_SIZE = 100000L
@@ -532,7 +532,7 @@ class LayoutAlignmentDao(
             from layout.track_number tn
               left join layout.track_number_version_segment sv
                 on sv.track_number_id = tn.id
-                  and sv.track_layout_context_id = tn.layout_context_id
+                  and sv.track_number_layout_context_id = tn.layout_context_id
                   and sv.track_number_version = tn.version
             order by tn.id, tn.layout_context_id, sv.segment_index
             """
@@ -580,7 +580,7 @@ class LayoutAlignmentDao(
             """
             insert into layout.track_number_version_segment(
                 track_number_id,
-                track_layout_context_id,
+                track_number_layout_context_id,
                 track_number_version,
                 segment_index,
                 start_m,
@@ -706,7 +706,7 @@ class LayoutAlignmentDao(
               geometry_id
             from layout.track_number_version_segment
             where track_number_id = :track_number_id
-              and track_layout_context_id = :track_layout_context_id
+              and track_number_layout_context_id = :track_number_layout_context_id
               and track_number_version = :track_number_version
             order by segment_index
             """
@@ -714,7 +714,7 @@ class LayoutAlignmentDao(
         val params =
             mapOf(
                 "track_number_id" to version.id.intValue,
-                "track_layout_context_id" to version.context.toSqlString(),
+                "track_number_layout_context_id" to version.context.toSqlString(),
                 "track_number_version" to version.version,
             )
 
@@ -911,7 +911,7 @@ class LayoutAlignmentDao(
                 from layout.track_number_version_segment sv
                   inner join layout.segment_geometry on segment_geometry.id = sv.geometry_id
                 where sv.track_number_id = :track_number_id
-                  and sv.track_layout_context_id = :track_layout_context_id
+                  and sv.track_number_layout_context_id = :track_number_layout_context_id
                   and sv.track_number_version = :track_number_version
                   and (
                       :use_bounding_box = false or postgis.st_intersects(
@@ -943,14 +943,14 @@ class LayoutAlignmentDao(
                     and segment_metadata.track_number_id = :track_number_id
                   inner join layout.track_number_version_segment segment
                     on segment.track_number_id = segment_metadata.track_number_id
-                    and segment.track_layout_context_id = 'main_official'
+                    and segment.track_number_layout_context_id = 'main_official'
                     and segment.track_number_version = 1
                     and segment.segment_index = segment_metadata.segment_index
                     and segment.source = 'IMPORTED'
                   inner join layout.track_number_version_segment current_segment
                     on current_segment.geometry_id = segment.geometry_id
                     and current_segment.track_number_id = :track_number_id
-                    and current_segment.track_layout_context_id = :track_layout_context_id
+                    and current_segment.track_number_layout_context_id = :track_number_layout_context_id
                     and current_segment.track_number_version = :track_number_version
                     and current_segment.geometry_alignment_id is null
                   left join layout.segment_geometry on segment.geometry_id = segment_geometry.id
@@ -981,7 +981,7 @@ class LayoutAlignmentDao(
                   left join geometry.plan_file on plan_file.plan_id = geom_alignment.plan_id
                   left join orig_metadata on orig_metadata.current_segment_index = segment.segment_index
                 where segment.track_number_id = :track_number_id
-                  and segment.track_layout_context_id = :track_layout_context_id
+                  and segment.track_number_layout_context_id = :track_number_layout_context_id
                   and segment.track_number_version = :track_number_version
               ),
               metadata_segments as (
@@ -1019,7 +1019,7 @@ class LayoutAlignmentDao(
         val params =
             mapOf(
                 "track_number_id" to trackNumberVersion.id.intValue,
-                "track_layout_context_id" to trackNumberVersion.context.toSqlString(),
+                "track_number_layout_context_id" to trackNumberVersion.context.toSqlString(),
                 "track_number_version" to trackNumberVersion.version,
                 "external_id" to metadataExternalId,
                 "use_bounding_box" to (boundingBox != null),
@@ -1266,7 +1266,7 @@ class LayoutAlignmentDao(
                     from layout.track_number_version_segment sv
                       inner join layout.track_number tn
                         on tn.id = sv.track_number_id
-                          and tn.layout_context_id = sv.track_layout_context_id
+                          and tn.layout_context_id = sv.track_number_layout_context_id
                           and tn.version = sv.track_number_version
                   union all
                   select s.geometry_id

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDao.kt
@@ -24,11 +24,11 @@ import fi.fta.geoviite.infra.util.getTrackMeter
 import fi.fta.geoviite.infra.util.getTrackNumber
 import fi.fta.geoviite.infra.util.setForceCustomPlan
 import fi.fta.geoviite.infra.util.setUser
+import java.sql.ResultSet
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
 
 const val TRACK_NUMBER_CACHE_SIZE = 1000L
 
@@ -342,7 +342,7 @@ class LayoutTrackNumberDao(
                     from layout.track_number_version_segment sv
                       inner join layout.segment_geometry on segment_geometry.id = sv.geometry_id
                     where sv.track_number_id = track_number.id
-                      and sv.track_layout_context_id = track_number.layout_context_id
+                      and sv.track_number_layout_context_id = track_number.layout_context_id
                       and sv.track_number_version = track_number.version
                       and postgis.st_intersects(
                         postgis.st_makeenvelope(:x_min, :y_min, :x_max, :y_max, :layout_srid),

--- a/infra/src/main/resources/db/migration/prod/V149_03__combine_reference_line_and_track_number.sql
+++ b/infra/src/main/resources/db/migration/prod/V149_03__combine_reference_line_and_track_number.sql
@@ -685,18 +685,18 @@ alter table layout.track_number_version
 -- Add new segment table that relies on track number version instead of a separate alignment
 create table layout.track_number_version_segment
 (
-  track_number_id         int                    not null,
-  track_layout_context_id varchar                not null,
-  track_number_version    int                    not null,
-  segment_index           int                    not null,
-  start_m                 decimal(13, 6)         not null,
-  geometry_alignment_id   int                    null,
-  geometry_element_index  int                    null,
-  source_start_m          decimal(13, 6)         null,
-  source                  layout.geometry_source not null,
-  geometry_id             int                    not null,
-  primary key (track_number_id, track_layout_context_id, track_number_version, segment_index),
-  foreign key (track_number_id, track_layout_context_id, track_number_version) references layout.track_number_version (id, layout_context_id, version),
+  track_number_id                int                    not null,
+  track_number_layout_context_id varchar                not null,
+  track_number_version           int                    not null,
+  segment_index                  int                    not null,
+  start_m                        decimal(13, 6)         not null,
+  geometry_alignment_id          int                    null,
+  geometry_element_index         int                    null,
+  source_start_m                 decimal(13, 6)         null,
+  source                         layout.geometry_source not null,
+  geometry_id                    int                    not null,
+  primary key (track_number_id, track_number_layout_context_id, track_number_version, segment_index),
+  foreign key (track_number_id, track_number_layout_context_id, track_number_version) references layout.track_number_version (id, layout_context_id, version),
   foreign key (geometry_alignment_id) references geometry.alignment (id),
   foreign key (geometry_alignment_id, geometry_element_index) references geometry.element (alignment_id, element_index),
   foreign key (geometry_id) references layout.segment_geometry (id)
@@ -784,7 +784,7 @@ select
 
 -- Populate track_number_version_segment from segment_version via reference_line_version's alignment reference
 insert into layout.track_number_version_segment
-  (track_number_id, track_layout_context_id, track_number_version,
+  (track_number_id, track_number_layout_context_id, track_number_version,
    segment_index,
    start_m, source_start_m, source,
    geometry_alignment_id, geometry_element_index,

--- a/infra/src/main/resources/db/migration/repeatable/R__10.06_layout_track_number_ends_view.sql
+++ b/infra/src/main/resources/db/migration/repeatable/R__10.06_layout_track_number_ends_view.sql
@@ -9,13 +9,13 @@ select
   from layout.track_number_version tnv
     left join layout.track_number_version_segment first_seg
               on tnv.id = first_seg.track_number_id
-                and tnv.layout_context_id = first_seg.track_layout_context_id
+                and tnv.layout_context_id = first_seg.track_number_layout_context_id
                 and tnv.version = first_seg.track_number_version
                 and first_seg.segment_index = 0
     left join layout.segment_geometry first_geom on first_seg.geometry_id = first_geom.id
     left join layout.track_number_version_segment last_seg
               on tnv.id = last_seg.track_number_id
-                and tnv.layout_context_id = last_seg.track_layout_context_id
+                and tnv.layout_context_id = last_seg.track_number_layout_context_id
                 and tnv.version = last_seg.track_number_version
                 and last_seg.segment_index = tnv.segment_count - 1
     left join layout.segment_geometry last_geom on last_seg.geometry_id = last_geom.id;


### PR DESCRIPTION
Testailin vielä sql:llä eri juttuja datasta että migrat meni oikein. Data vaikuttaa OK:lta mutta bongasin tuolla huonosti nimetyn columnin, joten tässä pullari joka korjaa sen. En tee tätä versioituna vaan muutetaan vain itse migraa ja resetoin devin kannan samalla kun mergeilen tämän.