### PR TITLE
GVT-3662 Add ktfmtCheck to PR workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
+      - name: Check Kotlin formatting
+        run: |
+          cd infra
+          ./gradlew ktfmtCheck
+
       - name: Create cache key for Postgres Docker image
         id: hash-postgres-dockerfile
         env:


### PR DESCRIPTION
Tälläkään siis ktfmtCheck ei tulisi vielä vaadituksi, mutta että github sentään valittelisi, jos formaatit menee päin honkia. Tosin koska tämä tarkistus tarkistaa jokaisen Kotlin-tiedoston, niin formatointia pitää käytännössä käsitellä pakkona, koska jos joku tekee jotain, mistä ktmft ei pidä, niin sitten siitä tulee jokaisella pullarilla valitusta.