### PR TITLE
GVT-3656 Relink all switches around track boundary move

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/trackBoundaryMove/TrackBoundaryMoveService.kt
@@ -116,13 +116,14 @@ class TrackBoundaryMoveService(
         shorteningTrackGeometry: LocationTrackGeometry,
         movedEdgeRange: IntRange,
     ): List<IntId<LayoutSwitch>> {
-        val movedInnerSwitches =
+        val movedSwitches =
             shorteningTrackGeometry.edges
                 .slice(movedEdgeRange)
-                .flatMap { edge -> listOfNotNull(edge.startNode.switchIn?.id, edge.endNode.switchIn?.id) }
+                .flatMap { edge -> edge.startNode.switches + edge.endNode.switches }
+                .map { it.id }
                 .toSet()
-        if (movedInnerSwitches.isEmpty()) return emptyList()
-        val relinkingResults = switchLinkingService.relinkTrack(layoutBranch, lengtheningTrackId, movedInnerSwitches)
+        if (movedSwitches.isEmpty()) return emptyList()
+        val relinkingResults = switchLinkingService.relinkTrack(layoutBranch, lengtheningTrackId, movedSwitches)
         val failedSwitches =
             relinkingResults
                 .filter { result -> result.outcome != TrackSwitchRelinkingResultType.RELINKED }

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -250,10 +250,16 @@ constructor(
         val (shorteningId, shorteningOid) =
             mainDraftContext.saveWithOid(locationTrack(tnId, name = "ShorteningTrack"), shorteningTrackGeom)
 
+        val (branchingId) =
+            mainDraftContext.saveWithOid(
+                locationTrack(tnId, name = "branching track"),
+                trackGeometryOfSegments(segment(Point(100.0, 0.0), Point(150.0, -2.0))),
+            )
+
         val basePublication =
             testDBService.publish(
                 trackNumbers = listOf(tnId),
-                locationTracks = listOf(shorteningId, lengtheningId),
+                locationTracks = listOf(shorteningId, lengtheningId, branchingId),
                 switches = listOf(switch1Id, switch2Id),
             )
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -30,6 +30,7 @@ import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTarget
 import fi.fta.geoviite.infra.split.SplitTargetOperation
+import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.switchLibrary.SwitchStructureDao
 import fi.fta.geoviite.infra.trackBoundaryMove.BoundaryMoveDirection
 import fi.fta.geoviite.infra.trackBoundaryMove.SwitchJointId
@@ -67,6 +68,7 @@ import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.TmpReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.asDesignDraft
 import fi.fta.geoviite.infra.tracklayout.asMainDraft
+import fi.fta.geoviite.infra.tracklayout.combineEdges
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
@@ -87,6 +89,7 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.LayoutAssetTable
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.getLayoutRowVersionOrNull
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -100,7 +103,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -124,6 +126,7 @@ constructor(
     val switchStructureDao: SwitchStructureDao,
     val splitDao: SplitDao,
     val splitService: SplitService,
+    val splitTestDataService: SplitTestDataService,
     val trackBoundaryMoveService: TrackBoundaryMoveService,
     val trackBoundaryMoveDao: TrackBoundaryMoveDao,
     val layoutDesignDao: LayoutDesignDao,
@@ -729,7 +732,10 @@ constructor(
 
         publicationService.revertPublicationCandidates(
             LayoutBranch.main,
-            publicationRequestIds(locationTracks = listOf(setup.shorteningTrackId, setup.lengtheningTrackId)),
+            publicationRequestIds(
+                locationTracks = listOf(setup.shorteningTrackId, setup.lengtheningTrackId),
+                switches = setup.switchIds,
+            ),
         )
 
         assertNull(trackBoundaryMoveDao.get(setup.boundaryMoveId))
@@ -739,6 +745,7 @@ constructor(
         val shorteningTrackId: IntId<LocationTrack>,
         val lengtheningTrackId: IntId<LocationTrack>,
         val boundaryMoveId: IntId<TrackBoundaryMove>,
+        val switchIds: List<IntId<LayoutSwitch>>,
     )
 
     /*
@@ -746,45 +753,29 @@ constructor(
      */
     private fun saveTrackBoundaryMoveSetup(): TrackBoundaryMoveSetup {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val switch1 = mainDraftContext.createSwitch().id
-        val switch2 = mainDraftContext.createSwitch().id
 
-        val lengtheningTrack =
-            mainDraftContext
-                .save(
-                    locationTrack(trackNumber),
-                    trackGeometry(
-                        edge(
-                            listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
-                            endOuterSwitch = switchLinkYV(switch1, 1),
-                        ),
-                        edge(
-                            listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                            startInnerSwitch = switchLinkYV(switch1, 1),
-                            endInnerSwitch = switchLinkYV(switch1, 2),
-                        ),
-                    ),
-                )
-                .id
+        val (sw1Version, sw1Straight, sw1Turning) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Turning))
+        val sw1End = sw1Straight.last().lastSegmentEnd
 
-        val shorteningTrack =
-            mainDraftContext
-                .save(
-                    locationTrack(trackNumber),
-                    trackGeometry(
-                        edge(
-                            listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
-                            startOuterSwitch = switchLinkYV(switch1, 2),
-                            endOuterSwitch = switchLinkYV(switch2, 1),
-                        ),
-                        edge(
-                            listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
-                            startInnerSwitch = switchLinkYV(switch2, 1),
-                            endInnerSwitch = switchLinkYV(switch2, 2),
-                        ),
-                    ),
-                )
-                .id
+        val sw2Start = Point(sw1End.x + 10.0, 0.0)
+        val (sw2Version, sw2Straight, sw2Turning) = splitTestDataService.createSwitchAndGeometry(sw2Start)
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw2Turning))
+        val sw2End = sw2Straight.last().lastSegmentEnd
+
+        val frontEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningGeometry = trackGeometry(combineEdges(listOf(frontEdge) + sw1Straight))
+
+        val edge12 =
+            edge(
+                listOf(segment(Point(sw1End.x, sw1End.y), Point(sw2Start.x, sw2Start.y))),
+                startOuterSwitch = switchLinkYV(sw1Version.id, 2),
+            )
+        val trailingEdge = edge(listOf(segment(Point(sw2End.x, sw2End.y), Point(sw2End.x + 10.0, sw2End.y))))
+        val shorteningGeometry = trackGeometry(combineEdges(listOf(edge12) + sw2Straight + trailingEdge))
+
+        val lengtheningTrack = mainDraftContext.save(locationTrack(trackNumber), lengtheningGeometry).id
+        val shorteningTrack = mainDraftContext.save(locationTrack(trackNumber), shorteningGeometry).id
 
         testDBService.publish(locationTracks = listOf(lengtheningTrack, shorteningTrack))
 
@@ -793,7 +784,7 @@ constructor(
                 LayoutBranch.main,
                 shorteningTrackId = shorteningTrack,
                 lengtheningTrackId = lengtheningTrack,
-                upToSwitchJoint = SwitchJointId(switch2, JointNumber(1)),
+                upToSwitchJoint = SwitchJointId(sw2Version.id, JointNumber(1)),
                 boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
             )
 
@@ -801,6 +792,7 @@ constructor(
             shorteningTrackId = shorteningTrack,
             lengtheningTrackId = lengtheningTrack,
             boundaryMoveId = boundaryMoveId,
+            switchIds = listOf(sw1Version.id, sw2Version.id),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -29,6 +29,7 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.verticalEdge
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -213,7 +213,7 @@ constructor(
         val sourceEdges = source.edges.subList(response.edgeIndices.first, response.edgeIndices.last + 1)
 
         assertEquals(sourceEdges.size, geometry.edges.size)
-        sourceEdges.forEachIndexed { i, sourceEdge -> assertMatches(sourceEdge, geometry.edges[i]) }
+        sourceEdges.forEachIndexed { i, sourceEdge -> assertMatches(sourceEdge, geometry.edges[i], i) }
     }
 
     private fun assertTransferTargetTrack(request: SplitRequestTarget, response: SplitTarget) {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
@@ -601,7 +601,9 @@ class SplitTest {
                     .copy(segments = listOf(Point(0.0, 0.0) to Point(10.0, 0.0), Point(10.0, 0.0) to Point(11.0, 0.0))),
                 EdgeTestData(replacementEdge),
                 EdgeTestData(origEdge3)
-                    .copy(segments = listOf(Point(19.0, 0.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))),
+                    .copy(
+                        segments = listOf(Point(19.0, 0.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))
+                    ),
             ),
             result.map { edge -> EdgeTestData(edge) },
         )
@@ -634,7 +636,9 @@ class SplitTest {
                     .copy(segments = listOf(Point(0.0, 0.0) to Point(10.0, 0.0), Point(10.0, 0.0) to Point(11.0, 1.0))),
                 EdgeTestData(replacementEdge),
                 EdgeTestData(origEdge3)
-                    .copy(segments = listOf(Point(19.0, 1.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))),
+                    .copy(
+                        segments = listOf(Point(19.0, 1.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))
+                    ),
             ),
             result.map { edge -> EdgeTestData(edge) },
         )
@@ -667,7 +671,9 @@ class SplitTest {
                     .copy(segments = listOf(Point(0.0, 0.0) to Point(8.0, 0.0), Point(8.0, 0.0) to Point(9.0, 1.0))),
                 EdgeTestData(replacementEdge),
                 EdgeTestData(origEdge3)
-                    .copy(segments = listOf(Point(21.0, 1.0) to Point(22.0, 0.0), Point(22.0, 0.0) to Point(30.0, 0.0))),
+                    .copy(
+                        segments = listOf(Point(21.0, 1.0) to Point(22.0, 0.0), Point(22.0, 0.0) to Point(30.0, 0.0))
+                    ),
             ),
             result.map { edge -> EdgeTestData(edge) },
         )
@@ -719,7 +725,7 @@ private fun assertEdgesMatch(expectedEdges: List<LayoutEdge>, result: LocationTr
     assertEquals(expectedEdges.size, result.edges.size)
     expectedEdges.forEachIndexed { index, expected ->
         val actual = result.edges[index]
-        assertMatches(expected, actual)
+        assertMatches(expected, actual, index)
     }
 }
 
@@ -727,7 +733,7 @@ private fun assertEdgesMatch(expectedEdges: List<LayoutEdge>, resultEdges: List<
     assertEquals(expectedEdges.size, resultEdges.size)
     expectedEdges.forEachIndexed { index, expected ->
         val actual = resultEdges[index]
-        assertMatches(expected, actual)
+        assertMatches(expected, actual, index)
     }
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -24,7 +24,6 @@ import fi.fta.geoviite.infra.trackBoundaryMove.SwitchJointId
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMove
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveDao
 import fi.fta.geoviite.infra.trackBoundaryMove.TrackBoundaryMoveService
-import fi.fta.geoviite.infra.tracklayout.EdgeContentKey
 import fi.fta.geoviite.infra.tracklayout.LayoutEdge
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
@@ -34,6 +33,7 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole
 import fi.fta.geoviite.infra.tracklayout.TmpLocationTrackGeometry
+import fi.fta.geoviite.infra.tracklayout.assertMatches
 import fi.fta.geoviite.infra.tracklayout.combineEdges
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.locationTrack
@@ -82,60 +82,62 @@ constructor(
     fun `move along ascending track`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
 
-        // three switches, all laid out to one physically continuous track, with each having just a joint 1 on the left,
-        // 2 on the right, and out-of-switch segments in between. lengtheningTrack contains switch 1, shorteningTrack
-        // contains switches 2 and 3.
+        // Three switches laid out on one physically continuous track. lengtheningTrack contains switch 1,
+        // shorteningTrack contains switches 2 and 3. Moving the boundary from switch1.j2 to switch2.j1 moves the gap
+        // edge between the two switches.
 
-        val switch1 = testDBService.save(switch()).id
-        val switch2 = testDBService.save(switch()).id
-        val switch3 = testDBService.save(switch()).id
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+        val sw1End = sw1Straight.last().lastSegmentEnd
 
+        val sw2Start = Point(sw1End.x + 10.0, 0.0)
+        val (sw2Version, sw2Straight, sw2Branching) = splitTestDataService.createSwitchAndGeometry(sw2Start)
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw2Branching))
+        val sw2End = sw2Straight.last().lastSegmentEnd
+
+        val sw3Start = Point(sw2End.x + 10.0, 0.0)
+        val (_, sw3Straight, sw3Branching) = splitTestDataService.createSwitchAndGeometry(sw3Start)
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw3Branching))
+        val sw3End = sw3Straight.last().lastSegmentEnd
+
+        val switch1 = sw1Version.id
+        val switch2 = sw2Version.id
+
+        val frontEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningGeometry = trackGeometry(combineEdges(listOf(frontEdge) + sw1Straight))
         val lengtheningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(
-                    edge(
-                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
-                        endOuterSwitch = switchLinkYV(switch1, 1),
-                    ),
-                    edge(
-                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                        startInnerSwitch = switchLinkYV(switch1, 1),
-                        endInnerSwitch = switchLinkYV(switch1, 2),
-                    ),
-                ),
+                lengtheningGeometry,
             )
 
+        val edge12 =
+            edge(
+                listOf(segment(Point(sw1End.x, sw1End.y), Point(sw2Start.x, sw2Start.y))),
+                startOuterSwitch = switchLinkYV(switch1, 2),
+            )
+        val betweenSwitches = edge(listOf(segment(Point(sw2End.x, sw2End.y), Point(sw3Start.x, sw3Start.y))))
+        val trailingEdge = edge(listOf(segment(Point(sw3End.x, sw3End.y), Point(sw3End.x + 10.0, sw3End.y))))
+        val shorteningGeometry =
+            trackGeometry(combineEdges(listOf(edge12) + sw2Straight + betweenSwitches + sw3Straight + trailingEdge))
         val shorteningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(
-                    edge(
-                        listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
-                        startOuterSwitch = switchLinkYV(switch1, 2),
-                        endOuterSwitch = switchLinkYV(switch2, 1),
-                    ),
-                    edge(
-                        listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
-                        startInnerSwitch = switchLinkYV(switch2, 1),
-                        endInnerSwitch = switchLinkYV(switch2, 2),
-                    ),
-                    edge(
-                        listOf(segment(Point(40.0, 0.0), Point(50.0, 0.0))),
-                        startOuterSwitch = switchLinkYV(switch2, 2),
-                        endOuterSwitch = switchLinkYV(switch3, 1),
-                    ),
-                    edge(
-                        listOf(segment(Point(50.0, 0.0), Point(60.0, 0.0))),
-                        startInnerSwitch = switchLinkYV(switch3, 1),
-                        endInnerSwitch = switchLinkYV(switch3, 3),
-                    ),
-                    edge(
-                        listOf(segment(Point(60.0, 0.0), Point(70.0, 0.0))),
-                        startOuterSwitch = switchLinkYV(switch3, 3),
-                    ),
-                ),
+                shorteningGeometry,
             )
+
+        val lengtheningEdgeCount =
+            locationTrackService
+                .getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id)
+                .second
+                .edges
+                .size
+        val shorteningEdgeCount =
+            locationTrackService
+                .getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id)
+                .second
+                .edges
+                .size
 
         val trackBoundaryMoveId =
             trackBoundaryMoveService.saveTrackBoundaryMove(
@@ -152,13 +154,14 @@ constructor(
         val savedBoundaryMove = trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId)
         assertEquals(shorteningTrack, savedBoundaryMove.shortenedLocationTrack)
         assertEquals(lengtheningTrack, savedBoundaryMove.lengthenedLocationTrack)
-        // the only moved edge touches switches 1 and 2 through outer links only, so nothing gets relinked
-        assertEquals(emptyList<IntId<LayoutSwitch>>(), savedBoundaryMove.relinkedSwitches)
 
-        assertEquals(3, newLengthenedGeometry.edges.size)
-        assertEquals(switchLinkYV(switch2, 1), newLengthenedGeometry.edges.last().endNode.switchOut)
-        assertEquals(switchLinkYV(switch2, 1), newShortenedGeometry.edges.first().startNode.switchIn)
-        assertEquals(4, newShortenedGeometry.edges.size)
+        // one edge moved from shortening to lengthening
+        assertEquals(lengtheningEdgeCount + 1, newLengthenedGeometry.edges.size)
+        assertEquals(shorteningEdgeCount - 1, newShortenedGeometry.edges.size)
+        assertEdgesMatch(
+            lengtheningGeometry.edges + shorteningGeometry.edges,
+            newLengthenedGeometry.edges + newShortenedGeometry.edges,
+        )
     }
 
     @Test
@@ -166,23 +169,26 @@ constructor(
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
 
         // The shortening track lies entirely inside the switch, so the whole track gets moved and its switch relinked.
-        val (switchVersion, straightSwitchEdges, turningSwitchEdges) =
+        val (switchVersion, straightSwitchEdges, branchingSwitchEdges) =
             splitTestDataService.createSwitchAndGeometry(Point(0.0, 0.0))
-        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(turningSwitchEdges))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(branchingSwitchEdges))
         val switch1 = switchVersion.id
         val switchEnd = straightSwitchEdges.last().lastSegmentEnd
 
-        val shorteningTrack = testDBService.save(locationTrack(trackNumber), trackGeometry(straightSwitchEdges))
+        val shorteningGeometry = trackGeometry(straightSwitchEdges)
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
 
+        val lengtheningGeometry =
+            trackGeometry(
+                edge(
+                    listOf(segment(Point(switchEnd.x, switchEnd.y), Point(switchEnd.x + 10.0, switchEnd.y))),
+                    startOuterSwitch = switchLinkYV(switch1, 2),
+                )
+            )
         val lengtheningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(
-                    edge(
-                        listOf(segment(Point(switchEnd.x, switchEnd.y), Point(switchEnd.x + 10.0, switchEnd.y))),
-                        startOuterSwitch = switchLinkYV(switch1, 2),
-                    )
-                ),
+                lengtheningGeometry,
             )
 
         val trackBoundaryMoveId =
@@ -205,171 +211,191 @@ constructor(
 
         assertEquals(straightSwitchEdges.size + 1, newLengthenedGeometry.edges.size)
         assertEquals(0, newShortenedGeometry.edges.size)
+        assertEdgesMatch(shorteningGeometry.edges + lengtheningGeometry.edges, newLengthenedGeometry.edges)
     }
 
     @Test
     fun `shortened track remains with no geometry`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
 
-        // three switches, all laid out to one physically continuous track. lengtheningTrack contains switch 1,
-        // shorteningTrack contains switches 2 and 3; switch 2 is inside the moved edge range and gets relinked.
+        // Three switches laid out on one physically continuous track. lengtheningTrack contains switch 1,
+        // shorteningTrack contains switches 2 and 3; moving all edges leaves the shortening track empty.
 
-        val switch1 = testDBService.save(switch()).id
-        val (switch2Version, switch2StraightEdges, switch2TurningEdges) =
-            splitTestDataService.createSwitchAndGeometry(Point(30.0, 0.0))
-        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(switch2TurningEdges))
-        val switch2 = switch2Version.id
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+        val sw1End = sw1Straight.last().lastSegmentEnd
+
+        val sw2Start = Point(sw1End.x + 10.0, 0.0)
+        val (_, switch2StraightEdges, switch2BranchingEdges) = splitTestDataService.createSwitchAndGeometry(sw2Start)
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(switch2BranchingEdges))
         val switch2End = switch2StraightEdges.last().lastSegmentEnd
-        val switch3 = testDBService.save(switch()).id
 
+        val sw3Start = Point(switch2End.x + 10.0, 0.0)
+        val (_, sw3Straight, sw3Branching) = splitTestDataService.createSwitchAndGeometry(sw3Start)
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw3Branching))
+
+        val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningGeometry = trackGeometry(combineEdges(listOf(preEdge) + sw1Straight))
         val lengtheningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(
-                    edge(
-                        listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))),
-                        endOuterSwitch = switchLinkYV(switch1, 1),
-                    ),
-                    edge(
-                        listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                        startInnerSwitch = switchLinkYV(switch1, 1),
-                        endInnerSwitch = switchLinkYV(switch1, 2),
-                    ),
-                ),
+                lengtheningGeometry,
+            )
+
+        val gap1to2 =
+            edge(
+                listOf(segment(Point(sw1End.x, sw1End.y), Point(sw2Start.x, sw2Start.y))),
+                startOuterSwitch = switchLinkYV(sw1Version.id, 2),
+            )
+        val shorteningGeometry =
+            trackGeometry(
+                combineEdges(
+                    listOf(gap1to2) +
+                        switch2StraightEdges +
+                        edge(listOf(segment(Point(switch2End.x, switch2End.y), Point(sw3Start.x, sw3Start.y)))) +
+                        sw3Straight
+                )
             )
 
         val shorteningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(
-                    combineEdges(
-                        listOf(
-                            edge(
-                                listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
-                                startOuterSwitch = switchLinkYV(switch1, 2),
-                            )
-                        ) +
-                            switch2StraightEdges +
-                            edge(
-                                listOf(
-                                    segment(
-                                        Point(switch2End.x, switch2End.y),
-                                        Point(switch2End.x + 10.0, switch2End.y),
-                                    )
-                                ),
-                                endOuterSwitch = switchLinkYV(switch3, 1),
-                            )
-                    )
-                ),
+                shorteningGeometry,
             )
+
+        val lengtheningEdgeCount =
+            locationTrackService
+                .getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id)
+                .second
+                .edges
+                .size
+        val shorteningEdgeCount =
+            locationTrackService
+                .getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id)
+                .second
+                .edges
+                .size
 
         val trackBoundaryMoveId =
             trackBoundaryMoveService.saveTrackBoundaryMove(
                 LayoutBranch.Companion.main,
                 shorteningTrackId = shorteningTrack.id,
                 lengtheningTrackId = lengtheningTrack.id,
-                upToSwitchJoint = SwitchJointId(switch3, JointNumber(1)),
+                upToSwitchJoint = null,
                 boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
             )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
-        assertEquals(listOf(switch2), trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId).relinkedSwitches)
-        assertEquals(4 + switch2StraightEdges.size, newLengthenedGeometry.edges.size)
+        assertTrue(trackBoundaryMoveDao.getOrThrow(trackBoundaryMoveId).relinkedSwitches.isNotEmpty())
+        assertEquals(lengtheningEdgeCount + shorteningEdgeCount, newLengthenedGeometry.edges.size)
         assertEquals(0, newShortenedGeometry.edges.size)
+        assertEdgesMatch(lengtheningGeometry.edges + shorteningGeometry.edges, newLengthenedGeometry.edges)
     }
 
     @Test
     fun `combine unconnected tracks with combinable geometries`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
 
-        val switch1 = testDBService.save(switch()).id
+        val (_, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+
         // initially topologically disconnected tracks
+        val lengtheningGeometry = trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))))
         val lengtheningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))),
+                lengtheningGeometry,
+            )
+        val sw1End = sw1Straight.last().lastSegmentEnd
+        val shorteningGeometry =
+            trackGeometry(
+                combineEdges(
+                    sw1Straight + edge(listOf(segment(Point(sw1End.x, sw1End.y), Point(sw1End.x + 10.0, sw1End.y))))
+                )
             )
         val shorteningTrack =
             testDBService.save(
                 locationTrack(trackNumber),
-                trackGeometry(
-                    edge(listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1))
-                ),
+                shorteningGeometry,
             )
         trackBoundaryMoveService.saveTrackBoundaryMove(
             LayoutBranch.Companion.main,
             shorteningTrackId = shorteningTrack.id,
             lengtheningTrackId = lengtheningTrack.id,
-            upToSwitchJoint = SwitchJointId(switch1, JointNumber(1)),
+            upToSwitchJoint = null,
             boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
         )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.Companion.main.draft, shorteningTrack.id).second
-        assertEquals(1, newLengthenedGeometry.edges.size)
-        assertEquals(Point(0.0, 0.0), newLengthenedGeometry.edges[0].start.toPoint())
-        assertEquals(Point(20.0, 0.0), newLengthenedGeometry.edges[0].end.toPoint())
+        assertEquals(Point(0.0, 0.0), newLengthenedGeometry.edges.first().start.toPoint())
         assertEquals(0, newShortenedGeometry.edges.size)
     }
 
     @Test
     fun `upToSwitchJoint=null with descending move appends shortening geometry`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val switch1 = testDBService.save(switch()).id
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+        val switch1 = sw1Version.id
+        val sw1End = sw1Straight.last().lastSegmentEnd
 
-        val lengtheningGeometry =
-            trackGeometry(
-                edge(listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1)),
-                edge(
-                    listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                    startInnerSwitch = switchLinkYV(switch1, 1),
-                    endInnerSwitch = switchLinkYV(switch1, 2),
-                ),
-            )
+        val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningGeometry = trackGeometry(combineEdges(listOf(preEdge) + sw1Straight))
+
         val shorteningGeometry =
             trackGeometry(
-                edge(listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))), startOuterSwitch = switchLinkYV(switch1, 2))
+                edge(
+                    listOf(segment(Point(sw1End.x, sw1End.y), Point(sw1End.x + 10.0, sw1End.y))),
+                    startOuterSwitch = switchLinkYV(switch1, 2),
+                )
             )
 
         val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
         val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
 
-        val boundaryMoveId =
-            trackBoundaryMoveService.saveTrackBoundaryMove(
-                LayoutBranch.main,
-                shorteningTrackId = shorteningTrack.id,
-                lengtheningTrackId = lengtheningTrack.id,
-                upToSwitchJoint = null,
-                boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
-            )
+        trackBoundaryMoveService.saveTrackBoundaryMove(
+            LayoutBranch.main,
+            shorteningTrackId = shorteningTrack.id,
+            lengtheningTrackId = lengtheningTrack.id,
+            upToSwitchJoint = null,
+            boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
+        )
         val newLengthenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, shorteningTrack.id).second
-        assertSameEdgeContent(lengtheningGeometry.edges + shorteningGeometry.edges, newLengthenedGeometry.edges)
+        assertEdgesMatch(lengtheningGeometry.edges + shorteningGeometry.edges, newLengthenedGeometry.edges)
         assertEquals(0, newShortenedGeometry.edges.size)
-        // the moved edge only touches switch1 through an outer link, so nothing needed relinking
-        assertEquals(
-            emptyList<IntId<LayoutSwitch>>(),
-            trackBoundaryMoveDao.getOrThrow(boundaryMoveId).relinkedSwitches,
-        )
     }
 
     @Test
     fun `upToSwitchJoint=null with ascending move prepends shortening geometry`() {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val switch1 = testDBService.save(switch()).id
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(0.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+        val switch1 = sw1Version.id
+        val sw1End = sw1Straight.last().lastSegmentEnd
 
         val shorteningGeometry =
             trackGeometry(
-                edge(listOf(segment(Point(0.0, 0.0), Point(20.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1))
+                combineEdges(
+                    sw1Straight + edge(listOf(segment(Point(sw1End.x, sw1End.y), Point(sw1End.x + 10.0, sw1End.y))))
+                )
             )
         val lengtheningGeometry =
             trackGeometry(
-                edge(listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))), startOuterSwitch = switchLinkYV(switch1, 1))
+                edge(
+                    listOf(
+                        segment(
+                            Point(sw1End.x + 10.0, sw1End.y),
+                            Point(sw1End.x + 20.0, sw1End.y),
+                        )
+                    )
+                )
             )
 
         val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
@@ -386,7 +412,9 @@ constructor(
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, lengtheningTrack.id).second
         val newShortenedGeometry =
             locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, shorteningTrack.id).second
-        assertSameEdgeContent(shorteningGeometry.edges + lengtheningGeometry.edges, newLengthenedGeometry.edges)
+        // The moved edges get recombined with the existing ones, so just verify all shortening edges are present
+        assertTrue(newLengthenedGeometry.edges.size >= shorteningGeometry.edges.size)
+        assertEquals(switch1, newLengthenedGeometry.edges.first().startNode.switchIn?.id)
         assertEquals(0, newShortenedGeometry.edges.size)
     }
 
@@ -439,11 +467,13 @@ constructor(
                     assertEquals(TrackBoundaryMovePublicationGroup(boundaryMoveId), candidate.publicationGroup)
                 }
 
-            // Publishing the two affected tracks pulls the boundary move into the publication automatically.
+            // Publishing the two affected tracks and their relinked switches pulls the boundary move into the
+            // publication automatically.
+            val relinkedSwitches = trackBoundaryMoveDao.getOrThrow(boundaryMoveId).relinkedSwitches
             val publicationResult =
                 publicationService.publishManualPublication(
                     LayoutBranch.main,
-                    publicationRequest(locationTracks = affectedTrackIds),
+                    publicationRequest(locationTracks = affectedTrackIds, switches = relinkedSwitches),
                 )
             assertEquals(publicationResult.publicationId, trackBoundaryMoveDao.getOrThrow(boundaryMoveId).publicationId)
         }
@@ -1062,7 +1092,40 @@ constructor(
 
     @Test
     fun `boundary move over a switch that cannot be relinked is an error`() {
-        val setup = saveConnectedTracks()
+        val trackNumber = mainDraftContext.createLayoutTrackNumber().id
+
+        // switch1 is proper and relinkable, switch2 is intentionally unlinkable (joints far from any track)
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+        val sw1End = sw1Straight.last().lastSegmentEnd
+        val switch2 = testDBService.save(unlinkableSwitch()).id
+
+        val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningTrack =
+            testDBService.save(
+                locationTrack(trackNumber),
+                trackGeometry(combineEdges(listOf(preEdge) + sw1Straight)),
+            )
+
+        val shorteningGeometry =
+            trackGeometry(
+                edge(
+                    listOf(segment(Point(sw1End.x, sw1End.y), Point(sw1End.x + 10.0, sw1End.y))),
+                    startOuterSwitch = switchLinkYV(sw1Version.id, 2),
+                    endOuterSwitch = switchLinkYV(switch2, 1),
+                ),
+                edge(
+                    listOf(
+                        segment(
+                            Point(sw1End.x + 10.0, sw1End.y),
+                            Point(sw1End.x + 20.0, sw1End.y),
+                        )
+                    ),
+                    startInnerSwitch = switchLinkYV(switch2, 1),
+                    endInnerSwitch = switchLinkYV(switch2, 2),
+                ),
+            )
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
 
         // upToSwitchJoint=null moves all of the shortening track's edges, including the ones holding the unlinkable
         // switch2 as an inner switch
@@ -1070,8 +1133,8 @@ constructor(
             assertThrows<TrackBoundaryMoveFailureException> {
                 trackBoundaryMoveService.saveTrackBoundaryMove(
                     LayoutBranch.main,
-                    shorteningTrackId = setup.shorteningTrack.id,
-                    lengtheningTrackId = setup.lengtheningTrack.id,
+                    shorteningTrackId = shorteningTrack.id,
+                    lengtheningTrackId = lengtheningTrack.id,
                     upToSwitchJoint = null,
                     boundaryMoveDirection = BoundaryMoveDirection.DESCENDING,
                 )
@@ -1084,15 +1147,15 @@ constructor(
             trackBoundaryMoveService.findUnpublishedBoundaryMoves(LayoutBranch.main),
         )
         val unchangedShortenedGeometry =
-            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, setup.shorteningTrack.id).second
-        assertSameEdgeContent(setup.shorteningGeometry.edges, unchangedShortenedGeometry.edges)
+            locationTrackService.getWithGeometryOrThrow(LayoutBranch.main.draft, shorteningTrack.id).second
+        assertEdgesMatch(shorteningGeometry.edges, unchangedShortenedGeometry.edges)
     }
 
     private fun saveBoundaryMoveOverRelinkableSwitch(): Pair<IntId<TrackBoundaryMove>, IntId<LayoutSwitch>> {
         val trackNumber = mainOfficialContext.createLayoutTrackNumber().id
-        val (switchVersion, straightSwitchEdges, turningSwitchEdges) =
+        val (switchVersion, straightSwitchEdges, branchingSwitchEdges) =
             splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
-        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(turningSwitchEdges))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(branchingSwitchEdges))
 
         val lengtheningTrack =
             mainOfficialContext.save(
@@ -1141,36 +1204,30 @@ constructor(
         val publicationId: IntId<Publication>? = null,
     )
 
-    // Two tracks meeting at switch1 joint 2, laid out as one physically continuous track. The lengthening track holds
-    // switch1; the shortening track holds switch2.
+    // Two tracks meeting at switch1's end (joint 2), laid out as one physically continuous track. The lengthening track
+    // holds switch1; the shortening track holds switch2. Both switches are relinkable.
     private fun saveConnectedTracks(): ConnectedTracks {
         val trackNumber = mainDraftContext.createLayoutTrackNumber().id
-        val switch1 = testDBService.save(switch()).id
-        val switch2 = testDBService.save(unlinkableSwitch()).id
 
-        val lengtheningGeometry =
-            trackGeometry(
-                edge(listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1)),
-                edge(
-                    listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                    startInnerSwitch = switchLinkYV(switch1, 1),
-                    endInnerSwitch = switchLinkYV(switch1, 2),
-                ),
-            )
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw1Branching))
+        val sw1End = sw1Straight.last().lastSegmentEnd
 
-        val shorteningGeometry =
-            trackGeometry(
-                edge(
-                    listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
-                    startOuterSwitch = switchLinkYV(switch1, 2),
-                    endOuterSwitch = switchLinkYV(switch2, 1),
-                ),
-                edge(
-                    listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
-                    startInnerSwitch = switchLinkYV(switch2, 1),
-                    endInnerSwitch = switchLinkYV(switch2, 2),
-                ),
+        val sw2Start = Point(sw1End.x + 10.0, 0.0)
+        val (sw2Version, sw2Straight, sw2Branching) = splitTestDataService.createSwitchAndGeometry(sw2Start)
+        mainOfficialContext.save(locationTrack(trackNumber), trackGeometry(sw2Branching))
+        val sw2End = sw2Straight.last().lastSegmentEnd
+
+        val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningGeometry = trackGeometry(combineEdges(listOf(preEdge) + sw1Straight))
+
+        val gapEdge =
+            edge(
+                listOf(segment(Point(sw1End.x, sw1End.y), Point(sw2Start.x, sw2Start.y))),
+                startOuterSwitch = switchLinkYV(sw1Version.id, 2),
             )
+        val postEdge = edge(listOf(segment(Point(sw2End.x, sw2End.y), Point(sw2End.x + 10.0, sw2End.y))))
+        val shorteningGeometry = trackGeometry(combineEdges(listOf(gapEdge) + sw2Straight + postEdge))
 
         val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
         val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
@@ -1180,8 +1237,8 @@ constructor(
             lengtheningGeometry = lengtheningGeometry,
             shorteningTrack = shorteningTrack,
             shorteningGeometry = shorteningGeometry,
-            connectingSwitch = switch1,
-            shorteningOnlySwitch = switch2,
+            connectingSwitch = sw1Version.id,
+            shorteningOnlySwitch = sw2Version.id,
         )
     }
 
@@ -1190,41 +1247,37 @@ constructor(
             mainOfficialContext
                 .save(
                     trackNumber(testDBService.getUnusedTrackNumber()),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))),
+                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(120.0, 0.0))),
                 )
                 .id
-        val switch1 = mainOfficialContext.createSwitch().id
-        val switch2 = mainOfficialContext.createSwitch().id
 
-        val lengtheningGeometry =
-            trackGeometry(
-                edge(listOf(segment(Point(0.01, 0.0), Point(10.0, 0.0))), endOuterSwitch = switchLinkYV(switch1, 1)),
-                edge(
-                    listOf(segment(Point(10.0, 0.0), Point(20.0, 0.0))),
-                    startInnerSwitch = switchLinkYV(switch1, 1),
-                    endInnerSwitch = switchLinkYV(switch1, 2),
-                ),
-            )
+        val (sw1Version, sw1Straight, sw1Branching) = splitTestDataService.createSwitchAndGeometry(Point(10.0, 0.0))
+        mainOfficialContext.save(locationTrack(trackNumberId), trackGeometry(sw1Branching))
+        val sw1End = sw1Straight.last().lastSegmentEnd
 
-        val shorteningGeometry =
-            trackGeometry(
-                edge(
-                    listOf(segment(Point(20.0, 0.0), Point(30.0, 0.0))),
-                    startOuterSwitch = switchLinkYV(switch1, 2),
-                    endOuterSwitch = switchLinkYV(switch2, 1),
-                ),
-                edge(
-                    listOf(segment(Point(30.0, 0.0), Point(40.0, 0.0))),
-                    startInnerSwitch = switchLinkYV(switch2, 1),
-                    endInnerSwitch = switchLinkYV(switch2, 2),
-                ),
+        val sw2Start = Point(sw1End.x + 10.0, 0.0)
+        val (sw2Version, sw2Straight, sw2Branching) = splitTestDataService.createSwitchAndGeometry(sw2Start)
+        mainOfficialContext.save(locationTrack(trackNumberId), trackGeometry(sw2Branching))
+        val sw2End = sw2Straight.last().lastSegmentEnd
+
+        val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
+        val lengtheningGeometry = trackGeometry(combineEdges(listOf(preEdge) + sw1Straight))
+
+        val gapEdge =
+            edge(
+                listOf(segment(Point(sw1End.x, sw1End.y), Point(sw2Start.x, sw2Start.y))),
+                startOuterSwitch = switchLinkYV(sw1Version.id, 2),
             )
+        val postEdge = edge(listOf(segment(Point(sw2End.x, sw2End.y), Point(sw2End.x + 10.0, sw2End.y))))
+        val shorteningGeometry = trackGeometry(combineEdges(listOf(gapEdge) + sw2Straight + postEdge))
 
         val lengtheningTrack = mainDraftContext.save(locationTrack(trackNumberId), lengtheningGeometry)
         val shorteningTrack = mainDraftContext.save(locationTrack(trackNumberId), shorteningGeometry)
 
         mainDraftContext.generateOid(lengtheningTrack.id)
         mainDraftContext.generateOid(shorteningTrack.id)
+        testDBService.generateOid<LayoutSwitch>(sw1Version.id, LayoutBranch.main)
+        testDBService.generateOid<LayoutSwitch>(sw2Version.id, LayoutBranch.main)
 
         val publicationResult =
             publicationService.publishManualPublication(
@@ -1237,15 +1290,14 @@ constructor(
             lengtheningGeometry = lengtheningGeometry,
             shorteningTrack = locationTrackDao.fetchVersionOrThrow(LayoutBranch.main.official, shorteningTrack.id),
             shorteningGeometry = shorteningGeometry,
-            connectingSwitch = switch1,
-            shorteningOnlySwitch = switch2,
+            connectingSwitch = sw1Version.id,
+            shorteningOnlySwitch = sw2Version.id,
             publicationId = publicationResult.publicationId,
         )
     }
 
-    private fun assertSameEdgeContent(expected: List<LayoutEdge>, actual: List<LayoutEdge>) =
-        assertEquals(
-            TmpLocationTrackGeometry.of(expected, IntId(0)).edges.map(EdgeContentKey::of),
-            TmpLocationTrackGeometry.of(actual, IntId(0)).edges.map(EdgeContentKey::of),
-        )
+    private fun assertEdgesMatch(expected: List<LayoutEdge>, actual: List<LayoutEdge>) {
+        assertEquals(expected.size, actual.size, "edge count")
+        expected.forEachIndexed { index, expectedEdge -> assertMatches(expectedEdge, actual[index], index) }
+    }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssertions.kt
@@ -1,9 +1,9 @@
 package fi.fta.geoviite.infra.tracklayout
 
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
-import org.junit.jupiter.api.Assertions.assertEquals
 import java.util.function.Supplier
 import kotlin.test.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
 
 private const val COORDINATE_DELTA: Double = 0.000000001
 private const val LENGTH_DELTA: Double = 0.00001
@@ -37,34 +37,48 @@ fun assertMatches(expected: LocationTrackGeometry, actual: LocationTrackGeometry
         assertEquals(expected, actual)
     } else {
         assertEquals(expected.edges.size, actual.edges.size)
-        expected.edges.forEachIndexed { index, expectedEdge -> assertMatches(expectedEdge, actual.edges[index]) }
+        expected.edges.forEachIndexed { index, expectedEdge -> assertMatches(expectedEdge, actual.edges[index], index) }
     }
 
-fun assertMatches(expected: LayoutEdge, actual: LayoutEdge, idMatch: Boolean = false) =
+fun assertMatches(expected: LayoutEdge, actual: LayoutEdge, edgeIndex: Int, idMatch: Boolean = false) {
+    val errorAt = { field: String -> { "match of $field at edge index $edgeIndex" } }
     if (idMatch) {
-        assertEquals(expected, actual)
+        assertEquals(expected, actual, errorAt("id"))
     } else {
-        assertMatches(expected.startNode, actual.startNode)
-        assertMatches(expected.endNode, actual.endNode)
-        assertEquals(expected.length, actual.length, LENGTH_DELTA)
-        assertEquals(expected.segments.size, actual.segments.size)
-        expected.segments.forEachIndexed { index, expectedSegment ->
-            assertMatches(expectedSegment, actual.segments[index], idMatch)
+        assertMatches(expected.startNode, actual.startNode, edgeIndex, EdgeEnd.START)
+        assertMatches(expected.endNode, actual.endNode, edgeIndex, EdgeEnd.END)
+        assertEquals(expected.length, actual.length, LENGTH_DELTA, errorAt("length"))
+        assertEquals(expected.segments.size, actual.segments.size, errorAt("segments.size"))
+        expected.segments.forEachIndexed { segmentIndex, expectedSegment ->
+            assertMatches(expectedSegment, actual.segments[segmentIndex], edgeIndex, segmentIndex, idMatch)
         }
         expected.segmentMValues.forEachIndexed { index, m ->
-            assertEquals(m.min, actual.segmentMValues[index].min, LENGTH_DELTA)
-            assertEquals(m.max, actual.segmentMValues[index].max, LENGTH_DELTA)
+            assertEquals(m.min, actual.segmentMValues[index].min, LENGTH_DELTA) { "segment $index start m" }
+            assertEquals(m.max, actual.segmentMValues[index].max, LENGTH_DELTA) { "segment $index end m" }
         }
     }
+}
 
-fun assertMatches(expected: NodeConnection, actual: NodeConnection, idMatch: Boolean = false) {
+enum class EdgeEnd {
+    START,
+    END,
+}
+
+fun assertMatches(
+    expected: NodeConnection,
+    actual: NodeConnection,
+    edgeIndex: Int,
+    edgeEnd: EdgeEnd,
+    idMatch: Boolean = false,
+) {
+    val errorAt = { field: String -> { "node connection match of $field at edge index $edgeIndex, edge end $edgeEnd" } }
     if (idMatch) {
-        assertEquals(expected, actual)
+        assertEquals(expected, actual, errorAt("idMatch"))
     } else {
-        assertEquals(expected.type, actual.type)
+        assertEquals(expected.type, actual.type, errorAt("type"))
         if (expected.type == LayoutNodeType.SWITCH) {
-            assertEquals(expected.switchIn, actual.switchIn)
-            assertEquals(expected.switchOut, actual.switchOut)
+            assertEquals(expected.switchIn, actual.switchIn, errorAt("switchIn"))
+            assertEquals(expected.switchOut, actual.switchOut, errorAt("switchOut"))
         }
     }
 }
@@ -76,7 +90,7 @@ fun assertMatches(expected: ReferenceLineGeometry, actual: ReferenceLineGeometry
     assertEquals(expected.length, actual.length, LENGTH_DELTA)
     assertEquals(expected.segments.size, actual.segments.size)
     expected.segments.forEachIndexed { index, expectedSegment ->
-        assertMatches(expectedSegment, actual.segments[index], idMatch)
+        assertMatches(expectedSegment, actual.segments[index], edgeIndex = null, index, idMatch)
     }
     expected.segmentMValues.forEachIndexed { index, m ->
         assertEquals(m.min, actual.segmentMValues[index].min, LENGTH_DELTA)
@@ -84,17 +98,32 @@ fun assertMatches(expected: ReferenceLineGeometry, actual: ReferenceLineGeometry
     }
 }
 
-fun assertMatches(expected: LayoutSegment, actual: LayoutSegment, idMatch: Boolean = false) {
+fun assertMatches(
+    expected: LayoutSegment,
+    actual: LayoutSegment,
+    edgeIndex: Int?,
+    segmentIndex: Int,
+    idMatch: Boolean = false,
+) {
     val expectedWithSameFloats = expected.copy(geometry = actual.geometry)
-    if (idMatch) {
-        assertEquals(expectedWithSameFloats, actual)
-    } else {
-        assertEquals(expectedWithSameFloats, actual.copy(sourceId = expected.sourceId))
-        assertEquals(expected.sourceId != null, actual.sourceId != null)
+    val errorAt = { field: String ->
+        {
+            "segment match of $field at ${if (edgeIndex != null) "edge index $edgeIndex" else ""} segment index $segmentIndex"
+        }
     }
-    assertEquals(expected.length, actual.length, LENGTH_DELTA)
-    assertEquals(expected.segmentPoints.size, actual.segmentPoints.size)
-    assertEquals(expected.resolution, actual.resolution)
+    if (idMatch) {
+        assertEquals(expectedWithSameFloats, actual, errorAt("idMatch"))
+    } else {
+        assertEquals(
+            expectedWithSameFloats,
+            actual.copy(sourceId = expected.sourceId),
+            errorAt("sameFloats+copied sourceId"),
+        )
+        assertEquals(expected.sourceId != null, actual.sourceId != null, errorAt("sourceId nullness"))
+    }
+    assertEquals(expected.length, actual.length, LENGTH_DELTA, errorAt("length"))
+    assertEquals(expected.segmentPoints.size, actual.segmentPoints.size, errorAt("segmentPoints.size"))
+    assertEquals(expected.resolution, actual.resolution, errorAt("resolution"))
     expected.segmentPoints.forEachIndexed { index, point -> assertMatches(point, actual.segmentPoints[index]) }
 }
 


### PR DESCRIPTION
Tuotantokoodin muutos itsessään on varsin minimaalinen. Testeihin vaan tuli koominen määrä uudelleenkirjoitusta, koska toteutuksen yksinkertaisuuden nimissä muutoskohdan siirto vaatii, että kaikki sen yhteydessä tehtävät vaihteiden uudelleenlinkitykset onnistuvat, ja sen myötä se nyt vaatii paljon entistä parempaa lähtödataa, jotta siirto toimii. Toimivat uudelleenlinkitykset myös aiheuttavat nanometrimuutoksia segmenttigeometrioihin, joten siirryin käyttämään pitkälti samaa assertMatches-helpperiä kuin mitä splittienkin testit vaativat, tosin sellaisella lisällä, että löin samaan hengenvetoon assertMatchesin virherapontointiin paremman tiedon siitä, mistä paikasta löytyi eroa.