### PR TITLE
GVT-3605 Improve ext-api responses in bad coordinate transform situations

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterOpenApiConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterOpenApiConstantsV1.kt
@@ -5,7 +5,8 @@ const val FRAME_CONVERTER_TAG_TRACK_ADDRESS_TO_COORDINATE = "Rataosoitteesta koo
 
 const val FRAME_CONVERTER_OPENAPI_COORDINATE_SYSTEM =
     "Koordinaatisto, jossa syöte- ja tuloskoordinaatit käsitellään (oletus EPSG:3067, eli ETRS-TM35FIN). <br />" +
-        "Sallitut arvot ovat EPSG-tunnuksia, esim. EPSG:4326."
+        "Sallitut arvot ovat EPSG-tunnuksia, esim. EPSG:4326. <br />" +
+        "Sallitut koordinaattijärjestelmät on listattu parametrin sallituissa arvoissa."
 
 const val FRAME_CONVERTER_OPENAPI_X = "Koordinaatti X annetussa koordinaatistossa."
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutConstantsV1.kt
@@ -103,7 +103,9 @@ const val EXT_OPENAPI_SWITCH_OID_DESCRIPTION = "Vaihteen OID-tunnus."
 const val EXT_OPENAPI_TRACK_NUMBER_OID_DESCRIPTION = "Ratanumeron OID-tunnus."
 
 const val EXT_OPENAPI_COORDINATE_SYSTEM =
-    "Hyödynnettävän koordinaattijärjestelmän EPSG-tunnus. Oletuksena käytetään paikannuspohjan koordinaatistoa EPSG:3067 (ETRS-TM35FIN)."
+    "Hyödynnettävän koordinaattijärjestelmän EPSG-tunnus. " +
+        "Oletuksena käytetään paikannuspohjan koordinaatistoa EPSG:3067 (ETRS-TM35FIN). " +
+        "Sallitut koordinaattijärjestelmät on listattu parametrin sallituissa arvoissa."
 
 const val EXT_OPENAPI_RESOLUTION =
     "Palautettavien osoitepisteiden metriväli. Oletuksena osoitepisteet palautetaan yhden metrin välein."

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutResponseDataV1.kt
@@ -13,8 +13,13 @@ import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.Uuid
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
 import fi.fta.geoviite.infra.error.UnsupportedSridException
+import fi.fta.geoviite.infra.geography.ETRS89_SRID
+import fi.fta.geoviite.infra.geography.ETRS89_TM35FIN_NE_SRID
+import fi.fta.geoviite.infra.geography.ETRS89_TM35FIN_SRID
 import fi.fta.geoviite.infra.geography.GeometryPoint
-import fi.fta.geoviite.infra.geography.isKKJ
+import fi.fta.geoviite.infra.geography.WGS_84_SRID
+import fi.fta.geoviite.infra.geography.etrsGkFinSrids
+import fi.fta.geoviite.infra.geography.gkFinSrids
 import fi.fta.geoviite.infra.math.IPoint
 import fi.fta.geoviite.infra.publication.Publication
 import fi.fta.geoviite.infra.ratko.model.OperationalPointRatoType
@@ -441,14 +446,52 @@ data class ExtModifiedCenterLineTrackIntervalV1(
 @Schema(
     description = "Koordinaattijärjestelmän EPSG-koodi",
     type = "string",
-    format = "epsg-code",
-    pattern = "^EPSG:\\d{4,5}$",
-    example = "EPSG:3067",
+    allowableValues =
+        [
+            "EPSG:3067", // ETRS-TM35FIN (layout default)
+            "EPSG:5048", // ETRS-TM35FIN(N,E) — same as 3067, axes swapped
+            "EPSG:4258", // ETRS89
+            "EPSG:4326", // WGS84
+            "EPSG:3873",
+            "EPSG:3874",
+            "EPSG:3875",
+            "EPSG:3876", // GK19–GK22FIN
+            "EPSG:3877",
+            "EPSG:3878",
+            "EPSG:3879",
+            "EPSG:3880", // GK23–GK26FIN
+            "EPSG:3881",
+            "EPSG:3882",
+            "EPSG:3883",
+            "EPSG:3884",
+            "EPSG:3885", // GK27–GK31FIN
+            "EPSG:3126",
+            "EPSG:3127",
+            "EPSG:3128",
+            "EPSG:3129", // ETRS-GK19–GK22FIN (legacy)
+            "EPSG:3130",
+            "EPSG:3131",
+            "EPSG:3132",
+            "EPSG:3133", // ETRS-GK23–GK26FIN (legacy)
+            "EPSG:3134",
+            "EPSG:3135",
+            "EPSG:3136",
+            "EPSG:3137",
+            "EPSG:3138", // ETRS-GK27–GK31FIN (legacy)
+        ],
+    defaultValue = "EPSG:3067",
 )
 data class ExtSridV1(val value: Srid) {
 
+    companion object {
+        val SUPPORTED: Set<Srid> =
+            setOf(ETRS89_TM35FIN_SRID, ETRS89_TM35FIN_NE_SRID, ETRS89_SRID, WGS_84_SRID) +
+                gkFinSrids +
+                etrsGkFinSrids
+    }
+
     init {
-        if (isKKJ(value)) throw UnsupportedSridException(value)
+        if (value !in SUPPORTED) throw UnsupportedSridException(value)
     }
 
     @JsonValue override fun toString() = value.toString()

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CommonSrid.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/CommonSrid.kt
@@ -2,10 +2,11 @@ package fi.fta.geoviite.infra.geography
 
 import fi.fta.geoviite.infra.common.Srid
 
-val WGS_84_SRID = Srid(4326)
+val WGS_84_SRID = Srid(4326) // Common global coordinate system (degrees)
 
-val ETRS89_SRID = Srid(4258)
-val ETRS89_TM35FIN_SRID = Srid(3067)
+val ETRS89_SRID = Srid(4258) // Common European coordinate system (degrees)
+val ETRS89_TM35FIN_SRID = Srid(3067) // Finnish national coordinate system, standard axis order (E,N) — used as layout SRID
+val ETRS89_TM35FIN_NE_SRID = Srid(5048) // Same projection as ETRS89_TM35FIN_SRID, but axes are swapped (N,E)
 
 val FIN_GK19_SRID = Srid(3873)
 val FIN_GK20_SRID = Srid(3874)
@@ -35,6 +36,37 @@ val gkFinSrids =
         FIN_GK29_SRID,
         FIN_GK30_SRID,
         FIN_GK31_SRID,
+    )
+
+// Legacy ETRS-GK-FIN series (EPSG:3126–3138), superseded by GK-FIN (EPSG:3873–3885) above
+val ETRS_GK19_FIN_SRID = Srid(3126)
+val ETRS_GK20_FIN_SRID = Srid(3127)
+val ETRS_GK21_FIN_SRID = Srid(3128)
+val ETRS_GK22_FIN_SRID = Srid(3129)
+val ETRS_GK23_FIN_SRID = Srid(3130)
+val ETRS_GK24_FIN_SRID = Srid(3131)
+val ETRS_GK25_FIN_SRID = Srid(3132)
+val ETRS_GK26_FIN_SRID = Srid(3133)
+val ETRS_GK27_FIN_SRID = Srid(3134)
+val ETRS_GK28_FIN_SRID = Srid(3135)
+val ETRS_GK29_FIN_SRID = Srid(3136)
+val ETRS_GK30_FIN_SRID = Srid(3137)
+val ETRS_GK31_FIN_SRID = Srid(3138)
+val etrsGkFinSrids =
+    setOf(
+        ETRS_GK19_FIN_SRID,
+        ETRS_GK20_FIN_SRID,
+        ETRS_GK21_FIN_SRID,
+        ETRS_GK22_FIN_SRID,
+        ETRS_GK23_FIN_SRID,
+        ETRS_GK24_FIN_SRID,
+        ETRS_GK25_FIN_SRID,
+        ETRS_GK26_FIN_SRID,
+        ETRS_GK27_FIN_SRID,
+        ETRS_GK28_FIN_SRID,
+        ETRS_GK29_FIN_SRID,
+        ETRS_GK30_FIN_SRID,
+        ETRS_GK31_FIN_SRID,
     )
 
 val KKJ0_SRID = Srid(3386)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -210,6 +210,8 @@ data class GeotoolsTransformation(override val sourceSrid: Srid, override val ta
     private val math: MathTransform =
         try {
             CRS.findMathTransform(sourceCrs, targetCrs)
+        } catch (e: UnsupportedSridException) {
+            throw e
         } catch (e: Exception) {
             throw UnsupportedSridException(targetSrid, e)
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geography/GeoToolsGeometries.kt
@@ -9,9 +9,6 @@ import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.math.Range
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.util.logger
-import java.util.concurrent.ConcurrentHashMap
-import kotlin.concurrent.getOrSet
-import kotlin.math.round
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem
 import org.geotools.api.referencing.operation.MathTransform
 import org.geotools.geometry.jts.GeometryBuilder
@@ -20,12 +17,15 @@ import org.geotools.geometry.jts.JTSFactoryFinder
 import org.geotools.referencing.CRS
 import org.geotools.referencing.GeodeticCalculator
 import org.locationtech.jts.algorithm.ConvexHull
-import org.locationtech.jts.geom.Coordinate as JtsCoordinate
 import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.getOrSet
+import kotlin.math.round
+import org.locationtech.jts.geom.Coordinate as JtsCoordinate
 import org.locationtech.jts.geom.LineString as JtsLineString
 import org.locationtech.jts.geom.Point as JtsPoint
 import org.locationtech.jts.geom.Polygon as JtsPolygon
-import org.locationtech.jts.geom.PrecisionModel
 
 val FINNISH_GK_LONGITUDE_RANGE = 19..31
 
@@ -207,7 +207,12 @@ sealed class Transformation {
 }
 
 data class GeotoolsTransformation(override val sourceSrid: Srid, override val targetSrid: Srid) : Transformation() {
-    private val math: MathTransform = CRS.findMathTransform(sourceCrs, targetCrs)
+    private val math: MathTransform =
+        try {
+            CRS.findMathTransform(sourceCrs, targetCrs)
+        } catch (e: Exception) {
+            throw UnsupportedSridException(targetSrid, e)
+        }
 
     override fun transformJtsInternal(point: JtsPoint): JtsPoint = JTS.transform(point, math) as JtsPoint
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSridV1Test.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSridV1Test.kt
@@ -9,6 +9,10 @@ import fi.fta.geoviite.infra.geography.ETRS89_TM35FIN_SRID
 import fi.fta.geoviite.infra.geography.FIN_GK25_SRID
 import fi.fta.geoviite.infra.geography.WGS_84_SRID
 import fi.fta.geoviite.infra.geography.kkjSrids
+import fi.fta.geoviite.infra.geography.transformNonKKJCoordinate
+import fi.fta.geoviite.infra.math.Point
+import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -50,6 +54,20 @@ class ExtSridV1Test {
     }
 
     @Test
+    fun `all supported coordinate systems have working round-trip transformations`() {
+        // A point in the Helsinki area in LAYOUT_SRID (ETRS89/TM35FIN)
+        val original = Point(385123.0, 6672351.0)
+        val tolerance = 0.01 // 10 mm — accommodates floating-point noise in degree-based (WGS84/ETRS89) round-trips
+
+        ExtSridV1.SUPPORTED.forEach { srid ->
+            val transformed = transformNonKKJCoordinate(LAYOUT_SRID, srid, original)
+            val roundTripped = transformNonKKJCoordinate(srid, LAYOUT_SRID, transformed)
+            assertEquals(original.x, roundTripped.x, tolerance, "Round-trip x failed for $srid")
+            assertEquals(original.y, roundTripped.y, tolerance, "Round-trip y failed for $srid")
+        }
+    }
+
+    @Test
     fun `malformed SRID string is rejected`() {
         assertThrows<InputValidationException> { ExtSridV1("BOGUS") }
     }
@@ -59,3 +77,4 @@ class ExtSridV1Test {
         assertThrows<InputValidationException> { ExtSridV1("EPSG:99999") }
     }
 }
+

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSridV1Test.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSridV1Test.kt
@@ -1,7 +1,10 @@
 package fi.fta.geoviite.api.tracklayout.v1
 
+import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.error.InputValidationException
 import fi.fta.geoviite.infra.error.UnsupportedSridException
+import fi.fta.geoviite.infra.geography.ETRS89_SRID
+import fi.fta.geoviite.infra.geography.ETRS89_TM35FIN_NE_SRID
 import fi.fta.geoviite.infra.geography.ETRS89_TM35FIN_SRID
 import fi.fta.geoviite.infra.geography.FIN_GK25_SRID
 import fi.fta.geoviite.infra.geography.WGS_84_SRID
@@ -15,13 +18,35 @@ class ExtSridV1Test {
     @Test
     fun `common supported coordinate systems are accepted`() {
         assertDoesNotThrow { ExtSridV1(ETRS89_TM35FIN_SRID) }
+        assertDoesNotThrow { ExtSridV1(ETRS89_TM35FIN_NE_SRID) }
         assertDoesNotThrow { ExtSridV1(WGS_84_SRID) }
+        assertDoesNotThrow { ExtSridV1(ETRS89_SRID) }
         assertDoesNotThrow { ExtSridV1(FIN_GK25_SRID) }
+    }
+
+    @Test
+    fun `all GK-FIN coordinate systems are accepted`() {
+        ExtSridV1.SUPPORTED.filter { it.code in 3873..3885 }.forEach { srid ->
+            assertDoesNotThrow { ExtSridV1(srid) }
+        }
+    }
+
+    @Test
+    fun `all legacy ETRS-GK-FIN coordinate systems are accepted`() {
+        (3126..3138).forEach { code ->
+            assertDoesNotThrow { ExtSridV1(Srid(code)) }
+        }
     }
 
     @Test
     fun `all KKJ coordinate systems are rejected`() {
         kkjSrids.forEach { kkjSrid -> assertThrows<UnsupportedSridException> { ExtSridV1(kkjSrid) } }
+    }
+
+    @Test
+    fun `valid SRID not in allowlist is rejected`() {
+        // EPSG:3006 is Swedish SWEREF99 TM — valid range, transformable, but not a supported API coordinate system
+        assertThrows<UnsupportedSridException> { ExtSridV1(Srid(3006)) }
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
@@ -474,6 +474,7 @@ constructor(
 
     @Test
     fun `Ext api asset endpoints should return HTTP 400 if the coordinate system is unsupported`() {
+        val dummyOid = someOid<Nothing>().toString()
         val unsupportedCoordinateSystems =
             kkjSrids.map { it.toString() } +
                 listOf(
@@ -484,11 +485,11 @@ constructor(
                 )
 
         unsupportedCoordinateSystems.forEach { srid ->
-            errorTests.forEach { (create, apiCall) ->
-                apiCall(create().toString(), arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
+            errorTests.forEach { (_, apiCall) ->
+                apiCall(dummyOid, arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
             }
-            modificationErrorTests.forEach { (create, apiCall) ->
-                apiCall(create().toString(), arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
+            modificationErrorTests.forEach { (_, apiCall) ->
+                apiCall(dummyOid, arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
             }
             collectionErrorTests.forEach { apiCall ->
                 apiCall(arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
@@ -500,7 +501,6 @@ constructor(
     }
 
     private fun setupValidTrackNumber(): Oid<LayoutTrackNumber> {
-        initUser()
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
         val (trackNumberId, oid) =
             mainDraftContext.saveWithOid(
@@ -514,7 +514,6 @@ constructor(
     }
 
     private fun setupValidTrackNumberCollection(): Publication {
-        initUser()
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
         val trackNumberIds =
@@ -528,7 +527,6 @@ constructor(
     }
 
     private fun setupValidLocationTrack(): Oid<LocationTrack> {
-        initUser()
         val plan =
             testDBService.savePlan(
                 plan(
@@ -562,7 +560,6 @@ constructor(
     }
 
     private fun setupValidLocationTrackCollection(): Publication {
-        initUser()
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
         val (trackNumberId, _) =
@@ -585,7 +582,6 @@ constructor(
     }
 
     private fun setupValidSwitch(): Oid<LayoutSwitch> {
-        initUser()
         val structure = switchStructureYV60_300_1_9()
         val joint1 = switchJoint(1, Point(0.0, 0.0))
         val joint2 = switchJoint(2, Point(100.0, 0.0))
@@ -597,7 +593,6 @@ constructor(
     }
 
     private fun setupValidSwitchCollection(): Publication {
-        initUser()
         val structure = switchStructureYV60_300_1_9()
 
         val ids =
@@ -611,7 +606,6 @@ constructor(
     }
 
     private fun setupValidOperationalPoint(): Oid<OperationalPoint> {
-        initUser()
         val opId =
             mainDraftContext
                 .save(operationalPoint(name = "Test Point", abbreviation = "TP", location = Point(0.5, 0.5)))
@@ -624,7 +618,6 @@ constructor(
     }
 
     private fun setupValidOperationalPointCollection(): Publication {
-        initUser()
         val ops =
             listOf(1, 2, 3).map { idx ->
                 mainDraftContext

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
@@ -474,21 +474,21 @@ constructor(
 
     @Test
     fun `Ext api asset endpoints should return HTTP 400 if the coordinate system is unsupported`() {
-        val dummyOid = someOid<Nothing>().toString()
         val unsupportedCoordinateSystems =
             kkjSrids.map { it.toString() } +
                 listOf(
                     "EPSG:1023", // Out of allowed SRID range
                     "EPSG:32768", // Out of allowed SRID range
                     "BOGUS", // Malformed
+                    "EPSG:2390", // Valid SRID with no transform path from TM35FIN
                 )
 
         unsupportedCoordinateSystems.forEach { srid ->
-            errorTests.forEach { (_, apiCall) ->
-                apiCall(dummyOid, arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
+            errorTests.forEach { (create, apiCall) ->
+                apiCall(create().toString(), arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
             }
-            modificationErrorTests.forEach { (_, apiCall) ->
-                apiCall(dummyOid, arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
+            modificationErrorTests.forEach { (create, apiCall) ->
+                apiCall(create().toString(), arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
             }
             collectionErrorTests.forEach { apiCall ->
                 apiCall(arrayOf(COORDINATE_SYSTEM to srid), HttpStatus.BAD_REQUEST)
@@ -500,6 +500,7 @@ constructor(
     }
 
     private fun setupValidTrackNumber(): Oid<LayoutTrackNumber> {
+        initUser()
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
         val (trackNumberId, oid) =
             mainDraftContext.saveWithOid(
@@ -513,6 +514,7 @@ constructor(
     }
 
     private fun setupValidTrackNumberCollection(): Publication {
+        initUser()
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
         val trackNumberIds =
@@ -526,6 +528,7 @@ constructor(
     }
 
     private fun setupValidLocationTrack(): Oid<LocationTrack> {
+        initUser()
         val plan =
             testDBService.savePlan(
                 plan(
@@ -559,6 +562,7 @@ constructor(
     }
 
     private fun setupValidLocationTrackCollection(): Publication {
+        initUser()
         val segment = segment(Point(0.0, 0.0), Point(100.0, 0.0))
 
         val (trackNumberId, _) =
@@ -581,6 +585,7 @@ constructor(
     }
 
     private fun setupValidSwitch(): Oid<LayoutSwitch> {
+        initUser()
         val structure = switchStructureYV60_300_1_9()
         val joint1 = switchJoint(1, Point(0.0, 0.0))
         val joint2 = switchJoint(2, Point(100.0, 0.0))
@@ -592,6 +597,7 @@ constructor(
     }
 
     private fun setupValidSwitchCollection(): Publication {
+        initUser()
         val structure = switchStructureYV60_300_1_9()
 
         val ids =
@@ -605,6 +611,7 @@ constructor(
     }
 
     private fun setupValidOperationalPoint(): Oid<OperationalPoint> {
+        initUser()
         val opId =
             mainDraftContext
                 .save(operationalPoint(name = "Test Point", abbreviation = "TP", location = Point(0.5, 0.5)))
@@ -617,6 +624,7 @@ constructor(
     }
 
     private fun setupValidOperationalPointCollection(): Publication {
+        initUser()
         val ops =
             listOf(1, 2, 3).map { idx ->
                 mainDraftContext

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geography/CoordinateTransformationServiceIT.kt
@@ -2,15 +2,17 @@ package fi.fta.geoviite.infra.geography
 
 import fi.fta.geoviite.infra.DBTestBase
 import fi.fta.geoviite.infra.common.Srid
+import fi.fta.geoviite.infra.error.UnsupportedSridException
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -145,5 +147,11 @@ constructor(private val transformationService: CoordinateTransformationService) 
         // Expected values are from paikkatietoikkuna
         Assertions.assertEquals(5426728.7305, transformedPoint.x, 0.001)
         Assertions.assertEquals(6978302.5687, transformedPoint.y, 0.001)
+    }
+
+    @Test
+    fun `Getting transformation to untransformable SRID throws UnsupportedSridException`() {
+        // SRID 2390 is a valid SRID but has no transform path from TM35FIN
+        assertThrows<UnsupportedSridException> { transformationService.getTransformation(LAYOUT_SRID, Srid(2390)) }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TransformationTest.kt
@@ -1,7 +1,9 @@
 package fi.fta.geoviite.infra.geometry
 
 import fi.fta.geoviite.infra.common.RotationDirection.CCW
+import fi.fta.geoviite.infra.common.Srid
 import fi.fta.geoviite.infra.common.VerticalCoordinateSystem
+import fi.fta.geoviite.infra.error.UnsupportedSridException
 import fi.fta.geoviite.infra.geography.HeightTriangle
 import fi.fta.geoviite.infra.geography.KKJ2_SRID
 import fi.fta.geoviite.infra.geography.geotoolsTransformation
@@ -12,10 +14,10 @@ import fi.fta.geoviite.infra.ratko.model.RATKO_SRID
 import fi.fta.geoviite.infra.tracklayout.LAYOUT_SRID
 import fi.fta.geoviite.infra.tracklayout.lengthPoints
 import fi.fta.geoviite.infra.tracklayout.toPointList
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
 
 class TransformationTest {
 
@@ -77,6 +79,12 @@ class TransformationTest {
     @Test
     fun `Creating LAYOUT_SRID to RATKO_SRID transformation works without triangulation network`() {
         assertDoesNotThrow { geotoolsTransformation(LAYOUT_SRID, RATKO_SRID) }
+    }
+
+    @Test
+    fun `Creating transformation to untransformable SRID throws UnsupportedSridException`() {
+        // SRID 2390 is a valid SRID, but has no mathematical transform path from TM35FIN (EPSG:3067)
+        assertThrows<UnsupportedSridException> { geotoolsTransformation(LAYOUT_SRID, Srid(2390)) }
     }
 }
 


### PR DESCRIPTION
Alkuperäinen bugi oli että tietyillä valideilla mutta meidän käyttöön sopimattomilla koordinaattijärjestelmillä saatiin rumat 500-virheet kun käyttäjälle kannattaisi raportoida vain 400 bad request tiedolla että kyseessä oli hapan koordinaattijärjestelmän valinta. 

Korjattu nyt 2 eri tason ongelmina:

1. Jos mathtransformin luonti epäonnistuu, annetaan tästä järkevämpi virhe. Tämä koskee koko geoviitettä, sillä saman tilanteen saisi aikaan esim. luomalla sopivanlaisen inframallin (laittamalla sinne joku SRID toiselta puolen planeettaa)
2. Ext-API:in listattu sallitut koordinaattijärjestelmät, validoidaan ne jo argumentin sisään tullessa ja dokumentoidaan ne swaggerissa. Tämä voi olla vielä rajatumpi joukko, koska ei ext-apista muutenkaan käytetä mitä vain.