### PR TITLE
GVT-3667 Tighten geocoding treatment past reference line ends

### DIFF
--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -249,6 +249,14 @@ private const val PROJECTION_LINE_DISTANCE_DEVIATION = 0.05
  */
 private const val PROJECTION_LINE_MAX_ANGLE_DELTA = PI / 16
 
+/**
+ * For the purpose of geocoding, we treat reference lines as very slightly longer than they actually are (extended in
+ * their start and end directions). In theory, assuming the straight extrapolation was correct in the first place, half
+ * a millimeter would be the length that it's correct to assign addresses that will be rounded to 3 decimals at the end;
+ * but because there are earlier rounding steps as well, we give an extra half-mm of slack.
+ */
+private const val PROJECTION_LINE_PAST_END_EXTRAPOLATION_DISTANCE = 0.001
+
 private val logger: Logger = LoggerFactory.getLogger(GeocodingContext::class.java)
 
 data class ValidatedGeocodingContext<M : GeocodingAlignmentM<M>>(
@@ -334,8 +342,10 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
             val startDir = referenceLineGeometry.segments.firstOrNull()?.startDirection ?: return@lazy null
             ProjectionLine<M>(
                 start.address,
-                start.projection.move(pointInDirection(distance = -1.0, direction = startDir)),
-                LineM(-1.0),
+                start.projection.move(
+                    pointInDirection(distance = -PROJECTION_LINE_PAST_END_EXTRAPOLATION_DISTANCE, direction = startDir)
+                ),
+                LineM(-PROJECTION_LINE_PAST_END_EXTRAPOLATION_DISTANCE),
                 start.referenceDirection,
             )
         }
@@ -348,8 +358,10 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
             val endDir = referenceLineGeometry.segments.lastOrNull()?.endDirection ?: return@lazy null
             ProjectionLine(
                 end.address,
-                end.projection.move(pointInDirection(distance = 1.0, direction = endDir)),
-                referenceLineGeometry.length + 1.0,
+                end.projection.move(
+                    pointInDirection(distance = PROJECTION_LINE_PAST_END_EXTRAPOLATION_DISTANCE, direction = endDir)
+                ),
+                referenceLineGeometry.length + PROJECTION_LINE_PAST_END_EXTRAPOLATION_DISTANCE,
                 end.referenceDirection,
             )
         }
@@ -369,8 +381,6 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
     private fun getProjectionLineInContext(address: TrackMeter): ProjectionLineInContext<M>? =
         when (val surrounding = getSurroundingProjectionLines(address)) {
             is PastReferenceLineEnd -> null
-            is ExactHit ->
-                ProjectionLineInContext(useAddressPrecision(surrounding.projectionLine, address), surrounding.index)
             is ProjectionLineInterval ->
                 ProjectionLineInContext(
                     interpolateProjectionLine(address, surrounding.left, surrounding.right),
@@ -379,19 +389,20 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
         }
 
     private fun getSurroundingProjectionLines(address: TrackMeter): SurroundingProjectionLines<M> {
-        val extrapolatedStart = extrapolatedBeforeStartProjectionLine
-        val extrapolatedEnd = extrapolatedAfterEndProjectionLine
         val projectionLines = getProjectionLines(Resolution.ONE_METER)
-        return if (projectionLines.isEmpty() || extrapolatedStart == null || extrapolatedEnd == null)
-            PastReferenceLineEnd()
+        return if (projectionLines.isEmpty()) PastReferenceLineEnd()
         else
             projectionLines
                 .binarySearch { line -> line.address.compareTo(address) }
                 .let { ix ->
-                    if (ix == -1) ProjectionLineInterval(extrapolatedStart, projectionLines.first(), -1)
-                    else if (ix == -(projectionLines.size + 1))
-                        ProjectionLineInterval(projectionLines.last(), extrapolatedEnd, projectionLines.lastIndex)
-                    else if (ix >= 0) ExactHit(projectionLines[ix], ix)
+                    if (ix == -1 || ix == -(projectionLines.size + 1)) PastReferenceLineEnd()
+                    else if (ix == projectionLines.lastIndex)
+                        ProjectionLineInterval(
+                            projectionLines[projectionLines.lastIndex - 1],
+                            projectionLines.last(),
+                            projectionLines.lastIndex - 1,
+                        )
+                    else if (ix >= 0) ProjectionLineInterval(projectionLines[ix], projectionLines[ix + 1], ix)
                     else ProjectionLineInterval(projectionLines[-(ix + 2)], projectionLines[-(ix + 1)], -(ix + 2))
                 }
     }
@@ -554,13 +565,24 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
         val meters =
             round(km.startMeters.toDouble() + closestReferenceLineM.distance - km.referenceLineM.min.distance, decimals)
         return if (!TrackMeter.isMetersValid(meters)) null
-        else
-            getAddressInInterval(
-                getMeterProjectionLineAtExtrapolatedIndex(),
-                queryCoordinate,
-                getSurroundingProjectionLines(TrackMeter(km.kmNumber, meters)),
-                decimals,
-            )
+        else {
+            val addressInInterval =
+                getAddressInInterval(
+                    getMeterProjectionLineAtExtrapolatedIndex(),
+                    queryCoordinate,
+                    getSurroundingProjectionLines(TrackMeter(km.kmNumber, meters)),
+                )
+            if (addressInInterval == null) null
+            else roundAddress(addressInInterval.first, addressInInterval.second, decimals)
+        }
+    }
+
+    private fun roundAddress(kmNumber: KmNumber, meters: BigDecimal, decimals: Int): TrackMeter {
+        val kmIndex = findKmIndex(kmNumber)
+        val roundedMeters = round(meters, decimals)
+        return if (roundedMeters == round(kms[kmIndex].endAddress.meters, decimals) && kmIndex < kms.lastIndex)
+            kms[kmIndex + 1].startAddress
+        else TrackMeter(kmNumber, roundedMeters)
     }
 
     fun getReferenceLineAddressesWithResolution(
@@ -761,6 +783,15 @@ data class GeocodingContext<M : GeocodingAlignmentM<M>>(
             }
             .let(kms::getOrNull)
             ?: throw GeocodingFailureException("Target point is not within the reference line length")
+    }
+
+    private fun findKmIndex(kmNumber: KmNumber): Int {
+        return kms.binarySearch { km -> km.kmNumber.compareTo(kmNumber) }
+            .also { ix ->
+                if (ix < 0 || ix > kms.lastIndex) {
+                    throw GeocodingFailureException("km number $kmNumber does not exist in geocoding context")
+                }
+            }
     }
 
     fun cutRangeByKms(
@@ -1192,9 +1223,6 @@ private fun <M : GeocodingAlignmentM<M>> interpolateProjectionLine(
 sealed class SurroundingProjectionLines<M : GeocodingAlignmentM<M>>
 
 class PastReferenceLineEnd<M : GeocodingAlignmentM<M>> : SurroundingProjectionLines<M>()
-
-data class ExactHit<M : GeocodingAlignmentM<M>>(val projectionLine: ProjectionLine<M>, val index: Int) :
-    SurroundingProjectionLines<M>()
 
 data class ProjectionLineInterval<M : GeocodingAlignmentM<M>>(
     val left: ProjectionLine<M>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/Geocoding.kt
@@ -1194,14 +1194,6 @@ data class PolyLineEdge<M : AlignmentM<M>>(
         if (portion <= 0.0) start else if (portion >= 1.0) end else interpolateToSegmentPoint(start, end, portion)
 }
 
-private fun <M : GeocodingAlignmentM<M>> useAddressPrecision(projectionLine: ProjectionLine<M>, address: TrackMeter) =
-    if (address.decimalCount() == projectionLine.address.decimalCount()) projectionLine
-    else {
-        val lineAddress = projectionLine.address
-        val lineMeters = lineAddress.meters
-        projectionLine.copy(address = lineAddress.copy(meters = lineMeters.setScale(address.meters.scale())))
-    }
-
 private fun <M : GeocodingAlignmentM<M>> interpolateProjectionLine(
     address: TrackMeter,
     left: ProjectionLine<M>,

--- a/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/ProjectionLineSearch.kt
+++ b/infra/src/main/kotlin/fi/fta/geoviite/infra/geocoding/ProjectionLineSearch.kt
@@ -8,7 +8,6 @@ import fi.fta.geoviite.infra.math.Line
 import fi.fta.geoviite.infra.math.directionBetweenPoints
 import fi.fta.geoviite.infra.math.lineIntersection
 import fi.fta.geoviite.infra.math.pointInDirection
-import fi.fta.geoviite.infra.math.round
 import fi.fta.geoviite.infra.tracklayout.GeocodingAlignmentM
 import java.math.BigDecimal
 
@@ -16,8 +15,7 @@ fun <M : GeocodingAlignmentM<M>> getAddressInInterval(
     getMeterProjectionLine: (index: Int) -> ProjectionLine<M>?,
     queryCoordinate: IPoint,
     initialSurroundingProjectionLines: SurroundingProjectionLines<M>,
-    decimals: Int,
-): TrackMeter? {
+): Pair<KmNumber, BigDecimal>? {
     var surroundingProjectionLines = initialSurroundingProjectionLines
     var lastStepDirection: StepDirection? = null
 
@@ -25,7 +23,7 @@ fun <M : GeocodingAlignmentM<M>> getAddressInInterval(
         val step = getAddressInIntervalStep(getMeterProjectionLine, queryCoordinate, surroundingProjectionLines)
         return when (step) {
             is NotFound -> null
-            is Resolved -> TrackMeter(step.kmNumber, round(step.meters, decimals))
+            is Resolved -> step.kmNumber to step.meters
             is TakeStep<M> -> {
                 // Mathematically, the line segment from a point to the nearest point to it on a smooth curve hits the
                 // curve either perpendicularly or at an end. Floatingpointly, with line strings, it mightn't, and so we
@@ -62,7 +60,6 @@ private fun <M : GeocodingAlignmentM<M>> getAddressInIntervalStep(
 ): AddressInIntervalSearchStepResult<M> =
     when (surroundingProjectionLines) {
         is PastReferenceLineEnd -> NotFound()
-        is ExactHit<*> -> Resolved(surroundingProjectionLines.projectionLine.address)
         is ProjectionLineInterval<M> ->
             getAddressInIntervalBetweenSurroundingLinesStep(
                 getMeterProjectionLine,
@@ -92,6 +89,10 @@ private fun <M : GeocodingAlignmentM<M>> getAddressInIntervalBetweenSurroundingL
         val stepDirection = if (isLeftOfLeftProjectionLine) StepDirection.Backward else StepDirection.Forward
         val next = getNextSurroundingProjectionLines(getMeterProjectionLine, interval, stepDirection)
         if (next == null) NotFound() else TakeStep(stepDirection, next)
+    } else if (interval.leftIndex == -1 || getMeterProjectionLine(interval.leftIndex + 2) == null) {
+        // the interval is one of the extrapolated-past-end ones, which have the same address at both ends of the
+        // interval, so just picking the left one is fine
+        Resolved(left.address)
     } else {
         val proportion =
             -leftIntersection.segment1Portion / (rightIntersection.segment1Portion - leftIntersection.segment1Portion)
@@ -125,9 +126,6 @@ private fun <M : GeocodingAlignmentM<M>> getNextSurroundingProjectionLines(
     val (leftIndex, rightIndex) =
         when (here) {
             is PastReferenceLineEnd -> return null
-            is ExactHit ->
-                if (stepDirection == StepDirection.Backward) here.index - 1 to here.index
-                else here.index to here.index + 1
             is ProjectionLineInterval -> here.leftIndex + stepDirection.diff to here.leftIndex + 1 + stepDirection.diff
         }
     return getMeterProjectionLine(leftIndex)?.let { left ->

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -1251,6 +1251,19 @@ class GeocodingTest {
     }
 
     @Test
+    fun `getAddress() rounds an address up to the next track kilometer when close enough to a km end`() {
+        val context =
+            createContext(
+                geometryPoints = listOf(Point(0.0, 0.0), Point(10.0, 0.0)),
+                startAddress = TrackMeter(1, 0),
+                kmPoints = listOf(TrackMeter(2, 0) to 5.0),
+            )
+
+        assertEquals(TrackMeter(2, 0), context.getAddress(Point(4.9997, 0.0), 3)?.first)
+        assertEquals(TrackMeter(1, "4.999"), context.getAddress(Point(4.9990, 0.0), 3)?.first)
+    }
+
+    @Test
     fun `getAddress() rejects geocoding points too far past reference line ends`() {
         val startPoint = context.referenceLineGeometry.start!!.toPoint()
         val startDirection = context.referenceLineGeometry.segments[0].startDirection

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -1128,7 +1128,7 @@ class GeocodingTest {
         val referenceLineGeometry =
             referenceLineGeometry(
                 segment(Point(0.0, 100.0), Point(10.0, 100.0)), // reference line is convex toward track
-                segment(Point(10.0, 100.0), Point(20.0, 99.9)),
+                segment(Point(10.0, 100.0), Point(190.0, 90.0)),
             )
         val locationTrackGeometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(20.0, 0.0)))
 
@@ -1172,7 +1172,7 @@ class GeocodingTest {
                 segment(Point(5.0, 100.0), Point(15.0, 100.0)),
                 segment(Point(15.0, 100.0), Point(20.0, 99.0)),
             )
-        val locationTrackGeometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(20.0, 0.0)))
+        val locationTrackGeometry = trackGeometryOfSegments(segment(Point(0.0, 99.0), Point(20.0, 99.0)))
         val context =
             GeocodingContext.create(
                     trackNumber = TrackNumber("001"),
@@ -1248,6 +1248,24 @@ class GeocodingTest {
                 addressFilter = AddressFilter(KmLimit(KmNumber(3, "A")), KmLimit(KmNumber(3, "A"))),
             ) is AddressPointsResult.InvalidEndpoint
         )
+    }
+
+    @Test
+    fun `getAddress() rejects geocoding points too far past reference line ends`() {
+        val startPoint = context.referenceLineGeometry.start!!.toPoint()
+        val startDirection = context.referenceLineGeometry.segments[0].startDirection
+        val endPoint = context.referenceLineGeometry.end!!.toPoint()
+        val endDirection = context.referenceLineGeometry.segments.last().endDirection
+
+        val farFromStart = pointInDirection(startPoint, -0.0014, startDirection)
+        val nearStart = pointInDirection(startPoint, -0.0006, startDirection)
+        val nearEnd = pointInDirection(endPoint, 0.0006, endDirection)
+        val farFromEnd = pointInDirection(endPoint, 0.0014, endDirection)
+
+        assertEquals(null, context.getAddress(farFromStart)?.first)
+        assertEquals(context.startAddress.round(3), context.getAddress(nearStart)?.first)
+        assertEquals(context.endAddress.round(3), context.getAddress(nearEnd)?.first)
+        assertEquals(null, context.getAddress(farFromEnd)?.first)
     }
 
     private fun <M : AlignmentM<M>> assertEqualsRounded(

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geocoding/GeocodingTest.kt
@@ -1165,14 +1165,35 @@ class GeocodingTest {
     }
 
     @Test
-    fun `getAddressPoints() handles overly concave reference line without crashing`() {
+    fun `getAddressPoints() rejects geocoding against overly concave reference line`() {
         val referenceLineGeometry =
             referenceLineGeometry(
                 segment(Point(0.0, 99.0), Point(5.0, 100.0)),
                 segment(Point(5.0, 100.0), Point(15.0, 100.0)),
                 segment(Point(15.0, 100.0), Point(20.0, 99.0)),
             )
-        val locationTrackGeometry = trackGeometryOfSegments(segment(Point(0.0, 99.0), Point(20.0, 99.0)))
+        val locationTrackGeometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(20.0, 0.0)))
+        val context =
+            GeocodingContext.create(
+                    trackNumber = TrackNumber("001"),
+                    startAddress = TrackMeter(KmNumber(0), 0),
+                    referenceLineGeometry = referenceLineGeometry,
+                    kmPosts = listOf(),
+                )
+                .geocodingContext
+        assertNull(context.getAddressPoints(locationTrackGeometry).addresses)
+    }
+
+    @Test
+    fun `getAddressPoints() survives reference line with a concavity in the middle without crashing`() {
+        val referenceLineGeometry =
+            referenceLineGeometry(
+                segment(Point(0.0, 99.0), Point(5.0, 99.0)),
+                segment(Point(5.0, 99.0), Point(10.0, 100.0)),
+                segment(Point(10.0, 100.0), Point(15.0, 99.0)),
+                segment(Point(15.0, 99.0), Point(20.0, 99.0)),
+            )
+        val locationTrackGeometry = trackGeometryOfSegments(segment(Point(0.0, 0.0), Point(20.0, 0.0)))
         val context =
             GeocodingContext.create(
                     trackNumber = TrackNumber("001"),

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/geometry/GeometryServiceIT.kt
@@ -291,11 +291,9 @@ constructor(
                     ),
                 )
                 .id
-        // geocoding rounds m-values to three decimals half-up, so placing the km post juuuuuuuust
-        // here in fact rounds
-        // its position back to exactly 10, causing the 9..10 connection segment's end address to
-        // also be in
-        // track km 0155
+        // geocoding rounds m-values to three decimals half-up, so placing the km post juuuuuuuust here in fact rounds
+        // its position back to exactly 10, causing the 9..10 connection segment's end address to also be in track km
+        // 0155
         val post = kmPost(trackNumberId, KmNumber("0155"), kmPostGkLocation(0.0, 10.00001), draft = true)
         kmPostService.saveDraft(LayoutBranch.main, post)
 

--- a/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
+++ b/infra/src/test/kotlin/fi/fta/geoviite/infra/publication/PublicationValidationServiceIT.kt
@@ -1716,7 +1716,7 @@ constructor(
         val designOfficialContext = testDBService.testContext(designBranch, OFFICIAL)
         val trackNumber =
             designOfficialContext
-                .save(trackNumber(), referenceLineGeometry(segment(Point(0.0, 0.0), Point(40.0, 0.0))))
+                .save(trackNumber(), referenceLineGeometry(segment(Point(-1.0, 0.0), Point(40.0, 0.0))))
                 .id
 
         val switchName = "TST V0001"


### PR DESCRIPTION
Geokoodauksessa oli itse asiassa muutamakin logiikkabugi tapauksissa, missä geokoodattiin hieman pituusmittauslinjan yli menevää koordinaattia.

Geokoodauksen peruskonsepti on nyt jonkin aikaa ollut sellainen, että pituusmittauslinjalta heitetään metripisteittäin projektioviivat, ja geokoodattavan pisteen osoite määrittyy sillä perusteella, mihin kohtaan kahden vierekkäisen projektioviivan välistä sarkaa (ProjectionLineInterval) se osuu.

Tämä peruskonsepti ei itsessään pysty sanomaan mitään siitä, miten voitaisiin asettaa osoite pisteelle, joka ei sisälly mihinkään sarkaan; mutta koska on tavallista, että pituusmittauslinjat päättyvät suunnilleen samaan kohtaan kuin raidekin, ja näissä kohdissa voi eri laskutoimitusten pyöristykset mennä suuntaan tai toiseen, peruskonseptiin pitää lisätä hilkkusen verran liikkumavaraa pituusmittauslinjojen päihin.

Tämä liikkumavara on toteutettu ekstrapoloimalla vielä yksi projektioviiva edemmäs pituusmittauslinjan alusta ja lopusta, ja tekemällä sitten samat käsittelyt tähän sarkaan (alusta ekstrapoloidun projektioviivan ja alkuprojektioviivan välinen sarka; tai lopusta ekstrapoloidun ja lopun välinen) osuville pisteille kuin muillekin.

Aiemmassa koodissa vaan oli bugeja niin, että:
- Ekstrapolaatio tehtiin metrin etäisyyteen, vaikka periaatteessa vähän yli puoli milliä riittää
- Ekstrapoloituun sarkaan osuvan pisteen osoitteen pitäisi luonnostaan olla vaan linjan alku- tai loppuosoite; mutta nille tehtiinkin sama varsinaisen osoitteen laskenta interpolaatiolla pituusmittauslinjan m-arvojen perusteella kuin muillekin saroille, minkä takia pisteillä ennen pituusmittauslinjan alkupistettä oli itse asiassa *isompi* osoite kuin pituusmittauslinjan alkuosoite

Molemma bugit fiksattu tässä.