### PR TITLE
GVT-3662 ktfmt again

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterControllerV1.kt
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
+import java.math.BigDecimal
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -24,7 +25,6 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestParam
-import java.math.BigDecimal
 
 const val EXT_FRAME_CONVERTER_BASE_PATH = "/rata-vkm"
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/frameconverter/v1/FrameConverterServiceV1.kt
@@ -38,9 +38,9 @@ import fi.fta.geoviite.infra.util.Right
 import fi.fta.geoviite.infra.util.all
 import fi.fta.geoviite.infra.util.processRights
 import fi.fta.geoviite.infra.util.produceIf
-import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.math.RoundingMode
+import org.springframework.beans.factory.annotation.Autowired
 
 @GeoviiteService
 class FrameConverterServiceV1
@@ -74,8 +74,9 @@ constructor(
         params: FrameConverterQueryParamsV1,
     ): List<List<CoordinateToTrackAddressResponseV1>> {
         val spatialCache = locationTrackSpatialCache.get(branch.official)
-        val nearbyTracks =
-            requestsWithPoints.map { (request, point) -> spatialCache.getClosestTracks(point, request.searchRadius) }
+        val nearbyTracks = requestsWithPoints.map { (request, point) ->
+            spatialCache.getClosestTracks(point, request.searchRadius)
+        }
 
         val distinctTrackNumberIds = distinctTrackNumberIdsFromCacheHits(nearbyTracks)
         val trackNumberInfo = getTrackNumberInfo(distinctTrackNumberIds, branch)
@@ -268,14 +269,13 @@ constructor(
                 .mapNotNull { (oid, locationTrack) -> locationTrack?.id?.let { id -> id as IntId to oid } }
                 .toMap()
 
-        val requestIndicesOnTrack =
-            requests.mapIndexedNotNull { index, request ->
-                index.takeIf {
-                    filterByLocationTrackName(request.locationTrackName, locationTrack) &&
-                        filterByLocationTrackType(request.locationTrackType, locationTrack) &&
-                        filterByLocationTrackOid(request.locationTrackOid, locationTrack, locationTrackOidLookup)
-                }
+        val requestIndicesOnTrack = requests.mapIndexedNotNull { index, request ->
+            index.takeIf {
+                filterByLocationTrackName(request.locationTrackName, locationTrack) &&
+                    filterByLocationTrackType(request.locationTrackType, locationTrack) &&
+                    filterByLocationTrackOid(request.locationTrackOid, locationTrack, locationTrackOidLookup)
             }
+        }
         val trackAddresses =
             geocodingContext.getTrackLocations(geometry, requests.map { request -> request.trackAddress })
         return requestIndicesOnTrack
@@ -312,9 +312,10 @@ constructor(
                     FrameConverterErrorV1.SearchRadiusUnderRange
                 },
                 produceIf(
-                    request.searchRadius != null && request.searchRadius > allowedSearchRadiusRange.endInclusive) {
-                        FrameConverterErrorV1.SearchRadiusOverRange
-                    },
+                    request.searchRadius != null && request.searchRadius > allowedSearchRadiusRange.endInclusive
+                ) {
+                    FrameConverterErrorV1.SearchRadiusOverRange
+                },
             )
 
         val (mappedLocationTrackTypeOrNull, trackTypeErrors) =
@@ -361,7 +362,8 @@ constructor(
                     locationTrackName = locationTrackNameOrNull,
                     locationTrackOid = locationTrackOidOrNull,
                     locationTrackType = mappedLocationTrackTypeOrNull,
-                ))
+                )
+            )
         else Left(createErrorResponse(identifier = request.identifier, errors = errors))
     }
 
@@ -375,10 +377,9 @@ constructor(
                 .let { oids -> trackNumberDao.getByExternalIds(branch.official, oids) }
                 .mapValues { (_, layoutTrackNumber) -> layoutTrackNumber?.number }
 
-        val trackNumberNames =
-            requests.flatMap { request ->
-                listOfNotNull(request.trackNumberName?.let(::createValidTrackNumberNameOrNull)?.first)
-            }
+        val trackNumberNames = requests.flatMap { request ->
+            listOfNotNull(request.trackNumberName?.let(::createValidTrackNumberNameOrNull)?.first)
+        }
 
         val trackNumberLookup =
             (trackNumberOidLookup.values.filterNotNull() + trackNumberNames).distinct().associateWith { trackNumber ->
@@ -444,7 +445,8 @@ constructor(
                     locationTrackOid = locationTrackOidOrNull,
                     locationTrackName = locationTrackNameOrNull,
                     locationTrackType = mappedLocationTrackTypeOrNull,
-                ))
+                )
+            )
         } else {
             Left(createErrorResponse(identifier = request.identifier, errors = errors))
         }
@@ -463,7 +465,8 @@ constructor(
             GeoJsonFeatureErrorResponseV1(
                 identifier = identifier,
                 errorMessages = errors.map { error -> translation.t(error.localizationKey) },
-            ))
+            )
+        )
     }
 
     private fun createCoordinateToTrackAddressResponse(
@@ -498,7 +501,8 @@ constructor(
                         featureMatchSimple = featureMatchSimple,
                         featureMatchDetails = conversionDetails,
                     ),
-            ))
+            )
+        )
     }
 
     private fun createTrackAddressToCoordinateResponse(
@@ -564,7 +568,8 @@ constructor(
                     LAYOUT_SRID -> request.searchCoordinate
                     else ->
                         transformNonKKJCoordinate(request.searchCoordinate.srid, LAYOUT_SRID, request.searchCoordinate)
-                })
+                }
+            )
         } catch (ex: ClientException) {
             Left(createErrorResponse(request.identifier, FrameConverterErrorV1.InputCoordinateTransformationFailed))
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileServiceV1.kt
@@ -40,9 +40,9 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
-import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.time.Instant
+import org.springframework.beans.factory.annotation.Autowired
 
 @GeoviiteService
 class ExtLocationTrackProfileServiceV1

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackServiceV1.kt
@@ -21,10 +21,10 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.util.produceIf
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 
 @GeoviiteService
 class ExtLocationTrackServiceV1

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointServiceV1.kt
@@ -18,10 +18,10 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 
 @GeoviiteService
 class ExtOperationalPointServiceV1

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeServiceV1.kt
@@ -145,11 +145,10 @@ constructor(
         val getTrackOid = { id: DomainId<LocationTrack> -> locationTrackOids[id]?.oid ?: throwOidNotFound(branch, id) }
 
         val sourceTracks: Map<LayoutRowVersion<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>> =
-            locationTrackService
-                .getManyWithGeometries(moves.map { it.shortenedTrackVersion }.distinct())
-                .associateBy { it.first.getVersionOrThrow() }
-        val targetTracks =
-            locationTrackDao.fetchManyByVersion(moves.map { it.lengthenedTrackVersion })
+            locationTrackService.getManyWithGeometries(moves.map { it.shortenedTrackVersion }.distinct()).associateBy {
+                it.first.getVersionOrThrow()
+            }
+        val targetTracks = locationTrackDao.fetchManyByVersion(moves.map { it.lengthenedTrackVersion })
 
         val geocodingContexts = geocodingService.getLazyGeocodingContextsByMoments(branch)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutExceptionsV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackLayoutExceptionsV1.kt
@@ -8,8 +8,8 @@ import fi.fta.geoviite.infra.tracklayout.LayoutAsset
 import fi.fta.geoviite.infra.tracklayout.LayoutRowVersion
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
-import org.springframework.http.HttpStatus
 import java.time.Instant
+import org.springframework.http.HttpStatus
 
 class ExtOidNotFoundExceptionV1(
     message: String,

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberGeometryServiceV1.kt
@@ -124,9 +124,7 @@ constructor(
                     trackInterval =
                         // Address points are null for example in case when the user provided
                         // address filter is outside the track boundaries.
-                        filteredAddressPoints?.let { addressPoints ->
-                            toExtInterval(addressPoints, coordinateSystem)
-                        },
+                        filteredAddressPoints?.let { addressPoints -> toExtInterval(addressPoints, coordinateSystem) },
                 )
             }
     }

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmServiceV1.kt
@@ -83,10 +83,9 @@ constructor(
             }
         val trackNumberIds = trackNumbers.map { trackNumber -> trackNumber.id as IntId }
         val trackNumberExtIds = trackNumberDao.fetchExternalIds(branch, trackNumberIds)
-        val geocodingContexts =
-            trackNumbers.associate {
-                it.id to geocodingService.getGeocodingContextAtMoment(branch, it.id as IntId, moment)
-            }
+        val geocodingContexts = trackNumbers.associate {
+            it.id to geocodingService.getGeocodingContextAtMoment(branch, it.id as IntId, moment)
+        }
         return ExtTrackKmsCollectionResponseV1(
             trackLayoutVersion = ExtLayoutVersionV1(publication),
             coordinateSystem = ExtSridV1(coordinateSystem),

--- a/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberServiceV1.kt
@@ -19,10 +19,10 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.Instant
 
 @GeoviiteService
 class ExtTrackNumberServiceV1

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/authorization/AuthorizationDao.kt
@@ -40,10 +40,8 @@ class AuthorizationDao(
             .recordStats()
             .build()
 
-    override fun cacheStats() = mapOf(
-        "authorization-role-code" to roleCodeCache.stats(),
-        "authorization-user-group" to userGroupCache.stats(),
-    )
+    override fun cacheStats() =
+        mapOf("authorization-role-code" to roleCodeCache.stats(), "authorization-user-group" to userGroupCache.stats())
 
     fun getRolesByRoleCodes(roleCodes: List<AuthCode>): List<Role> {
         return roleCodes.mapNotNull { roleCode -> getRoleByRoleCode(roleCode = roleCode) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/common/ChangeTimeController.kt
@@ -13,10 +13,10 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
+import java.time.Instant
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
-import java.time.Instant
 
 data class CollectedChangeTimes(
     val layoutTrackNumber: Instant,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheConfiguration.kt
@@ -28,7 +28,6 @@ const val CACHE_KKJ_TM35FIN_TRIANGULATION_NETWORK = "kkj-tm35fin-triangles"
 const val CACHE_GEOCODING_CONTEXTS = "geocoding-contexts"
 const val CACHE_PLAN_GEOCODING_CONTEXTS = "plan-geocoding-contexts"
 
-
 val planCacheDuration: Duration = Duration.ofMinutes(60)
 val layoutCacheDuration: Duration = Duration.ofMinutes(60)
 val staticDataCacheDuration: Duration = Duration.ofHours(24)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheHealthIndicator.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CacheHealthIndicator.kt
@@ -22,19 +22,19 @@ class CacheHealthIndicator(
         val details = buildMap {
             cacheManager.cacheNames.forEach { name ->
                 val nativeCache = (cacheManager.getCache(name) as? CaffeineCache)?.nativeCache
-                put(name, if (nativeCache != null) nativeCache.stats().toDetailMap() else mapOf("stats" to "unavailable"))
+                put(
+                    name,
+                    if (nativeCache != null) nativeCache.stats().toDetailMap() else mapOf("stats" to "unavailable"),
+                )
             }
-            manualCacheStatsProviders.flatMap { it.cacheStats().entries }.forEach { (name, stats) ->
-                put(name, stats.toDetailMap())
-            }
+            manualCacheStatsProviders
+                .flatMap { it.cacheStats().entries }
+                .forEach { (name, stats) -> put(name, stats.toDetailMap()) }
         }
 
         return Health.up().withDetails(details).build()
     }
 }
 
-private fun CacheStats.toDetailMap() = mapOf(
-    "hitRate" to hitRate(),
-    "loadCount" to loadCount(),
-    "evictionCount" to evictionCount(),
-)
+private fun CacheStats.toDetailMap() =
+    mapOf("hitRate" to hitRate(), "loadCount" to loadCount(), "evictionCount" to evictionCount())

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/CachePreloadService.kt
@@ -14,12 +14,12 @@ import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackDao
 import fi.fta.geoviite.infra.tracklayout.LocationTrackSpatialCache
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 
 @GeoviiteService
 class CachePreloadService(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/SecurityConfiguration.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/configuration/SecurityConfiguration.kt
@@ -43,10 +43,7 @@ class SecurityConfiguration {
                     // Block direct access to internal SpringDoc api-docs paths. These are only
                     // meant to be reached via server-side forwards from SwaggerController, which
                     // are not matched here (FORWARD dispatch type is excluded).
-                    .requestMatchers(
-                        directRequestMatcher("/swagger-ui/**"),
-                        directRequestMatcher("/v3/api-docs/**"),
-                    )
+                    .requestMatchers(directRequestMatcher("/swagger-ui/**"), directRequestMatcher("/v3/api-docs/**"))
                     .denyAll()
                     // Browser-facing openapi forwarding paths for geoviite.
                     .requestMatchers(OPENAPI_GEOVIITE_PATH, OPENAPI_GEOVIITE_DEV_PATH)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -440,16 +440,15 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
         private fun <M : GeocodingAlignmentM<M>> createKms(
             kmReferencePoints: List<KmReferencePoint<M>>,
             referenceLineGeometry: IAlignment<M>,
-        ): List<GeocodingKm<M>> =
-            kmReferencePoints.mapIndexed { index, prev ->
-                val next = kmReferencePoints.getOrNull(index + 1)
-                GeocodingKm(
-                    prev.km,
-                    prev.meter,
-                    Range(prev.referenceLineM, next?.referenceLineM ?: referenceLineGeometry.length),
-                    index == kmReferencePoints.lastIndex,
-                )
-            }
+        ): List<GeocodingKm<M>> = kmReferencePoints.mapIndexed { index, prev ->
+            val next = kmReferencePoints.getOrNull(index + 1)
+            GeocodingKm(
+                prev.km,
+                prev.meter,
+                Range(prev.referenceLineM, next?.referenceLineM ?: referenceLineGeometry.length),
+                index == kmReferencePoints.lastIndex,
+            )
+        }
 
         private fun validateKmPosts(
             kmPosts: List<LayoutKmPost>,
@@ -978,18 +977,17 @@ private fun <M : GeocodingAlignmentM<M>> createProjectionLines(
     }
 
     var edgeIndex = 0
-    val midProjections =
-        kms.flatMap { km ->
-            km.getMetersSequence(resolution).map { meter ->
-                val referenceLineM = km.referenceLineM.min + meter.toDouble() - km.startMeters.toDouble()
-                while (edgeIndex < edges.lastIndex && edges[edgeIndex].endM < referenceLineM) {
-                    edgeIndex++
-                }
-                val edge = edges[edgeIndex]
-                val address = TrackMeter(km.kmNumber, meter)
-                ProjectionLine(address, edge.crossSectionAt(referenceLineM), referenceLineM, edge.referenceDirection)
+    val midProjections = kms.flatMap { km ->
+        km.getMetersSequence(resolution).map { meter ->
+            val referenceLineM = km.referenceLineM.min + meter.toDouble() - km.startMeters.toDouble()
+            while (edgeIndex < edges.lastIndex && edges[edgeIndex].endM < referenceLineM) {
+                edgeIndex++
             }
+            val edge = edges[edgeIndex]
+            val address = TrackMeter(km.kmNumber, meter)
+            ProjectionLine(address, edge.crossSectionAt(referenceLineM), referenceLineM, edge.referenceDirection)
         }
+    }
 
     return listOf(
             listOfNotNull(createStartProjectionIfNeeded(kms, edges, resolution)),
@@ -1008,12 +1006,11 @@ private fun <M : GeocodingAlignmentM<M>> validateProjectionLines(
     val distanceRange = (resolution.meters.toDouble() - distanceDelta)..(resolution.meters.toDouble() + distanceDelta)
     return lines.filterIndexed { index, line ->
         val previous = lines.getOrNull(index - 1)
-        val distanceApprox =
-            previous?.let { prev ->
-                if (prev.address.kmNumber == line.address.kmNumber) {
-                    lineLength(prev.projection.start, line.projection.start)
-                } else null
-            }
+        val distanceApprox = previous?.let { prev ->
+            if (prev.address.kmNumber == line.address.kmNumber) {
+                lineLength(prev.projection.start, line.projection.start)
+            } else null
+        }
         val angleDiff = previous?.let { prev -> angleDiffRads(prev.projection.angle, line.projection.angle) }
         val isStartOrEndProjection = index == 1 || index == lines.lastIndex
         if (distanceApprox != null && distanceApprox !in distanceRange && !isStartOrEndProjection) {

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingCacheService.kt
@@ -21,11 +21,11 @@ import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignment
 import fi.fta.geoviite.infra.tracklayout.PlanLayoutAlignmentM
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.context.annotation.Lazy
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 sealed interface GeocodingContextCacheKey
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/BoundingPolygon.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/BoundingPolygon.kt
@@ -7,8 +7,9 @@ import fi.fta.geoviite.infra.math.MIN_POLYGON_POINTS
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 
-fun collectAnglePoints(alignments: List<GeometryAlignment>): List<Point> =
-    alignments.flatMap { a: GeometryAlignment -> a.elements.flatMap { e -> e.bounds } }
+fun collectAnglePoints(alignments: List<GeometryAlignment>): List<Point> = alignments.flatMap { a: GeometryAlignment ->
+    a.elements.flatMap { e -> e.bounds }
+}
 
 fun getBoundingPolygonFromPlan(plan: GeometryPlan, transformation: Transformation): Polygon? =
     tryCreateBoundingPolygon(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfile.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryProfile.kt
@@ -40,13 +40,14 @@ data class GeometryProfile(val name: PlanElementName, val elements: List<Vertica
             distance.distance >= elements.last().point.x -> elements.last().point.y
             else -> {
                 val x = distance.distance
-                val segment = binarySearchSegment(segments, x)
-                    ?: throw IllegalArgumentException(
-                        "Requested point outside profile segments: " +
-                            "$distance <> " +
-                            "[${elements.first().point.x} to ${elements.last().point.x}] => " +
-                            "${segments.map { s -> "${s.start.x}-${s.end.x}" }}"
-                    )
+                val segment =
+                    binarySearchSegment(segments, x)
+                        ?: throw IllegalArgumentException(
+                            "Requested point outside profile segments: " +
+                                "$distance <> " +
+                                "[${elements.first().point.x} to ${elements.last().point.x}] => " +
+                                "${segments.map { s -> "${s.start.x}-${s.end.x}" }}"
+                        )
                 segment.getYValueAt(x)
             }
         }
@@ -253,11 +254,10 @@ fun halfAngleOfPviPoint(deltaX: Double, deltaY: Double): Double =
         else if (deltaY > 0.0) atan(deltaX / deltaY) else PI / 2.0 + abs(atan(deltaY / deltaX))
     )
 
-fun checkHalfAngle(halfAngle: Double) =
-    halfAngle.also { angle ->
-        require(angle > 0.0) { "VI half-angle component should be positive: angle=$angle" }
-        require(angle < PI) { "VI half-angle component should under PI: angle=$angle" }
-    }
+fun checkHalfAngle(halfAngle: Double) = halfAngle.also { angle ->
+    require(angle > 0.0) { "VI half-angle component should be positive: angle=$angle" }
+    require(angle < PI) { "VI half-angle component should under PI: angle=$angle" }
+}
 
 fun lengthFromPviToTangent(leftHalfAngle: Double, rightHalfAngle: Double, radius: Double): Double {
     val halfAngleOfAlfa = (leftHalfAngle + rightHalfAngle) / 2

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryService.kt
@@ -618,13 +618,12 @@ constructor(
                 .zipWithNext { a, b -> a.alignment == b.alignment }
                 .mapIndexedNotNull { i, equals -> if (equals) null else i }
 
-        val alignmentBoundaryAddresses =
-            alignmentLinkEndSegmentIndices.flatMap { i ->
-                listOf(
-                    GeometryAlignmentBoundaryPoint(geometry.segmentMValues[i].max, i),
-                    GeometryAlignmentBoundaryPoint(geometry.segmentMValues[i + 1].min, i + 1),
-                )
-            }
+        val alignmentBoundaryAddresses = alignmentLinkEndSegmentIndices.flatMap { i ->
+            listOf(
+                GeometryAlignmentBoundaryPoint(geometry.segmentMValues[i].max, i),
+                GeometryAlignmentBoundaryPoint(geometry.segmentMValues[i + 1].min, i + 1),
+            )
+        }
 
         val kmTicks =
             collectTrackMeterTicks(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometrySwitch.kt
@@ -22,8 +22,9 @@ data class GeometrySwitch(
     val joints: List<GeometrySwitchJoint>,
     val id: DomainId<GeometrySwitch> = StringId(),
 ) : Loggable {
-    fun getJoint(location: Point, delta: Double): GeometrySwitchJoint? =
-        joints.find { j -> j.location.isSame(location, delta) }
+    fun getJoint(location: Point, delta: Double): GeometrySwitchJoint? = joints.find { j ->
+        j.location.isSame(location, delta)
+    }
 
     fun getJoint(number: JointNumber): GeometrySwitchJoint? = joints.find { j -> j.number == number }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geometry/GeometryValidation.kt
@@ -279,25 +279,24 @@ fun validateSwitches(
                 } else null
             }
             .toSet()
-    val duplicateErrors =
-        duplicateNames.map { name -> SwitchDefinitionError("duplicate-name", OBSERVATION_MAJOR, name) }
-    val switchErrors =
-        switches.flatMap { switch ->
-            validateSwitch(
-                switch,
-                switch.switchStructureId?.let(switchStructures::get),
-                alignments.mapNotNull { a -> collectAlignmentSwitchJoints(switch.id, a) },
-            )
-        }
+    val duplicateErrors = duplicateNames.map { name ->
+        SwitchDefinitionError("duplicate-name", OBSERVATION_MAJOR, name)
+    }
+    val switchErrors = switches.flatMap { switch ->
+        validateSwitch(
+            switch,
+            switch.switchStructureId?.let(switchStructures::get),
+            alignments.mapNotNull { a -> collectAlignmentSwitchJoints(switch.id, a) },
+        )
+    }
     return duplicateErrors + switchErrors
 }
 
 fun validateKmPosts(kmPosts: List<GeometryKmPost>): List<GeometryValidationIssue> {
-    val singularKmPostsValidations =
-        kmPosts.flatMapIndexed { i, p ->
-            // Don't validate 1st km-post as it's just a 0-point with different data
-            if (i > 0) validateKmPost(p) else listOf()
-        }
+    val singularKmPostsValidations = kmPosts.flatMapIndexed { i, p ->
+        // Don't validate 1st km-post as it's just a 0-point with different data
+        if (i > 0) validateKmPost(p) else listOf()
+    }
 
     return singularKmPostsValidations + validateKmPostCollection(kmPosts)
 }
@@ -336,8 +335,9 @@ fun validateKmPost(post: GeometryKmPost) =
     )
 
 fun validateAlignmentCollection(alignments: List<GeometryAlignment>): List<GeometryValidationIssue> {
-    val referenceLineAlignments =
-        alignments.filter { alignment -> alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE }
+    val referenceLineAlignments = alignments.filter { alignment ->
+        alignment.featureTypeCode == REFERENCE_LINE_TYPE_CODE
+    }
     return listOfNotNull(
         validate(referenceLineAlignments.isNotEmpty()) {
             CollectionIssue("no-reference-lines", VALIDATION_ALIGNMENT, OBSERVATION_MAJOR)
@@ -809,13 +809,12 @@ fun validateSwitchGeometry(switch: GeometrySwitch, switchStructure: SwitchStruct
             validate(joints.size <= 1) { SwitchDefinitionError("location-difference", OBSERVATION_MAJOR, switch.name) }
         )
     } else {
-        val locationPairs =
-            joints.mapNotNull { joint ->
-                switchStructure.joints
-                    .find { structureJoint -> structureJoint.number == joint.number }
-                    ?.let { structureJoint -> transformSwitchPoint(positionTransformation, structureJoint.location) }
-                    ?.let { calculatedLocation -> joint.location to calculatedLocation }
-            }
+        val locationPairs = joints.mapNotNull { joint ->
+            switchStructure.joints
+                .find { structureJoint -> structureJoint.number == joint.number }
+                ?.let { structureJoint -> transformSwitchPoint(positionTransformation, structureJoint.location) }
+                ?.let { calculatedLocation -> joint.location to calculatedLocation }
+        }
         listOfNotNull(
             validate(locationPairs.all { (loc, calc) -> loc.isSame(calc, ACCURATE_JOINT_LOCATION_DELTA) }) {
                 val isIncorrect = locationPairs.any { (loc, calc) -> !loc.isSame(calc, JOINT_LOCATION_DELTA) }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/InfraModelConversion.kt
@@ -544,10 +544,9 @@ fun collectGeometrySwitches(
     switchTypeNameAliases: Map<String, String>,
     alignmentGroups: List<InfraModelAlignmentGroup>,
 ): Map<SwitchKey, GeometrySwitch> {
-    val tempSwitchAndJoints: List<TempSwitchAndJoints> =
-        alignmentGroups.flatMap { group ->
-            group.alignments.flatMap { alignment -> getInfraModelSwitches(alignment, group.state) }
-        }
+    val tempSwitchAndJoints: List<TempSwitchAndJoints> = alignmentGroups.flatMap { group ->
+        group.alignments.flatMap { alignment -> getInfraModelSwitches(alignment, group.state) }
+    }
 
     return tempSwitchAndJoints
         // Switches have no proper id -> group individual pieces by a composite key of name + other
@@ -568,11 +567,10 @@ fun collectGeometrySwitches(
                     if (switchType != null) switchTypeRequiresHandedness(switchType.parts.baseType) else false
                 }
             val switchTypeHand = verifySameField("Switch hand", xmlSwitches, TempSwitch::hand, TempSwitch::name)
-            val fullSwitchTypeName =
-                switchTypeHand.let { hand ->
-                    if (hand == SwitchHand.NONE || !switchTypeRequiresHandedness) switchTypeName
-                    else "$switchTypeName-${hand.abbreviation}"
-                }
+            val fullSwitchTypeName = switchTypeHand.let { hand ->
+                if (hand == SwitchHand.NONE || !switchTypeRequiresHandedness) switchTypeName
+                else "$switchTypeName-${hand.abbreviation}"
+            }
 
             val switchType = SwitchType.tryParse(fullSwitchTypeName)
             val switchStructure = switchType?.let { type -> switchStructuresByType[type] }
@@ -635,11 +633,10 @@ fun toGeometrySwitchJoints(originalElements: List<TempSwitchElement>): TempSwitc
     // Unify representations: Repeating joint-numbers mean that the same element has been split ->
     // resolve as 0
     val sortedElements = originalElements.sortedBy { element -> element.elementIndex }
-    val elements: List<TempSwitchElement> =
-        sortedElements.mapIndexed { index, element ->
-            val prevNumber = sortedElements.getOrNull(index - 1)?.jointNumber
-            if (prevNumber == element.jointNumber) element.copy(jointNumber = 0) else element
-        }
+    val elements: List<TempSwitchElement> = sortedElements.mapIndexed { index, element ->
+        val prevNumber = sortedElements.getOrNull(index - 1)?.jointNumber
+        if (prevNumber == element.jointNumber) element.copy(jointNumber = 0) else element
+    }
 
     val switch = elements.first().switch
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/StringParsing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/inframodel/StringParsing.kt
@@ -30,8 +30,9 @@ fun parseInt(name: String, value: String): Int = parseMandatory(name, value, Str
 
 fun splitStringOnSpaces(string: String): List<String> = string.trim().split(Regex(FIELD_DATA_SEPARATOR))
 
-inline fun <reified T : Enum<T>> parseOptionalEnum(name: String, value: String?): T? =
-    value?.let { v -> if (isMissingEnum(v)) null else parseEnum<T>(name, v) }
+inline fun <reified T : Enum<T>> parseOptionalEnum(name: String, value: String?): T? = value?.let { v ->
+    if (isMissingEnum(v)) null else parseEnum<T>(name, v)
+}
 
 inline fun <reified T : Enum<T>> parseEnum(name: String, value: String): T {
     return parseMandatory(name, value.uppercase(), ::enumValueOf)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/AddressChangesService.kt
@@ -54,11 +54,13 @@ private fun <M : AlignmentM<M>> findDiffAddresses(
     return differences
 }
 
-private fun findFirstIndexAfterKm(list: List<AddressPoint<*>>, kmNumber: KmNumber) =
-    list.indexOfFirst { point -> point.address.kmNumber > kmNumber }
+private fun findFirstIndexAfterKm(list: List<AddressPoint<*>>, kmNumber: KmNumber) = list.indexOfFirst { point ->
+    point.address.kmNumber > kmNumber
+}
 
-private fun findFirstIndexForKm(list: List<AddressPoint<*>>, kmNumber: KmNumber?) =
-    kmNumber?.let { km -> list.indexOfFirst { point -> point.address.kmNumber == km } }
+private fun findFirstIndexForKm(list: List<AddressPoint<*>>, kmNumber: KmNumber?) = kmNumber?.let { km ->
+    list.indexOfFirst { point -> point.address.kmNumber == km }
+}
 
 data class AddressChanges(
     val changedKmNumbers: Set<KmNumber>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesService.kt
@@ -49,9 +49,9 @@ import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole
 import fi.fta.geoviite.infra.tracklayout.TrackSwitchLinkType
 import fi.fta.geoviite.infra.util.mapNonNullValues
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import kotlin.reflect.KClass
+import org.springframework.transaction.annotation.Transactional
 
 data class TrackNumberChange(
     val trackNumberId: IntId<LayoutTrackNumber>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/LinkingTransformation.kt
@@ -140,19 +140,18 @@ private fun tryCreateLinkedReferenceLineGeometry(
         )
     }
 
-private fun validateSegments(newSegments: List<LayoutSegment>) =
-    newSegments.forEachIndexed { index, segment ->
-        newSegments.getOrNull(index - 1)?.let { previous ->
-            val diff = angleDiffRads(previous.endDirection, segment.startDirection)
-            if (diff > PI / 2)
-                throw LinkingFailureException(
-                    message =
-                        "Linked geometry has over 90 degree angles between segments: " +
-                            "segments=${index-1}-$index prevEnd=${previous.endDirection} next=${segment.endDirection} angle=${radsToDegrees(diff)} point=${segment.segmentStart}",
-                    localizedMessageKey = "segments-sharp-angle",
-                )
-        }
+private fun validateSegments(newSegments: List<LayoutSegment>) = newSegments.forEachIndexed { index, segment ->
+    newSegments.getOrNull(index - 1)?.let { previous ->
+        val diff = angleDiffRads(previous.endDirection, segment.startDirection)
+        if (diff > PI / 2)
+            throw LinkingFailureException(
+                message =
+                    "Linked geometry has over 90 degree angles between segments: " +
+                        "segments=${index-1}-$index prevEnd=${previous.endDirection} next=${segment.endDirection} angle=${radsToDegrees(diff)} point=${segment.segmentStart}",
+                localizedMessageKey = "segments-sharp-angle",
+            )
     }
+}
 
 fun splice(
     geometry: ReferenceLineGeometry,
@@ -205,21 +204,20 @@ fun <M : AlignmentM<M>> slice(
     segmentsWithM: List<Pair<ISegment, Range<LineM<M>>>>,
     mRange: Range<LineM<M>>,
     snapDistance: Double = ALIGNMENT_LINKING_SNAP,
-): List<LayoutSegment> =
-    segmentsWithM.mapNotNull { (segment, segmentM) ->
-        if (segmentM.max - snapDistance <= mRange.min || segmentM.min + snapDistance >= mRange.max) {
-            null
-        } else if (segmentM.min >= mRange.min - snapDistance && segmentM.max <= mRange.max + snapDistance) {
-            toLayoutSegment(segment)
-        } else {
-            val range =
-                Range<LineM<SegmentM>>(
-                    LineM(max(mRange.min.distance - segmentM.min.distance, 0.0)),
-                    LineM(min(mRange.max.distance - segmentM.min.distance, segment.length)),
-                )
-            toLayoutSegment(segment).slice(segmentMRange = range, snapDistance = snapDistance)
-        }
+): List<LayoutSegment> = segmentsWithM.mapNotNull { (segment, segmentM) ->
+    if (segmentM.max - snapDistance <= mRange.min || segmentM.min + snapDistance >= mRange.max) {
+        null
+    } else if (segmentM.min >= mRange.min - snapDistance && segmentM.max <= mRange.max + snapDistance) {
+        toLayoutSegment(segment)
+    } else {
+        val range =
+            Range<LineM<SegmentM>>(
+                LineM(max(mRange.min.distance - segmentM.min.distance, 0.0)),
+                LineM(min(mRange.max.distance - segmentM.min.distance, segment.length)),
+            )
+        toLayoutSegment(segment).slice(segmentMRange = range, snapDistance = snapDistance)
     }
+}
 
 fun slice(
     geometry: LocationTrackGeometry,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingService.kt
@@ -521,22 +521,21 @@ private fun findIntersectionsBetweenLineLists(
     lines2: List<Line>,
     alignment1: IAlignment<LocationTrackM>,
     alignment2: IAlignment<LocationTrackM>,
-) =
-    lines1.flatMap { line1 ->
-        lines2.mapNotNull { line2 ->
-            val intersection = lineIntersection(line1.start, line1.end, line2.start, line2.end)
-            if (intersection != null && intersection.linesIntersect()) {
-                TrackIntersection(
-                    point = intersection.point,
-                    distance = 0.0,
-                    alignment1 = alignment1,
-                    alignment2 = alignment2,
-                )
-            } else {
-                tryFindingNearIntersection(line1, line2, alignment1, alignment2)
-            }
+) = lines1.flatMap { line1 ->
+    lines2.mapNotNull { line2 ->
+        val intersection = lineIntersection(line1.start, line1.end, line2.start, line2.end)
+        if (intersection != null && intersection.linesIntersect()) {
+            TrackIntersection(
+                point = intersection.point,
+                distance = 0.0,
+                alignment1 = alignment1,
+                alignment2 = alignment2,
+            )
+        } else {
+            tryFindingNearIntersection(line1, line2, alignment1, alignment2)
         }
     }
+}
 
 private fun tryFindingNearIntersection(
     line1: Line,
@@ -590,8 +589,9 @@ private fun getClosestPointAsIntersection(
         }
 }
 
-private fun <T> pairsOf(things: List<T>): List<Pair<T, T>> =
-    things.flatMapIndexed { index, t1 -> things.drop(index + 1).map { t2 -> t1 to t2 } }
+private fun <T> pairsOf(things: List<T>): List<Pair<T, T>> = things.flatMapIndexed { index, t1 ->
+    things.drop(index + 1).map { t2 -> t1 to t2 }
+}
 
 private fun findTrackIntersectionsForGridPoints(
     trackAlignments: List<IAlignment<LocationTrackM>>,
@@ -604,12 +604,9 @@ private fun findTrackIntersectionsForGridPoints(
         grid.mapMulti(parallel = true) { gridPoint ->
             allActualIntersections.sortedWith(orderIntersectionsWithDesiredPoint(gridPoint)).take(2).toSet()
         }
-    val closestPointsAsIntersections =
-        grid.mapMulti { gridPoint ->
-            trackPairs
-                .mapNotNull { (track1, track2) -> getClosestPointAsIntersection(track1, track2, gridPoint) }
-                .toSet()
-        }
+    val closestPointsAsIntersections = grid.mapMulti { gridPoint ->
+        trackPairs.mapNotNull { (track1, track2) -> getClosestPointAsIntersection(track1, track2, gridPoint) }.toSet()
+    }
 
     return closestPointsAsIntersections.zipWithByPoint(closestActualIntersections, Set<TrackIntersection>::plus)
 }
@@ -804,14 +801,13 @@ private fun selectBestSuggestedSwitch(
 ): FittedSwitch {
     assert(switchSuggestions.isNotEmpty()) { "switchSuggestions.isNotEmpty()" }
 
-    val maxFarthestJointDistance =
-        switchSuggestions.maxOf { suggestedSwitch ->
-            suggestedSwitch.joints.maxOf { joint ->
-                if (joint.number == farthestJoint.number) {
-                    lineLength(desiredLocation, joint.location)
-                } else 0.0
-            }
+    val maxFarthestJointDistance = switchSuggestions.maxOf { suggestedSwitch ->
+        suggestedSwitch.joints.maxOf { joint ->
+            if (joint.number == farthestJoint.number) {
+                lineLength(desiredLocation, joint.location)
+            } else 0.0
         }
+    }
 
     return switchSuggestions.maxBy { fittedSwitch ->
         getSuggestedSwitchScore(
@@ -852,8 +848,9 @@ fun findBestSwitchFitForAllPointsInSamplingGrid(
     val pointBboxes =
         grid.points.associateWith { point -> BoundingBox(0.0..pointBboxSize, 0.0..pointBboxSize).centerAt(point) }
 
-    val croppedTracks =
-        nearbyLocationTracks.map { (track, geometry) -> track to cropPoints(track.id as IntId, geometry, gridBbox) }
+    val croppedTracks = nearbyLocationTracks.map { (track, geometry) ->
+        track to cropPoints(track.id as IntId, geometry, gridBbox)
+    }
 
     val intersections = findTrackIntersectionsForGridPoints(croppedTracks.map { it.second }, grid)
     val (sharedSwitchJoint, switchAlignmentsContainingSharedJoint) = getSharedSwitchJoint(switchStructure)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinking.kt
@@ -85,8 +85,9 @@ data class FittedSwitchJoint(
 data class TopologyLinkFindingSwitch(val joints: List<ISwitchJoint>, val id: IntId<LayoutSwitch>)
 
 data class FittedSwitch(val switchStructure: SwitchStructure, val joints: List<FittedSwitchJoint>) {
-    fun isFittedOn(trackId: IntId<LocationTrack>): Boolean =
-        joints.any { joint -> joint.matches.any { match -> match.locationTrackId == trackId } }
+    fun isFittedOn(trackId: IntId<LocationTrack>): Boolean = joints.any { joint ->
+        joint.matches.any { match -> match.locationTrackId == trackId }
+    }
 }
 
 data class SwitchPlacingRequest(val points: SamplingGridPoints, val layoutSwitchId: IntId<LayoutSwitch>)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingService.kt
@@ -82,8 +82,9 @@ constructor(
             collectOriginallyLinkedLocationTracks(branch, requests.map { it.layoutSwitchId })
         val newlyMatchedByRequestIndex =
             collectNewlyMatchedLocationTracks(fitGrids, originallyLinkedByRequestIndex, branch)
-        val originalSwitches =
-            requests.map { request -> switchDao.fetch(switchDao.fetchVersion(branch.draft, request.layoutSwitchId)!!) }
+        val originalSwitches = requests.map { request ->
+            switchDao.fetch(switchDao.fetchVersion(branch.draft, request.layoutSwitchId)!!)
+        }
         val switchStructures = originalSwitches.map { switchLibraryService.getSwitchStructure(it.switchStructureId) }
 
         return fitGrids
@@ -126,15 +127,12 @@ constructor(
         originallyLinkedByRequestIndex: List<Map<IntId<LocationTrack>, Pair<LocationTrack, DbLocationTrackGeometry>>>,
         branch: LayoutBranch,
     ): List<Map<IntId<LocationTrack>, Pair<LocationTrack, DbLocationTrackGeometry>>> {
-        val matchedLocationTracksByRequestIndex =
-            fitGrids.map { grid ->
-                grid
-                    .keys()
-                    .flatMap { fit ->
-                        fit.joints.flatMap { joint -> joint.matches.map { match -> match.locationTrackId } }
-                    }
-                    .toSet()
-            }
+        val matchedLocationTracksByRequestIndex = fitGrids.map { grid ->
+            grid
+                .keys()
+                .flatMap { fit -> fit.joints.flatMap { joint -> joint.matches.map { match -> match.locationTrackId } } }
+                .toSet()
+        }
         return processFlattened(
                 matchedLocationTracksByRequestIndex.zip(originallyLinkedByRequestIndex) { matched, original ->
                     matched.minus(original.keys).toList()
@@ -170,14 +168,14 @@ constructor(
                     .joinToString(", ")
             "expected to find a switch for every ID in replacement request, but none were found for $notFound"
         }
-        val switchStructures =
-            originalSwitches.map { switch -> switchLibraryService.getSwitchStructure(switch.switchStructureId) }
-        val alignmentsNearRequests =
-            requests.map { request ->
-                locationTrackCache.getWithinBoundingBox(request.points.bounds + TRACK_SEARCH_AREA_SIZE).sortedBy {
-                    (it.first.id as IntId).intValue
-                }
+        val switchStructures = originalSwitches.map { switch ->
+            switchLibraryService.getSwitchStructure(switch.switchStructureId)
+        }
+        val alignmentsNearRequests = requests.map { request ->
+            locationTrackCache.getWithinBoundingBox(request.points.bounds + TRACK_SEARCH_AREA_SIZE).sortedBy {
+                (it.first.id as IntId).intValue
             }
+        }
         return requests
             .mapIndexed { i, r -> i to r }
             .parallelStream()
@@ -308,7 +306,7 @@ constructor(
     }
 
     @Transactional
-    fun  relinkTrack(
+    fun relinkTrack(
         branch: LayoutBranch,
         trackId: IntId<LocationTrack>,
         restrictToSwitches: Set<IntId<LayoutSwitch>>? = null,
@@ -326,18 +324,10 @@ constructor(
         val changedLocationTracks: MutableMap<IntId<LocationTrack>, Pair<LocationTrack, LocationTrackGeometry>> =
             mutableMapOf()
 
-        val relinkingResults =
-            originalSwitches.mapIndexedNotNull { index, (switchId, originalSwitch) ->
-                val originallyLinked = originallyLinkedLocationTracksByIndex[index]
-                relinkOneSwitchOnTrack(
-                    branch,
-                    trackId,
-                    originalSwitch,
-                    switchId,
-                    originallyLinked,
-                    changedLocationTracks,
-                )
-            }
+        val relinkingResults = originalSwitches.mapIndexedNotNull { index, (switchId, originalSwitch) ->
+            val originallyLinked = originallyLinkedLocationTracksByIndex[index]
+            relinkOneSwitchOnTrack(branch, trackId, originalSwitch, switchId, originallyLinked, changedLocationTracks)
+        }
         saveLocationTrackChanges(
             branch,
             changedLocationTracks.values.toList(),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchTrackRelinkingValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchTrackRelinkingValidationService.kt
@@ -156,8 +156,9 @@ constructor(
 
 // some validation logic depends on draftness state, so we need to pre-draft tracks for online
 // validation
-private fun draft(tracks: List<Pair<LocationTrack, LocationTrackGeometry>>) =
-    tracks.map { (track, geometry) -> asDraft(track.branch, track) to geometry }
+private fun draft(tracks: List<Pair<LocationTrack, LocationTrackGeometry>>) = tracks.map { (track, geometry) ->
+    asDraft(track.branch, track) to geometry
+}
 
 private fun currentSwitchLocationsAsSwitchPlacingRequests(
     switchIds: List<IntId<LayoutSwitch>>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/logging/LoggerExternal.kt
@@ -101,19 +101,17 @@ fun Logger.serviceCall(method: String, params: List<Pair<String, *>>) {
     if (isDebugEnabled) debug("method={} params={}", method, paramsToLog(params))
 }
 
-fun paramsToLog(vararg params: Pair<String, *>): List<String> =
-    params.map { p ->
-        "${p.first}=${p.second?.let { obj ->
+fun paramsToLog(vararg params: Pair<String, *>): List<String> = params.map { p ->
+    "${p.first}=${p.second?.let { obj ->
             formatForLog(if (obj is Loggable) obj.toLog() else obj.toString(), 1000)
         }}"
-    }
+}
 
-fun paramsToLog(params: List<Pair<String, *>>): List<String> =
-    params.map { p ->
-        "${p.first}=${p.second?.let { obj ->
+fun paramsToLog(params: List<Pair<String, *>>): List<String> = params.map { p ->
+    "${p.first}=${p.second?.let { obj ->
             formatForLog(if (obj is Loggable) obj.toLog() else obj.toString(), 1000)
         }}"
-    }
+}
 
 fun returnValueToLog(returnValue: Any?): String {
     return formatForLog(if (returnValue is Loggable) returnValue.toLog() else returnValue.toString(), 1000)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/map/AlignmentGeometry.kt
@@ -107,10 +107,7 @@ data class AlignmentPolyLine<T, M : AlignmentM<M>>(
     override fun toLog(): String = logFormat("id" to id, "type" to alignmentType, "points" to points.size)
 }
 
-fun toAlignmentHeader(
-    trackNumber: LayoutTrackNumber,
-    geometry: ReferenceLineGeometry?,
-) =
+fun toAlignmentHeader(trackNumber: LayoutTrackNumber, geometry: ReferenceLineGeometry?) =
     ReferenceLineHeader(
         version = trackNumber.getVersionOrThrow(),
         name = AlignmentName(trackNumber.number.toString()),

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/math/MultiPoint.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/math/MultiPoint.kt
@@ -11,8 +11,9 @@ data class MultiPoint(val points: List<Point>) {
         require(points.isNotEmpty()) { "Cannot create empty ${MultiPoint::class.simpleName}" }
     }
 
-    fun isWithinDistance(target: IPoint, distance: Double): Boolean =
-        points.any { p -> lineLength(target, p) <= distance }
+    fun isWithinDistance(target: IPoint, distance: Double): Boolean = points.any { p ->
+        lineLength(target, p) <= distance
+    }
 
     fun toWkt(): String = create2DMultiPoint(points)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationLogService.kt
@@ -50,12 +50,12 @@ import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.SortOrder
 import fi.fta.geoviite.infra.util.nullsFirstComparator
 import fi.fta.geoviite.infra.util.printCsv
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.ZoneId
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
 
 const val DISTANCE_CHANGE_THRESHOLD = 0.0005
 
@@ -550,11 +550,7 @@ constructor(
                 DISTANCE_CHANGE_THRESHOLD,
                 ::roundTo1Decimal,
                 PropKey("length"),
-                getLengthChangedRemarkOrNull(
-                    translation,
-                    trackNumberChanges.length.old,
-                    trackNumberChanges.length.new,
-                ),
+                getLengthChangedRemarkOrNull(translation, trackNumberChanges.length.old, trackNumberChanges.length.new),
             ),
             compareChange(
                 { !pointsAreSame(trackNumberChanges.startPoint.old, trackNumberChanges.startPoint.new) },
@@ -574,11 +570,7 @@ constructor(
                 trackNumberChanges.endPoint.new,
                 ::formatLocation,
                 PropKey("end-location"),
-                getPointMovedRemarkOrNull(
-                    translation,
-                    trackNumberChanges.endPoint.old,
-                    trackNumberChanges.endPoint.new,
-                ),
+                getPointMovedRemarkOrNull(translation, trackNumberChanges.endPoint.old, trackNumberChanges.endPoint.new),
             ),
             if (changedKmNumbers.isNotEmpty()) {
                 PublicationChange(
@@ -860,8 +852,7 @@ constructor(
             compareChangeValues(
                 changes.rinfType,
                 { rinfType ->
-                    if (rinfType == null) null
-                    else translation.t("enum.OperationalPointRinfType.${rinfType.type.name}")
+                    if (rinfType == null) null else translation.t("enum.OperationalPointRinfType.${rinfType.type.name}")
                 },
                 PropKey("rinf-type"),
             ),
@@ -882,12 +873,7 @@ constructor(
                 ::formatLocation,
                 PropKey("location"),
                 remark =
-                    getPointMovedRemarkOrNull(
-                        translation,
-                        changes.location.old,
-                        changes.location.new,
-                        "moved-x-meters",
-                    ),
+                    getPointMovedRemarkOrNull(translation, changes.location.old, changes.location.new, "moved-x-meters"),
             ),
             compareChangeValues(changes.state, { it }, PropKey("state"), enumLocalizationKey = "OperationalPointState"),
         )
@@ -1097,11 +1083,7 @@ constructor(
         val publicationTrackNumberChanges =
             if (canSkipLoadingChanges(publication, publicationLogAsset, PublishableObjectType.TRACK_NUMBER)) {
                 mapOf()
-            } else
-                publicationDao.fetchPublicationTrackNumberChanges(
-                    publication.layoutBranch.branch,
-                    publication.id,
-                )
+            } else publicationDao.fetchPublicationTrackNumberChanges(publication.layoutBranch.branch, publication.id)
         val publicationKmPostChanges =
             if (canSkipLoadingChanges(publication, publicationLogAsset, PublishableObjectType.KM_POST)) mapOf()
             else publicationDao.fetchPublicationKmPostChanges(publication.id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationService.kt
@@ -45,12 +45,12 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.OperationalPointDao
 import fi.fta.geoviite.infra.tracklayout.OperationalPointService
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
 
 @GeoviiteService
 class PublicationService
@@ -180,7 +180,11 @@ constructor(
         val revertSplitSwitches = revertSplits.flatMap { s -> s.relinkedSwitches }.distinct()
 
         val trackBoundaryMoves =
-            trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, locationTrackIds.toList(), requestIds.switches)
+            trackBoundaryMoveService.findUnpublishedBoundaryMoves(
+                branch,
+                locationTrackIds.toList(),
+                requestIds.switches,
+            )
         val trackBoundaryMoveTracks = trackBoundaryMoves.flatMap { s -> s.locationTracks.map { it.id } }.distinct()
         val trackBoundaryMoveSwitches = trackBoundaryMoves.flatMap { move -> move.relinkedSwitches }.distinct()
 
@@ -216,7 +220,8 @@ constructor(
             splitService.deleteSplit(split.id)
         }
 
-        trackBoundaryMoveService.findUnpublishedBoundaryMoves(branch, toDelete.locationTracks, toDelete.switches)
+        trackBoundaryMoveService
+            .findUnpublishedBoundaryMoves(branch, toDelete.locationTracks, toDelete.switches)
             .forEach { trackBoundaryMove ->
                 val shortenedTrackIncluded =
                     toDelete.locationTracks.contains(trackBoundaryMove.shortenedLocationTrack.id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidation.kt
@@ -613,13 +613,7 @@ fun validateSwitchTopologicalConnectivity(
     val existingTracks = locationTracksAndGeometries.filter { it.first.exists }
     return listOf(
             listOfNotNull(validateFrontJointTopology(switch, structure, existingTracks, validatingTrack)),
-            validateSwitchAlignmentTopology(
-                switch.id as IntId,
-                structure,
-                existingTracks,
-                switch.name,
-                validatingTrack,
-            ),
+            validateSwitchAlignmentTopology(switch.id as IntId, structure, existingTracks, switch.name, validatingTrack),
         )
         .flatten()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationService.kt
@@ -91,9 +91,7 @@ constructor(
         validationContext.preloadKmPostsByTrackNumbers(trackNumberIds)
         validationContext.preloadLocationTracksByTrackNumbers(trackNumberIds)
 
-        return trackNumberIds.map { id ->
-            ValidatedAsset(id, validateTrackNumber(id, validationContext))
-        }
+        return trackNumberIds.map { id -> ValidatedAsset(id, validateTrackNumber(id, validationContext)) }
     }
 
     @Transactional(readOnly = true)
@@ -331,9 +329,7 @@ constructor(
         versions.locationTracks.forEach { version ->
             assertNoErrors(version, validateLocationTrack(version.id, validationContext))
         }
-        versions.switches.forEach { version ->
-            assertNoErrors(version, validateSwitch(version.id, validationContext))
-        }
+        versions.switches.forEach { version -> assertNoErrors(version, validateSwitch(version.id, validationContext)) }
         versions.operationalPoints.forEach { version ->
             assertNoErrors(version, validateOperationalPoint(version.id, validationContext))
         }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/publication/ValidationContext.kt
@@ -282,11 +282,13 @@ class ValidationContext(
         publicationSet.containsSplit(split.id)
     }
 
-    fun getPublicationTrackBoundaryMoves(): List<TrackBoundaryMove> =
-        allUnpublishedTrackBoundaryMoves.filter { move -> publicationSet.containsTrackBoundaryMove(move.id) }
+    fun getPublicationTrackBoundaryMoves(): List<TrackBoundaryMove> = allUnpublishedTrackBoundaryMoves.filter { move ->
+        publicationSet.containsTrackBoundaryMove(move.id)
+    }
 
-    fun getUnfinishedSplits(): List<Split> =
-        allUnfinishedSplits.filter { split -> split.publicationId != null || publicationSet.containsSplit(split.id) }
+    fun getUnfinishedSplits(): List<Split> = allUnfinishedSplits.filter { split ->
+        split.publicationId != null || publicationSet.containsSplit(split.id)
+    }
 
     fun isLocationTrackSourceOfAnyFinishedSplit(id: IntId<LocationTrack>): Boolean =
         splitService.isLocationTrackSourceOfAnyFinishedSplit(target.candidateBranch, id)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoAssetService.kt
@@ -25,9 +25,9 @@ import fi.fta.geoviite.infra.tracklayout.LayoutStateCategory
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchDao
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchJoint
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoClient.kt
@@ -57,6 +57,7 @@ import fi.fta.geoviite.infra.split.Split
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitch
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
+import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -69,7 +70,6 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
-import java.time.Duration
 
 val defaultBlockTimeout: Duration = defaultResponseTimeout.plusMinutes(1L)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocationTrackService.kt
@@ -45,11 +45,11 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.LocationTrackState
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 data class LocationTrackKilometers(
     val id: IntId<LocationTrack>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDao.kt
@@ -33,10 +33,10 @@ import fi.fta.geoviite.infra.util.produceIf
 import fi.fta.geoviite.infra.util.queryOne
 import fi.fta.geoviite.infra.util.queryOptional
 import fi.fta.geoviite.infra.util.setUser
+import java.time.Instant
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 @Transactional(readOnly = true)
 @Component

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoRouteNumberService.kt
@@ -20,9 +20,9 @@ import fi.fta.geoviite.infra.tracklayout.LayoutState
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumber
 import fi.fta.geoviite.infra.tracklayout.LayoutTrackNumberDao
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import java.time.Instant
 
 @GeoviiteService
 @ConditionalOnBean(RatkoClientConfiguration::class)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/ratko/RatkoService.kt
@@ -43,13 +43,13 @@ import fi.fta.geoviite.infra.tracklayout.LayoutDesignDao
 import fi.fta.geoviite.infra.tracklayout.LayoutSwitchService
 import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
+import java.time.Duration
+import java.time.Instant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Duration
-import java.time.Instant
 
 class RatkoException(
     val type: RatkoPushErrorType,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/Split.kt
@@ -87,13 +87,15 @@ data class Split(
     @JsonIgnore
     val isPublishedAndWaitingTransfer: Boolean = bulkTransferState != BulkTransferState.DONE && publicationId != null
 
-    fun containsTargetTrack(trackId: IntId<LocationTrack>): Boolean =
-        targetLocationTracks.any { tlt -> tlt.locationTrackId == trackId }
+    fun containsTargetTrack(trackId: IntId<LocationTrack>): Boolean = targetLocationTracks.any { tlt ->
+        tlt.locationTrackId == trackId
+    }
 
     override fun containsLocationTrack(trackId: IntId<LocationTrack>): Boolean = locationTracks.contains(trackId)
 
-    fun getTargetLocationTrack(trackId: IntId<LocationTrack>): SplitTarget? =
-        targetLocationTracks.find { track -> track.locationTrackId == trackId }
+    fun getTargetLocationTrack(trackId: IntId<LocationTrack>): SplitTarget? = targetLocationTracks.find { track ->
+        track.locationTrackId == trackId
+    }
 
     override fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean = relinkedSwitches.contains(switchId)
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitService.kt
@@ -60,9 +60,9 @@ import fi.fta.geoviite.infra.tracklayout.collectSplitPoints
 import fi.fta.geoviite.infra.tracklayout.topologicalConnectivityTypeOf
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.produceIf
+import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 const val MAX_SPLIT_GEOM_ADJUSTMENT = 5.0
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/split/SplitValidation.kt
@@ -58,34 +58,32 @@ internal fun validateAdministrativeChangeContent(
             emptyList()
         }
 
-    val splitContentErrors =
-        publicationSplits.flatMap { split ->
-            val containsSource = trackVersions.any { it.id == split.sourceLocationTrackId }
-            val containsTargets =
-                split.targetLocationTracks.all { tlt -> trackVersions.any { it.id == tlt.locationTrackId } }
-            val containsSwitches = split.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
-            listOfNotNull(
-                    validate(containsSource && containsTargets, ERROR) {
-                        "$VALIDATION_SPLIT.split-missing-location-tracks"
-                    },
-                    validate(containsSwitches, ERROR) { "$VALIDATION_SPLIT.split-missing-switches" },
-                )
-                .map { e -> split to e }
-        }
+    val splitContentErrors = publicationSplits.flatMap { split ->
+        val containsSource = trackVersions.any { it.id == split.sourceLocationTrackId }
+        val containsTargets =
+            split.targetLocationTracks.all { tlt -> trackVersions.any { it.id == tlt.locationTrackId } }
+        val containsSwitches = split.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
+        listOfNotNull(
+                validate(containsSource && containsTargets, ERROR) {
+                    "$VALIDATION_SPLIT.split-missing-location-tracks"
+                },
+                validate(containsSwitches, ERROR) { "$VALIDATION_SPLIT.split-missing-switches" },
+            )
+            .map { e -> split to e }
+    }
 
-    val boundaryMoveContentErrors =
-        publicationTrackBoundaryMoves.flatMap { move ->
-            val containsShortened = trackVersions.any { it.id == move.shortenedLocationTrack.id }
-            val containsLengthened = trackVersions.any { it.id == move.lengthenedLocationTrack.id }
-            val containsSwitches = move.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
-            listOfNotNull(
-                    validate(containsShortened && containsLengthened, ERROR) {
-                        "$VALIDATION_BOUNDARY_MOVE.missing-location-tracks"
-                    },
-                    validate(containsSwitches, ERROR) { "$VALIDATION_BOUNDARY_MOVE.missing-switches" },
-                )
-                .map { e -> move to e }
-        }
+    val boundaryMoveContentErrors = publicationTrackBoundaryMoves.flatMap { move ->
+        val containsShortened = trackVersions.any { it.id == move.shortenedLocationTrack.id }
+        val containsLengthened = trackVersions.any { it.id == move.lengthenedLocationTrack.id }
+        val containsSwitches = move.relinkedSwitches.all { s -> switchVersions.any { sv -> sv.id == s } }
+        listOfNotNull(
+                validate(containsShortened && containsLengthened, ERROR) {
+                    "$VALIDATION_BOUNDARY_MOVE.missing-location-tracks"
+                },
+                validate(containsSwitches, ERROR) { "$VALIDATION_BOUNDARY_MOVE.missing-switches" },
+            )
+            .map { e -> move to e }
+    }
 
     return listOf(multipleChangesStagedErrors, splitContentErrors, boundaryMoveContentErrors).flatten()
 }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/switchLibrary/SwitchLibraryService.kt
@@ -50,10 +50,9 @@ class SwitchLibraryService(
     fun replaceExistingSwitchStructures(newSwitchStructures: List<SwitchStructureData>) {
         val existingSwitchStructures = switchStructureDao.fetchSwitchStructures()
         existingSwitchStructures.forEach { existingSwitchStructure ->
-            val existsInNewSet =
-                newSwitchStructures.any { newSwitchStructure ->
-                    newSwitchStructure.type == existingSwitchStructure.type
-                }
+            val existsInNewSet = newSwitchStructures.any { newSwitchStructure ->
+                newSwitchStructure.type == existingSwitchStructure.type
+            }
             if (!existsInNewSet) {
                 switchStructureDao.delete(existingSwitchStructure.id)
             }

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDao.kt
@@ -101,13 +101,14 @@ class LayoutAlignmentDao(
             .recordStats()
             .build()
 
-    override fun cacheStats() = mapOf(
-        "layout-alignment-nodes" to nodesCache.stats(),
-        "layout-alignment-edges" to edgesCache.stats(),
-        "layout-alignment-location-track-geometry" to locationTrackGeometryCache.stats(),
-        "layout-alignment-reference-line-geometry" to referenceLineGeometryCache.stats(),
-        "layout-alignment-segment-geometry" to segmentGeometryCache.stats(),
-    )
+    override fun cacheStats() =
+        mapOf(
+            "layout-alignment-nodes" to nodesCache.stats(),
+            "layout-alignment-edges" to edgesCache.stats(),
+            "layout-alignment-location-track-geometry" to locationTrackGeometryCache.stats(),
+            "layout-alignment-reference-line-geometry" to referenceLineGeometryCache.stats(),
+            "layout-alignment-segment-geometry" to segmentGeometryCache.stats(),
+        )
 
     fun getNode(id: IntId<LayoutNode>): DbLayoutNode = requireNotNull(getNodes(listOf(id))[id])
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutContextData.kt
@@ -95,14 +95,13 @@ sealed class LayoutContextData<T : LayoutAsset<T>> : LayoutContextAware<T> {
     open val originBranch: LayoutBranch?
         get() = null
 
-    protected fun requireStoredRowVersion() =
-        layoutAssetId.let { current ->
-            if (current is StoredAssetId) current.version
-            else
-                error(
-                    "Only $STORED rows can transition to a different context: context=${this::class.simpleName} dataType=$dataType"
-                )
-        }
+    protected fun requireStoredRowVersion() = layoutAssetId.let { current ->
+        if (current is StoredAssetId) current.version
+        else
+            error(
+                "Only $STORED rows can transition to a different context: context=${this::class.simpleName} dataType=$dataType"
+            )
+    }
 
     companion object {
         fun <T : LayoutAsset<T>> new(context: LayoutContext, id: IntId<T>?): LayoutContextData<T> =

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGraph.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutGraph.kt
@@ -120,7 +120,9 @@ private fun creteGraphNodes(edges: List<GraphEdgeData>): Map<IntId<LayoutNode>, 
         .associateBy { it.id }
 
 private fun createGraphEdges(edges: List<GraphEdgeData>): Map<DomainId<LayoutEdge>, LayoutGraphEdge> =
-    edges.associate { e -> e.id to LayoutGraphEdge(e) }
+    edges.associate { e ->
+        e.id to LayoutGraphEdge(e)
+    }
 
 data class LayoutGraphEdge(
     val id: DomainId<LayoutEdge>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitch.kt
@@ -55,8 +55,9 @@ data class LayoutSwitch(
     fun getJoint(location: AlignmentPoint<LocationTrackM>, delta: Double): LayoutSwitchJoint? =
         getJoint(Point(location.x, location.y), delta)
 
-    fun getJoint(location: Point, delta: Double): LayoutSwitchJoint? =
-        joints.find { j -> j.location.isSame(location, delta) }
+    fun getJoint(location: Point, delta: Double): LayoutSwitchJoint? = joints.find { j ->
+        j.location.isSame(location, delta)
+    }
 
     fun getJoint(number: JointNumber): LayoutSwitchJoint? = joints.find { j -> j.number == number }
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchDao.kt
@@ -35,13 +35,13 @@ import fi.fta.geoviite.infra.util.getOidOrNull
 import fi.fta.geoviite.infra.util.getPoint
 import fi.fta.geoviite.infra.util.setUser
 import fi.fta.geoviite.infra.util.toDbId
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.sql.ResultSet
-import java.sql.Timestamp
-import java.time.Instant
 
 const val SWITCH_CACHE_SIZE = 10000L
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutSwitchService.kt
@@ -23,9 +23,9 @@ import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.Page
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.page
+import java.time.Instant
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
 
 data class LayoutSwitchConnectionUpdates(val clearJoints: Boolean, val clearTracks: Boolean)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberController.kt
@@ -29,6 +29,7 @@ import fi.fta.geoviite.infra.publication.ValidatedAsset
 import fi.fta.geoviite.infra.util.FILENAME_DATE_FORMATTER
 import fi.fta.geoviite.infra.util.getCsvResponseEntity
 import fi.fta.geoviite.infra.util.toResponse
+import java.time.Instant
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -38,7 +39,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
-import java.time.Instant
 
 @GeoviiteController("/track-layout/track-numbers")
 class LayoutTrackNumberController(

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberService.kt
@@ -30,9 +30,9 @@ import fi.fta.geoviite.infra.util.CsvEntry
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.printCsv
-import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.stream.Collectors
+import org.springframework.transaction.annotation.Transactional
 
 const val KM_LENGTHS_CSV_TRANSLATION_PREFIX = "data-products.km-lengths.data"
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDao.kt
@@ -653,20 +653,18 @@ class LocationTrackDao(
                 )
             }
 
-        val byTrackNumber =
-            trackNumberIds.associateWith { trackNumberId ->
-                rows.filter { it.trackNumberId == trackNumberId }.map { it.version }
-            }
-        val byOperationalPoint =
-            operationalPointIds.associateWith { operationalPointId ->
-                rows.filter { it.operationalPointIds.contains(operationalPointId) }.map { it.version }
-            }
-        val byDuplicateOfLocationTrack =
-            duplicateOfLocationTrackIds.associateWith { duplicateOfLocationTrackId ->
-                rows.filter { it.duplicateOfLocationTrackId == duplicateOfLocationTrackId }.map { it.version }
-            }
-        val bySwitch =
-            switchIds.associateWith { switchId -> rows.filter { it.switchIds.contains(switchId) }.map { it.version } }
+        val byTrackNumber = trackNumberIds.associateWith { trackNumberId ->
+            rows.filter { it.trackNumberId == trackNumberId }.map { it.version }
+        }
+        val byOperationalPoint = operationalPointIds.associateWith { operationalPointId ->
+            rows.filter { it.operationalPointIds.contains(operationalPointId) }.map { it.version }
+        }
+        val byDuplicateOfLocationTrack = duplicateOfLocationTrackIds.associateWith { duplicateOfLocationTrackId ->
+            rows.filter { it.duplicateOfLocationTrackId == duplicateOfLocationTrackId }.map { it.version }
+        }
+        val bySwitch = switchIds.associateWith { switchId ->
+            rows.filter { it.switchIds.contains(switchId) }.map { it.version }
+        }
 
         return LocationTrackVersionsForValidation(
                 byTrackNumber = byTrackNumber,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackGeometry.kt
@@ -692,11 +692,13 @@ sealed class LayoutNode {
 
     fun get(port: NodePortType) = if (port == A) portA else portB
 
-    fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean =
-        ports.any { port -> (port as? SwitchLink)?.id == switchId }
+    fun containsSwitch(switchId: IntId<LayoutSwitch>): Boolean = ports.any { port ->
+        (port as? SwitchLink)?.id == switchId
+    }
 
-    fun containsJoint(switchId: IntId<LayoutSwitch>, joint: JointNumber): Boolean =
-        ports.any { port -> (port as? SwitchLink)?.matches(switchId, joint) ?: false }
+    fun containsJoint(switchId: IntId<LayoutSwitch>, joint: JointNumber): Boolean = ports.any { port ->
+        (port as? SwitchLink)?.matches(switchId, joint) ?: false
+    }
 
     fun containsBoundary(boundary: TrackBoundary): Boolean = ports.any { port -> port == boundary }
 
@@ -1101,12 +1103,12 @@ private fun replaceEdges(
     edgesToReplace: List<LayoutEdge>,
     newEdges: List<LayoutEdge>,
 ): List<LayoutEdge> {
-    val replaceStartIndex =
-        originalEdges.indexOfFirst { originalEdge ->
-            originalEdge.startNode.node == edgesToReplace.first().startNode.node
-        }
-    val replaceEndIndex =
-        originalEdges.indexOfLast { originalEdge -> originalEdge.endNode.node == edgesToReplace.last().endNode.node }
+    val replaceStartIndex = originalEdges.indexOfFirst { originalEdge ->
+        originalEdge.startNode.node == edgesToReplace.first().startNode.node
+    }
+    val replaceEndIndex = originalEdges.indexOfLast { originalEdge ->
+        originalEdge.endNode.node == edgesToReplace.last().endNode.node
+    }
     require(replaceStartIndex != -1 && replaceEndIndex != -1) { "Cannot replace non existing edges" }
     val newAllEdges =
         originalEdges.subList(0, replaceStartIndex) +

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackService.kt
@@ -49,11 +49,11 @@ import fi.fta.geoviite.infra.tracklayout.DuplicateEndPointType.START
 import fi.fta.geoviite.infra.util.FreeText
 import fi.fta.geoviite.infra.util.mapNonNullValues
 import fi.fta.geoviite.infra.util.processFlattened
+import java.time.Instant
 import org.postgresql.util.PSQLException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.Instant
 
 const val TRACK_SEARCH_AREA_SIZE = 2.0
 const val OPERATIONAL_POINT_AROUND_SWITCH_SEARCH_AREA_SIZE = 1000.0

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointController.kt
@@ -38,7 +38,7 @@ class OperationalPointController(
     @PreAuthorize(AUTH_VIEW_LAYOUT_DRAFT)
     @GetMapping("/operational-points/{$LAYOUT_BRANCH}/draft/externally-changed")
     fun getExternallyChangedOperationalPointIds(
-        @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch,
+        @PathVariable(LAYOUT_BRANCH) layoutBranch: LayoutBranch
     ): List<IntId<OperationalPoint>> {
         val context = LayoutContext.of(layoutBranch, PublicationState.DRAFT)
         return operationalPointService.getExternallyChangedOperationalPointIds(context)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/PlanLayoutTransformation.kt
@@ -277,14 +277,13 @@ fun toSegmentGeometryPoint(
     verticalCoordinateSystem: VerticalCoordinateSystem?,
 ): SegmentPoint {
     // Profile station values are alignment m-values calculated from given station-start
-    val heightValue =
-        verticalCoordinateSystem?.let { vcs ->
-            if (vcs == VerticalCoordinateSystem.N43) null
-            else
-                profile?.getHeightAt(LineM(alignmentStartStation + segmentStart + mValue))?.let { value ->
-                    transformHeightValue(value, point, heightTriangles, vcs)
-                }
-        }
+    val heightValue = verticalCoordinateSystem?.let { vcs ->
+        if (vcs == VerticalCoordinateSystem.N43) null
+        else
+            profile?.getHeightAt(LineM(alignmentStartStation + segmentStart + mValue))?.let { value ->
+                transformHeightValue(value, point, heightTriangles, vcs)
+            }
+    }
     // Cant station values are alignment m-values, calculated from 0 (ignoring alignment
     // station-start)
     val cantValue = cant?.getCantValue(segmentStart + mValue)

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Routing.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/Routing.kt
@@ -15,13 +15,13 @@ import fi.fta.geoviite.infra.tracklayout.VertexDirection.IN
 import fi.fta.geoviite.infra.tracklayout.VertexDirection.OUT
 import fi.fta.geoviite.infra.util.alsoIfNull
 import fi.fta.geoviite.infra.util.produceIf
+import java.util.*
 import org.jgrapht.Graph
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath
 import org.jgrapht.graph.AsGraphUnion
 import org.jgrapht.graph.DirectedWeightedMultigraph
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.*
 
 private val logger: Logger = LoggerFactory.getLogger(RoutingGraph::class.java)
 

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/RoutingService.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/tracklayout/RoutingService.kt
@@ -8,7 +8,6 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.LayoutContext
 import fi.fta.geoviite.infra.common.PublicationState.DRAFT
 import fi.fta.geoviite.infra.common.PublicationState.OFFICIAL
-import com.github.benmanes.caffeine.cache.stats.CacheStats
 import fi.fta.geoviite.infra.configuration.ManualCacheStatsProvider
 import fi.fta.geoviite.infra.configuration.layoutCacheDuration
 import fi.fta.geoviite.infra.math.Point

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/DaoBase.kt
@@ -13,12 +13,12 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrack
 import fi.fta.geoviite.infra.tracklayout.OperationalPoint
 import fi.fta.geoviite.infra.util.FetchType.MULTI
 import fi.fta.geoviite.infra.util.FetchType.SINGLE
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.sql.ResultSet
 import java.time.Instant
 import kotlin.reflect.KClass
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 
 enum class FetchType {
     SINGLE,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/util/ResultSetExternal.kt
@@ -513,13 +513,12 @@ inline fun <reified T> verifyNotNull(
         "Value was null: type=${T::class.simpleName} column1=$column1 column2=$column2"
     }
 
-inline fun <reified T> verifyType(value: Any?): T =
-    value.let { v ->
-        require(v is T) {
-            "Value is of unexpected type: expected=${T::class.simpleName} actual=${v?.javaClass?.simpleName} value=${v}"
-        }
-        v
+inline fun <reified T> verifyType(value: Any?): T = value.let { v ->
+    require(v is T) {
+        "Value is of unexpected type: expected=${T::class.simpleName} actual=${v?.javaClass?.simpleName} value=${v}"
     }
+    v
+}
 
 fun <T : LayoutAsset<T>> ResultSet.getLayoutContextData(
     idName: String,

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiSwaggerIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/ExtApiSwaggerIT.kt
@@ -14,7 +14,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 
 @ActiveProfiles("dev", "test", "ext-api", "ext-api-dev-swagger")
 @SpringBootTest(classes = [InfraApplication::class])

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/CoordinateToTrackAddressIT.kt
@@ -30,6 +30,10 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.someOid
 import fi.fta.geoviite.infra.tracklayout.someTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
+import java.math.BigDecimal
+import java.util.*
+import kotlin.math.hypot
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -39,10 +43,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.math.BigDecimal
-import java.util.*
-import kotlin.math.hypot
-import kotlin.test.assertEquals
 
 private const val API_TRACK_ADDRESSES: FrameConverterUrl = "/rata-vkm/v1/rataosoitteet"
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/frameconverter/v1/TrackAddressToCoordinateIT.kt
@@ -28,6 +28,10 @@ import fi.fta.geoviite.infra.tracklayout.someReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.someTrackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,10 +40,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 private const val API_COORDINATES: FrameConverterUrl = "/rata-vkm/v1/koordinaatit"
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackCollectionIT.kt
@@ -59,10 +59,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
                 mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
             }
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = tracks.map { (id, _) -> id },
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = tracks.map { (id, _) -> id })
 
         val newestButEmptyPublication = testDBService.publish()
         val response = api.locationTrackCollection.get()
@@ -187,11 +184,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (trackId, trackOid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-        val publication =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         tests.forEach { (epsgCode, expectedStart, expectedEnd) ->
             val response =
@@ -231,10 +224,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
                 trackGeometryOfSegments(segment),
             )
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(deletedTrackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(deletedTrackId))
 
         val response = api.locationTrackCollection.get()
         assertEquals(0, response.sijaintiraiteet.size)
@@ -263,10 +253,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
                     trackOid to trackId
                 }
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = tracks.map { (_, id) -> id },
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = tracks.map { (_, id) -> id })
 
         val response = api.locationTrackCollection.get()
         assertEquals(tracks.size, response.sijaintiraiteet.size)
@@ -415,10 +402,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
             }
 
         val initialPublication =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = tracks.map { (id, _) -> id },
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = tracks.map { (id, _) -> id })
 
         val modifiedTrackDescription = "this is a modified track from publicationUuid=${initialPublication.uuid}"
         tracks.forEach { (id, _) ->
@@ -456,10 +440,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val trackOid = mainDraftContext.generateOid(trackId)
 
         val publicationStart =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val modifiedDescription = "previous track layout version uuid=${publicationStart.uuid}"
         locationTrackService.getWithGeometry(trackVersion).let { (track, geometry) ->
@@ -502,10 +483,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val trackOid = mainDraftContext.generateOid(trackId)
 
         val publicationStart =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val modifiedDescription = "previous track layout version uuid=${publicationStart.uuid}"
         locationTrackService.getWithGeometry(trackVersion).let { (track, geometry) ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackIT.kt
@@ -58,10 +58,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (track, geometry) = locationTrackService.getWithGeometry(trackVersion)
 
         val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackVersion.id),
-            )
+            testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackVersion.id))
 
         val modifiedDescription = "modified description after publication=${publication1.uuid}"
         mainDraftContext.save(track.copy(description = FreeText(modifiedDescription)), geometry)
@@ -83,11 +80,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-        val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication1 = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val publication2 = testDBService.publish()
 
@@ -132,10 +125,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         tests.forEach { (epsgCode, expectedStart, expectedEnd) ->
             val response = api.locationTracks.get(oid, "koordinaatisto" to epsgCode)
@@ -161,11 +151,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val geometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(100.0, 0.0)))
         val (trackId, oid) = mainDraftContext.saveWithOid(locationTrack(trackNumberId), geometry)
 
-        val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication1 = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         api.locationTrackGeometry.get(oid).also { response ->
             assertEquals(publication1.uuid.toString(), response.rataverkon_versio)
@@ -217,10 +203,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         Resolution.entries
             .map { it.meters }
@@ -257,10 +240,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         Resolution.entries
             .map { it.meters }
@@ -297,10 +277,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
                 Triple(trackOid, trackId, state)
             }
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = tracks.map { (_, id, _) -> id },
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = tracks.map { (_, id, _) -> id })
 
         tracks.forEach { (oid, _, state) ->
             val response = api.locationTracks.get(oid)
@@ -364,11 +341,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val trackGeom = trackGeometryOfSegments(segment(Point(20.0, 0.0), Point(40.0, 0.0)))
         val (trackId, trackOid) = mainDraftContext.saveWithOid(locationTrack(tnId), trackGeom)
 
-        val basePublication =
-            testDBService.publish(
-                trackNumbers = listOf(tnId),
-                locationTracks = listOf(trackId),
-            )
+        val basePublication = testDBService.publish(trackNumbers = listOf(tnId), locationTracks = listOf(trackId))
         assertEquals("0000+0020.000", getExtLocationTrack(trackOid).alkusijainti?.rataosoite)
         api.locationTracks.assertNoModificationSince(trackOid, basePublication.uuid)
 
@@ -410,11 +383,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(segment))
 
-        val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication1 = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         api.locationTrackGeometry.get(oid).also { response ->
             assertEquals(publication1.uuid.toString(), response.rataverkon_versio)
@@ -441,11 +410,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
 
         val trackGeom = trackGeometryOfSegments(segment(Point(10.0, 0.0), Point(90.0, 0.0)))
         val (trackId, trackOid) = mainDraftContext.saveWithOid(locationTrack(tnId), trackGeom)
-        val initPublication =
-            testDBService.publish(
-                trackNumbers = listOf(tnId),
-                locationTracks = listOf(trackId),
-            )
+        val initPublication = testDBService.publish(trackNumbers = listOf(tnId), locationTracks = listOf(trackId))
         val startWithAddress = ExtTestAddressPointV1(10.0, 0.0, "0000+0010.000")
         val startWithoutAddress = ExtTestAddressPointV1(10.0, 0.0, null)
         val endWithAddress = ExtTestAddressPointV1(90.0, 0.0, "0000+0090.000")
@@ -603,11 +568,7 @@ constructor(mockMvc: MockMvc, private val locationTrackService: LocationTrackSer
         val trackGeom = trackGeometryOfSegments(segment(Point(20.0, 0.0), Point(40.0, 0.0)))
         val (trackId, oid) = mainDraftContext.saveWithOid(locationTrack(tnId), trackGeom)
 
-        val basePub =
-            testDBService.publish(
-                trackNumbers = listOf(tnId),
-                locationTracks = listOf(trackId),
-            )
+        val basePub = testDBService.publish(trackNumbers = listOf(tnId), locationTracks = listOf(trackId))
         api.locationTrackGeometry.get(oid).osoitevali!!.also { interval ->
             assertEquals("0000+0020.000", interval.alkuosoite)
             assertEquals("0000+0040.000", interval.loppuosoite)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtLocationTrackProfileIT.kt
@@ -52,6 +52,7 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometryOfElements
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FileName
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -63,7 +64,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.math.BigDecimal
 
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
@@ -108,11 +108,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
 
         // Publication 1: track with plan-linked profile
-        val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication1 = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         // Publication 2: empty publish — no changes to the track
         val publication2 = testDBService.publish()
@@ -220,11 +216,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
                 locationTrack(trackNumberId),
                 trackGeometryOfElements(plan.alignments[0].elements),
             )
-        val publication =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val response = api.locationTrackProfile.get(oid)
         assertProfileResponseTopLevel(response, oid, publication.uuid)
@@ -307,10 +299,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val pviPoint = api.locationTrackProfile.get(oid).osoitevali.taitepisteet.single()
 
@@ -338,10 +327,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val pviPoint = api.locationTrackProfile.get(oid).osoitevali.taitepisteet.single()
 
@@ -368,10 +354,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val pviPoint = api.locationTrackProfile.get(oid).osoitevali.taitepisteet.single()
 
@@ -411,10 +394,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val addressRange = api.locationTrackProfile.get(oid).osoitevali
         assertEquals("0000+0000.000", addressRange.alku, "Address range should start at track start")
@@ -489,10 +469,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
                     segment(toSegmentPoints(to3DMPoints(points2)), sourceId = sourceElement2.id, sourceStartM = 0.0),
                 ),
             )
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         // Plan1 curve at station 300 → track address 0+300. Plan2 curve at station 300 → track address 800+300=1100.
         val pviAddresses =
@@ -582,10 +559,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
                     segment(toSegmentPoints(to3DMPoints(points2)), sourceId = sourceElement2.id, sourceStartM = 0.0),
                 ),
             )
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         // Plan1 curve at station 490 → track address ~490. Plan2 curve at station 510 → track address ~510.
         // Both curves describe overlapping profile near the connection point.
@@ -646,10 +620,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
             )
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfSegments(refLineSegment))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val addressRange = api.locationTrackProfile.get(oid).osoitevali
         assertNotNull(addressRange.alku, "Address range start should be present for existing track")
@@ -690,11 +661,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements1)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements1))
-        val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(trackNumberId),
-                locationTracks = listOf(trackId),
-            )
+        val publication1 = testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         // Publication 2: re-link the same track to a different plan with modified profile
         val plan2 =
@@ -873,10 +840,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements, FIN_GK25_SRID)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements, FIN_GK25_SRID))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val pviPoint = api.locationTrackProfile.get(oid).osoitevali.taitepisteet.single()
         val location = pviPoint.taite.sijainti!!
@@ -936,10 +900,7 @@ constructor(mockMvc: MockMvc, private val heightTriangleDao: HeightTriangleDao) 
         val trackNumberId = insertTrackNumberWithReferenceLine(elements, FIN_GK25_SRID)
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements, FIN_GK25_SRID))
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         val pviPoint = api.locationTrackProfile.get(oid).osoitevali.taitepisteet.single()
         val pviLayout = transformNonKKJCoordinate(FIN_GK25_SRID, LAYOUT_SRID, gk25Pvi)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtOperationalPointIT.kt
@@ -25,6 +25,7 @@ import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -36,7 +37,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import kotlin.random.Random
 
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])
@@ -451,10 +451,7 @@ class ExtOperationalPointIT @Autowired constructor(mockMvc: MockMvc) : DBTestBas
             )
 
         val trackPublication =
-            testDBService.publish(
-                locationTracks = listOf(trackId),
-                trackNumbers = listOf(trackNumberId),
-            )
+            testDBService.publish(locationTracks = listOf(trackId), trackNumbers = listOf(trackNumberId))
 
         // Operational point should show as changed again
         val trackModification = api.operationalPoint.getModifiedSince(opOid, switchPublication.uuid)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtSwitchIT.kt
@@ -32,6 +32,7 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -41,7 +42,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import kotlin.test.assertNotEquals
 
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTestTrackLayoutV1IT.kt
@@ -550,10 +550,7 @@ constructor(
         val (trackId, oid) =
             mainDraftContext.saveWithOid(locationTrack(trackNumberId), trackGeometryOfElements(elements))
 
-        testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = listOf(trackId),
-        )
+        testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = listOf(trackId))
 
         return oid
     }
@@ -574,10 +571,7 @@ constructor(
                 trackId
             }
 
-        return testDBService.publish(
-            trackNumbers = listOf(trackNumberId),
-            locationTracks = tracks,
-        )
+        return testDBService.publish(trackNumbers = listOf(trackNumberId), locationTracks = tracks)
     }
 
     private fun setupValidSwitch(): Oid<LayoutSwitch> {

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackBoundaryChangeIT.kt
@@ -58,10 +58,11 @@ constructor(
     @Test
     fun `LocationTrack split shows up a boundary change`() {
         val tn = testDBService.getUnusedTrackNumber()
-        val (tnId, tnOid) = mainDraftContext.saveWithOid(
-            trackNumber(tn),
-            referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0))),
-        )
+        val (tnId, tnOid) =
+            mainDraftContext.saveWithOid(
+                trackNumber(tn),
+                referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0))),
+            )
         val structureId = switchStructureYV60_300_1_9().id
         val switch1Joints = listOf(switchJoint(1, Point(200.0, 0.0)), switchJoint(2, Point(210.0, 10.0)))
         val switch1Id = mainDraftContext.save(switch(structureId, switch1Joints)).id
@@ -200,10 +201,11 @@ constructor(
     @Test
     fun `Track boundary change shows up with vaihtumiskohdan_siirto type`() {
         val tn = testDBService.getUnusedTrackNumber()
-        val (tnId, tnOid) = mainDraftContext.saveWithOid(
-            trackNumber(tn),
-            referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0))),
-        )
+        val (tnId, tnOid) =
+            mainDraftContext.saveWithOid(
+                trackNumber(tn),
+                referenceLineGeometry(segment(Point(0.0, 0.0), Point(500.0, 0.0))),
+            )
 
         // Switch1 at 100: current boundary between tracks
         // Switch2 at 200: new boundary point (on shortening track)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberCollectionIT.kt
@@ -365,10 +365,7 @@ constructor(mockMvc: MockMvc, private val layoutTrackNumberService: LayoutTrackN
         val (matchingId, matchingOid) =
             mainDraftContext.saveWithOid(trackNumber(TrackNumber("001 MATCHING")), referenceLineGeometry(someSegment()))
         val (otherId, _) =
-            mainDraftContext.saveWithOid(
-                trackNumber(TrackNumber("999 OTHER")),
-                referenceLineGeometry(someSegment()),
-            )
+            mainDraftContext.saveWithOid(trackNumber(TrackNumber("999 OTHER")), referenceLineGeometry(someSegment()))
 
         testDBService.publish(trackNumbers = listOf(matchingId, otherId))
 
@@ -385,10 +382,7 @@ constructor(mockMvc: MockMvc, private val layoutTrackNumberService: LayoutTrackN
         val (matchingId, matchingOid) =
             mainDraftContext.saveWithOid(trackNumber(TrackNumber("001 MATCHING")), referenceLineGeometry(someSegment()))
         val (otherId, _) =
-            mainDraftContext.saveWithOid(
-                trackNumber(TrackNumber("999 OTHER")),
-                referenceLineGeometry(someSegment()),
-            )
+            mainDraftContext.saveWithOid(trackNumber(TrackNumber("999 OTHER")), referenceLineGeometry(someSegment()))
 
         val fromPublication = testDBService.publish(trackNumbers = listOf(matchingId, otherId)).uuid
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberIT.kt
@@ -418,11 +418,7 @@ constructor(mockMvc: MockMvc, private val layoutTrackNumberDao: LayoutTrackNumbe
         // Use km-posts to reset address calculation, as otherwise any change would change the geometry until the end
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(2), gkLocation = kmPostGkLocation(15.0, 0.0))).id
         val kmp2Id = mainDraftContext.save(kmPost(tnId, KmNumber(3), gkLocation = kmPostGkLocation(65.0, 0.0))).id
-        val publication1 =
-            testDBService.publish(
-                trackNumbers = listOf(tnId),
-                kmPosts = listOf(kmp1Id, kmp2Id),
-            )
+        val publication1 = testDBService.publish(trackNumbers = listOf(tnId), kmPosts = listOf(kmp1Id, kmp2Id))
 
         api.trackNumberGeometry.get(tnOid).also { response ->
             assertEquals(publication1.uuid.toString(), response.rataverkon_versio)
@@ -550,11 +546,7 @@ constructor(mockMvc: MockMvc, private val layoutTrackNumberDao: LayoutTrackNumbe
         val kmp1Id = mainDraftContext.save(kmPost(tnId, KmNumber(2), gkLocation = kmPostGkLocation(15.0, 0.0))).id
         val kmp2Id = mainDraftContext.save(kmPost(tnId, KmNumber(4), gkLocation = kmPostGkLocation(65.0, 0.0))).id
 
-        val basePub =
-            testDBService.publish(
-                trackNumbers = listOf(tnId),
-                kmPosts = listOf(kmp1Id, kmp2Id),
-            )
+        val basePub = testDBService.publish(trackNumbers = listOf(tnId), kmPosts = listOf(kmp1Id, kmp2Id))
         api.trackNumberGeometry.get(tnOid).osoitevali!!.also { interval ->
             assertEquals("0001+0100.000", interval.alkuosoite)
             assertEquals("0004+0035.000", interval.loppuosoite)

--- a/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmsIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/api/tracklayout/v1/ExtTrackNumberKmsIT.kt
@@ -15,6 +15,8 @@ import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import java.math.BigDecimal
+import kotlin.math.abs
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -27,8 +29,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
-import java.math.BigDecimal
-import kotlin.math.abs
 
 @ActiveProfiles("dev", "test", "ext-api")
 @SpringBootTest(classes = [InfraApplication::class])

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestApi.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestApi.kt
@@ -23,12 +23,9 @@ class TestApi(val mapper: ObjectMapper, val mockMvc: MockMvc) {
 
     fun doGet(url: String, expectedStatus: HttpStatus, dispatcherType: DispatcherType): String {
         return doGet(
-            MockMvcRequestBuilders.get(url)
-                .with { request ->
-                    request.apply { this.dispatcherType = dispatcherType }
-                },
+            MockMvcRequestBuilders.get(url).with { request -> request.apply { this.dispatcherType = dispatcherType } },
             expectedStatus,
-            )
+        )
     }
 
     fun doGet(requestBuilder: RequestBuilder, expectedStatus: HttpStatus): String {

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/TestDBService.kt
@@ -83,10 +83,10 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.DbTable
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.setUser
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 import kotlin.reflect.KClass
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.transaction.support.TransactionTemplate
 
 interface TestDB {
     val jdbc: NamedParameterJdbcTemplate
@@ -399,11 +399,7 @@ class TestDBService(
     final inline fun <reified T : LayoutAsset<T>> saveOid(id: IntId<T>, branch: LayoutBranch, oid: Oid<T>) {
         when (T::class) {
             LayoutTrackNumber::class ->
-                trackNumberDao.insertExternalId(
-                    id as IntId<LayoutTrackNumber>,
-                    branch,
-                    oid as Oid<LayoutTrackNumber>,
-                )
+                trackNumberDao.insertExternalId(id as IntId<LayoutTrackNumber>, branch, oid as Oid<LayoutTrackNumber>)
             LocationTrack::class ->
                 locationTrackDao.insertExternalId(id as IntId<LocationTrack>, branch, oid as Oid<LocationTrack>)
             LayoutSwitch::class ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/common/SwitchStructureIT.kt
@@ -164,8 +164,9 @@ constructor(val switchStructureDao: SwitchStructureDao, val switchLibraryService
     @Test
     fun `Should produce different hashcode when switch structures are modified`() {
         val firstSet = switchStructures
-        val modifiedSet =
-            firstSet.mapIndexed { index, struct -> struct.takeIf { index > 0 } ?: modifyStructure(struct) }
+        val modifiedSet = firstSet.mapIndexed { index, struct ->
+            struct.takeIf { index > 0 } ?: modifyStructure(struct)
+        }
         assertNotEquals(firstSet, modifiedSet)
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/configuration/CacheHealthIndicatorTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/configuration/CacheHealthIndicatorTest.kt
@@ -24,8 +24,7 @@ class CacheHealthIndicatorTest {
         assertNotNull(details["foo"]) { "expected 'foo' cache in health details" }
         assertNotNull(details["bar"]) { "expected 'bar' cache in health details" }
 
-        @Suppress("UNCHECKED_CAST")
-        val fooStats = details["foo"] as Map<String, Any>
+        @Suppress("UNCHECKED_CAST") val fooStats = details["foo"] as Map<String, Any>
         assertNotNull(fooStats["hitRate"])
         assertNotNull(fooStats["loadCount"])
         assertNotNull(fooStats["evictionCount"])
@@ -46,8 +45,7 @@ class CacheHealthIndicatorTest {
         assertNotNull(details["spring-cache"]) { "expected 'spring-cache' in health details" }
         assertNotNull(details["manual-cache"]) { "expected 'manual-cache' in health details" }
 
-        @Suppress("UNCHECKED_CAST")
-        val manualStats = details["manual-cache"] as Map<String, Any>
+        @Suppress("UNCHECKED_CAST") val manualStats = details["manual-cache"] as Map<String, Any>
         assertNotNull(manualStats["hitRate"])
         assertNotNull(manualStats["loadCount"])
         assertNotNull(manualStats["evictionCount"])

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/error/TransactionConfigurationIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/error/TransactionConfigurationIT.kt
@@ -43,12 +43,11 @@ class TransactionConfigurationIT @Autowired constructor(val transactionTestServi
 
     @Test
     fun transactionSeesOwnChanges() {
-        val allValues =
-            transactionTestService.run {
-                insert("test 1")
-                insert("test 2")
-                fetchAll()
-            }
+        val allValues = transactionTestService.run {
+            insert("test 1")
+            insert("test 2")
+            fetchAll()
+        }
         assertEquals(allValues, listOf(1 to "test 1", 2 to "test 2"))
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingDaoIT.kt
@@ -82,10 +82,7 @@ constructor(
             draftKey,
             geocodingDao.getLayoutGeocodingContextCacheKey(
                 tnId,
-                validationVersions(
-                    trackNumbers = listOf(tnDraft),
-                    kmPosts = listOf(kmPost1Draft, kmPost2OnlyDraft),
-                ),
+                validationVersions(trackNumbers = listOf(tnDraft), kmPosts = listOf(kmPost1Draft, kmPost2OnlyDraft)),
             ),
         )
 
@@ -146,10 +143,7 @@ constructor(
 
         val designKeyV1 =
             geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key ->
-                assertEquals(
-                    geocodingContextCacheKey(tnDesignV1, kmp1DesignV1, kmp2MainV1, kmp3DesignV1),
-                    key,
-                )
+                assertEquals(geocodingContextCacheKey(tnDesignV1, kmp1DesignV1, kmp2MainV1, kmp3DesignV1), key)
             }
 
         // --- Version 2
@@ -172,18 +166,12 @@ constructor(
 
         val mainKeyV2 =
             geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also { key ->
-                assertEquals(
-                    geocodingContextCacheKey(tnMainV2, kmp1MainV2, kmp2MainV1, kmp4MainV2),
-                    key,
-                )
+                assertEquals(geocodingContextCacheKey(tnMainV2, kmp1MainV2, kmp2MainV1, kmp4MainV2), key)
             }
 
         val designKeyV2 =
             geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key ->
-                assertEquals(
-                    geocodingContextCacheKey(tnDesignV2, kmp2MainV1, kmp3DesignV2, kmp4MainV2),
-                    key,
-                )
+                assertEquals(geocodingContextCacheKey(tnDesignV2, kmp2MainV1, kmp3DesignV2, kmp4MainV2), key)
             }
 
         // --- Version 3
@@ -199,17 +187,11 @@ constructor(
 
         val mainKeyV3 =
             geocodingDao.getLayoutGeocodingContextCacheKey(MainLayoutContext.official, tnId).also { key ->
-                assertEquals(
-                    geocodingContextCacheKey(tnMainV2, kmp1MainV2, kmp3MainV3, kmp4MainV2),
-                    key,
-                )
+                assertEquals(geocodingContextCacheKey(tnMainV2, kmp1MainV2, kmp3MainV3, kmp4MainV2), key)
             }
         val designKeyV3 =
             geocodingDao.getLayoutGeocodingContextCacheKey(designBranch.official, tnId).also { key ->
-                assertEquals(
-                    geocodingContextCacheKey(tnDesignV2, kmp1MainV2, kmp3MainV3, kmp4MainV2),
-                    key,
-                )
+                assertEquals(geocodingContextCacheKey(tnDesignV2, kmp1MainV2, kmp3MainV3, kmp4MainV2), key)
             }
 
         // Verify fetching each key with time

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingServiceIT.kt
@@ -22,6 +22,7 @@ import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.ui.testdata.createGeometryKmPost
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -20,14 +20,13 @@ import fi.fta.geoviite.infra.tracklayout.GeometrySource.GENERATED
 import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
 import fi.fta.geoviite.infra.tracklayout.LineM
 import fi.fta.geoviite.infra.tracklayout.LocationTrackM
-import fi.fta.geoviite.infra.tracklayout.ReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.ReferenceLineM
 import fi.fta.geoviite.infra.tracklayout.SegmentPoint
+import fi.fta.geoviite.infra.tracklayout.TmpReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.assertEquals
 import fi.fta.geoviite.infra.tracklayout.edge
 import fi.fta.geoviite.infra.tracklayout.kmPost
 import fi.fta.geoviite.infra.tracklayout.kmPostGkLocation
-import fi.fta.geoviite.infra.tracklayout.TmpReferenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometry
 import fi.fta.geoviite.infra.tracklayout.referenceLineGeometryOfPoints
 import fi.fta.geoviite.infra.tracklayout.segment
@@ -346,19 +345,18 @@ class GeocodingTest {
                 Point(180.0, 220.0),
             )
         val points = points1 + points2
-        val edges =
-            points.mapIndexedNotNull { index: Int, point: SegmentPoint ->
-                if (index == 0) null
-                else
-                    PolyLineEdge(
-                        start = points[index - 1],
-                        end = point,
-                        segmentStart =
-                            if (index <= points1.lastIndex) LineM<ReferenceLineM>(0.0)
-                            else points1.last().m.castToDifferentM(),
-                        referenceDirection = directionBetweenPoints(points[index - 1], point),
-                    )
-            }
+        val edges = points.mapIndexedNotNull { index: Int, point: SegmentPoint ->
+            if (index == 0) null
+            else
+                PolyLineEdge(
+                    start = points[index - 1],
+                    end = point,
+                    segmentStart =
+                        if (index <= points1.lastIndex) LineM<ReferenceLineM>(0.0)
+                        else points1.last().m.castToDifferentM(),
+                    referenceDirection = directionBetweenPoints(points[index - 1], point),
+                )
+        }
 
         val intersection1 = getIntersection(projection1, edges)
         assertNotNull(intersection1)
@@ -1153,8 +1151,9 @@ class GeocodingTest {
                 TrackMeter(KmNumber(0), BigDecimal("0.001") * milli.toBigDecimal() + 10.toBigDecimal())
             }
 
-        val singleAroundBump =
-            aroundBumpAddresses.map { address -> context.getTrackLocation(locationTrackGeometry, address) }
+        val singleAroundBump = aroundBumpAddresses.map { address ->
+            context.getTrackLocation(locationTrackGeometry, address)
+        }
         val multiAroundBump = context.getTrackLocations(locationTrackGeometry, aroundBumpAddresses)
         assertEquals(singleAroundBump, multiAroundBump)
         // Track addresses can hit a location track out of order. This is still a bad result and maybe will be handled

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/DataProductsTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/DataProductsTestData.kt
@@ -7,30 +7,29 @@ import fi.fta.geoviite.infra.math.Point
 fun createAlignment(vararg elementTypes: GeometryElementType) =
     geometryAlignment(id = IntId(1), elements = createElements(1, *elementTypes))
 
-fun createElements(parentId: Int, vararg types: GeometryElementType) =
-    types.mapIndexed { index, t ->
-        when (t) {
-            GeometryElementType.LINE ->
-                minimalLine(
-                    id = IndexedId(parentId, index),
-                    start = Point(index.toDouble(), index.toDouble()),
-                    end = Point((index + 1).toDouble(), (index + 1).toDouble()),
-                )
+fun createElements(parentId: Int, vararg types: GeometryElementType) = types.mapIndexed { index, t ->
+    when (t) {
+        GeometryElementType.LINE ->
+            minimalLine(
+                id = IndexedId(parentId, index),
+                start = Point(index.toDouble(), index.toDouble()),
+                end = Point((index + 1).toDouble(), (index + 1).toDouble()),
+            )
 
-            GeometryElementType.CURVE ->
-                minimalCurve(
-                    id = IndexedId(parentId, index),
-                    start = Point(index.toDouble(), index.toDouble()),
-                    end = Point((index + 1).toDouble(), (index + 1).toDouble()),
-                )
+        GeometryElementType.CURVE ->
+            minimalCurve(
+                id = IndexedId(parentId, index),
+                start = Point(index.toDouble(), index.toDouble()),
+                end = Point((index + 1).toDouble(), (index + 1).toDouble()),
+            )
 
-            GeometryElementType.CLOTHOID ->
-                minimalClothoid(
-                    id = IndexedId(parentId, index),
-                    start = Point(index.toDouble(), index.toDouble()),
-                    end = Point((index + 1).toDouble(), (index + 1).toDouble()),
-                )
+        GeometryElementType.CLOTHOID ->
+            minimalClothoid(
+                id = IndexedId(parentId, index),
+                start = Point(index.toDouble(), index.toDouble()),
+                end = Point((index + 1).toDouble(), (index + 1).toDouble()),
+            )
 
-            else -> throw IllegalStateException("element $t not supported by this test method")
-        }
+        else -> throw IllegalStateException("element $t not supported by this test method")
     }
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ElementListingTest.kt
@@ -34,10 +34,10 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.switchLinkKV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.util.FileName
+import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
 
 private val allElementTypes = GeometryElementType.entries
 private val allTrackElementTypes = TrackGeometryElementType.entries

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryDaoIT.kt
@@ -13,6 +13,8 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.tracklayout.LocationTrackService
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.segment
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
@@ -21,8 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertNotNull
 
 const val TEST_NAME_PREFIX = "GEOM_DAO_IT_"
 
@@ -250,8 +250,6 @@ constructor(val geometryDao: GeometryDao, val locationTrackService: LocationTrac
 
     @Test
     fun `getPlanFiles throws NoSuchEntityException for nonexistent plan id`() {
-        assertThrows(NoSuchEntityException::class.java) {
-            geometryDao.getPlanFiles(listOf(IntId(-1)))
-        }
+        assertThrows(NoSuchEntityException::class.java) { geometryDao.getPlanFiles(listOf(IntId(-1))) }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -30,6 +30,8 @@ import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.FileName
+import java.math.BigDecimal
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -39,8 +41,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -175,12 +175,7 @@ constructor(
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = true)
         val geom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
         val trackNumberId =
-            layoutTrackNumberDao
-                .save(
-                    trackNumber(trackNumber.number, draft = true, geometry = geom),
-                    geom,
-                )
-                .id
+            layoutTrackNumberDao.save(trackNumber(trackNumber.number, draft = true, geometry = geom), geom).id
         val p1 = insertPlanWithGeometry("plan1.xml", trackNumber.number)
         val p2 = insertPlanWithGeometry("plan2.xml", trackNumber.number)
         val p3 = insertPlanWithGeometry("plan3.xml", trackNumber.number)
@@ -431,12 +426,7 @@ constructor(
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = true)
         val geom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
         val trackNumberId =
-            layoutTrackNumberDao
-                .save(
-                    trackNumber(trackNumber.number, draft = true, geometry = geom),
-                    geom,
-                )
-                .id
+            layoutTrackNumberDao.save(trackNumber(trackNumber.number, draft = true, geometry = geom), geom).id
         val profile =
             GeometryProfile(
                 PlanElementName("profile"),
@@ -483,12 +473,7 @@ constructor(
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = true)
         val geom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
         val trackNumberId =
-            layoutTrackNumberDao
-                .save(
-                    trackNumber(trackNumber.number, draft = true, geometry = geom),
-                    geom,
-                )
-                .id
+            layoutTrackNumberDao.save(trackNumber(trackNumber.number, draft = true, geometry = geom), geom).id
         val locationTrackId =
             locationTrackService
                 .saveDraft(
@@ -508,12 +493,7 @@ constructor(
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = true)
         val geom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
         val trackNumberId =
-            layoutTrackNumberDao
-                .save(
-                    trackNumber(trackNumber.number, draft = true, geometry = geom),
-                    geom,
-                )
-                .id
+            layoutTrackNumberDao.save(trackNumber(trackNumber.number, draft = true, geometry = geom), geom).id
         // Two plans with distinct profiles so deduplication keeps both entries
         val profile1 =
             GeometryProfile(
@@ -577,12 +557,7 @@ constructor(
         val trackNumber = trackNumber(testDBService.getUnusedTrackNumber(), draft = true)
         val geom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(0.0, 100.0)))
         val trackNumberId =
-            layoutTrackNumberDao
-                .save(
-                    trackNumber(trackNumber.number, draft = true, geometry = geom),
-                    geom,
-                )
-                .id
+            layoutTrackNumberDao.save(trackNumber(trackNumber.number, draft = true, geometry = geom), geom).id
         // Two plans with distinct profiles whose curve tangent ranges overlap in geocoded addresses.
         // Addresses are computed from plan alignment coordinates, so curves at similar stations
         // on both plans produce entries with overlapping address ranges.

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TestGeometryPlanService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/TestGeometryPlanService.kt
@@ -81,15 +81,14 @@ constructor(val switchStructureDao: SwitchStructureDao, val geometryDao: Geometr
         }
 
         fun save(): GeometryPlan {
-            val builtAlignments =
-                alignments.map { build ->
-                    createGeometryAlignment(
-                        alignmentName = build.name,
-                        basePoint = DEFAULT_BASE_POINT + build.firstPoint,
-                        incrementPoints = build.incrementPoints,
-                        switchData = build.switchData,
-                    )
-                }
+            val builtAlignments = alignments.map { build ->
+                createGeometryAlignment(
+                    alignmentName = build.name,
+                    basePoint = DEFAULT_BASE_POINT + build.firstPoint,
+                    incrementPoints = build.incrementPoints,
+                    switchData = build.switchData,
+                )
+            }
             return saveAndRefetchGeometryPlan(
                 plan(
                     trackNumber,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/ValidationTest.kt
@@ -137,8 +137,9 @@ class ValidationTest {
         val angle = PI / 4
         val switch = createSwitch(yvStructure, location, angle)
         val alignments = createSwitchAlignments(switch, yvStructure)
-        val alignmentSwitches =
-            alignments.mapNotNull { alignment -> collectAlignmentSwitchJoints(switch.id, alignment) }
+        val alignmentSwitches = alignments.mapNotNull { alignment ->
+            collectAlignmentSwitchJoints(switch.id, alignment)
+        }
         assertEquals(listOf<GeometryValidationIssue>(), validateSwitch(switch, yvStructure, alignmentSwitches))
     }
 
@@ -160,8 +161,9 @@ class ValidationTest {
                     }
             )
         val alignments = createSwitchAlignments(invalidSwitch, yvStructure)
-        val alignmentSwitches =
-            alignments.mapNotNull { alignment -> collectAlignmentSwitchJoints(invalidSwitch.id, alignment) }
+        val alignmentSwitches = alignments.mapNotNull { alignment ->
+            collectAlignmentSwitchJoints(invalidSwitch.id, alignment)
+        }
         assertGeometryValidationIssues(
             validateSwitch(invalidSwitch, yvStructure, alignmentSwitches),
             listOf("$VALIDATION_SWITCH.incorrect-joint-locations"),
@@ -186,8 +188,9 @@ class ValidationTest {
                     }
             )
         val alignments = createSwitchAlignments(inaccurateSwitch, yvStructure)
-        val alignmentSwitches =
-            alignments.mapNotNull { alignment -> collectAlignmentSwitchJoints(inaccurateSwitch.id, alignment) }
+        val alignmentSwitches = alignments.mapNotNull { alignment ->
+            collectAlignmentSwitchJoints(inaccurateSwitch.id, alignment)
+        }
         assertGeometryValidationIssues(
             validateSwitch(inaccurateSwitch, yvStructure, alignmentSwitches),
             listOf("$VALIDATION_SWITCH.inaccurate-joint-locations"),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/AddressChangesServiceIT.kt
@@ -44,16 +44,16 @@ import fi.fta.geoviite.infra.tracklayout.splitSegment
 import fi.fta.geoviite.infra.tracklayout.toAlignmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.time.Instant
 import kotlin.math.ceil
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -295,20 +295,14 @@ constructor(
                     Point(100.0, 100.0) to TrackMeter(2, 1),
                     Point(100.0, 200.0) to TrackMeter(2, 101),
                 ),
-                createEmptyAddresses(
-                    Point(100.0, 100.0) to TrackMeter(2, 1),
-                    Point(100.0, 200.0) to TrackMeter(2, 101),
-                ),
+                createEmptyAddresses(Point(100.0, 100.0) to TrackMeter(2, 1), Point(100.0, 200.0) to TrackMeter(2, 101)),
             ),
         )
         assertEquals(
             setOf(KmNumber(3)),
             resolveChangedGeometryKilometers(
                 createAddresses(Point(100.0, 100.0) to TrackMeter(3, 1), Point(100.0, 200.0) to TrackMeter(3, 101)),
-                createEmptyAddresses(
-                    Point(100.0, 100.0) to TrackMeter(3, 1),
-                    Point(100.0, 200.0) to TrackMeter(3, 101),
-                ),
+                createEmptyAddresses(Point(100.0, 100.0) to TrackMeter(3, 1), Point(100.0, 200.0) to TrackMeter(3, 101)),
             ),
         )
         assertEquals(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/integration/CalculatedChangesServiceIT.kt
@@ -66,11 +66,6 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkingAtStart
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.*
@@ -80,6 +75,11 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/LinkingServiceIT.kt
@@ -65,6 +65,7 @@ import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -74,7 +75,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchFittingTestData.kt
@@ -147,11 +147,11 @@ fun cutFromStart(
     val newEdges =
         geometry.edgesWithM.mapNotNull { (edge, range) ->
             if (cutPosition <= range.min)
-            // is fully included
-            edge
+                // is fully included
+                edge
             else if (cutPosition >= range.max)
-            // is fully excluded
-            null
+                // is fully excluded
+                null
             else {
                 // is partly included
                 // TODO GVT-3172 This is an actual M-type confusion
@@ -180,11 +180,11 @@ fun cutFromEnd(
     val newEdges =
         geometry.edgesWithM.mapNotNull { (edge, range) ->
             if (cutPosition <= range.min)
-            // is fully included
-            edge
+                // is fully included
+                edge
             else if (cutPosition >= range.max)
-            // is fully excluded
-            null
+                // is fully excluded
+                null
             else {
                 // is partly included
                 val newSegments = splitSegments(edge.segmentsWithM, cutPosition.castToDifferentM()).first
@@ -274,15 +274,14 @@ fun fittedSwitch(
     vararg matches: FittedSwitchJointMatch,
 ): FittedSwitch {
     val matchesByJointNumber = matches.groupBy({ match -> match.switchJoint.number }, { match -> match })
-    val fittedJoints =
-        matchesByJointNumber.map { (jointNumber, matches) ->
-            FittedSwitchJoint(
-                number = jointNumber,
-                location = switchStructure.getJointLocation(jointNumber) + jointTranslation,
-                locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED,
-                matches = matches,
-            )
-        }
+    val fittedJoints = matchesByJointNumber.map { (jointNumber, matches) ->
+        FittedSwitchJoint(
+            number = jointNumber,
+            location = switchStructure.getJointLocation(jointNumber) + jointTranslation,
+            locationAccuracy = LocationAccuracy.GEOMETRY_CALCULATED,
+            matches = matches,
+        )
+    }
     return FittedSwitch(asSwitchStructure(switchStructure), fittedJoints)
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingServiceIT.kt
@@ -1221,9 +1221,7 @@ constructor(
                             localizationKey =
                                 LocalizationKey.of("validation.layout.split.track-links-missing-after-relinking"),
                             params =
-                                LocalizationParams(
-                                    mapOf("switchName" to "somewhere else", "sourceName" to "topoTrack")
-                                ),
+                                LocalizationParams(mapOf("switchName" to "somewhere else", "sourceName" to "topoTrack")),
                         ),
                     ),
             )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/linking/switches/SwitchLinkingTest.kt
@@ -1231,18 +1231,17 @@ fun assertJointsOnSequentialEdges(
     joints: List<Int>,
 ) {
     val (locationTrack, geometry) = assertTrackAndGeometry(tracks, locationTrackId)
-    val nodeIndexes =
-        joints.map { joint ->
-            val nodeIndex =
-                geometry.trackSwitchLinks.indexOfFirst { link ->
-                    link.switchId == switchId && link.jointNumber.intValue == joint
-                }
-            assertTrue(
-                nodeIndex != -1,
-                "Location track ${locationTrack.name} nodes do not contain switch $switchId with joint $joint",
-            )
-            nodeIndex
-        }
+    val nodeIndexes = joints.map { joint ->
+        val nodeIndex =
+            geometry.trackSwitchLinks.indexOfFirst { link ->
+                link.switchId == switchId && link.jointNumber.intValue == joint
+            }
+        assertTrue(
+            nodeIndex != -1,
+            "Location track ${locationTrack.name} nodes do not contain switch $switchId with joint $joint",
+        )
+        nodeIndex
+    }
     val isContinuous = nodeIndexes.zipWithNext { index1, index2 -> index1 + 1 == index2 }.all { it }
     assertTrue(isContinuous, "Joints $joints are not in continuous edges, node indexes: $nodeIndexes")
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BoundingBoxTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/math/BoundingBoxTest.kt
@@ -136,8 +136,7 @@ class BoundingBoxTest {
         // axial distance
         assertEquals(
             1.0,
-            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0))
-                .minimumDistance(BoundingBox(Point(2.0, 0.0), Point(3.0, 1.0))),
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(BoundingBox(Point(2.0, 0.0), Point(3.0, 1.0))),
         )
         assertEquals(
             1.0,
@@ -156,30 +155,24 @@ class BoundingBoxTest {
         // intersection
         assertEquals(
             0.0,
-            BoundingBox(Point(0.0, 0.0), Point(3.0, 3.0))
-                .minimumDistance(BoundingBox(Point(1.0, 1.0), Point(5.0, 2.0))),
+            BoundingBox(Point(0.0, 0.0), Point(3.0, 3.0)).minimumDistance(BoundingBox(Point(1.0, 1.0), Point(5.0, 2.0))),
         )
 
         // touch axially or diagonally
         assertEquals(
             0.0,
-            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0))
-                .minimumDistance(BoundingBox(Point(1.0, 0.0), Point(2.0, 1.0))),
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(BoundingBox(Point(1.0, 0.0), Point(2.0, 1.0))),
         )
         assertEquals(
             0.0,
-            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0))
-                .minimumDistance(BoundingBox(Point(1.0, 1.0), Point(2.0, 2.0))),
+            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(BoundingBox(Point(1.0, 1.0), Point(2.0, 2.0))),
         )
     }
 
     @Test
     fun minimumDistanceByPoint() {
         // inside
-        assertEquals(
-            0.0,
-            BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(Point(0.5, 0.5)),
-        )
+        assertEquals(0.0, BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(Point(0.5, 0.5)))
 
         // horizontal axial distance
         assertEquals(0.4, BoundingBox(Point(0.0, 0.0), Point(1.0, 1.0)).minimumDistance(Point(1.4, 0.5)), 0.001)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationDaoIT.kt
@@ -52,14 +52,14 @@ import fi.fta.geoviite.infra.tracklayout.switch
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -496,8 +496,6 @@ constructor(
 
     @Test
     fun `getPublications throws NoSuchEntityException for nonexistent publication id`() {
-        assertThrows(NoSuchEntityException::class.java) {
-            publicationDao.getPublications(setOf(IntId(-1)))
-        }
+        assertThrows(NoSuchEntityException::class.java) { publicationDao.getPublications(setOf(IntId(-1))) }
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationLogServiceIT.kt
@@ -75,16 +75,16 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.tracklayout.trackNumberSaveRequest
 import fi.fta.geoviite.infra.util.SortOrder
+import kotlin.math.absoluteValue
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.math.absoluteValue
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -213,10 +213,7 @@ constructor(
         val thisAndPreviousPublication =
             publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val changes =
-            publicationDao.fetchPublicationTrackNumberChanges(
-                LayoutBranch.main,
-                thisAndPreviousPublication.first().id,
-            )
+            publicationDao.fetchPublicationTrackNumberChanges(LayoutBranch.main, thisAndPreviousPublication.first().id)
 
         val diff =
             publicationLogService.diffTrackNumber(
@@ -305,10 +302,7 @@ constructor(
         val thisAndPreviousPublication =
             publicationLogService.fetchLatestPublicationDetails(LayoutBranchType.MAIN, 2).items
         val changes =
-            publicationDao.fetchPublicationTrackNumberChanges(
-                LayoutBranch.main,
-                thisAndPreviousPublication.first().id,
-            )
+            publicationDao.fetchPublicationTrackNumberChanges(LayoutBranch.main, thisAndPreviousPublication.first().id)
         val updatedTrackNumber = trackNumberService.getOrThrow(MainLayoutContext.official, idOfUpdated)
 
         val diff =
@@ -539,13 +533,7 @@ constructor(
                 MainLayoutContext.draft,
                 kmPostService.insertKmPost(
                     LayoutBranch.main,
-                    LayoutKmPostSaveRequest(
-                        KmNumber(0),
-                        LayoutState.IN_USE,
-                        trackNumberId,
-                        gkLocation,
-                        sourceId = null,
-                    ),
+                    LayoutKmPostSaveRequest(KmNumber(0), LayoutState.IN_USE, trackNumberId, gkLocation, sourceId = null),
                 ),
             )
         publish(
@@ -1445,13 +1433,7 @@ constructor(
                     uicCode = UicCode("321"),
                     location = Point(25.0, 20.0),
                     polygon =
-                        Polygon(
-                            Point(0.0, 0.0),
-                            Point(40.0, 0.0),
-                            Point(40.0, 40.0),
-                            Point(0.0, 40.0),
-                            Point(0.0, 0.0),
-                        ),
+                        Polygon(Point(0.0, 0.0), Point(40.0, 0.0), Point(40.0, 40.0), Point(0.0, 40.0), Point(0.0, 0.0)),
                 )
         )
         publish(publicationService, operationalPoints = listOf(operationalPointId))
@@ -1477,7 +1459,11 @@ constructor(
                     null,
                 ),
                 PublicationChange(PropKey("uic-code"), ChangeValue(UicCode("123"), UicCode("321")), null),
-                PublicationChange(PropKey("rinf-type"), ChangeValue("Asema (koodi 10)", "Asema (pieni) (koodi 20)"), null),
+                PublicationChange(
+                    PropKey("rinf-type"),
+                    ChangeValue("Asema (koodi 10)", "Asema (pieni) (koodi 20)"),
+                    null,
+                ),
                 PublicationChange(PropKey("polygon"), ChangeValue(null, null), remark = "Alue muuttunut"),
                 PublicationChange(
                     PropKey("location"),
@@ -1563,19 +1549,14 @@ constructor(
             )
             assertEquals(listOf(), indirectChanges)
         }
-        publicationDao
-            .fetchPublicationTrackNumberChanges(
-                LayoutBranch.main,
-                originalPublication,
-            )
-            .let { changes ->
-                assertEquals(1, changes.size)
-                val change = changes[trackNumber.id]!!
-                assertEquals(null, change.trackNumber.old)
-                assertEquals("original", change.trackNumber.new.toString())
-                assertEquals(null, change.startPoint.old)
-                assertEquals(Point(0.0, 0.0), change.startPoint.new)
-            }
+        publicationDao.fetchPublicationTrackNumberChanges(LayoutBranch.main, originalPublication).let { changes ->
+            assertEquals(1, changes.size)
+            val change = changes[trackNumber.id]!!
+            assertEquals(null, change.trackNumber.old)
+            assertEquals("original", change.trackNumber.new.toString())
+            assertEquals(null, change.startPoint.old)
+            assertEquals(Point(0.0, 0.0), change.startPoint.new)
+        }
         publicationDao.fetchPublishedLocationTracks(setOf(originalPublication)).getValue(originalPublication).let {
             (directChanges, indirectChanges) ->
             assertEquals(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationRatkoIT.kt
@@ -46,6 +46,9 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.util.getIntId
 import fi.fta.geoviite.infra.util.getLayoutRowVersion
 import fi.fta.geoviite.infra.util.queryOne
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -53,9 +56,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationServiceIT.kt
@@ -884,10 +884,7 @@ constructor(
     @Test
     fun `Publication rejects duplicate track number names`() {
         val geom = referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 10.0)))
-        trackNumberDao.save(
-            trackNumber(number = TrackNumber("TN"), draft = false),
-            geom,
-        )
+        trackNumberDao.save(trackNumber(number = TrackNumber("TN"), draft = false), geom)
         val draftTrackNumberId = trackNumberDao.save(trackNumber(number = TrackNumber("TN"), draft = true), geom).id
 
         val exception =
@@ -1181,10 +1178,7 @@ constructor(
     fun `create linked switch in design and publish`() {
         val trackNumber =
             mainOfficialContext
-                .save(
-                    trackNumber(),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 10.0))),
-                )
+                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 10.0))))
                 .id
         val testBranch = DesignBranch.of(layoutDesignDao.insert(layoutDesign()))
         val testDraftContext = testDBService.testContext(testBranch, DRAFT)
@@ -1854,13 +1848,7 @@ constructor(
         assertPublicationResults(null, initialPublishResult)
 
         val mainUpdatedResult =
-            touchAsDraftAndPublish(
-                LayoutBranch.main,
-                listOf(tn.id),
-                listOf(kmp.id),
-                listOf(sw.id),
-                listOf(lt.id),
-            )
+            touchAsDraftAndPublish(LayoutBranch.main, listOf(tn.id), listOf(kmp.id), listOf(sw.id), listOf(lt.id))
         assertPublicationResults(initialPublishResult, mainUpdatedResult)
 
         val designBranch = testDBService.createDesignBranch()
@@ -1868,23 +1856,11 @@ constructor(
         testDBService.generateOid(sw.id, designBranch)
         testDBService.generateOid(lt.id, designBranch)
         val designCreatedResult =
-            touchAsDraftAndPublish(
-                designBranch,
-                listOf(tn.id),
-                listOf(kmp.id),
-                listOf(sw.id),
-                listOf(lt.id),
-            )
+            touchAsDraftAndPublish(designBranch, listOf(tn.id), listOf(kmp.id), listOf(sw.id), listOf(lt.id))
         assertPublicationResults(mainUpdatedResult, designCreatedResult)
 
         val designUpdatedResult =
-            touchAsDraftAndPublish(
-                designBranch,
-                listOf(tn.id),
-                listOf(kmp.id),
-                listOf(sw.id),
-                listOf(lt.id),
-            )
+            touchAsDraftAndPublish(designBranch, listOf(tn.id), listOf(kmp.id), listOf(sw.id), listOf(lt.id))
         assertPublicationResults(designCreatedResult, designUpdatedResult)
     }
 
@@ -2101,10 +2077,7 @@ constructor(
     ) =
         publicationService.publishManualPublication(
             layoutBranch,
-            PublicationRequest(
-                publicationRequestIds(trackNumbers, locationTracks, switches, kmPosts),
-                message,
-            ),
+            PublicationRequest(publicationRequestIds(trackNumbers, locationTracks, switches, kmPosts), message),
         )
 
     data class PublicationGroupTestData(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationTestSupportService.kt
@@ -38,12 +38,12 @@ import fi.fta.geoviite.infra.tracklayout.switchJoint
 import fi.fta.geoviite.infra.tracklayout.switchLinkYV
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackNumber
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Service
-import org.springframework.test.context.ActiveProfiles
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("dev", "test")
 @Service

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -69,6 +69,7 @@ import fi.fta.geoviite.infra.tracklayout.switchStructureYV60_300_1_9
 import fi.fta.geoviite.infra.tracklayout.trackGeometry
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.tracklayout.trackNumber
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -80,7 +81,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -109,10 +109,7 @@ constructor(
     fun cleanup() {
         testDBService.clearPublicationTables()
         testDBService.clearLayoutTables()
-        testDBService.deleteFromTables(
-            "layout",
-            "operational_point_id",
-        )
+        testDBService.deleteFromTables("layout", "operational_point_id")
     }
 
     @Test
@@ -1049,10 +1046,7 @@ constructor(
             LayoutValidationIssue(
                 LayoutValidationIssueType.WARNING,
                 "validation.layout.switch.track-linkage.switch-alignment-multiply-connected",
-                mapOf(
-                    "locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})",
-                    "switch" to "TV123",
-                ),
+                mapOf("locationTracks" to "4-5-3 (${locationTrack2.name}, ${locationTrack3.name})", "switch" to "TV123"),
             ),
         )
     }
@@ -1660,10 +1654,7 @@ constructor(
         val designOfficialContext = testDBService.testContext(designBranch, OFFICIAL)
         val trackNumber =
             designOfficialContext
-                .save(
-                    trackNumber(),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-                )
+                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
         val trackGeometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val locationTrack = designDraftContext.save(locationTrack(trackNumber), trackGeometry).id
@@ -1671,10 +1662,7 @@ constructor(
         val validated =
             publicationValidationService.validatePublicationCandidates(
                 publicationService.collectPublicationCandidates(PublicationInDesign(designBranch)),
-                publicationRequestIds(
-                    trackNumbers = listOf(trackNumber),
-                    locationTracks = listOf(locationTrack),
-                ),
+                publicationRequestIds(trackNumbers = listOf(trackNumber), locationTracks = listOf(locationTrack)),
             )
         assertEquals(
             listOf("validation.layout.location-track.reference-to-track-number.cancelled"),
@@ -1689,10 +1677,7 @@ constructor(
         val designOfficialContext = testDBService.testContext(designBranch, OFFICIAL)
         val trackNumber =
             designOfficialContext
-                .save(
-                    trackNumber(),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-                )
+                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
         val trackGeometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(10.0, 0.0)))
         val mainLocationTrack = designOfficialContext.save(locationTrack(trackNumber), trackGeometry).id
@@ -1731,10 +1716,7 @@ constructor(
         val designOfficialContext = testDBService.testContext(designBranch, OFFICIAL)
         val trackNumber =
             designOfficialContext
-                .save(
-                    trackNumber(),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))),
-                )
+                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))))
                 .id
 
         val switchName = "TST V0001"
@@ -1876,16 +1858,10 @@ constructor(
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
         val trackNumber =
             mainOfficialContext
-                .save(
-                    trackNumber(),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-                )
+                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
         designDraftContext.save(mainOfficialContext.fetch(trackNumber)!!)
-        publicationTestSupportService.publish(
-            designBranch,
-            publicationRequestIds(trackNumbers = listOf(trackNumber)),
-        )
+        publicationTestSupportService.publish(designBranch, publicationRequestIds(trackNumbers = listOf(trackNumber)))
         trackNumberService.cancel(designBranch, trackNumber)
         designDraftContext.save(designOfficialContext.fetch(trackNumber)!!)
         val validateTrackNumber =
@@ -1911,10 +1887,7 @@ constructor(
         val trackNumberNumber = trackNumber()
         val trackNumber =
             designOfficialContext
-                .save(
-                    trackNumberNumber,
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-                )
+                .save(trackNumberNumber, referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
         val kmPost = designOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(1.0, 0.0))).id
         designDraftContext.save(designOfficialContext.fetch(kmPost)!!)
@@ -1932,10 +1905,7 @@ constructor(
         val validateBoth =
             publicationValidationService.validatePublicationCandidates(
                 publicationService.collectPublicationCandidates(PublicationInDesign(designBranch)),
-                publicationRequestIds(
-                    trackNumbers = listOf(trackNumber),
-                    kmPosts = listOf(kmPost),
-                ),
+                publicationRequestIds(trackNumbers = listOf(trackNumber), kmPosts = listOf(kmPost)),
             )
         assertEquals(
             listOf(
@@ -1978,10 +1948,7 @@ constructor(
         val trackNumberNumber = trackNumber()
         val trackNumber =
             designOfficialContext
-                .save(
-                    trackNumberNumber,
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))),
-                )
+                .save(trackNumberNumber, referenceLineGeometry(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
                 .id
         val kmPost = designOfficialContext.save(kmPost(trackNumber, KmNumber(1), kmPostGkLocation(1.0, 0.0))).id
         designDraftContext.save(designOfficialContext.fetch(kmPost)!!.copy(state = LayoutState.DELETED))
@@ -2000,10 +1967,7 @@ constructor(
         val validateBoth =
             publicationValidationService.validatePublicationCandidates(
                 publicationService.collectPublicationCandidates(PublicationInDesign(designBranch)),
-                publicationRequestIds(
-                    trackNumbers = listOf(trackNumber),
-                    kmPosts = listOf(kmPost),
-                ),
+                publicationRequestIds(trackNumbers = listOf(trackNumber), kmPosts = listOf(kmPost)),
             )
 
         assertEquals(
@@ -2035,10 +1999,7 @@ constructor(
         val designDraftContext = testDBService.testContext(designBranch, DRAFT)
         val trackNumber =
             designOfficialContext
-                .save(
-                    trackNumber(),
-                    referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))),
-                )
+                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))))
                 .id
         val switchName = "some switch"
         val switch =
@@ -2046,8 +2007,7 @@ constructor(
                 .save(
                     switch(
                         name = switchName,
-                        joints =
-                            listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(10.0, 0.0), null)),
+                        joints = listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(10.0, 0.0), null)),
                     )
                 )
                 .id
@@ -2197,8 +2157,7 @@ constructor(
                 .save(
                     switch(
                         name = "impossiboru switch name",
-                        joints =
-                            listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(20.0, 0.0), null)),
+                        joints = listOf(LayoutSwitchJoint(JointNumber(1), SwitchJointRole.MAIN, Point(20.0, 0.0), null)),
                     )
                 )
                 .id
@@ -2592,13 +2551,7 @@ constructor(
                         location = Point(5.0, 5.0),
                         uicCode = "123",
                         polygon =
-                            Polygon(
-                                Point(0.0, 0.0),
-                                Point(5.0, 0.0),
-                                Point(5.0, 5.0),
-                                Point(0.0, 5.0),
-                                Point(0.0, 0.0),
-                            ),
+                            Polygon(Point(0.0, 0.0), Point(5.0, 0.0), Point(5.0, 5.0), Point(0.0, 5.0), Point(0.0, 0.0)),
                     )
                 )
                 .id

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationTest.kt
@@ -185,10 +185,9 @@ class PublicationValidationTest {
     @Test
     fun switchValidationCatchesLocationMismatch() {
         val (switch, alignments) = switchAndMatchingAlignments(IntId(0), structure, draft = true)
-        val broken =
-            alignments.mapIndexed { index, (track, geometry) ->
-                if (index == 0) track to offsetGeometry(geometry, Point(5.0, 0.0)) else track to geometry
-            }
+        val broken = alignments.mapIndexed { index, (track, geometry) ->
+            if (index == 0) track to offsetGeometry(geometry, Point(5.0, 0.0)) else track to geometry
+        }
         assertSwitchSegmentStructureError(
             hasError = false,
             switch = switch,
@@ -332,9 +331,7 @@ class PublicationValidationTest {
             validateAddressPoints(trackNumber(draft = true), locationTrack(trackNumberId = IntId(1), draft = true), "")
             // Alignment at slight angle to reference line -> should be OK
             {
-                context.getAddressPoints(
-                    referenceLineGeometry(segment(Point(10.0, 10.0), Point(20.0, 100.0)))
-                )
+                context.getAddressPoints(referenceLineGeometry(segment(Point(10.0, 10.0), Point(20.0, 100.0))))
             },
         )
     }
@@ -349,15 +346,15 @@ class PublicationValidationTest {
         val geocode = {
             context.getAddressPoints(
                 referenceLineGeometry(
-                        segment(
-                            Point(0.0, 10.0),
-                            Point(0.0, 20.0),
-                            Point(10.0, 40.0),
-                            Point(30.0, 60.0),
-                            Point(50.0, 70.0), // Over 45 degree diff to reference line -> should fail
-                            Point(70.0, 90.0),
-                        )
+                    segment(
+                        Point(0.0, 10.0),
+                        Point(0.0, 20.0),
+                        Point(10.0, 40.0),
+                        Point(30.0, 60.0),
+                        Point(50.0, 70.0), // Over 45 degree diff to reference line -> should fail
+                        Point(70.0, 90.0),
                     )
+                )
             )
         }
         assertAddressPointError(true, geocode, "$VALIDATION_GEOCODING.stretched-meters")
@@ -374,8 +371,8 @@ class PublicationValidationTest {
         val geocode = {
             context.getAddressPoints(
                 referenceLineGeometry(
-                        segment(Point(0.0, 0.0), Point(120.0, 50.0), Point(120.0, 60.0), Point(240.0, 110.0))
-                    )
+                    segment(Point(0.0, 0.0), Point(120.0, 50.0), Point(120.0, 60.0), Point(240.0, 110.0))
+                )
             )
         }
         assertSingleAddressPointErrorRangeDescription(geocode, "0000+0000..0000+0050, 0000+0060..0000+0110")
@@ -395,9 +392,7 @@ class PublicationValidationTest {
             )
         val geocode = {
             //  alignment goes straight up at offset -> should get non-continuous points
-            context.getAddressPoints(
-                referenceLineGeometry(segment(Point(5.0, 5.0), Point(5.0, 25.0)))
-            )
+            context.getAddressPoints(referenceLineGeometry(segment(Point(5.0, 5.0), Point(5.0, 25.0))))
         }
         assertAddressPointError(true, geocode, "$VALIDATION_GEOCODING.sharp-angle")
     }
@@ -409,11 +404,7 @@ class PublicationValidationTest {
 
         val sharpAngleTrack = to3DMPoints<SegmentM>(listOf(Point(10.0, 0.0), Point(10.0, 10.0), Point(0.0, 0.0)))
 
-        val geocode = {
-            context.getAddressPoints(
-                referenceLineGeometry(segment(toSegmentPoints(sharpAngleTrack)))
-            )
-        }
+        val geocode = { context.getAddressPoints(referenceLineGeometry(segment(toSegmentPoints(sharpAngleTrack)))) }
 
         assertAddressPointError(true, geocode, "$VALIDATION_GEOCODING.sharp-angle")
         // the correct error range is hard to calculate because it depends on how lines get
@@ -1490,13 +1481,7 @@ class PublicationValidationTest {
         trackNumber: LayoutTrackNumber,
         locationTrack: LocationTrack,
         error: String,
-    ) =
-        assertTrackNumberReferenceError(
-            hasError,
-            trackNumber,
-            error,
-            locationTracks = listOf(locationTrack),
-        )
+    ) = assertTrackNumberReferenceError(hasError, trackNumber, error, locationTracks = listOf(locationTrack))
 
     private fun assertTrackNumberReferenceError(
         hasError: Boolean,

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/SwitchTopologicalConnectivityTest.kt
@@ -357,10 +357,7 @@ class SwitchTopologicalConnectivityTest {
                     ),
                 )
             )
-        assertEquals(
-            expected,
-            validateSwitchTopologicalConnectivity(switch, switchStructure, tracks, null),
-        )
+        assertEquals(expected, validateSwitchTopologicalConnectivity(switch, switchStructure, tracks, null))
     }
 
     // might be a segment's start and/or end joint, might be a track's topology start or end link
@@ -396,16 +393,15 @@ class SwitchTopologicalConnectivityTest {
                 duplicateOf = if (isDuplicate) IntId(12345) else null,
                 state = if (isDeleted) LocationTrackState.DELETED else LocationTrackState.IN_USE,
             )
-        val switchEdges =
-            switchLinks.mapIndexed { index, link ->
-                edge(
-                    startOuterSwitch = topologyLinks?.start?.takeIf { index == 0 },
-                    endOuterSwitch = topologyLinks?.end?.takeIf { index == switchLinks.lastIndex },
-                    startInnerSwitch = link?.start,
-                    endInnerSwitch = link?.end,
-                    segments = listOf(segment(Point(0.0, index.toDouble()), Point(0.0, index.toDouble() + 1.0))),
-                )
-            }
+        val switchEdges = switchLinks.mapIndexed { index, link ->
+            edge(
+                startOuterSwitch = topologyLinks?.start?.takeIf { index == 0 },
+                endOuterSwitch = topologyLinks?.end?.takeIf { index == switchLinks.lastIndex },
+                startInnerSwitch = link?.start,
+                endInnerSwitch = link?.end,
+                segments = listOf(segment(Point(0.0, index.toDouble()), Point(0.0, index.toDouble() + 1.0))),
+            )
+        }
         val edges =
             switchEdges.takeIf { it.isNotEmpty() }
                 ?: listOf(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/ExternalIdDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/ExternalIdDaoIT.kt
@@ -17,10 +17,7 @@ class ExternalIdDaoIT @Autowired constructor(private val trackNumberDao: LayoutT
 
     @Test
     fun `Multiple external ids can be found`() {
-        val testOids =
-            (1..2).map {
-                mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
-            }
+        val testOids = (1..2).map { mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber())) }
 
         testOids
             .map { (_, oid) -> oid }
@@ -30,10 +27,7 @@ class ExternalIdDaoIT @Autowired constructor(private val trackNumberDao: LayoutT
 
     @Test
     fun `External ids can be found one-by-one`() {
-        val testOids =
-            (1..2).map {
-                mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber()))
-            }
+        val testOids = (1..2).map { mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber())) }
 
         testOids.forEach { (id, oid) -> assertEquals(id, trackNumberDao.getByExternalId(oid)?.id) }
     }
@@ -42,9 +36,7 @@ class ExternalIdDaoIT @Autowired constructor(private val trackNumberDao: LayoutT
     fun `External ids which are not found are returned as nulls when searching for multiple oids`() {
         val notExistingOid = Oid<LayoutTrackNumber>("999.888.777")
         val testOids =
-            (1..2).map {
-                mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber())).second
-            }
+            (1..2).map { mainOfficialContext.saveWithOid(trackNumber(testDBService.getUnusedTrackNumber())).second }
 
         val oidResult = trackNumberDao.getByExternalIds(mainOfficialContext.context, testOids + listOf(notExistingOid))
         assertEquals(3, oidResult.size)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoLocalServiceTest.kt
@@ -52,10 +52,7 @@ class RatkoLocalServiceTest {
         val service = serviceWithClient(client)
         service.refreshOnlineStatus()
 
-        assertEquals(
-            RatkoClient.RatkoStatus(RatkoConnectionStatus.OFFLINE, null),
-            service.getRatkoOnlineStatus(),
-        )
+        assertEquals(RatkoClient.RatkoStatus(RatkoConnectionStatus.OFFLINE, null), service.getRatkoOnlineStatus())
     }
 
     @Test
@@ -69,9 +66,6 @@ class RatkoLocalServiceTest {
         service.refreshOnlineStatus()
         service.refreshOnlineStatus()
 
-        assertEquals(
-            RatkoClient.RatkoStatus(RatkoConnectionStatus.OFFLINE, null),
-            service.getRatkoOnlineStatus(),
-        )
+        assertEquals(RatkoClient.RatkoStatus(RatkoConnectionStatus.OFFLINE, null), service.getRatkoOnlineStatus())
     }
 }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoPushDaoIT.kt
@@ -32,16 +32,16 @@ import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.tracklayout.publishedVersions
 import fi.fta.geoviite.infra.util.getEnum
 import fi.fta.geoviite.infra.util.getInstantOrNull
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoServiceIT.kt
@@ -122,6 +122,12 @@ import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.tracklayout.verticalEdge
 import fi.fta.geoviite.infra.util.FileName
 import fi.fta.geoviite.infra.util.queryOne
+import java.time.Instant
+import java.time.LocalDate
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -131,12 +137,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import java.time.LocalDate
-import kotlin.test.assertIs
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -2628,9 +2628,7 @@ constructor(
 
         fakeRatko.respondsWithMalformedBodyForRouteNumberCreation(trackNumberOid.toString())
 
-        runCatching {
-            publishAndPush(trackNumbers = listOf(trackNumberId))
-        }
+        runCatching { publishAndPush(trackNumbers = listOf(trackNumberId)) }
 
         val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
         assertIs<RatkoPushGeneralError>(error)
@@ -2661,9 +2659,7 @@ constructor(
 
         fakeRatko.rejectsRouteNumberCreationWithError(trackNumberOid.toString(), "TN_ERROR", "Track number push failed")
 
-        runCatching {
-            publishAndPush(trackNumbers = listOf(trackNumberId))
-        }
+        runCatching { publishAndPush(trackNumbers = listOf(trackNumberId)) }
 
         val (error, _) = assertNotNull(ratkoPushDao.getCurrentRatkoPushError())
         assertIs<RatkoPushAssetError<*>>(error)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtilsTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ratko/RatkoUtilsTest.kt
@@ -26,13 +26,11 @@ class RatkoUtilsTest {
 
     @Test
     fun `should format unique Ratko switch types from Geoviite types`() {
-        val ratkoTypes =
-            switchStructures.mapNotNull { switchStructure ->
-                // Include non-left-handed switches only to pick only one of each YV/KV etc. switch
-                // type
-                if (switchStructure.type.parts.hand != SwitchHand.LEFT) asSwitchTypeString(switchStructure.type)
-                else null
-            }
+        val ratkoTypes = switchStructures.mapNotNull { switchStructure ->
+            // Include non-left-handed switches only to pick only one of each YV/KV etc. switch
+            // type
+            if (switchStructure.type.parts.hand != SwitchHand.LEFT) asSwitchTypeString(switchStructure.type) else null
+        }
         assertEquals(ratkoTypes, ratkoTypes.distinct())
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitServiceIT.kt
@@ -478,9 +478,7 @@ constructor(
                 targetRequest(switch1.id, "part2"),
                 targetRequest(switch2.id, "part3"),
             )
-        assertThrows<SplitFailureException> {
-            splitService.split(LayoutBranch.main, request)
-        }
+        assertThrows<SplitFailureException> { splitService.split(LayoutBranch.main, request) }
     }
 
     @Test

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/SplitTest.kt
@@ -601,9 +601,7 @@ class SplitTest {
                     .copy(segments = listOf(Point(0.0, 0.0) to Point(10.0, 0.0), Point(10.0, 0.0) to Point(11.0, 0.0))),
                 EdgeTestData(replacementEdge),
                 EdgeTestData(origEdge3)
-                    .copy(
-                        segments = listOf(Point(19.0, 0.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))
-                    ),
+                    .copy(segments = listOf(Point(19.0, 0.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))),
             ),
             result.map { edge -> EdgeTestData(edge) },
         )
@@ -636,9 +634,7 @@ class SplitTest {
                     .copy(segments = listOf(Point(0.0, 0.0) to Point(10.0, 0.0), Point(10.0, 0.0) to Point(11.0, 1.0))),
                 EdgeTestData(replacementEdge),
                 EdgeTestData(origEdge3)
-                    .copy(
-                        segments = listOf(Point(19.0, 1.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))
-                    ),
+                    .copy(segments = listOf(Point(19.0, 1.0) to Point(20.0, 0.0), Point(20.0, 0.0) to Point(30.0, 0.0))),
             ),
             result.map { edge -> EdgeTestData(edge) },
         )
@@ -671,9 +667,7 @@ class SplitTest {
                     .copy(segments = listOf(Point(0.0, 0.0) to Point(8.0, 0.0), Point(8.0, 0.0) to Point(9.0, 1.0))),
                 EdgeTestData(replacementEdge),
                 EdgeTestData(origEdge3)
-                    .copy(
-                        segments = listOf(Point(21.0, 1.0) to Point(22.0, 0.0), Point(22.0, 0.0) to Point(30.0, 0.0))
-                    ),
+                    .copy(segments = listOf(Point(21.0, 1.0) to Point(22.0, 0.0), Point(22.0, 0.0) to Point(30.0, 0.0))),
             ),
             result.map { edge -> EdgeTestData(edge) },
         )

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/split/TrackBoundaryMoveIT.kt
@@ -105,11 +105,7 @@ constructor(
 
         val frontEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
         val lengtheningGeometry = trackGeometry(combineEdges(listOf(frontEdge) + sw1Straight))
-        val lengtheningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                lengtheningGeometry,
-            )
+        val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
 
         val edge12 =
             edge(
@@ -120,11 +116,7 @@ constructor(
         val trailingEdge = edge(listOf(segment(Point(sw3End.x, sw3End.y), Point(sw3End.x + 10.0, sw3End.y))))
         val shorteningGeometry =
             trackGeometry(combineEdges(listOf(edge12) + sw2Straight + betweenSwitches + sw3Straight + trailingEdge))
-        val shorteningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                shorteningGeometry,
-            )
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
 
         val lengtheningEdgeCount =
             locationTrackService
@@ -185,11 +177,7 @@ constructor(
                     startOuterSwitch = switchLinkYV(switch1, 2),
                 )
             )
-        val lengtheningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                lengtheningGeometry,
-            )
+        val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
 
         val trackBoundaryMoveId =
             trackBoundaryMoveService.saveTrackBoundaryMove(
@@ -236,11 +224,7 @@ constructor(
 
         val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
         val lengtheningGeometry = trackGeometry(combineEdges(listOf(preEdge) + sw1Straight))
-        val lengtheningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                lengtheningGeometry,
-            )
+        val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
 
         val gap1to2 =
             edge(
@@ -257,11 +241,7 @@ constructor(
                 )
             )
 
-        val shorteningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                shorteningGeometry,
-            )
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
 
         val lengtheningEdgeCount =
             locationTrackService
@@ -303,11 +283,7 @@ constructor(
 
         // initially topologically disconnected tracks
         val lengtheningGeometry = trackGeometry(edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0)))))
-        val lengtheningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                lengtheningGeometry,
-            )
+        val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
         val sw1End = sw1Straight.last().lastSegmentEnd
         val shorteningGeometry =
             trackGeometry(
@@ -315,11 +291,7 @@ constructor(
                     sw1Straight + edge(listOf(segment(Point(sw1End.x, sw1End.y), Point(sw1End.x + 10.0, sw1End.y))))
                 )
             )
-        val shorteningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                shorteningGeometry,
-            )
+        val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
         trackBoundaryMoveService.saveTrackBoundaryMove(
             LayoutBranch.Companion.main,
             shorteningTrackId = shorteningTrack.id,
@@ -387,16 +359,7 @@ constructor(
                 )
             )
         val lengtheningGeometry =
-            trackGeometry(
-                edge(
-                    listOf(
-                        segment(
-                            Point(sw1End.x + 10.0, sw1End.y),
-                            Point(sw1End.x + 20.0, sw1End.y),
-                        )
-                    )
-                )
-            )
+            trackGeometry(edge(listOf(segment(Point(sw1End.x + 10.0, sw1End.y), Point(sw1End.x + 20.0, sw1End.y)))))
 
         val shorteningTrack = testDBService.save(locationTrack(trackNumber), shorteningGeometry)
         val lengtheningTrack = testDBService.save(locationTrack(trackNumber), lengtheningGeometry)
@@ -1102,10 +1065,7 @@ constructor(
 
         val preEdge = edge(listOf(segment(Point(0.0, 0.0), Point(10.0, 0.0))))
         val lengtheningTrack =
-            testDBService.save(
-                locationTrack(trackNumber),
-                trackGeometry(combineEdges(listOf(preEdge) + sw1Straight)),
-            )
+            testDBService.save(locationTrack(trackNumber), trackGeometry(combineEdges(listOf(preEdge) + sw1Straight)))
 
         val shorteningGeometry =
             trackGeometry(
@@ -1115,12 +1075,7 @@ constructor(
                     endOuterSwitch = switchLinkYV(switch2, 1),
                 ),
                 edge(
-                    listOf(
-                        segment(
-                            Point(sw1End.x + 10.0, sw1End.y),
-                            Point(sw1End.x + 20.0, sw1End.y),
-                        )
-                    ),
+                    listOf(segment(Point(sw1End.x + 10.0, sw1End.y), Point(sw1End.x + 20.0, sw1End.y))),
                     startInnerSwitch = switchLinkYV(switch2, 1),
                     endInnerSwitch = switchLinkYV(switch2, 2),
                 ),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAlignmentDaoIT.kt
@@ -28,6 +28,9 @@ import fi.fta.geoviite.infra.tracklayout.GeometrySource.PLAN
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole.CONNECTION
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole.MAIN
 import fi.fta.geoviite.infra.tracklayout.SwitchJointRole.MATH
+import java.math.BigDecimal
+import kotlin.random.Random
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -36,9 +39,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.random.Random
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetDaoIT.kt
@@ -6,13 +6,13 @@ import fi.fta.geoviite.infra.common.PublicationState
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.getIntId
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutAssetServiceIT.kt
@@ -9,13 +9,13 @@ import fi.fta.geoviite.infra.common.SwitchName
 import fi.fta.geoviite.infra.common.TrackMeter
 import fi.fta.geoviite.infra.common.TrackNumber
 import fi.fta.geoviite.infra.common.TrackNumberDescription
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutDesignServiceIT.kt
@@ -14,14 +14,14 @@ import fi.fta.geoviite.infra.publication.PublicationTestSupportService
 import fi.fta.geoviite.infra.publication.publicationRequestIds
 import fi.fta.geoviite.infra.util.LayoutAssetTable
 import fi.fta.geoviite.infra.util.queryOne
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutKmPostServiceIT.kt
@@ -7,13 +7,13 @@ import fi.fta.geoviite.infra.common.LayoutBranch
 import fi.fta.geoviite.infra.common.MainLayoutContext
 import fi.fta.geoviite.infra.linking.LayoutKmPostSaveRequest
 import fi.fta.geoviite.infra.math.Point
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberDaoIT.kt
@@ -16,6 +16,7 @@ import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.boundingBoxAroundPoint
 import fi.fta.geoviite.infra.tracklayout.LayoutState.DELETED
 import fi.fta.geoviite.infra.tracklayout.LayoutState.IN_USE
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
@@ -25,7 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -369,10 +369,7 @@ constructor(
 
         assertEquals(
             listOf(existingMainAndNearby),
-            trackNumberDao.fetchVersionsNear(
-                mainOfficialContext.context,
-                boundingBoxAroundPoint(Point(0.0, 0.0), 1.0),
-            ),
+            trackNumberDao.fetchVersionsNear(mainOfficialContext.context, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0)),
         )
         assertEquals(
             listOf(existingMainButDistant),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LayoutTrackNumberServiceIT.kt
@@ -17,6 +17,8 @@ import fi.fta.geoviite.infra.linking.TrackNumberSaveRequest
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.assertApproximatelyEquals
 import fi.fta.geoviite.infra.util.FreeText
+import java.math.BigDecimal
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -28,8 +30,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackDaoIT.kt
@@ -19,6 +19,9 @@ import fi.fta.geoviite.infra.tracklayout.LocationTrackType.MAIN
 import fi.fta.geoviite.infra.tracklayout.LocationTrackType.SIDE
 import fi.fta.geoviite.infra.util.getInstant
 import fi.fta.geoviite.infra.util.queryOne
+import kotlin.random.Random
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,9 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.random.Random
-import kotlin.test.assertContains
-import kotlin.test.assertFalse
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -676,10 +676,7 @@ constructor(
         )
         assertEquals(
             listOf(officialTrackVersion),
-            locationTrackDao.fetchVersionsNear(
-                MainLayoutContext.official,
-                boundingBoxAroundPoint(Point(0.0, 0.0), 1.0),
-            ),
+            locationTrackDao.fetchVersionsNear(MainLayoutContext.official, boundingBoxAroundPoint(Point(0.0, 0.0), 1.0)),
         )
     }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/LocationTrackServiceIT.kt
@@ -24,6 +24,7 @@ import fi.fta.geoviite.infra.split.SplitDao
 import fi.fta.geoviite.infra.split.SplitService
 import fi.fta.geoviite.infra.split.SplitTestDataService
 import fi.fta.geoviite.infra.util.FreeText
+import kotlin.test.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/OperationalPointServiceIT.kt
@@ -9,6 +9,8 @@ import fi.fta.geoviite.infra.math.BoundingBox
 import fi.fta.geoviite.infra.math.Point
 import fi.fta.geoviite.infra.math.Polygon
 import fi.fta.geoviite.infra.ratko.RatkoTestService
+import kotlin.test.assertContains
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
@@ -19,8 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertNull
 
 @ActiveProfiles("dev", "test")
 @SpringBootTest
@@ -215,13 +215,7 @@ constructor(
                 operationalPoint(
                     location = Point(7.0, 7.0),
                     polygon =
-                        Polygon(
-                            Point(0.0, 0.0),
-                            Point(10.0, 0.0),
-                            Point(10.0, 10.0),
-                            Point(0.0, 10.0),
-                            Point(0.0, 0.0),
-                        ),
+                        Polygon(Point(0.0, 0.0), Point(10.0, 0.0), Point(10.0, 10.0), Point(0.0, 10.0), Point(0.0, 0.0)),
                 )
             )
         assertEquals(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/StationLinkServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/StationLinkServiceIT.kt
@@ -146,9 +146,7 @@ class StationLinkServiceIT @Autowired constructor(private val stationLinkService
         val track1 =
             mainOfficialContext.save(
                 locationTrack(trackNumberId = tnVersion.id, operationalPointIds = setOf(op1.id, op2.id)),
-                trackGeometry(
-                    edge(segments = listOf(segment(Point(5.0, 2.0), Point(55.0, 2.0), calc = M_CALC.LAYOUT)))
-                ),
+                trackGeometry(edge(segments = listOf(segment(Point(5.0, 2.0), Point(55.0, 2.0), calc = M_CALC.LAYOUT)))),
             )
 
         // Track 2 connects OP2 and OP3 directly (no switches)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLinkTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/SwitchLocationTrackLinkTest.kt
@@ -336,5 +336,6 @@ fun switchSplitPoint(switchId: Int, joint: Int): SwitchSplitPoint {
     return SwitchSplitPoint(emptyPoint(), null, IntId(switchId), JointNumber(joint))
 }
 
-fun matchRange(vararg switchToJoint: Pair<Int, Int>): List<SplitPoint> =
-    switchToJoint.map { (id, joint) -> SwitchSplitPoint(emptyPoint(), null, IntId(id), JointNumber(joint)) }
+fun matchRange(vararg switchToJoint: Pair<Int, Int>): List<SplitPoint> = switchToJoint.map { (id, joint) ->
+    SwitchSplitPoint(emptyPoint(), null, IntId(id), JointNumber(joint))
+}

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/tracklayout/TrackLayoutDBTestData.kt
@@ -151,8 +151,7 @@ fun moveAlignmentPoints(
                 val newPoints =
                     segment.segmentPoints.mapNotNull { point ->
                         moveFunc(point.toAlignmentPoint(m.min))?.let { newPoint ->
-                            val segmentM =
-                                prevPoint?.let { p -> p.m + lineLength(p, newPoint) } ?: LineM<SegmentM>(0.0)
+                            val segmentM = prevPoint?.let { p -> p.m + lineLength(p, newPoint) } ?: LineM<SegmentM>(0.0)
                             point.copy(x = newPoint.x, y = newPoint.y, m = segmentM.castToDifferentM()).also { p ->
                                 prevPoint = p
                             }

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/E2ETestWatcher.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/E2ETestWatcher.kt
@@ -4,11 +4,11 @@ import fi.fta.geoviite.infra.ui.util.SHOW_BROWSER
 import fi.fta.geoviite.infra.ui.util.closeBrowser
 import fi.fta.geoviite.infra.ui.util.printBrowserLogs
 import fi.fta.geoviite.infra.ui.util.takeScreenShot
+import java.lang.reflect.Method
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestWatcher
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.lang.reflect.Method
 
 class E2ETestWatcher : TestWatcher {
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/SeleniumTest.kt
@@ -8,13 +8,13 @@ import fi.fta.geoviite.infra.ui.util.SHOW_BROWSER
 import fi.fta.geoviite.infra.ui.util.browser
 import fi.fta.geoviite.infra.ui.util.openBrowser
 import fi.fta.geoviite.infra.ui.util.openRemoteBrowser
+import java.util.*
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.test.context.ActiveProfiles
-import java.util.*
 
 /**
  * To run UI test with visible browser:

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/frontpage/FrontPage.kt
@@ -7,14 +7,14 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.pagemodel.common.waitAndClearToast
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenClickable
-import org.openqa.selenium.By
-import org.openqa.selenium.support.pagefactory.ByChained
-import waitUntilExists
-import waitUntilNotExist
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import org.openqa.selenium.By
+import org.openqa.selenium.support.pagefactory.ByChained
+import waitUntilExists
+import waitUntilNotExist
 
 class E2EFrontPage : E2EViewFragment(By.className("frontpage")) {
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/E2ETrackLayoutPage.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/pagemodel/map/E2ETrackLayoutPage.kt
@@ -14,6 +14,8 @@ import fi.fta.geoviite.infra.ui.util.javaScriptExecutor
 import getElementIfExists
 import getElementWhenExists
 import getNonNullAttribute
+import java.time.Instant
+import kotlin.math.roundToInt
 import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.interactions.Actions
@@ -21,8 +23,6 @@ import tryWait
 import waitUntilExists
 import waitUntilNotExist
 import waitUntilNotNull
-import java.time.Instant
-import kotlin.math.roundToInt
 
 class E2ETrackLayoutPage : E2EViewFragment(byQaId("track-layout-content")) {
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testdata/CommonTestData.kt
@@ -134,10 +134,7 @@ fun locationTrack(
     return track to geometry
 }
 
-fun referenceLineGeometryFromPoints(
-    basePoint: Point,
-    incrementPoints: List<Point>,
-): ReferenceLineGeometry {
+fun referenceLineGeometryFromPoints(basePoint: Point, incrementPoints: List<Point>): ReferenceLineGeometry {
     return referenceLineGeometry(segmentsFromPointIncrementList(basePoint, incrementPoints))
 }
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/FrontPageTestUI.kt
@@ -26,13 +26,13 @@ import fi.fta.geoviite.infra.tracklayout.toSegmentPoints
 import fi.fta.geoviite.infra.tracklayout.trackNumber
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.frontpage.E2EFrontPage
+import java.time.Instant
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.time.Instant
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/InfraModelTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/InfraModelTestUI.kt
@@ -80,8 +80,9 @@ class InfraModelTestUI : SeleniumTest() {
         val infraModelPageAfterUpload = E2EInfraModelPage()
         val infraModelRowsAfterUpload = infraModelPageAfterUpload.infraModelsList
 
-        val uploadedPlanRow =
-            infraModelRowsAfterUpload.getItemWhenMatches { r -> r.projectName == "TEST_Clothoid_and_parabola" }
+        val uploadedPlanRow = infraModelRowsAfterUpload.getItemWhenMatches { r ->
+            r.projectName == "TEST_Clothoid_and_parabola"
+        }
         assertNotNull(uploadedPlanRow)
         assertEquals("testfile_clothoid_and_parabola.xml", uploadedPlanRow.fileName)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/PublicationLogSearchTestUI.kt
@@ -14,6 +14,10 @@ import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.util.DaoBase
 import fi.fta.geoviite.infra.util.setUser
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -22,10 +26,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Component
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
-import java.time.Instant
-import java.time.ZoneOffset
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest
@@ -42,17 +42,11 @@ constructor(
 
         val westTrackNumberId =
             mainDraftContext
-                .save(
-                    trackNumber(TrackNumber("Test track number")),
-                    HelsinkiTestData.westReferenceLineGeometry(),
-                )
+                .save(trackNumber(TrackNumber("Test track number")), HelsinkiTestData.westReferenceLineGeometry())
                 .id
         val eastTrackNumberId =
             mainDraftContext
-                .save(
-                    trackNumber(TrackNumber("Test track number 2")),
-                    HelsinkiTestData.eastReferenceLineGeometry(),
-                )
+                .save(trackNumber(TrackNumber("Test track number 2")), HelsinkiTestData.eastReferenceLineGeometry())
                 .id
         val someTrack = HelsinkiTestData.westMainLocationTrack(westTrackNumberId, draft = true)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SearchTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SearchTestUI.kt
@@ -2,12 +2,12 @@ package fi.fta.geoviite.infra.ui.testgroup1
 
 import fi.fta.geoviite.infra.tracklayout.locationTrackAndGeometry
 import fi.fta.geoviite.infra.ui.SeleniumTest
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/SplitTestUI.kt
@@ -23,15 +23,15 @@ import fi.fta.geoviite.infra.ui.pagemodel.common.E2EAppBar
 import fi.fta.geoviite.infra.ui.testdata.HelsinkiTestData
 import fi.fta.geoviite.infra.ui.util.byQaId
 import getElementWhenExists
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/UserRoleTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup1/UserRoleTestUI.kt
@@ -37,10 +37,8 @@ import waitUntilNotExist
 @SpringBootTest
 class UserRoleTestUI
 @Autowired
-constructor(
-    private val trackNumberDao: LayoutTrackNumberDao,
-    private val layoutDesignDao: LayoutDesignDao,
-) : SeleniumTest() {
+constructor(private val trackNumberDao: LayoutTrackNumberDao, private val layoutDesignDao: LayoutDesignDao) :
+    SeleniumTest() {
     @BeforeEach
     fun beforeEach() {
         testDBService.clearAllTables()

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/GeometryElementListTestUI.kt
@@ -22,6 +22,7 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/LinkingTestUI.kt
@@ -34,16 +34,16 @@ import fi.fta.geoviite.infra.ui.testdata.pointsFromIncrementList
 import fi.fta.geoviite.infra.ui.testdata.referenceLineGeometryFromPoints
 import fi.fta.geoviite.infra.ui.util.metersToDouble
 import fi.fta.geoviite.infra.ui.util.pointToCoordinateString
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import kotlin.test.assertContains
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 // the point where the map opens up by default
 val DEFAULT_BASE_POINT = Point(385782.89, 6672277.83)

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryDiagramTestUI.kt
@@ -28,12 +28,12 @@ import fi.fta.geoviite.infra.tracklayout.segment
 import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.pagemodel.map.E2ETrackLayoutPage
+import java.math.BigDecimal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/testgroup2/VerticalGeometryElementListTestUI.kt
@@ -26,15 +26,15 @@ import fi.fta.geoviite.infra.tracklayout.trackGeometryOfSegments
 import fi.fta.geoviite.infra.ui.LocalHostWebClient
 import fi.fta.geoviite.infra.ui.SeleniumTest
 import fi.fta.geoviite.infra.ui.testdata.createGeometryKmPost
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import java.math.BigDecimal
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @ActiveProfiles("dev", "test", "e2e")
 @SpringBootTest

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/AssertionUtil.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/AssertionUtil.kt
@@ -11,8 +11,9 @@ import org.slf4j.LoggerFactory
 
 private val logger: Logger = LoggerFactory.getLogger("BROWSER")
 
-fun assertStringContains(expectedList: List<String>, actual: String) =
-    expectedList.forEach { expected -> kotlin.test.assertContains(actual, expected) }
+fun assertStringContains(expectedList: List<String>, actual: String) = expectedList.forEach { expected ->
+    kotlin.test.assertContains(actual, expected)
+}
 
 fun assertZeroErrorToasts() {
     val toasts =

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Browser.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Browser.kt
@@ -1,6 +1,13 @@
 package fi.fta.geoviite.infra.ui.util
 
 import defaultWait
+import java.io.File
+import java.net.URL
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.atomic.AtomicReference
+import java.util.logging.Level
 import org.apache.commons.io.FileUtils
 import org.json.JSONObject
 import org.openqa.selenium.By
@@ -22,13 +29,6 @@ import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.File
-import java.net.URL
-import java.time.Duration
-import java.time.Instant
-import java.util.*
-import java.util.concurrent.atomic.AtomicReference
-import java.util.logging.Level
 
 const val DEV_DEBUG = false
 const val SHOW_BROWSER = false // NOTE! Do not push "true" to remote repository

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Elements.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/ui/util/Elements.kt
@@ -1,5 +1,8 @@
 import fi.fta.geoviite.infra.ui.pagemodel.common.E2EViewFragment
 import fi.fta.geoviite.infra.ui.util.browser
+import java.time.Duration
+import java.time.Instant
+import java.util.regex.Pattern
 import org.openqa.selenium.By
 import org.openqa.selenium.NoSuchElementException
 import org.openqa.selenium.StaleElementReferenceException
@@ -18,9 +21,6 @@ import org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLoca
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.Duration
-import java.time.Instant
-import java.util.regex.Pattern
 
 private val logger: Logger = LoggerFactory.getLogger(E2EViewFragment::class.java)
 


### PR DESCRIPTION
Uusi `gradlew ktfmtFormat`-ajo, ei muita muutoksia. Tarkistin ettei tämä riko https://github.com/finnishtransportagency/geoviite/pull/2426 mergeä, ja https://github.com/finnishtransportagency/geoviite/pull/2428 ei koske Kotlin-tiedostoihin, eli lennossa olevissa pullareissa ei näyttäisi olevan juuri mitään, minkä takia tämä aiheuttaisi työläitä mergejä. Laitan ktfmt-formatoinnin vaatimisen ehdolle erikseen omana pullarinaan.