### PR TITLE
GVT-3637 update docs to reflect refactored tracknumber/referenceline data model

### DIFF
--- a/doc/julkaisut.md
+++ b/doc/julkaisut.md
@@ -33,10 +33,6 @@ classDiagram
         id: Int
         version: Int
     }
-    class ReferenceLine {
-        id: Int
-        version: Int
-    }
     class KmPost {
         id: Int
         version: Int
@@ -44,7 +40,6 @@ classDiagram
     Publication <-- LocationTrack
     Publication <-- Switch
     Publication <-- TrackNumber
-    Publication <-- ReferenceLine
     Publication <-- KmPost
 ```
 

--- a/doc/paikannuspohjan_muokkaus.md
+++ b/doc/paikannuspohjan_muokkaus.md
@@ -5,15 +5,14 @@ Paikannuspohjan käsitteitä muokataan Geoviitteessä **linkittämällä** tai m
 ## Linkitys
 
 Linkityksellä muokataan Geoviitteen paikannuspohjan käsitteiden geometriaa ja niiden välisiä yhteyksiä. Geoviitteessä
-voi linkittää ratanumeroita/pituusmittauslinjoja, sijaintiraiteita, vaihteita ja kilometripylväitä. Suurin osa
-linkityksistä tapahtuu geometriasuunnitelmien ja Geoviitteen paikannuspohjan välillä ja se on Geoviitteen pääasiallinen
-mekanismi paikannuspohjan geometrioiden ja sen käsitteiden välisten yhteyksien muokkaamiseen.
+voi linkittää ratanumeroita, sijaintiraiteita, vaihteita ja kilometripylväitä. Suurin osa linkityksistä tapahtuu
+geometriasuunnitelmien ja Geoviitteen paikannuspohjan välillä ja se on Geoviitteen pääasiallinen mekanismi
+paikannuspohjan geometrioiden ja sen käsitteiden välisten yhteyksien muokkaamiseen.
 
-Linkitys koskee _lähes_ pelkästään kohteiden geometriatietoja. Paikannuspohjan käsitteiden ominaisuustiedot (
-nimi/tunnus, tila
-jne.) on siis määriteltävä käsin. Tähän ainoa poikkeus on sijaintiraiteet (sijaintiraidetunnus ja kuvaukset voivat
-riippua vaihdelinkityksistä), josta on tarkempi maininta sijaintiraiteiden ja pituusmittauslinjojen linkityksen
-yhteydessä.
+Linkitys koskee _lähes_ pelkästään kohteiden geometriatietoja. Paikannuspohjan käsitteiden ominaisuustiedot
+(nimi/tunnus, tila jne.) on siis määriteltävä käsin. Tähän ainoa poikkeus on sijaintiraiteet (sijaintiraidetunnus ja
+kuvaukset voivat riippua vaihdelinkityksistä), josta on tarkempi maininta sijaintiraiteiden ja ratanumeroiden
+linkityksen yhteydessä.
 
 Linkitys ei koskaan muokkaa suoraan virallista paikannuspohjaa, vaan se muodostaa luonnoksia. Luonnosten tulee läpäistä
 julkaisuvalidointi ja ne julkaistaan Geoviitteen julkaisuprosessin mukaisesti.
@@ -22,15 +21,16 @@ julkaisuvalidointi ja ne julkaistaan Geoviitteen julkaisuprosessin mukaisesti.
 
 Geometriasuunnitelmissa käytetty käsitteistö eroaa jonkin verran paikannuspohjan käsitteistöstä, sillä suunnitelmissa
 kaikki nauhamaiset kohteet on esitetty alignment-olioina. Paikannuspohjassa nauhamaiset kohteet voivat olla joko
-sijaintiraiteita tai pituusmittauslinjoja. Alla on esitetty taulukko, joka yhdistää nämä toisiinsa korkealla tasolla.
-Tarkempi kuvaus tietomallista ja käsitteiden välisistä suhteista löytyy tiedostosta [Tietomalli](tietomalli.md):
+sijaintiraiteita tai ratanumeroita (pituusmittauslinjoja). Alla on esitetty taulukko, joka yhdistää nämä toisiinsa
+korkealla tasolla. Tarkempi kuvaus tietomallista ja käsitteiden välisistä suhteista löytyy
+tiedostosta [Tietomalli](tietomalli.md):
 
-| Linkitystyyppi               | Lähde             | Kohde             |
-|------------------------------|-------------------|-------------------|
-| Sijaintiraiteen linkitys     | GeometryAlignment | LocationTrack     |
-| Pituusmittauslinjan linkitys | GeometryAlignment | LayoutTrackNumber |
-| Vaihteen linkitys            | GeometrySwitch    | LayoutSwitch      |
-| Kilometripylvään linkitys    | GeometryKmPost    | LayoutKmPost      |
+| Linkitystyyppi               | Lähde             | Kohde                                     |
+|------------------------------|-------------------|-------------------------------------------|
+| Sijaintiraiteen linkitys     | GeometryAlignment | LocationTrack & LocationTrackGeometry     |
+| Pituusmittauslinjan linkitys | GeometryAlignment | LayoutTrackNumber & ReferenceLineGeometry |
+| Vaihteen linkitys            | GeometrySwitch    | LayoutSwitch & LayoutSwitchJoint          |
+| Kilometripylvään linkitys    | GeometryKmPost    | LayoutKmPost                              |
 
 ## Kohteiden muokkaus
 
@@ -55,7 +55,7 @@ Nauhamaisten kohteiden linkitys perustuu segmentteihin. Kokonaan linkitettävät
 linkitetään sellaisinaan. Jos linkitys katkaisee paikannuspohjan ja/tai geometrian segmentin, paikannuspohjaan
 generoidaan aiemman geometrian perusteella segmentti joka sisältää vain jäljellejäävän osuuden (näin voi käydä vain
 linkitettävän osuuden alussa tai lopussa). Linkityksessä poistetut segmentit poistetaan kokonaan paikannuspohjan
-kohteelta. Jos raiteen/pituusmittauslinjan aiempi geometria ei yhdisty saumattomasti suunnitelmasta linkitettävään
+kohteelta. Jos raiteen/ratanumeron aiempi geometria ei yhdisty saumattomasti suunnitelmasta linkitettävään
 geometriaan, niin niiden välille generoidaan välisegmentti. Tämä segmentti eroaa muista segmenteistä siten, että
 Geoviitteen generoimana sillä ei ole suunnitelmaviittausta eikä sille generoida pystygeometriatietoja. Lisäksi tällaiset
 generoidut välisegmentit voivat vaihdella suunnan suhteen huomattavasti varsinaisesta linjasta, mikä joudutaan
@@ -65,9 +65,9 @@ huomioimaan erikseen [geokoodauksessa](geokoodaus.md).
 
 - Nauhamaisia kohteita on myös mahdollista lyhentää käyttöliittymältä. Tämä ei ole varsinainen linkitysoperaatio, mutta
   se poistaa ja typistää nauhamaisen kohteen segmenttejä samalla tavalla kuin linkitys.
-- Olemassaolevien ratanumeroiden pittussmittauslinjan muokkaaminen muuttaa herkästi kyseisen ratanumeron osoitteistoa,
-  joten se aiheuttaa laskettuja muutoksia myös kaikkiin sen varrella oleviin kohteisiin muuttuneiden ratakilometrien
-  matkalta.
+- Olemassaolevien ratanumeroiden (mkl. pituusmittauslinjan geometrian) tai kilometripylväiden muokkaaminen muuttaa
+  herkästi kyseisen ratanumeron osoitteistoa, joten se aiheuttaa laskettuja muutoksia myös kaikkiin ratanumeron
+  kohteisiin muuttuneiden ratakilometrien matkalta.
 - Sijaintiraiteen nimeämisskeemasta ja kuvauksen tyypistä riippuen sen päihin linkitettyjen vaihteiden nimet voivat
   kuulua osaksi sen nimeä ja kuvausta. Tällöin nämä ominaisuustiedot muuttuvat raitteen vaihdelinkitysten muuttuessa.
 - Raiteen ja vaihteen välisiä linkityksiä voidaan irrottaa käsin käyttöliittymältä.

--- a/doc/paikannuspohjan_muokkaus.md
+++ b/doc/paikannuspohjan_muokkaus.md
@@ -9,7 +9,8 @@ voi linkittää ratanumeroita/pituusmittauslinjoja, sijaintiraiteita, vaihteita 
 linkityksistä tapahtuu geometriasuunnitelmien ja Geoviitteen paikannuspohjan välillä ja se on Geoviitteen pääasiallinen
 mekanismi paikannuspohjan geometrioiden ja sen käsitteiden välisten yhteyksien muokkaamiseen.
 
-Linkitys koskee _lähes_ pelkästään kohteiden geometriatietoja. Paikannuspohjan käsitteiden ominaisuustiedot (nimi/tunnus, tila
+Linkitys koskee _lähes_ pelkästään kohteiden geometriatietoja. Paikannuspohjan käsitteiden ominaisuustiedot (
+nimi/tunnus, tila
 jne.) on siis määriteltävä käsin. Tähän ainoa poikkeus on sijaintiraiteet (sijaintiraidetunnus ja kuvaukset voivat
 riippua vaihdelinkityksistä), josta on tarkempi maininta sijaintiraiteiden ja pituusmittauslinjojen linkityksen
 yhteydessä.
@@ -24,16 +25,17 @@ kaikki nauhamaiset kohteet on esitetty alignment-olioina. Paikannuspohjassa nauh
 sijaintiraiteita tai pituusmittauslinjoja. Alla on esitetty taulukko, joka yhdistää nämä toisiinsa korkealla tasolla.
 Tarkempi kuvaus tietomallista ja käsitteiden välisistä suhteista löytyy tiedostosta [Tietomalli](tietomalli.md):
 
-| Linkitystyyppi               | Lähde             | Kohde         |
-|------------------------------|-------------------|---------------|
-| Sijaintiraiteen linkitys     | GeometryAlignment | LocationTrack |
-| Pituusmittauslinjan linkitys | GeometryAlignment | ReferenceLine |
-| Vaihteen linkitys            | GeometrySwitch    | LayoutSwitch  |
-| Kilometripylvään linkitys    | GeometryKmPost    | LayoutKmPost  |
+| Linkitystyyppi               | Lähde             | Kohde             |
+|------------------------------|-------------------|-------------------|
+| Sijaintiraiteen linkitys     | GeometryAlignment | LocationTrack     |
+| Pituusmittauslinjan linkitys | GeometryAlignment | LayoutTrackNumber |
+| Vaihteen linkitys            | GeometrySwitch    | LayoutSwitch      |
+| Kilometripylvään linkitys    | GeometryKmPost    | LayoutKmPost      |
 
 ## Kohteiden muokkaus
 
-Kohteiden ominaisuustietoja hallinnoidaan Geoviitteessä pääasiassa käsin. Geometriaa hallinnoidaan pääasiassa linkittämällä,
+Kohteiden ominaisuustietoja hallinnoidaan Geoviitteessä pääasiassa käsin. Geometriaa hallinnoidaan pääasiassa
+linkittämällä,
 mutta tiettyjen kohteiden geometriaa tai linkityksiä muihin kohteisiin voidaan kuitenkin hallinnoida myös käsin. Näistä
 on selitetty tarkemmin kuhunkin kohdetyyppiin keskittyvissä kappaleissa.
 
@@ -41,12 +43,13 @@ Geometriasuunnitelmien käsitteitä linkitettäessä paikannuspohjan kohteeseen 
 kohteeseen. Yhteys purkautuu jos käsite linkitetään jostain muusta suunnitelmasta tai jos sen geometriaa muokataan
 käsin.
 
-### Nauhamaisten kohteiden (sijaintiraiteiden ja pituusmittauslinjojen) muokkaus
+### Nauhamaisten kohteiden (sijaintiraiteiden ja ratanumeroiden pituusmittauslinjojen) muokkaus
 
 Nauhamaisten kohteiden geometrian muokkaaminen tapahtuu pääosin linkittämällä sitä geometriatiedostoista. Tällöin
 geometriatiedostossa määritellyt keskilinjat linkitetään joko paikannuspohjan sijaintiraiteisiin tai
-pituusmittauslinjoihin. Geometriatiedoston keskilinjaa ei ole pakko linkittää kokonaan, vaan siitä voidaan valita myös vain
-osa. Jos paikannuspohjan kohteella oli jo geometriaa kyseisessä kohdassa, linkitys ylikirjoittaa sen.
+ratanumeroihin (pituusmittauslinjoihin). Geometriatiedoston keskilinjaa ei ole pakko linkittää kokonaan, vaan siitä
+voidaan valita myös vain osa. Jos paikannuspohjan kohteella oli jo geometriaa kyseisessä kohdassa, linkitys
+ylikirjoittaa sen.
 
 Nauhamaisten kohteiden linkitys perustuu segmentteihin. Kokonaan linkitettävät geometria-keskilinjan segmentit
 linkitetään sellaisinaan. Jos linkitys katkaisee paikannuspohjan ja/tai geometrian segmentin, paikannuspohjaan
@@ -54,15 +57,17 @@ generoidaan aiemman geometrian perusteella segmentti joka sisältää vain jälj
 linkitettävän osuuden alussa tai lopussa). Linkityksessä poistetut segmentit poistetaan kokonaan paikannuspohjan
 kohteelta. Jos raiteen/pituusmittauslinjan aiempi geometria ei yhdisty saumattomasti suunnitelmasta linkitettävään
 geometriaan, niin niiden välille generoidaan välisegmentti. Tämä segmentti eroaa muista segmenteistä siten, että
-Geoviitteen generoimana sillä ei ole suunnitelmaviittausta. Sille ei myöskään generoida pystygeometriatietoja.
+Geoviitteen generoimana sillä ei ole suunnitelmaviittausta eikä sille generoida pystygeometriatietoja. Lisäksi tällaiset
+generoidut välisegmentit voivat vaihdella suunnan suhteen huomattavasti varsinaisesta linjasta, mikä joudutaan
+huomioimaan erikseen [geokoodauksessa](geokoodaus.md).
 
 #### Hyvä tietää
 
 - Nauhamaisia kohteita on myös mahdollista lyhentää käyttöliittymältä. Tämä ei ole varsinainen linkitysoperaatio, mutta
   se poistaa ja typistää nauhamaisen kohteen segmenttejä samalla tavalla kuin linkitys.
-- Olemassaolevien pituusmittauslinjojen geometrian muokkaaminen muuttaa herkästi kyseisen pituusmittauslinjan
-  osoitteistoa, joten se aiheuttaa laskettuja muutoksia myös kaikkiin sen varrella oleviin kohteisiin muuttuneiden
-  ratakilometrien matkalta.
+- Olemassaolevien ratanumeroiden pittussmittauslinjan muokkaaminen muuttaa herkästi kyseisen ratanumeron osoitteistoa,
+  joten se aiheuttaa laskettuja muutoksia myös kaikkiin sen varrella oleviin kohteisiin muuttuneiden ratakilometrien
+  matkalta.
 - Sijaintiraiteen nimeämisskeemasta ja kuvauksen tyypistä riippuen sen päihin linkitettyjen vaihteiden nimet voivat
   kuulua osaksi sen nimeä ja kuvausta. Tällöin nämä ominaisuustiedot muuttuvat raitteen vaihdelinkitysten muuttuessa.
 - Raiteen ja vaihteen välisiä linkityksiä voidaan irrottaa käsin käyttöliittymältä.

--- a/doc/paikannuspohjan_validointi.md
+++ b/doc/paikannuspohjan_validointi.md
@@ -21,9 +21,9 @@ rakentajassa). Tärkeimpiä näistä ovat:
     - Tekstikenttien sallitut merkit ja pituudet
     - Numeeristen arvojen oikeat arvovälit
     - Enumeraatioiden sallitut arvot
-- Raiteen / pituusmittauslinjan keskilinjageometrian sisäinen eheys
-    - Keskilinjat ja pituusmittauslinjat ovat jatkuvia, eli viiva on ehjä eikä pisteiden välistä puutu mitään
-    - Keskilinjat ja pituusmittauslinjat eivät voi tehdä yli 90 asteen kulmia 2 pistevälin välillä
+- Raiteen / ratanumeron (pituusmittauslinjan) keskilinjageometrian sisäinen eheys
+    - Keskilinjat ovat jatkuvia, eli viiva on ehjä eikä pisteiden välistä puutu mitään
+    - Keskilinjat eivät voi tehdä yli 90 asteen kulmia 2 pistevälin välillä
     - Geometria koostuu segmenteistä, joista kukin sisältää vähintään 2 toisistaan eroavaa pistettä (viiva ei ole
       pistemäinen)
     - Segmenttien sisällä sama piste ei voi toistua
@@ -73,20 +73,14 @@ Validointi suoritetaan aina "julkaisujoukolle", johon kerätään koko se tila j
 
 #### Ratanumero
 
-- Ratanumerolla on oltava pituusmittauslinja
-- Ratanumeron tunnus on uniikki (ei saman nimisiä ratanumeroita)
-- Ratanumeron geokoodauskonteksti on validi (kts. Geokoodauskonteksti)
-
-#### Pituusmittauslinja
-
-- Pituusmittauslinjalla on ratanumero
-- Pituusmittauslinjalla on ei-tyhjä keskilinjageometria
+- Ratanumerolla on ei-tyhjä pituusmittauslinjan geometria
     - Huom. sisäinen validius oliokohtaisessa validoinnissa varmistaa että ei-tyhjä geometria on jatkuva jne (kts. yllä)
+- Ratanumeron tunnus on uniikki (ei saman nimisiä ratanumeroita)
 - Ratanumeron geokoodauskonteksti on validi (kts. Geokoodauskonteksti)
 
 #### Tasakilometripiste
 
-- Tasakilometripisteellä on oltava ratanumero ja pituusmittauslinja
+- Tasakilometripisteellä on oltava ratanumero
 - Tasakilometripisteellä on sijainti jos se ei ole poistettu
 - Tasakilometripisteen numero on uniikki ratanumerolla (jos piste ei ole poistettu)
 - Ratanumeron geokoodauskonteksti on validi (kts. Geokoodauskonteksti)
@@ -155,7 +149,7 @@ Validointi suoritetaan aina "julkaisujoukolle", johon kerätään koko se tila j
 #### Geokoodauskonteksti
 
 Geokoodauskonteksti (kts. [Geokoodaus](geokoodaus.md)) validoidaan kokonaisuutena aina kun kontekstiin kuuluvat asiat
-muuttuvat: ratanumero, pituusmittauslinja, tasakilometripisteet
+muuttuvat: ratanumero ja sen pituusmittauslinjan geometria sekä tasakilometripisteet.
 
 - Tasakilometripisteet ovat km-tunnuksen mukaisessa järjestyksessä
 - Kilometrit eivät ole liian pitkiä, eli tasakilometripisteiden väli ei ole liian pitkä (osoitteen esityksessä metreille

--- a/doc/suunnitelmatila.md
+++ b/doc/suunnitelmatila.md
@@ -169,7 +169,6 @@ classDiagram
     class LocationTrack
     class LayoutSwitch
     class LayoutKmPost
-    class ReferenceLine
     class OperationalPoint
     
     LayoutAsset --> LayoutDesign
@@ -178,7 +177,6 @@ classDiagram
     LocationTrack --|> LayoutAsset
     LayoutSwitch --|> LayoutAsset
     LayoutKmPost --|> LayoutAsset
-    ReferenceLine --|> LayoutAsset
     OperationalPoint --|> LayoutAsset
 ```
 

--- a/doc/tietomalli.md
+++ b/doc/tietomalli.md
@@ -18,51 +18,50 @@ käsitteistön kannalta oleellista osaa niiden tietosisällöstä.
 
 ## Termistö
 
-| Luokkanimi                            | Tietokantataulu                    | Käsite suomeksi                                               | Selite                                                                                                                       |
-|---------------------------------------|------------------------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| **Suunnitelman käsitteet**            |                                    |                                                               |                                                                                                                              |
-| GeometryPlan                          | geometry.plan                      | Suunnitelma                                                   | InfraModel (IM)-tiedoston jäsennetty muoto                                                                                   |
-| Author                                | geometry.plan_author               | Suunnitelman luoja                                            | IM:n luoneen yrityksen tiedot                                                                                                |
-| Application                           | geometry.plan_application          | Suunniteluohjelma                                             | Ohjelma jolla IM luotiin                                                                                                     |
-| GeometryUnits                         | (osana geometry.plan taulua)       | Suunnitelman yksiköt                                          | Pituus, kulma, koordinaattijärjestelmä, jne.                                                                                 |
-| GeometryAlignment                     | geometry.alignment                 | Suunnitelman keskilinjan geometria                            |                                                                                                                              |
-| GeometryElement                       | geometry.element                   | Suunnitelman geometrian elementti (kantaluokka)               |                                                                                                                              |
-| GeometryLine                          | (osana geometry.element taulua)    | Suunnitelman suora (geometriaelementti)                       |                                                                                                                              |
-| GeometryCurve                         | (osana geometry.element taulua)    | Suunnitelman ympyräkaari (geometriaelementti)                 |                                                                                                                              |
-| GeometrySpiral                        | (osana geometry.element taulua)    | Suunnitelman siirtymäkaari (geometriaelementti - kantaluokka) |                                                                                                                              |
-| GeometryClothoid                      | (osana geometry.element taulua)    | Suunnitelman klotoidi (geometriaelementti)                    |                                                                                                                              |
-| GeometryBiquadraticParabola           | (osana geometry.element taulua)    | Suunnitelman toisen asteen paraabeli (geometriaelementti)     |                                                                                                                              |
-| GeometrySwitch                        | geometry.switch                    | Suunnitelman vaihde                                           |                                                                                                                              |
-| GeometrySwitchJoint                   | geometry.switch_joint              | Suunnitelman vaihteen jatkospiste                             |                                                                                                                              |
-| GeometryKmPost                        | geometry.km_post                   | Suunnitelman tasakilometripiste                               | Aiemmin kilometripylväs                                                                                                      |
-| GeometryProfile                       | (osana geometry.alignment taulua)  | Suunnitelman pystygeometria                                   |                                                                                                                              |
-| VerticalIntersection                  | geometry.vertical_intersection     | Suunnitelman pystygeometrian piste (kantaluokka)              | Määrityskohta pystygeometrialle: korkeus suhteessa raiteen pituuteen                                                         |
-| VIPoint                               | geometry.vertical_intersection     | Suunnitelman pistemäinen pystygeometrian piste                | Määrittelee pystygeometrian arvon tietyssä kohdassa                                                                          |
-| VICircularCurve                       | geometry.vertical_intersection     | Suunnitelman kaareva pystygeometrian määrityspiste            | Määrittelee pystygeometriaan kaaren                                                                                          |
-| GeometryCant                          | (osana geometry.alignment taulua)  | Suunnitelman raiteen kallistus                                |                                                                                                                              |
-| GeometryCantPoint                     | geometry.cant_point                | Suunnitelman raiteen kallistuspiste                           | Määrityskohta kaltevuudelle: arvo suhteessa raiteen pituuteen                                                                |
-| **Paikannuspohjan käsitteet**         |                                    |                                                               |                                                                                                                              |
-| LayoutTrackNumber                     | layout.track_number                | Paikannuspohjan ratanumero                                    |                                                                                                                              |
-| ReferenceLine                         | layout.reference_line              | Paikannuspohjan pituusmittauslinja                            | Ratanumeron osoitteiston määräävä linja. Yleensä seuraa pääraidetta.                                                         |
-| LayoutKmPost                          | layout.km_post                     | Paikannuspohjan tasakilometripiste                            | Rataosoitteen kilometrinumeron vaihtumiskohta pituusmittauslinjalla                                                          |
-| LocationTrack                         | layout.location_track              | Paikannuspohjan sijaintiraide                                 |                                                                                                                              |
-| LocationTrackGeometry                 | layout.location_track_version_edge | Paikannuspohjan sijaintiraiteen keskilinja                    | Sijaintiraiteen keskilinjan geometriaviiva (koostavat edget, versioituu raiteen mukana)                                      |
-| LayoutAlignment                       | layout.alignment                   | Paikannuspohjan pituusmittauslinjan keskilinja                | Pituusmittauslinjan geometriaviiva (kokonaisuus)                                                                             |
-| LayoutSegment                         | layout.segment_version             | Paikannuspohjan keskilinjan segmentti                         | Geometriaviivan pätkä: metatiedoiltaan yhtenevä osa                                                                          |
-| SegmentGeometry                       | layout.segment_geometry            | Paikannuspohjan segmenttigeometria                            | Uniikki segmentin geometriapätkä                                                                                             |
-| LayoutSwitch                          | layout.switch                      | Paikannuspohjan vaihde                                        |                                                                                                                              |
-| LayoutSwitchJoint                     | layout.switch_joint                | Paikannuspohjan vaihdepiste                                   |                                                                                                                              |
-| **Rataverkkograafin käsitteet**       |                                    |                                                               |                                                                                                                              |
-| LayoutEdge                            | layout.edge                        | Graafin kaari                                                 | Geometria joka yhdistää 2 solmua                                                                                             |
-| NodeConnection                        | (osana layout.edge taulua)         | Graafin kaaren ja solmun välinen kytkentä                     | Yhdistää kaaren johonkin solmuun tietyn portin puolelta                                                                      |
-| LayoutNode                            | layout.node                        | Graafin solmu                                                 | Solmupiste: identiteetti rataverkon haarautumiskohdalle                                                                      |
-| NodePort                              | layout.node_port                   | Graafin solmun portti (kiinnityskohta)                        | Jos solmussa yhdistyy kaksi eri käsitettä (yleensä vaihdepistettä) portit kuvaavat suuntia joista kaari voi siihen kytkeytyä |
-| LayoutSegment (sama luokka kuin yllä) | layout.edge_segment                | Graafin kaaren geometrian (keskilinjan) segmentti             | Geometriaviivan pätkä: metatiedoiltaan yhtenevä osa pisteviivaa                                                              |
-| **Muut käsitteet**                    |                                    |                                                               |                                                                                                                              |
-| PVDocument                            | projektivelho.document             | Projektivelhon dokumentti                                     | Projektivelhosta ladattu yksittäinen tiedosto                                                                                |
-| SwitchStructure                       | common.switch_structure            | Vaihdetyyppi                                                  | Vaihdetyypin kuvaus ja sen RATO-määrityksen mukainen rakenne                                                                 |
-| SwitchOwner                           | common.switch_owner                | Vaihteen omistaja                                             |                                                                                                                              |
-| LocationTrackOwner                    | common.location_track_owner        | Sijaintiraiteen omistaja                                      |                                                                                                                              |
+| Luokkanimi                            | Tietokantataulu                                           | Käsite suomeksi                                               | Selite                                                                                                                       |
+|---------------------------------------|-----------------------------------------------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
+| **Suunnitelman käsitteet**            |                                                           |                                                               |                                                                                                                              |
+| GeometryPlan                          | geometry.plan                                             | Suunnitelma                                                   | InfraModel (IM)-tiedoston jäsennetty muoto                                                                                   |
+| Author                                | geometry.plan_author                                      | Suunnitelman luoja                                            | IM:n luoneen yrityksen tiedot                                                                                                |
+| Application                           | geometry.plan_application                                 | Suunniteluohjelma                                             | Ohjelma jolla IM luotiin                                                                                                     |
+| GeometryUnits                         | (osana geometry.plan taulua)                              | Suunnitelman yksiköt                                          | Pituus, kulma, koordinaattijärjestelmä, jne.                                                                                 |
+| GeometryAlignment                     | geometry.alignment                                        | Suunnitelman keskilinjan geometria                            |                                                                                                                              |
+| GeometryElement                       | geometry.element                                          | Suunnitelman geometrian elementti (kantaluokka)               |                                                                                                                              |
+| GeometryLine                          | (osana geometry.element taulua)                           | Suunnitelman suora (geometriaelementti)                       |                                                                                                                              |
+| GeometryCurve                         | (osana geometry.element taulua)                           | Suunnitelman ympyräkaari (geometriaelementti)                 |                                                                                                                              |
+| GeometrySpiral                        | (osana geometry.element taulua)                           | Suunnitelman siirtymäkaari (geometriaelementti - kantaluokka) |                                                                                                                              |
+| GeometryClothoid                      | (osana geometry.element taulua)                           | Suunnitelman klotoidi (geometriaelementti)                    |                                                                                                                              |
+| GeometryBiquadraticParabola           | (osana geometry.element taulua)                           | Suunnitelman toisen asteen paraabeli (geometriaelementti)     |                                                                                                                              |
+| GeometrySwitch                        | geometry.switch                                           | Suunnitelman vaihde                                           |                                                                                                                              |
+| GeometrySwitchJoint                   | geometry.switch_joint                                     | Suunnitelman vaihteen jatkospiste                             |                                                                                                                              |
+| GeometryKmPost                        | geometry.km_post                                          | Suunnitelman tasakilometripiste                               | Aiemmin kilometripylväs                                                                                                      |
+| GeometryProfile                       | (osana geometry.alignment taulua)                         | Suunnitelman pystygeometria                                   |                                                                                                                              |
+| VerticalIntersection                  | geometry.vertical_intersection                            | Suunnitelman pystygeometrian piste (kantaluokka)              | Määrityskohta pystygeometrialle: korkeus suhteessa raiteen pituuteen                                                         |
+| VIPoint                               | geometry.vertical_intersection                            | Suunnitelman pistemäinen pystygeometrian piste                | Määrittelee pystygeometrian arvon tietyssä kohdassa                                                                          |
+| VICircularCurve                       | geometry.vertical_intersection                            | Suunnitelman kaareva pystygeometrian määrityspiste            | Määrittelee pystygeometriaan kaaren                                                                                          |
+| GeometryCant                          | (osana geometry.alignment taulua)                         | Suunnitelman raiteen kallistus                                |                                                                                                                              |
+| GeometryCantPoint                     | geometry.cant_point                                       | Suunnitelman raiteen kallistuspiste                           | Määrityskohta kaltevuudelle: arvo suhteessa raiteen pituuteen                                                                |
+| **Paikannuspohjan käsitteet**         |                                                           |                                                               |                                                                                                                              |
+| LayoutTrackNumber                     | layout.track_number                                       | Paikannuspohjan ratanumero                                    |                                                                                                                              |
+| ReferenceLineGeometry                 | layout.track_number_version_segment                       | Paikannuspohjan ratanumeron (pituusmittauslinjan) geometria   | Ratanumeron pituusmittauslinjan geometria (koostavat segmentit, versioituu ratanumeron mukana)                               |
+| LayoutKmPost                          | layout.km_post                                            | Paikannuspohjan tasakilometripiste                            | Rataosoitteen kilometrinumeron vaihtumiskohta pituusmittauslinjalla                                                          |
+| LocationTrack                         | layout.location_track                                     | Paikannuspohjan sijaintiraide                                 |                                                                                                                              |
+| LocationTrackGeometry                 | layout.location_track_version_edge                        | Paikannuspohjan sijaintiraiteen keskilinja                    | Sijaintiraiteen keskilinjan geometriaviiva (koostavat edget, versioituu raiteen mukana)                                      |
+| LayoutSegment                         | layout.track_number_version_segment / layout.edge_segment | Paikannuspohjan keskilinjan (ratanumero tai raide) segmentti  | Geometriaviivan pätkä: metatiedoiltaan yhtenevä osa keskilinjageometriaa                                                     |
+| SegmentGeometry                       | layout.segment_geometry                                   | Paikannuspohjan segmenttigeometria                            | Uniikki segmentin geometriapätkä                                                                                             |
+| LayoutSwitch                          | layout.switch                                             | Paikannuspohjan vaihde                                        |                                                                                                                              |
+| LayoutSwitchJoint                     | layout.switch_joint                                       | Paikannuspohjan vaihdepiste                                   |                                                                                                                              |
+| **Rataverkkograafin käsitteet**       |                                                           |                                                               |                                                                                                                              |
+| LayoutEdge                            | layout.edge                                               | Graafin kaari                                                 | Geometria joka yhdistää 2 solmua                                                                                             |
+| NodeConnection                        | (osana layout.edge taulua)                                | Graafin kaaren ja solmun välinen kytkentä                     | Yhdistää kaaren johonkin solmuun tietyn portin puolelta                                                                      |
+| LayoutNode                            | layout.node                                               | Graafin solmu                                                 | Solmupiste: identiteetti rataverkon haarautumiskohdalle                                                                      |
+| NodePort                              | layout.node_port                                          | Graafin solmun portti (kiinnityskohta)                        | Jos solmussa yhdistyy kaksi eri käsitettä (yleensä vaihdepistettä) portit kuvaavat suuntia joista kaari voi siihen kytkeytyä |
+| LayoutSegment (sama luokka kuin yllä) | layout.edge_segment                                       | Graafin kaaren geometrian (keskilinjan) segmentti             | Geometriaviivan pätkä: metatiedoiltaan yhtenevä osa pisteviivaa                                                              |
+| **Muut käsitteet**                    |                                                           |                                                               |                                                                                                                              |
+| PVDocument                            | projektivelho.document                                    | Projektivelhon dokumentti                                     | Projektivelhosta ladattu yksittäinen tiedosto                                                                                |
+| SwitchStructure                       | common.switch_structure                                   | Vaihdetyyppi                                                  | Vaihdetyypin kuvaus ja sen RATO-määrityksen mukainen rakenne                                                                 |
+| SwitchOwner                           | common.switch_owner                                       | Vaihteen omistaja                                             |                                                                                                                              |
+| LocationTrackOwner                    | common.location_track_owner                               | Sijaintiraiteen omistaja                                      |                                                                                                                              |
 
 ## Sijaintien esitysmuodot
 
@@ -288,34 +287,35 @@ sinällään ole erityisen kiinnostava käyttäjän kannalta, mutta se kertoo ti
 lähdesuunnitelman josta se on linkitetty. Segmenttien jaottelu on siis pituuden puolesta mielivaltainen, mutta kukin
 segmentti on metatiedoiltaan yhtenevä geometrian pätkä.
 
-Segmenttigeometrioiden tallennuksessa on optimointi, joka varmistaa että itse geometria (linestring) tallennetaan vain
-kerran vaikka se olisi useammalla segmentillä. Tämä perustuu geometriataulun uniikkiin hash-avaimeen ja tapahtuu
-automaattisesti kun geometria tallennetaan. Tässä on kuitenkin se hyödyllinen ominaisuus että jos tallennetun segmentin
-geometryId on sama kuin toisella segmentillä, ne voidaan tietää identtisiksi ilman tarvetta vertailla pisteitä.
+Segmenttigeometrioiden tallennuksessa on optimointi, joka varmistaa että itse pisteviivana tallennettava geometria (
+linestring) tallennetaan vain kerran vaikka se olisi useammalla segmentillä. Tämä perustuu geometriataulun uniikkiin
+hash-avaimeen ja tapahtuu automaattisesti kun geometria tallennetaan. Tässä on kuitenkin se hyödyllinen ominaisuus että
+jos tallennetun segmentin geometryId on sama kuin toisella segmentillä, ne voidaan tietää identtisiksi ilman tarvetta
+vertailla pisteitä.
 
 ### Ratanumeron tietomalli
 
-Ratanumero koostuu tavallisten ominaisuustietojen lisäksi siihen liittyvästä pituusmittauslinjan geometriasta ja
-tasakilometripisteistä. Noiden käsitteiden yhdistelmästä muodostuu paikannuspohjaan ja ratanumeron rataosoitteiston
-viitekehys, eli Geoviitteen termistössä geokoodauskonteksti. Sen avulla voidaan laskea (geokoodata) ratanumeroon
-liittyvälle sijainnille rataosoite (rata, km, metrit). Vastaavasti ratanumerolle sidotulle rataosoitteelle voidaan
-laskea sijainti (koordinaatti) joko pituusmittauslinjalla tai jollain ratanumeroon sidotulla raiteella.
+Ratanumero koostuu tavallisten ominaisuustietojen lisäksi siihen liittyvästä geometriasta, jota kutsutaan
+pituusmittauslinjaksi. Ratanumeron pituusmittauslinjan geometria on tallennettu segmentteinä, jotka sidotaan rataverkon
+versioon, eli jokaisella ratanumeron versiolla on siihen liittyvä segmenttilista. Geometrian muodostus segmenteistä on
+kuvattu tarkemmin yllä, kts. [Segmenttigeometriat](#segmenttigeometriat).
+
+Lisäksi ratanumeroon liittyy keskeisesti sen tasakilometripisteet. Ratanumeron, pituusmittauslinjan geometrian ja
+tasakilometripisteiden yhdistelmästä muodostuu paikannuspohjaan ja ratanumeron rataosoitteiston viitekehys, eli
+Geoviitteen termistössä geokoodauskonteksti. Sen avulla voidaan laskea (geokoodata) ratanumeroon liittyvälle sijainnille
+rataosoite (rata, km, metrit). Vastaavasti ratanumerolle sidotulle rataosoitteelle voidaan laskea sijainti (
+koordinaatti) joko pituusmittauslinjalla tai jollain ratanumeroon sidotulla raiteella.
 
 Koska pituusmittauslinjan geometria muodostuu linkittämällä suunnitelmista, sen koostavat pätkät (segmentit) viittaavat
 lähdesuunnitelman keskilinjan elementtiin josta se on muodostettu. Yksittäinen segmentti ei muutoin ole erityisen
-merkittävä, mutta se muodostaa metatiedoiltaan (erityisesti tämä lähdetieto) yhtenevän jakson keskiviivaa.
-
-Pituusmittauslinjan geometria koostuu segmenteistä yllä kuvatulla tavalla (kts.
-[Segmenttigeometriat](#segmenttigeometriat)).
+merkittävä, mutta se muodostaa metatiedoiltaan (erityisesti tämä lähdetieto) yhtenevän jakson viivageometriaa.
 
 ```mermaid
 classDiagram
-    ReferenceLine *-- "1" LayoutAlignment
     LayoutSegment *-- "1" SegmentGeometry
     SegmentGeometry *-- SegmentPoint
-    LayoutTrackNumber <-- "1" ReferenceLine
+    LayoutTrackNumber *-- "n" LayoutSegment
     LayoutTrackNumber <-- "n" LayoutKmPost
-    LayoutAlignment *-- "n" LayoutSegment
     LayoutSegment --> "0..1" GeometryElement
 
     class LayoutTrackNumber {
@@ -323,20 +323,19 @@ classDiagram
         number: String
         description: String
         state: IN_USE/NOT_IN_USE/PLANNED/DELETED
-    }
-    class ReferenceLine {
         startAddress: TrackMeter
+        segmentCount: Int
+        length: Decimal
+        boundingBox: Polygon
     }
     class LayoutKmPost {
         kmNumber: KmNumber
         location: Point
         state: IN_USE/NOT_IN_USE/PLANNED/DELETED
     }
-    class LayoutAlignment {
-    }
     class LayoutSegment {
-        startJointNumber: Int?
-        endJointNumber: Int?
+        startM: Decimal
+        source: IMPORTED/LINKED/GENERATED
     }
     class SegmentGeometry {
         resolution: Int

--- a/doc/tietomalli.md
+++ b/doc/tietomalli.md
@@ -287,8 +287,8 @@ sinällään ole erityisen kiinnostava käyttäjän kannalta, mutta se kertoo ti
 lähdesuunnitelman josta se on linkitetty. Segmenttien jaottelu on siis pituuden puolesta mielivaltainen, mutta kukin
 segmentti on metatiedoiltaan yhtenevä geometrian pätkä.
 
-Segmenttigeometrioiden tallennuksessa on optimointi, joka varmistaa että itse pisteviivana tallennettava geometria (
-linestring) tallennetaan vain kerran vaikka se olisi useammalla segmentillä. Tämä perustuu geometriataulun uniikkiin
+Segmenttigeometrioiden tallennuksessa on optimointi, joka varmistaa että itse pisteviivana tallennettava geometria
+(linestring) tallennetaan vain kerran vaikka se olisi useammalla segmentillä. Tämä perustuu geometriataulun uniikkiin
 hash-avaimeen ja tapahtuu automaattisesti kun geometria tallennetaan. Tässä on kuitenkin se hyödyllinen ominaisuus että
 jos tallennetun segmentin geometryId on sama kuin toisella segmentillä, ne voidaan tietää identtisiksi ilman tarvetta
 vertailla pisteitä.
@@ -303,8 +303,8 @@ kuvattu tarkemmin yllä, kts. [Segmenttigeometriat](#segmenttigeometriat).
 Lisäksi ratanumeroon liittyy keskeisesti sen tasakilometripisteet. Ratanumeron, pituusmittauslinjan geometrian ja
 tasakilometripisteiden yhdistelmästä muodostuu paikannuspohjaan ja ratanumeron rataosoitteiston viitekehys, eli
 Geoviitteen termistössä geokoodauskonteksti. Sen avulla voidaan laskea (geokoodata) ratanumeroon liittyvälle sijainnille
-rataosoite (rata, km, metrit). Vastaavasti ratanumerolle sidotulle rataosoitteelle voidaan laskea sijainti (
-koordinaatti) joko pituusmittauslinjalla tai jollain ratanumeroon sidotulla raiteella.
+rataosoite (rata, km, metrit). Vastaavasti ratanumerolle sidotulle rataosoitteelle voidaan laskea sijainti
+(koordinaatti) joko pituusmittauslinjalla tai jollain ratanumeroon sidotulla raiteella.
 
 Koska pituusmittauslinjan geometria muodostuu linkittämällä suunnitelmista, sen koostavat pätkät (segmentit) viittaavat
 lähdesuunnitelman keskilinjan elementtiin josta se on muodostettu. Yksittäinen segmentti ei muutoin ole erityisen

--- a/doc/tietomalli.md
+++ b/doc/tietomalli.md
@@ -314,8 +314,9 @@ merkittävä, mutta se muodostaa metatiedoiltaan (erityisesti tämä lähdetieto
 classDiagram
     LayoutSegment *-- "1" SegmentGeometry
     SegmentGeometry *-- SegmentPoint
-    LayoutTrackNumber *-- "n" LayoutSegment
+    LayoutTrackNumber *-- "1" ReferenceLineGeometry
     LayoutTrackNumber <-- "n" LayoutKmPost
+    ReferenceLineGeometry *-- "n" LayoutSegment
     LayoutSegment --> "0..1" GeometryElement
 
     class LayoutTrackNumber {
@@ -327,6 +328,8 @@ classDiagram
         segmentCount: Int
         length: Decimal
         boundingBox: Polygon
+    }
+    class ReferenceLineGeometry {
     }
     class LayoutKmPost {
         kmNumber: KmNumber

--- a/doc/valimuisti.md
+++ b/doc/valimuisti.md
@@ -52,7 +52,7 @@ yksilöi [Layout konteksti](./paikannuspohjan_kontekstit.md). Välimuistin kanna
 
 Versioita voidaan myös koostaa jos välimuistin avaimeen tarvitaan useamman käsitteen yhdistelmä. Näin on tehty
 esimerkiksi [geokoodauskonteksteilla](./geokoodaus.md#geokoodauskonteksti-geocodingcontext), jonka sisältö riippuu
-ratanumerosta, sen pituusmittauslinjasta ja kilometripylväistä. Vasta noiden kaikkien versioiden yhdistelmä on riittävä
+ratanumerosta ja sen kilometripylväistä. Vasta noiden kaikkien versioiden yhdistelmä on riittävä
 yksilöimään koko geokoodauskontekstin, joten välimuistin avaimen on sisällettävä ne kaikki. Kun välimuistin avain on
 haettu, sen viittaamat oliot on edelleen nopea hakea kontekstin luomista varten esilämmitetyistä käsitekohtaisista
 välimuisteista avaimen sisältämillä versioilla. Luontiin sisältyy kuitenkin myös ei-triviaali määrä laskentaa, joten


### PR DESCRIPTION
Päivitetty dokumentaatiot vastaamaan uutta tietomallia https://github.com/finnishtransportagency/geoviite/pull/2416 mukaisesti.

Mergeän tämän nyt jo mainiin ennen lomille lähtöä koska dokumentaatio ei riko mitään, mutta saa silti kommentoida. Korjailen huomioita sitten loman jälkeen.